### PR TITLE
Sync integration tests and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,7 @@ server/ca-certificate.crt
 *.iml
 integration_tests/target/
 containers/qa.env
+containers/devtest.env
+server/qa-ca-certificate.crt
 clients/android/core/src/main/jniLibs/
+

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ all: core_fmt core_test core_lint server_fmt server_lint server_test cli_fmt cli
 clean:
 	-docker rm -f $$(docker ps -a -q)
 	-docker rmi -f $$(docker images -q)
+	-docker system prune -a -f
+	-git clean -fdX
 
 .PHONY: core
 core: is_docker_running

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -132,6 +132,7 @@ impl Client for ClientImpl {
             .map_err(Error::SendFailed)?;
         let status = response.status().as_u16();
         let response_body = response.text().map_err(Error::ReceiveFailed)?;
+        println!("MINIO RESPONSE: {} {:?}", status, &response_body);
         let encrypted_file: Document = Document {
             content: serde_json::from_str(response_body.as_str()).map_err(Error::Deserialize)?,
         };

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -132,7 +132,6 @@ impl Client for ClientImpl {
             .map_err(Error::SendFailed)?;
         let status = response.status().as_u16();
         let response_body = response.text().map_err(Error::ReceiveFailed)?;
-        println!("MINIO RESPONSE: {} {:?}", status, &response_body);
         let encrypted_file: Document = Document {
             content: serde_json::from_str(response_body.as_str()).map_err(Error::Deserialize)?,
         };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod service;
 mod android;
 
 pub static API_LOC: &str = "http://lockbook_server:8000";
-pub static BUCKET_LOC: &str = "http://filesdb:9000";
+pub static BUCKET_LOC: &str = "https://testbucket.universe.filesdb:9000";
 static DB_NAME: &str = "lockbook.sled";
 
 pub type DefaultCrypto = RsaImpl;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,7 @@ pub mod service;
 
 mod android;
 
-pub static API_LOC: &str = "http://localhost:8000";
+pub static API_LOC: &str = "http://lockbook_server:8000";
 pub static BUCKET_LOC: &str = "https://locked.nyc3.digitaloceanspaces.com";
 static DB_NAME: &str = "lockbook.sled";
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod service;
 mod android;
 
 pub static API_LOC: &str = "http://lockbook_server:8000";
-pub static BUCKET_LOC: &str = "https://testbucket.universe.filesdb:9000";
+pub static BUCKET_LOC: &str = "https://filesdb:9000/testbucket";
 static DB_NAME: &str = "lockbook.sled";
 
 pub type DefaultCrypto = RsaImpl;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,7 @@ pub mod service;
 
 mod android;
 
-pub static API_LOC: &str = "http://lockbook_server:8000";
+pub static API_LOC: &str = "http://localhost:8000";
 pub static BUCKET_LOC: &str = "https://locked.nyc3.digitaloceanspaces.com";
 static DB_NAME: &str = "lockbook.sled";
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,7 @@ pub mod service;
 
 mod android;
 
-pub static API_LOC: &str = "http://lockbook_server:8000";
+pub static API_LOC: &str = "http://api.lockbook.app:8000";
 pub static BUCKET_LOC: &str = "https://locked.nyc3.digitaloceanspaces.com";
 static DB_NAME: &str = "lockbook.sled";
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod service;
 mod android;
 
 pub static API_LOC: &str = "http://lockbook_server:8000";
-pub static BUCKET_LOC: &str = "https://filesdb";
+pub static BUCKET_LOC: &str = "http://filesdb:9000";
 static DB_NAME: &str = "lockbook.sled";
 
 pub type DefaultCrypto = RsaImpl;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod service;
 mod android;
 
 pub static API_LOC: &str = "http://lockbook_server:8000";
-pub static BUCKET_LOC: &str = "https://filesdb:9000/testbucket";
+pub static BUCKET_LOC: &str = "http://filesdb:9000/testbucket";
 static DB_NAME: &str = "lockbook.sled";
 
 pub type DefaultCrypto = RsaImpl;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,8 +35,8 @@ pub mod service;
 
 mod android;
 
-pub static API_LOC: &str = "http://api.lockbook.app:8000";
-pub static BUCKET_LOC: &str = "https://locked.nyc3.digitaloceanspaces.com";
+pub static API_LOC: &str = "http://lockbook_server:8000";
+pub static BUCKET_LOC: &str = "https://filesdb";
 static DB_NAME: &str = "lockbook.sled";
 
 pub type DefaultCrypto = RsaImpl;

--- a/core/src/model/crypto.rs
+++ b/core/src/model/crypto.rs
@@ -14,6 +14,14 @@ pub struct DecryptedValue {
     pub secret: String,
 }
 
+impl From<&str> for DecryptedValue {
+    fn from(s: &str) -> Self {
+        DecryptedValue {
+            secret: s.to_string(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct SignedValue {
     pub content: String,

--- a/core/src/model/local_changes.rs
+++ b/core/src/model/local_changes.rs
@@ -11,6 +11,16 @@ pub struct LocalChange {
     pub deleted: bool,
 }
 
+impl LocalChange {
+    pub fn ready_to_be_deleted(&self) -> bool {
+        self.renamed.is_none()
+            && self.moved.is_none()
+            && !self.new
+            && !self.content_edited
+            && !self.deleted
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Renamed {
     pub old_value: String,

--- a/core/src/model/work_unit.rs
+++ b/core/src/model/work_unit.rs
@@ -8,3 +8,12 @@ pub enum WorkUnit {
 
     ServerChange { metadata: FileMetadata },
 }
+
+impl WorkUnit {
+    pub fn get_metadata(&self) -> FileMetadata {
+        match self {
+            WorkUnit::LocalChange { metadata } => metadata,
+            WorkUnit::ServerChange { metadata } => metadata,
+        }.clone()
+    }
+}

--- a/core/src/model/work_unit.rs
+++ b/core/src/model/work_unit.rs
@@ -14,6 +14,7 @@ impl WorkUnit {
         match self {
             WorkUnit::LocalChange { metadata } => metadata,
             WorkUnit::ServerChange { metadata } => metadata,
-        }.clone()
+        }
+        .clone()
     }
 }

--- a/core/src/repo/db_provider.rs
+++ b/core/src/repo/db_provider.rs
@@ -32,6 +32,7 @@ impl DbProvider for TempBackedDB {
     fn connect_to_db(_config: &Config) -> Result<Db, Error> {
         let dir = tempdir().map_err(Error::TempFileError)?;
         let dir_path = dir.path().join(DB_NAME);
+        debug!("DB Location: {:?}", dir_path);
         Ok(sled::open(dir_path).map_err(Error::SledError)?)
     }
 }

--- a/core/src/repo/local_changes_repo.rs
+++ b/core/src/repo/local_changes_repo.rs
@@ -450,7 +450,6 @@ mod unit_tests {
             4
         );
 
-
         assert_eq!(
             LocalChangesRepoImpl::get_local_changes(&db, id).unwrap(),
             Some(LocalChange {

--- a/core/src/repo/local_changes_repo.rs
+++ b/core/src/repo/local_changes_repo.rs
@@ -241,15 +241,13 @@ impl LocalChangesRepo for LocalChangesRepoImpl {
                 edit.content_edited = false;
 
                 if edit.ready_to_be_deleted() {
-                    println!("Ready to be deleted!");
                     Self::delete_if_exists(&db, edit.id)?
                 } else {
-                tree.insert(
-                    id.as_bytes(),
-                    serde_json::to_vec(&edit).map_err(DbError::SerdeError)?,
-                )
+                    tree.insert(
+                        id.as_bytes(),
+                        serde_json::to_vec(&edit).map_err(DbError::SerdeError)?,
+                    )
                     .map_err(DbError::SledError)?;
-
                 }
 
                 Ok(())
@@ -398,12 +396,6 @@ mod unit_tests {
             })
         );
 
-        LocalChangesRepoImpl::untrack_edit(&db, id4).unwrap();
-        assert_eq!(
-            LocalChangesRepoImpl::get_local_changes(&db, id4).unwrap(),
-            None
-        );
-
         let id5 = Uuid::new_v4();
         LocalChangesRepoImpl::track_delete(&db, id).unwrap();
         LocalChangesRepoImpl::track_delete(&db, id5).unwrap();
@@ -435,6 +427,40 @@ mod unit_tests {
                 .unwrap()
                 .len(),
             5
+        );
+
+        LocalChangesRepoImpl::untrack_edit(&db, id4).unwrap();
+        assert_eq!(
+            LocalChangesRepoImpl::get_local_changes(&db, id4).unwrap(),
+            None
+        );
+
+        assert_eq!(
+            LocalChangesRepoImpl::get_all_local_changes(&db)
+                .unwrap()
+                .len(),
+            4
+        );
+
+        LocalChangesRepoImpl::untrack_edit(&db, id).unwrap();
+        assert_eq!(
+            LocalChangesRepoImpl::get_all_local_changes(&db)
+                .unwrap()
+                .len(),
+            4
+        );
+
+
+        assert_eq!(
+            LocalChangesRepoImpl::get_local_changes(&db, id).unwrap(),
+            Some(LocalChange {
+                id,
+                renamed: Some(Renamed::from("old_file")),
+                moved: Some(Moved::from(id2)),
+                new: true,
+                content_edited: false,
+                deleted: true,
+            })
         );
     }
 }

--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -6,6 +6,7 @@ use crate::client;
 use crate::client::Client;
 use crate::model::account::Account;
 use crate::model::api::NewAccountError;
+use crate::model::crypto::SignedValue;
 use crate::repo::account_repo;
 use crate::repo::account_repo::AccountRepo;
 use crate::repo::file_metadata_repo;
@@ -13,7 +14,6 @@ use crate::repo::file_metadata_repo::FileMetadataRepo;
 use crate::service::auth_service::{AuthGenError, AuthService};
 use crate::service::crypto_service::PubKeyCryptoService;
 use crate::service::file_encryption_service::{FileEncryptionService, RootFolderCreationError};
-use crate::model::crypto::SignedValue;
 
 #[derive(Debug)]
 pub enum AccountCreationError {
@@ -91,7 +91,10 @@ impl<
             .map_err(AccountCreationError::FolderError)?;
 
         info!("Sending username & public key to server");
-        let auth = SignedValue{ content: "".to_string(), signature: "".to_string() };
+        let auth = SignedValue {
+            content: "".to_string(),
+            signature: "".to_string(),
+        };
 
         let version = ApiClient::new_account(
             &account.username,

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -179,7 +179,7 @@ impl<PK: PubKeyCryptoService, AES: SymmetricCryptoService> FileEncryptionService
             file_type: Folder,
             id,
             name: account.username.clone(),
-            owner: "".to_string(),
+            owner: account.username.clone(),
             parent: id,
             content_version: 0,
             metadata_version: 0,

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -136,7 +136,7 @@ impl<PK: PubKeyCryptoService, AES: SymmetricCryptoService> FileEncryptionService
             file_type,
             id,
             name: name.to_string(),
-            owner: "".to_string(),
+            owner: account.username.to_string(),
             parent: parent_id,
             content_version: 0,
             metadata_version: 0,

--- a/core/src/service/sync_service.rs
+++ b/core/src/service/sync_service.rs
@@ -17,11 +17,11 @@ use crate::model::file_metadata::FileMetadata;
 use crate::model::file_metadata::FileType::Document;
 use crate::model::work_unit::WorkUnit;
 use crate::model::work_unit::WorkUnit::{LocalChange, ServerChange};
-use crate::repo::{account_repo, document_repo, file_metadata_repo, local_changes_repo};
 use crate::repo::account_repo::AccountRepo;
 use crate::repo::document_repo::DocumentRepo;
 use crate::repo::file_metadata_repo::FileMetadataRepo;
 use crate::repo::local_changes_repo::LocalChangesRepo;
+use crate::repo::{account_repo, document_repo, file_metadata_repo, local_changes_repo};
 use crate::service::auth_service::AuthService;
 use crate::service::sync_service::CalculateWorkError::{
     AccountRetrievalError, GetMetadataError, GetUpdatesError, LocalChangesRepoError,
@@ -107,14 +107,14 @@ pub struct FileSyncService<
 }
 
 impl<
-    FileMetadataDb: FileMetadataRepo,
-    ChangeDb: LocalChangesRepo,
-    DocsDb: DocumentRepo,
-    AccountDb: AccountRepo,
-    ApiClient: Client,
-    Auth: AuthService,
-> SyncService
-for FileSyncService<FileMetadataDb, ChangeDb, DocsDb, AccountDb, ApiClient, Auth>
+        FileMetadataDb: FileMetadataRepo,
+        ChangeDb: LocalChangesRepo,
+        DocsDb: DocumentRepo,
+        AccountDb: AccountRepo,
+        ApiClient: Client,
+        Auth: AuthService,
+    > SyncService
+    for FileSyncService<FileMetadataDb, ChangeDb, DocsDb, AccountDb, ApiClient, Auth>
 {
     fn calculate_work(db: &Db) -> Result<WorkCalculated, CalculateWorkError> {
         info!("Calculating Work");
@@ -131,7 +131,7 @@ for FileSyncService<FileMetadataDb, ChangeDb, DocsDb, AccountDb, ApiClient, Auth
             },
             last_sync,
         )
-            .map_err(GetUpdatesError)?;
+        .map_err(GetUpdatesError)?;
         debug!("Server Updates: {:#?}", server_updates);
 
         let mut most_recent_update_from_server: u64 = last_sync;
@@ -468,7 +468,8 @@ for FileSyncService<FileMetadataDb, ChangeDb, DocsDb, AccountDb, ApiClient, Auth
         // were never able to sync a file.
         let mut sync_errors: HashMap<Uuid, WorkExecutionError> = HashMap::new();
 
-        for _ in 0..10 { // Retry sync n times
+        for _ in 0..10 {
+            // Retry sync n times
             info!("Syncing");
             let account = AccountDb::get_account(&db).map_err(SyncError::AccountRetrievalError)?;
             let work_calculated =
@@ -483,7 +484,7 @@ for FileSyncService<FileMetadataDb, ChangeDb, DocsDb, AccountDb, ApiClient, Auth
                         &db,
                         work_calculated.most_recent_update_from_server,
                     )
-                        .map_err(SyncError::MetadataUpdateError)?;
+                    .map_err(SyncError::MetadataUpdateError)?;
                     return Ok(());
                 } else {
                     error!("We finished everything calculate work told us about, but still have errors, this is concerning, the errors are: {:#?}", sync_errors);

--- a/dev_utils/fmt_all.sh
+++ b/dev_utils/fmt_all.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+cd ../core
+cargo fmt
+
+cd ../server
+cargo fmt
+
+cd ../clients/cli
+cargo fmt
+
+cd ../../integration_tests
+cargo fmt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,5 +59,5 @@ services:
     entrypoint: >
       /bin/sh -c '\
         sleep 5 && \
-        cargo test \
+        RUSTLOG=lockbook_core=debug cargo test -- --nocapture \
       '

--- a/integration_tests/src/account_service_tests.rs
+++ b/integration_tests/src/account_service_tests.rs
@@ -3,10 +3,13 @@ mod account_tests {
     use lockbook_core::client::Error;
     use lockbook_core::model::api::NewAccountError::UsernameTaken;
     use lockbook_core::service::account_service::{AccountCreationError, AccountService};
-    use lockbook_core::DefaultAccountService;
+    use lockbook_core::{DefaultAccountService, DefaultSyncService, DefaultFileMetadataRepo, DefaultAccountRepo};
 
     use crate::{random_username, test_db};
     use lockbook_core::model::api::NewAccountError;
+    use lockbook_core::service::sync_service::SyncService;
+    use lockbook_core::repo::file_metadata_repo::FileMetadataRepo;
+    use lockbook_core::repo::account_repo::AccountRepo;
 
     #[test]
     fn create_account_successfully() {
@@ -55,5 +58,29 @@ mod account_tests {
         }
 
         panic!("This username should have been invalid.")
+    }
+
+    #[test]
+    fn import_sync() {
+        let db1 = test_db();
+        let account = DefaultAccountService::create_account(&db1, &random_username()).unwrap();
+
+        let account_string = DefaultAccountService::export_account(&db1).unwrap();
+        let home_folders1 = DefaultFileMetadataRepo::get_root(&db1).unwrap().unwrap();
+
+        let db2 = test_db();
+        assert!(DefaultAccountService::export_account(&db2).is_err());
+        assert!(DefaultAccountService::import_account(&db2, &account_string).is_ok());
+        assert_eq!(DefaultAccountRepo::get_account(&db2).unwrap(), account);
+        assert_eq!(DefaultFileMetadataRepo::get_last_updated(&db2).unwrap(), 0);
+
+        let work = DefaultSyncService::calculate_work(&db2).unwrap();
+        assert_ne!(work.most_recent_update_from_server, 0);
+        assert_eq!(work.work_units.len(), 1);
+        assert!(DefaultFileMetadataRepo::get_root(&db2).unwrap().is_none());
+        DefaultSyncService::sync(&db2).unwrap();
+        assert!(DefaultFileMetadataRepo::get_root(&db2).unwrap().is_some());
+        let home_folders2 = DefaultFileMetadataRepo::get_root(&db2).unwrap().unwrap();
+        assert_eq!(home_folders1, home_folders2);
     }
 }

--- a/integration_tests/src/account_service_tests.rs
+++ b/integration_tests/src/account_service_tests.rs
@@ -3,13 +3,15 @@ mod account_tests {
     use lockbook_core::client::Error;
     use lockbook_core::model::api::NewAccountError::UsernameTaken;
     use lockbook_core::service::account_service::{AccountCreationError, AccountService};
-    use lockbook_core::{DefaultAccountService, DefaultSyncService, DefaultFileMetadataRepo, DefaultAccountRepo};
+    use lockbook_core::{
+        DefaultAccountRepo, DefaultAccountService, DefaultFileMetadataRepo, DefaultSyncService,
+    };
 
     use crate::{random_username, test_db};
     use lockbook_core::model::api::NewAccountError;
-    use lockbook_core::service::sync_service::SyncService;
-    use lockbook_core::repo::file_metadata_repo::FileMetadataRepo;
     use lockbook_core::repo::account_repo::AccountRepo;
+    use lockbook_core::repo::file_metadata_repo::FileMetadataRepo;
+    use lockbook_core::service::sync_service::SyncService;
 
     #[test]
     fn create_account_successfully() {

--- a/integration_tests/src/account_service_tests.rs
+++ b/integration_tests/src/account_service_tests.rs
@@ -84,5 +84,9 @@ mod account_tests {
         assert!(DefaultFileMetadataRepo::get_root(&db2).unwrap().is_some());
         let home_folders2 = DefaultFileMetadataRepo::get_root(&db2).unwrap().unwrap();
         assert_eq!(home_folders1, home_folders2);
+        assert_eq!(
+            DefaultFileMetadataRepo::get_all(&db1).unwrap(),
+            DefaultFileMetadataRepo::get_all(&db2).unwrap()
+        );
     }
 }

--- a/integration_tests/src/sync_service_tests.rs
+++ b/integration_tests/src/sync_service_tests.rs
@@ -4,10 +4,11 @@ mod sync_tests {
     use lockbook_core::service::account_service::AccountService;
     use lockbook_core::service::file_service::FileService;
     use lockbook_core::service::sync_service::SyncService;
-    use lockbook_core::{DefaultAccountService, DefaultFileService, DefaultSyncService};
+    use lockbook_core::{DefaultAccountService, DefaultFileService, DefaultSyncService, init_logger_safely};
 
     #[test]
-    fn new_file_sync() {
+    fn test_new_account_sync() {
+        init_logger_safely();
         let db = test_db();
         let account = DefaultAccountService::create_account(&db, &random_username()).unwrap();
 
@@ -24,5 +25,15 @@ mod sync_tests {
             format!("{}/a/b/c/test", account.username).as_str(),
         )
         .unwrap();
+
+        assert_eq!(
+            DefaultSyncService::calculate_work(&db)
+                .unwrap()
+                .work_units
+                .len(),
+            4
+        );
+
+        assert!(DefaultSyncService::sync(&db).is_ok());
     }
 }

--- a/integration_tests/src/sync_service_tests.rs
+++ b/integration_tests/src/sync_service_tests.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod sync_tests {
     use crate::{random_username, test_db};
+    use lockbook_core::model::crypto::DecryptedValue;
+    use lockbook_core::model::work_unit::WorkUnit;
     use lockbook_core::repo::file_metadata_repo::FileMetadataRepo;
     use lockbook_core::service::account_service::AccountService;
     use lockbook_core::service::file_service::FileService;
@@ -58,5 +60,67 @@ mod sync_tests {
             DefaultFileMetadataRepo::get_all(&db).unwrap(),
             DefaultFileMetadataRepo::get_all(&db2).unwrap()
         );
+
+        assert_eq!(
+            DefaultSyncService::calculate_work(&db2)
+                .unwrap()
+                .work_units
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_edit_document_sync() {
+        let db = test_db();
+        let account = DefaultAccountService::create_account(&db, &random_username()).unwrap();
+
+        assert_eq!(
+            DefaultSyncService::calculate_work(&db)
+                .unwrap()
+                .work_units
+                .len(),
+            0
+        );
+
+        let file = DefaultFileService::create_at_path(
+            &db,
+            format!("{}/a/b/c/test", account.username).as_str(),
+        )
+        .unwrap();
+
+        assert!(DefaultSyncService::sync(&db).is_ok());
+
+        let db2 = test_db();
+        DefaultAccountService::import_account(
+            &db2,
+            &DefaultAccountService::export_account(&db).unwrap(),
+        )
+        .unwrap();
+
+        DefaultSyncService::sync(&db2).unwrap();
+
+        DefaultFileService::write_document(&db, file.id, &DecryptedValue::from("")).unwrap();
+
+        assert_eq!(
+            DefaultSyncService::calculate_work(&db)
+                .unwrap()
+                .work_units
+                .len(),
+            1
+        );
+
+        match DefaultSyncService::calculate_work(&db)
+            .unwrap()
+            .work_units
+            .get(0)
+            .unwrap()
+            .clone()
+        {
+            WorkUnit::LocalChange { metadata } => assert_eq!(metadata.name, file.name),
+            WorkUnit::ServerChange { .. } => {
+                panic!("This should have been a local change with no server changes!")
+            }
+        };
     }
 }

--- a/integration_tests/src/sync_service_tests.rs
+++ b/integration_tests/src/sync_service_tests.rs
@@ -4,7 +4,9 @@ mod sync_tests {
     use lockbook_core::service::account_service::AccountService;
     use lockbook_core::service::file_service::FileService;
     use lockbook_core::service::sync_service::SyncService;
-    use lockbook_core::{DefaultAccountService, DefaultFileService, DefaultSyncService, init_logger_safely};
+    use lockbook_core::{
+        init_logger_safely, DefaultAccountService, DefaultFileService, DefaultSyncService,
+    };
 
     #[test]
     fn test_new_account_sync() {

--- a/integration_tests/src/sync_service_tests.rs
+++ b/integration_tests/src/sync_service_tests.rs
@@ -7,7 +7,10 @@ mod sync_tests {
     use lockbook_core::service::account_service::AccountService;
     use lockbook_core::service::file_service::FileService;
     use lockbook_core::service::sync_service::SyncService;
-    use lockbook_core::{DefaultAccountService, DefaultFileMetadataRepo, DefaultFileService, DefaultSyncService, init_logger_safely};
+    use lockbook_core::{
+        init_logger_safely, DefaultAccountService, DefaultFileMetadataRepo, DefaultFileService,
+        DefaultSyncService,
+    };
 
     #[test]
     fn test_create_files_and_folders_sync() {

--- a/integration_tests/src/sync_service_tests.rs
+++ b/integration_tests/src/sync_service_tests.rs
@@ -1,16 +1,16 @@
 #[cfg(test)]
 mod sync_tests {
     use crate::{random_username, test_db};
+    use lockbook_core::repo::file_metadata_repo::FileMetadataRepo;
     use lockbook_core::service::account_service::AccountService;
     use lockbook_core::service::file_service::FileService;
     use lockbook_core::service::sync_service::SyncService;
     use lockbook_core::{
-        init_logger_safely, DefaultAccountService, DefaultFileService, DefaultSyncService,
+        DefaultAccountService, DefaultFileMetadataRepo, DefaultFileService, DefaultSyncService,
     };
 
     #[test]
-    fn test_new_account_sync() {
-        init_logger_safely();
+    fn test_create_files_and_folders_sync() {
         let db = test_db();
         let account = DefaultAccountService::create_account(&db, &random_username()).unwrap();
 
@@ -22,7 +22,7 @@ mod sync_tests {
             0
         );
 
-        let file = DefaultFileService::create_at_path(
+        DefaultFileService::create_at_path(
             &db,
             format!("{}/a/b/c/test", account.username).as_str(),
         )
@@ -37,5 +37,26 @@ mod sync_tests {
         );
 
         assert!(DefaultSyncService::sync(&db).is_ok());
+
+        let db2 = test_db();
+        DefaultAccountService::import_account(
+            &db2,
+            &DefaultAccountService::export_account(&db).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            DefaultSyncService::calculate_work(&db2)
+                .unwrap()
+                .work_units
+                .len(),
+            5
+        );
+
+        DefaultSyncService::sync(&db2).unwrap();
+        assert_eq!(
+            DefaultFileMetadataRepo::get_all(&db).unwrap(),
+            DefaultFileMetadataRepo::get_all(&db2).unwrap()
+        );
     }
 }

--- a/integration_tests/src/sync_service_tests.rs
+++ b/integration_tests/src/sync_service_tests.rs
@@ -122,5 +122,15 @@ mod sync_tests {
                 panic!("This should have been a local change with no server changes!")
             }
         };
+
+        DefaultSyncService::sync(&db).unwrap();
+
+        assert_eq!(
+            DefaultSyncService::calculate_work(&db)
+                .unwrap()
+                .work_units
+                .len(),
+            0
+        );
     }
 }

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -2,7 +2,6 @@ use crate::files_db;
 use crate::index_db;
 use crate::ServerState;
 use lockbook_core::model::api::*;
-use lockbook_core::model::crypto::SignedValue;
 use lockbook_core::model::file_metadata::FileType;
 
 pub fn username_is_valid(username: &str) -> bool {

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -3,6 +3,7 @@ use crate::index_db;
 use crate::ServerState;
 use lockbook_core::model::api::*;
 use lockbook_core::model::file_metadata::FileType;
+use lockbook_core::model::crypto::SignedValue;
 
 pub fn username_is_valid(username: &str) -> bool {
     username

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -2,8 +2,8 @@ use crate::files_db;
 use crate::index_db;
 use crate::ServerState;
 use lockbook_core::model::api::*;
-use lockbook_core::model::file_metadata::FileType;
 use lockbook_core::model::crypto::SignedValue;
+use lockbook_core::model::file_metadata::FileType;
 
 pub fn username_is_valid(username: &str) -> bool {
     username


### PR DESCRIPTION
Added integration tests that that exercised:
+ Creating an account
+ Exporting an account string
+ Importing an account string
+ Syncing early account state
+ Creating files and folders and syncing
+ Editing files and folders and syncing

The cool thing about these tests is that I assert various repo level things must be exactly the same post syncs (all files in db1 == all files in db2). Let's me catch all sorts of small errors that would get missed if you were just making sure `id`s or file contents are equal.

Also added some `dev_utils` and added the command I used to free up several hundred gigabytes on our compute node and locally. 