### PR TITLE
website: Move the main title heading and compress the text.

### DIFF
--- a/public_site/layouts/index.html
+++ b/public_site/layouts/index.html
@@ -24,7 +24,7 @@ hr {
                 <div>
                      {{- range .Site.Params.links -}}
                         <a class="getIcons" href="{{ .url | safeURL }}" title="{{ .title }}">
-                            <span class="{{ .iconset | default "fab" }} {{.iconorigin | default "fa" }}-{{ .icon }}" /span>
+                            <span class="{{ .iconset | default `fab` }} {{.iconorigin | default `fa` }}-{{ .icon }}"></span>
                         </a>
                      {{- end -}}
                 </div>

--- a/public_site/layouts/index.html
+++ b/public_site/layouts/index.html
@@ -1,6 +1,19 @@
 {{ define "main" }}
 
+<style>
+main {
+	max-width: 1250px;
+	margin: auto;
+}
+hr {
+	margin-bottom: 2rem;
+}
+</style>
+
 <main>
+   <h1 class="logo">Lockbook</h1>
+   <hr>
+
    <div class="block introduction">
         <div class="column left">
             <center>
@@ -20,7 +33,6 @@
 
         </div>
         <div class="column right">
-            <h1 class="logo">Lockbook</h1>
             <p>{{- partial "introduction.html" . -}}</p>
 
         </div>

--- a/public_site/layouts/partials/introduction.html
+++ b/public_site/layouts/partials/introduction.html
@@ -1,22 +1,32 @@
 <h2>Secure</h2>
-<p>All user generated content is <a href="https://en.wikipedia.org/wiki/End-to-end_encryption">encrypted</a> on clients with keys that never leave your hands.</p>
-<p>No Lockbook employee, cloud provider, or state actor can view your content.</p>
+<p>
+All user generated content is <a href="https://en.wikipedia.org/wiki/End-to-end_encryption">encrypted</a> on clients with keys that never leave your hands.
+No Lockbook employee, cloud provider, or state actor can view your content.
+</p>
 
 <h2>Minimal</h2>
-<p>Clear, snappy, native user interfaces. Deep support for offline use and background sync.</p>
-<p>Our clients include a CLI which requires no dependencies, and invokes your favorite text editor.</p>
-<p>Minimal software is secure software.</p>
+<p>
+Clear, snappy, native user interfaces. Deep support for offline use and background sync.
+Our clients include a CLI which requires no dependencies, and invokes your favorite text editor.
+Minimal software is secure software.
+</p>
 
 <h2>Private</h2>
-<p>No verification, no emails, no passwords.</p>
-<p>Our business model is straightforward ($/gb) and doesn't include selling your data.</p>
+<p>
+No verification, no emails, no passwords.
+Our business model is straightforward ($/gb) and doesn't include selling your data.
+</p>
 
 <h2>Open Source</h2>
-<p>Secure software <a href="https://en.wikipedia.org/wiki/Security_through_obscurity">cannot be closed</a> source. This is free and unencumbered software released into the public domain.</p>
-<p>Open source makes it easy for security researchers to inspect our code and provide feedback.</p>
-<p>Problems are discussed <a href="https://github.com/lockbook/lockbook/issues">openly</a> and <a href="https://github.com/lockbook/lockbook/pulls">anyone</a> can improve our software.</p>
+<p>
+Secure software <a href="https://en.wikipedia.org/wiki/Security_through_obscurity">cannot be closed</a> source. This is free and unencumbered software released into the public domain.
+Open source makes it easy for security researchers to inspect our code and provide feedback.
+Problems are discussed <a href="https://github.com/lockbook/lockbook/issues">openly</a> and <a href="https://github.com/lockbook/lockbook/pulls">anyone</a> can improve our software.
+</p>
 
 <h2>Everywhere</h2>
-<p>Native support for: Linux, macOS, iOS, iPadOS, Android, and Windows</p>
-<p>We capture the essence of each device / platform.</p>
-<p>This means a scriptable cli on linux, and Apple Pencil support on for our iPad app.</p>
+<p>
+Native support for: Linux, macOS, iOS, iPadOS, Android, and Windows.
+We capture the essence of each device / platform.
+This means a scriptable cli on linux, and Apple Pencil support on for our iPad app.
+</p>


### PR DESCRIPTION
This PR moves the main title heading to just above the other content and makes each section of text one paragraph instead of multiple. Due to these changes, the `main` element was also given a `max-width`.

It also includes a small syntax fix.