### PR TITLE
Make autosave far more CPU efficient

### DIFF
--- a/clients/windows/FileExplorer.xaml
+++ b/clients/windows/FileExplorer.xaml
@@ -72,6 +72,7 @@
                          IsEnabled="True"
                          TextChanged="TextChanged"
                          BorderThickness="0"
+                         DisabledFormattingAccelerators="All"
                          Background="Black">
 
             </RichEditBox>

--- a/clients/windows/windows.csproj
+++ b/clients/windows/windows.csproj
@@ -145,6 +145,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Core - Copy.cs" />
     <Compile Include="CoreModel.cs" />
     <Compile Include="Core.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/clients/windows/windows.csproj
+++ b/clients/windows/windows.csproj
@@ -145,7 +145,6 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Core - Copy.cs" />
     <Compile Include="CoreModel.cs" />
     <Compile Include="Core.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
we used to save (and encrypt) on every keystroke. now we batch saves takes the CPU utilization from like 25% back to barely measurable.

closes #225