### PR TITLE
Moves all builds to rust stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ core_fmt:
 
 .PHONY: core_lint
 core_lint:
-	docker run core:$(branch) cargo clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
+	docker run core:$(branch) cargo +stable clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
 
 .PHONY: core_test
 core_test:
@@ -85,7 +85,7 @@ server_fmt:
 
 .PHONY: server_lint
 server_lint:
-	docker run server:$(branch) cargo clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
+	docker run server:$(branch) cargo +stable clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
 
 .PHONY: server_test
 server_test:
@@ -115,7 +115,7 @@ cli_fmt:
 
 .PHONY: cli_lint
 cli_lint:
-	docker run cli:$(branch) cargo clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
+	docker run cli:$(branch) cargo +stable clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
 
 .PHONY: cli_test
 cli_test:
@@ -145,7 +145,7 @@ integration_tests_fmt:
 
 .PHONY: integration_tests_lint
 integration_tests_lint:
-	docker run integration_tests:$(branch) cargo clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
+	docker run integration_tests:$(branch) cargo +stable clippy -- -D warnings -A clippy::redundant-field-names -A clippy::ptr-arg -A clippy::missing-safety-doc -A clippy::expect-fun-call
 
 .PHONY: integration_tests_run
 integration_tests_run:

--- a/containers/Dockerfile.cli
+++ b/containers/Dockerfile.cli
@@ -1,10 +1,8 @@
 FROM rust
 # Use https://rust-lang.github.io/rustup-components-history/ to select one with cargo and rustfmt
 RUN rustup toolchain install stable
-RUN rustup toolchain install nightly-2020-05-15
-RUN rustup override set nightly
 RUN rustup component add rustfmt --toolchain stable
-RUN rustup component add clippy --toolchain nightly
+RUN rustup component add clippy --toolchain stable
 WORKDIR cli
 
 # CLI depends on core via a relative import

--- a/containers/Dockerfile.core
+++ b/containers/Dockerfile.core
@@ -1,10 +1,8 @@
 FROM rust
 # Use https://rust-lang.github.io/rustup-components-history/ to select one with cargo and rustfmt
 RUN rustup toolchain install stable
-RUN rustup toolchain install nightly-2020-05-15
-RUN rustup override set nightly
 RUN rustup component add rustfmt --toolchain stable
-RUN rustup component add clippy --toolchain nightly
+RUN rustup component add clippy --toolchain stable
 WORKDIR core
 
 # Required to get cargo to get and compile deps but not our source

--- a/containers/Dockerfile.integration_tests
+++ b/containers/Dockerfile.integration_tests
@@ -1,10 +1,8 @@
 FROM rust
 # Use https://rust-lang.github.io/rustup-components-history/ to select one with cargo and rustfmt
 RUN rustup toolchain install stable
-RUN rustup toolchain install nightly-2020-05-15
-RUN rustup override set nightly
 RUN rustup component add rustfmt --toolchain stable
-RUN rustup component add clippy --toolchain nightly
+RUN rustup component add clippy --toolchain stable
 WORKDIR integration_tests
 
 # Test depends on core via a relative import

--- a/containers/Dockerfile.server
+++ b/containers/Dockerfile.server
@@ -1,10 +1,8 @@
 FROM rust
 # Use https://rust-lang.github.io/rustup-components-history/ to select one with cargo and rustfmt
 RUN rustup toolchain install stable
-RUN rustup toolchain install nightly-2020-05-15
-RUN rustup override set nightly
 RUN rustup component add rustfmt --toolchain stable
-RUN rustup component add clippy --toolchain nightly
+RUN rustup component add clippy --toolchain stable
 WORKDIR server
 
 # Server depends on core via a relative import

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait)]
 extern crate reqwest;
 
 #[macro_use]

--- a/core/src/repo/account_repo.rs
+++ b/core/src/repo/account_repo.rs
@@ -1,5 +1,3 @@
-use std::option::NoneError;
-
 use sled::Db;
 
 use crate::error_enum;
@@ -9,7 +7,7 @@ error_enum! {
     enum Error {
         SledError(sled::Error),
         SerdeError(serde_json::Error),
-        AccountMissing(NoneError), // TODO: not required in get_account
+        AccountMissing(()),
     }
 }
 
@@ -30,7 +28,7 @@ impl AccountRepo for AccountRepoImpl {
     fn get_account(db: &Db) -> Result<Account, Error> {
         let tree = db.open_tree("account")?;
         let maybe_value = tree.get("you")?;
-        let val = maybe_value?;
+        let val = maybe_value.ok_or(())?;
         let account: Account = serde_json::from_slice(val.as_ref())?;
         Ok(account)
     }

--- a/core/src/repo/db_provider.rs
+++ b/core/src/repo/db_provider.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::option::NoneError;
 
 use crate::error_enum;
 use crate::model::state::Config;
@@ -11,7 +10,6 @@ error_enum! {
     enum Error {
         SledError(sled::Error),
         TempFileError(io::Error),
-        NoTempDir(NoneError),
     }
 }
 
@@ -34,11 +32,7 @@ impl DbProvider for DiskBackedDB {
 impl DbProvider for TempBackedDB {
     fn connect_to_db(_config: &Config) -> Result<Db, Error> {
         let dir = tempdir()?;
-        let dir_path = format!(
-            "{}/{}",
-            dir.path().to_str()?.to_string(),
-            DB_NAME.to_string()
-        );
+        let dir_path = dir.path().join(DB_NAME);
         Ok(sled::open(dir_path)?)
     }
 }

--- a/core/src/repo/file_metadata_repo.rs
+++ b/core/src/repo/file_metadata_repo.rs
@@ -1,5 +1,3 @@
-use std::option::NoneError;
-
 use crate::error_enum;
 use crate::model::client_file_metadata::ClientFileMetadata;
 use sled::Db;
@@ -15,7 +13,7 @@ error_enum! {
     enum Error {
         SledError(sled::Error),
         SerdeError(serde_json::Error),
-        FileRowMissing(NoneError),
+        FileRowMissing(()),
     }
 }
 
@@ -69,7 +67,7 @@ impl FileMetadataRepo for FileMetadataRepoImpl {
     fn get(db: &Db, id: &String) -> Result<ClientFileMetadata, Error> {
         let tree = db.open_tree(FILE_METADATA)?;
         let maybe_value = tree.get(id.as_bytes())?;
-        let value = maybe_value?;
+        let value = maybe_value.ok_or(())?;
         let file_metadata: ClientFileMetadata = serde_json::from_slice(value.as_ref())?;
 
         Ok(file_metadata)

--- a/core/src/repo/file_repo.rs
+++ b/core/src/repo/file_repo.rs
@@ -1,5 +1,3 @@
-use std::option::NoneError;
-
 use crate::error_enum;
 use crate::service::file_encryption_service::EncryptedFile;
 use sled::Db;
@@ -8,7 +6,7 @@ error_enum! {
     enum Error {
         SledError(sled::Error),
         SerdeError(serde_json::Error),
-        FileRowMissing(NoneError)
+        FileRowMissing(())
     }
 }
 
@@ -30,7 +28,7 @@ impl FileRepo for FileRepoImpl {
     fn get(db: &Db, id: &String) -> Result<EncryptedFile, Error> {
         let tree = db.open_tree(b"files")?;
         let maybe_value = tree.get(id.as_bytes())?;
-        let value = maybe_value?;
+        let value = maybe_value.ok_or(())?;
         let file: EncryptedFile = serde_json::from_slice(value.as_ref())?;
 
         Ok(file)

--- a/core/src/service/auth_service.rs
+++ b/core/src/service/auth_service.rs
@@ -37,8 +37,8 @@ impl From<SignatureVerificationFailed> for VerificationError {
 }
 
 impl From<()> for VerificationError {
-    fn from(e: ()) -> Self {
-        InvalidAuthLayout(e)
+    fn from(_e: ()) -> Self {
+        InvalidAuthLayout(())
     }
 }
 

--- a/core/src/service/auth_service.rs
+++ b/core/src/service/auth_service.rs
@@ -1,5 +1,4 @@
 use std::num::ParseIntError;
-use std::option::NoneError;
 
 use rsa::RSAPublicKey;
 use serde::export::PhantomData;
@@ -19,7 +18,7 @@ use crate::service::crypto_service::{
 pub enum VerificationError {
     TimeStampParseFailure(ParseIntError),
     CryptoVerificationError(SignatureVerificationFailed),
-    InvalidAuthLayout(NoneError),
+    InvalidAuthLayout(()),
     AuthDeserializationError(serde_json::error::Error),
     InvalidUsername,
     TimeStampOutOfBounds(u128),
@@ -37,8 +36,8 @@ impl From<SignatureVerificationFailed> for VerificationError {
     }
 }
 
-impl From<NoneError> for VerificationError {
-    fn from(e: NoneError) -> Self {
+impl From<()> for VerificationError {
+    fn from(e: ()) -> Self {
         InvalidAuthLayout(e)
     }
 }
@@ -83,11 +82,11 @@ impl<Time: Clock, Crypto: PubKeyCryptoService> AuthService for AuthServiceImpl<T
 
         let mut auth_comp = signed_val.content.split(',');
 
-        if &String::from(auth_comp.next()?) != username {
+        if &String::from(auth_comp.next().ok_or(())?) != username {
             return Err(InvalidUsername);
         }
 
-        let auth_time = auth_comp.next()?.parse::<u128>()?;
+        let auth_time = auth_comp.next().ok_or(())?.parse::<u128>()?;
         let range = auth_time..auth_time + max_auth_delay;
         let current_time = Time::get_time();
 

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -107,7 +107,11 @@ impl<PK: PubKeyCryptoService, AES: SymmetricCryptoService> FileEncryptionService
         file_before: &EncryptedFile,
         content: &DecryptedValue,
     ) -> Result<EncryptedFile, FileWriteError> {
-        let encrypted_key = &file_before.access_keys.get(&author.username).ok_or(())?.access_key;
+        let encrypted_key = &file_before
+            .access_keys
+            .get(&author.username)
+            .ok_or(())?
+            .access_key;
         let file_encryption_key = AesKey {
             key: PK::decrypt(&author.keys, encrypted_key)?.secret,
         };
@@ -125,7 +129,11 @@ impl<PK: PubKeyCryptoService, AES: SymmetricCryptoService> FileEncryptionService
         account: &Account,
         file: &EncryptedFile,
     ) -> Result<DecryptedValue, UnableToReadFile> {
-        let encrypted_key = &file.access_keys.get(&account.username).ok_or(())?.access_key;
+        let encrypted_key = &file
+            .access_keys
+            .get(&account.username)
+            .ok_or(())?
+            .access_key;
         let file_encryption_key = AesKey {
             key: PK::decrypt(&account.keys, encrypted_key)?.secret,
         };

--- a/docs/building.md
+++ b/docs/building.md
@@ -15,12 +15,11 @@ In this monorepo you will find code for our:
 
 ### Installing Rust
 
-curl down the `rustup` script and tell `rustup` to use rust nightly, required for `feature(try_trait)`
-```
+curl and execute the `rustup` script
+```shell script
 $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
-
-You should elect to do a **custom** install such that you can select **nightly** and **complete**.
+You should choose a **custom** install and select **complete**.
 
 ### Build Core
 
@@ -29,11 +28,6 @@ Navigate to the core folder and use cargo to build
 $ cd ./core
 $ cargo build
 ``` 
-
-If you don't tell `rustup` to use nightly you'll get the following error
-```shell script
-error[E0554]: `#![feature]` may not be used on the stable release channel
-```
 
 # iOS, iPadOs, macOS
 


### PR DESCRIPTION
Removes NoneError/TryTrait in core, which was keeping us on nightly, then sets channel to stable in dockerfiles and removes references from readme. Uses `.ok_or(())` for options and replaces `NoneError` with `()`.