### PR TITLE
Make sure not really changing a file doesn't change a file

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "atty",
  "chrono",

--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "atty",
  "chrono",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["parth"]
 edition = "2018"
 

--- a/core/src/repo/local_changes_repo.rs
+++ b/core/src/repo/local_changes_repo.rs
@@ -85,6 +85,10 @@ impl LocalChangesRepo for LocalChangesRepoImpl {
     }
 
     fn track_rename(db: &Db, id: Uuid, old_name: &str, new_name: &str) -> Result<(), DbError> {
+        if old_name == new_name {
+            return Ok(());
+        }
+
         let tree = db.open_tree(LOCAL_CHANGES).map_err(DbError::SledError)?;
 
         match Self::get_local_changes(&db, id)? {
@@ -127,6 +131,10 @@ impl LocalChangesRepo for LocalChangesRepoImpl {
     }
 
     fn track_move(db: &Db, id: Uuid, old_parent: Uuid, new_parent: Uuid) -> Result<(), DbError> {
+        if old_parent == new_parent {
+            return Ok(());
+        }
+
         let tree = db.open_tree(LOCAL_CHANGES).map_err(DbError::SledError)?;
 
         match Self::get_local_changes(&db, id)? {
@@ -176,6 +184,10 @@ impl LocalChangesRepo for LocalChangesRepoImpl {
         old_content_checksum: Vec<u8>,
         new_content_checksum: Vec<u8>,
     ) -> Result<(), DbError> {
+        if old_content_checksum == new_content_checksum {
+            return Ok(());
+        }
+
         let tree = db.open_tree(LOCAL_CHANGES).map_err(DbError::SledError)?;
 
         match Self::get_local_changes(&db, id)? {

--- a/core/tests/sync_service_tests.rs
+++ b/core/tests/sync_service_tests.rs
@@ -929,4 +929,42 @@ mod sync_tests {
             0
         );
     }
+
+    #[test]
+    fn test_not_really_renaming_should_not_cause_work() {
+        let db = test_db();
+        let account = DefaultAccountService::create_account(&db, &random_username()).unwrap();
+
+        let file =
+            DefaultFileService::create_at_path(&db, &format!("{}/file.md", account.username))
+                .unwrap();
+
+        DefaultSyncService::sync(&db).unwrap();
+
+        assert!(DefaultSyncService::calculate_work(&db)
+            .unwrap()
+            .work_units
+            .is_empty());
+
+        assert!(DefaultFileService::rename_file(&db, file.id, "file.md").is_err())
+    }
+
+    #[test]
+    fn test_not_really_moving_should_not_cause_work() {
+        let db = test_db();
+        let account = DefaultAccountService::create_account(&db, &random_username()).unwrap();
+
+        let file =
+            DefaultFileService::create_at_path(&db, &format!("{}/file.md", account.username))
+                .unwrap();
+
+        DefaultSyncService::sync(&db).unwrap();
+
+        assert!(DefaultSyncService::calculate_work(&db)
+            .unwrap()
+            .work_units
+            .is_empty());
+
+        assert!(DefaultFileService::move_file(&db, file.id, file.parent).is_err())
+    }
 }

--- a/core/tests/sync_service_tests.rs
+++ b/core/tests/sync_service_tests.rs
@@ -898,4 +898,35 @@ mod sync_tests {
             .contains("Offline Line"));
         assert_eq!(&db1.checksum().unwrap(), &db2.checksum().unwrap());
     }
+
+    #[test]
+    fn test_not_really_editing_should_not_cause_work() {
+        let db = test_db();
+        let account = DefaultAccountService::create_account(&db, &random_username()).unwrap();
+
+        let file =
+            DefaultFileService::create_at_path(&db, &format!("{}/file.md", account.username))
+                .unwrap();
+
+        DefaultFileService::write_document(&db, file.id, &DecryptedValue::from("original"))
+            .unwrap();
+
+        DefaultSyncService::sync(&db).unwrap();
+
+        assert!(DefaultSyncService::calculate_work(&db)
+            .unwrap()
+            .work_units
+            .is_empty());
+
+        DefaultFileService::write_document(&db, file.id, &DecryptedValue::from("original"))
+            .unwrap();
+
+        assert_eq!(
+            DefaultSyncService::calculate_work(&db)
+                .unwrap()
+                .work_units
+                .len(),
+            0
+        );
+    }
 }


### PR DESCRIPTION
`LocalChangesRepo` successfully is able to handle the following:

(no changes, a.content == "hi")
"hi" -> "bye" -- 1 change
"bye" -> "hi" -- 0 changes

But it did the following 
(no changes, a.content == "hi")
"hi" -> "hi" -- 1 change

This happened because it had no previous checksum to compare "hi" to.

This explicitly handles this (very common) edge case.