### PR TITLE
Makes CLI not accept usernames with whitespace

### DIFF
--- a/clients/cli/src/init.rs
+++ b/clients/cli/src/init.rs
@@ -17,6 +17,7 @@ pub fn init() {
     io::stdin()
         .read_line(&mut username)
         .expect("Failed to read from stdin");
+    username.retain(|c| c != '\n');
 
     match create_account(&get_config(), &username) {
         Ok(_) => exit_with("Account created successfully", SUCCESS),

--- a/clients/cli/src/init.rs
+++ b/clients/cli/src/init.rs
@@ -17,7 +17,6 @@ pub fn init() {
     io::stdin()
         .read_line(&mut username)
         .expect("Failed to read from stdin");
-    username.retain(|c| !c.is_whitespace());
 
     match create_account(&get_config(), &username) {
         Ok(_) => exit_with("Account created successfully", SUCCESS),


### PR DESCRIPTION
sample output:
```
~/code/lockbook/clients/cli 239-cli-whitespace* ❯ lockbook init
Enter a Username: travis 22
[2020-08-24 11:01:52] [lockbook_core::service::account_service ] [INFO ]: Checking if account already exists
[2020-08-24 11:01:52] [lockbook_core::service::account_service ] [INFO ]: Creating new account for travis 22
[2020-08-24 11:01:52] [lockbook_core::service::account_service ] [INFO ]: Generating Key...
[2020-08-24 11:01:52] [lockbook_core::service::account_service ] [INFO ]: Generating Root Folder
[2020-08-24 11:01:52] [lockbook_core::service::account_service ] [INFO ]: Sending username & public key to server
Username is not a-z || 0-9
```
```
~/code/lockbook/clients/cli 239-cli-whitespace* 2s ❯ lockbook init
Enter a Username: travis22
[2020-08-24 11:01:57] [lockbook_core::service::account_service ] [INFO ]: Checking if account already exists
[2020-08-24 11:01:57] [lockbook_core::service::account_service ] [INFO ]: Creating new account for travis22
[2020-08-24 11:01:57] [lockbook_core::service::account_service ] [INFO ]: Generating Key...
[2020-08-24 11:01:57] [lockbook_core::service::account_service ] [INFO ]: Generating Root Folder
[2020-08-24 11:01:57] [lockbook_core::service::account_service ] [INFO ]: Sending username & public key to server
[2020-08-24 11:01:57] [lockbook_core::service::account_service ] [INFO ]: Account creation success!
[2020-08-24 11:01:57] [lockbook_core::service::account_service ] [INFO ]: Saving account locally
Account created successfully
```