### PR TITLE
refactor: Remove the use of PhantomData in favor of underscore.

### DIFF
--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use sled::Db;
 
 use crate::client::Client;
@@ -66,12 +64,12 @@ pub struct AccountServiceImpl<
     FileCrypto: FileEncryptionService,
     FileMetadata: FileMetadataRepo,
 > {
-    encryption: PhantomData<Crypto>,
-    accounts: PhantomData<AccountDb>,
-    client: PhantomData<ApiClient>,
-    auth: PhantomData<Auth>,
-    file_crypto: PhantomData<FileCrypto>,
-    file_db: PhantomData<FileMetadata>,
+    _encryption: Crypto,
+    _accounts: AccountDb,
+    _client: ApiClient,
+    _auth: Auth,
+    _file_crypto: FileCrypto,
+    _file_db: FileMetadata,
 }
 
 impl<

--- a/core/src/service/auth_service.rs
+++ b/core/src/service/auth_service.rs
@@ -1,7 +1,6 @@
 use std::num::ParseIntError;
 
 use rsa::RSAPublicKey;
-use serde::export::PhantomData;
 
 use crate::model::account::Account;
 use crate::model::crypto::*;
@@ -63,8 +62,8 @@ pub trait AuthService {
 }
 
 pub struct AuthServiceImpl<Time: Clock, Crypto: PubKeyCryptoService> {
-    clock: PhantomData<Time>,
-    crypto: PhantomData<Crypto>,
+    _clock: Time,
+    _crypto: Crypto,
 }
 
 impl<Time: Clock, Crypto: PubKeyCryptoService> AuthService for AuthServiceImpl<Time, Crypto> {

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use serde::export::PhantomData;
 use uuid::Uuid;
 
 use crate::model::account::Account;
@@ -112,8 +111,8 @@ pub trait FileEncryptionService {
 }
 
 pub struct FileEncryptionServiceImpl<PK: PubKeyCryptoService, AES: SymmetricCryptoService> {
-    pk: PhantomData<PK>,
-    aes: PhantomData<AES>,
+    _pk: PK,
+    _aes: AES,
 }
 
 impl<PK: PubKeyCryptoService, AES: SymmetricCryptoService> FileEncryptionService

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -1,4 +1,3 @@
-use serde::export::PhantomData;
 use sled::Db;
 use uuid::Uuid;
 
@@ -137,11 +136,11 @@ pub struct FileServiceImpl<
     AccountDb: AccountRepo,
     FileCrypto: FileEncryptionService,
 > {
-    metadatas: PhantomData<FileMetadataDb>,
-    files: PhantomData<FileDb>,
-    changes_db: PhantomData<ChangesDb>,
-    account: PhantomData<AccountDb>,
-    file_crypto: PhantomData<FileCrypto>,
+    _metadatas: FileMetadataDb,
+    _files: FileDb,
+    _changes_db: ChangesDb,
+    _account: AccountDb,
+    _file_crypto: FileCrypto,
 }
 
 impl<

--- a/core/src/service/sync_service.rs
+++ b/core/src/service/sync_service.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::marker::PhantomData;
 
 use serde::Serialize;
 use sled::Db;
@@ -114,14 +113,14 @@ pub struct FileSyncService<
     FileCrypto: FileEncryptionService,
     Auth: AuthService,
 > {
-    metadatas: PhantomData<FileMetadataDb>,
-    changes: PhantomData<ChangeDb>,
-    docs: PhantomData<DocsDb>,
-    accounts: PhantomData<AccountDb>,
-    client: PhantomData<ApiClient>,
-    file: PhantomData<Files>,
-    file_crypto: PhantomData<FileCrypto>,
-    auth: PhantomData<Auth>,
+    _metadatas: FileMetadataDb,
+    _changes: ChangeDb,
+    _docs: DocsDb,
+    _accounts: AccountDb,
+    _client: ApiClient,
+    _file: Files,
+    _file_crypto: FileCrypto,
+    _auth: Auth,
 }
 
 impl<


### PR DESCRIPTION
Currently, `PhantomData` is being used to suppress `field is never read` warnings. `PhantomData` is described with the following excerpt ([3rd para](https://doc.rust-lang.org/nomicon/phantom-data.html)) from [The Rustonomicon](https://doc.rust-lang.org/nomicon/index.html) (a book on "The Dark Arts of Unsafe Rust"):
> We do this using PhantomData, which is a special marker type. PhantomData consumes no space, but simulates a field of the given type for the purpose of static analysis. This was deemed to be less error-prone than explicitly telling the type-system the kind of variance that you want, while also providing other useful things such as the information needed by drop check.

I think the more idiomatic way of suppressing unused warnings is to prefix the fields with an underscore:
* https://doc.rust-lang.org/stable/book/ch18-03-pattern-syntax.html?highlight=underscore#ignoring-an-unused-variable-by-starting-its-name-with-_
* https://cheats.rs/#miscellaneous
* https://stackoverflow.com/a/28531192