### PR TITLE
Make ref impl of sync easier to read

### DIFF
--- a/core/src/service/sync_service.rs
+++ b/core/src/service/sync_service.rs
@@ -639,15 +639,11 @@ impl<
                 }
             }
 
-            work_calculated =
-                Self::calculate_work(&db).map_err(SyncError::CalculateWorkError)?;
+            work_calculated = Self::calculate_work(&db).map_err(SyncError::CalculateWorkError)?;
         }
 
         if sync_errors.is_empty() {
-            FileMetadataDb::set_last_synced(
-                &db,
-                work_calculated.most_recent_update_from_server,
-            )
+            FileMetadataDb::set_last_synced(&db, work_calculated.most_recent_update_from_server)
                 .map_err(SyncError::MetadataUpdateError)?;
 
             Ok(())


### PR DESCRIPTION
```rust
    fn sync(db: &Db) -> Result<(), SyncError> {
        let account = AccountDb::get_account(&db).map_err(SyncError::AccountRetrievalError)?;

        let mut sync_errors: HashMap<Uuid, WorkExecutionError> = HashMap::new();

        let mut work_calculated =
            Self::calculate_work(&db).map_err(SyncError::CalculateWorkError)?;

        for _ in 0..10 {
            // Retry sync n times
            info!("Syncing");

            for work_unit in work_calculated.work_units {
                match Self::execute_work(&db, &account, work_unit.clone()) {
                    Ok(_) => {
                        sync_errors.remove(&work_unit.get_metadata().id);
                        debug!("{:#?} executed successfully", work_unit)
                    }
                    Err(err) => {
                        error!("Sync error detected: {:#?} {:#?}", work_unit, err);
                        sync_errors.insert(work_unit.get_metadata().id, err);
                    }
                }
            }

            work_calculated = Self::calculate_work(&db).map_err(SyncError::CalculateWorkError)?;
        }

        if sync_errors.is_empty() {
            FileMetadataDb::set_last_synced(&db, work_calculated.most_recent_update_from_server)
                .map_err(SyncError::MetadataUpdateError)?;

            Ok(())
        } else {
            error!("We finished everything calculate work told us about, but still have errors, this is concerning, the errors are: {:#?}", sync_errors);
            Err(SyncError::WorkExecutionError(sync_errors))
        }
    }
```