### PR TITLE
Backup and Restore via CLI

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "atty",
  "chrono",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook"
-version = "0.2.16"
+version = "0.2.17"
 authors = ["parth"]
 edition = "2018"
 

--- a/clients/cli/src/backup.rs
+++ b/clients/cli/src/backup.rs
@@ -5,7 +5,10 @@ use std::{env, fs};
 
 use chrono::{DateTime, Utc};
 use lockbook_core::repo::file_metadata_repo::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
-use lockbook_core::{get_file_by_path, list_paths, GetFileByPathError, ListPathsError, read_document, ReadDocumentError};
+use lockbook_core::{
+    get_file_by_path, list_paths, read_document, GetFileByPathError, ListPathsError,
+    ReadDocumentError,
+};
 
 use crate::utils::{exit_with, get_account_or_exit, get_config};
 use crate::{
@@ -119,15 +122,17 @@ pub fn backup() {
                 }
             });
 
-        let document_content = read_document(&get_config(), document_metadata.id).unwrap_or_else(|err| match err {
-            ReadDocumentError::TreatedFolderAsDocument |
-            ReadDocumentError::NoAccount |
-            ReadDocumentError::FileDoesNotExist |
-            ReadDocumentError::UnexpectedError(_) => exit_with(
-                &format!("Could not read file: {} error: {:?}", &doc, err),
-                UNEXPECTED_ERROR,
-            ),
-        }).secret;
+        let document_content = read_document(&get_config(), document_metadata.id)
+            .unwrap_or_else(|err| match err {
+                ReadDocumentError::TreatedFolderAsDocument
+                | ReadDocumentError::NoAccount
+                | ReadDocumentError::FileDoesNotExist
+                | ReadDocumentError::UnexpectedError(_) => exit_with(
+                    &format!("Could not read file: {} error: {:?}", &doc, err),
+                    UNEXPECTED_ERROR,
+                ),
+            })
+            .secret;
 
         document
             .write_all(document_content.as_bytes())

--- a/clients/cli/src/backup.rs
+++ b/clients/cli/src/backup.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{Error, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::{env, fs};
 

--- a/clients/cli/src/backup.rs
+++ b/clients/cli/src/backup.rs
@@ -1,0 +1,141 @@
+use std::fs::File;
+use std::io::{Error, Write};
+use std::path::PathBuf;
+use std::{env, fs};
+
+use chrono::{DateTime, Utc};
+use lockbook_core::repo::file_metadata_repo::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
+use lockbook_core::{get_file_by_path, list_paths, GetFileByPathError, ListPathsError, read_document, ReadDocumentError};
+
+use crate::utils::{exit_with, get_account_or_exit, get_config};
+use crate::{
+    COULD_NOT_CREATE_OS_DIRECTORY, COULD_NOT_WRITE_TO_OS_FILE, PWD_MISSING, UNEXPECTED_ERROR,
+};
+
+pub fn backup() {
+    get_account_or_exit();
+
+    let now: DateTime<Utc> = Utc::now();
+
+    let backup_directory = match env::current_dir() {
+        Ok(mut path) => {
+            path.push(format!("LOCKBOOK_BACKUP_{}", now.format("%Y-%m-%d")));
+            path
+        }
+        Err(err) => exit_with(
+            &format!("Could not get PWD from OS, error: {}", err),
+            PWD_MISSING,
+        ),
+    };
+
+    fs::create_dir(&backup_directory).unwrap_or_else(|err| {
+        exit_with(
+            &format!("Could not create backup directory! Error: {}", err),
+            COULD_NOT_CREATE_OS_DIRECTORY,
+        )
+    });
+
+    let leaf_nodes =
+        list_paths(&get_config(), Some(LeafNodesOnly)).unwrap_or_else(|err| match err {
+            ListPathsError::UnexpectedError(msg) => exit_with(
+                &format!("Unexpected error while listing leaf nodes: {}", msg),
+                UNEXPECTED_ERROR,
+            ),
+        });
+
+    let docs = list_paths(&get_config(), Some(DocumentsOnly)).unwrap_or_else(|err| match err {
+        ListPathsError::UnexpectedError(msg) => exit_with(
+            &format!("Unexpected error while listing documents: {}", msg),
+            UNEXPECTED_ERROR,
+        ),
+    });
+
+    let folders = list_paths(&get_config(), Some(FoldersOnly)).unwrap_or_else(|err| match err {
+        ListPathsError::UnexpectedError(msg) => exit_with(
+            &format!("Unexpected error while listing documents: {}", msg),
+            UNEXPECTED_ERROR,
+        ),
+    });
+
+    println!(
+        "Creating an index to keep track of {} files",
+        leaf_nodes.len()
+    );
+
+    let index_file_path = {
+        let mut dir = backup_directory.clone();
+        dir.push("lockbook.index");
+        dir
+    };
+    let mut index_file = File::create(&index_file_path).unwrap_or_else(|err| {
+        exit_with(
+            &format!("Could not create index file, error: {}", err),
+            COULD_NOT_WRITE_TO_OS_FILE,
+        )
+    });
+    let index_file_content: String = leaf_nodes.join("\n");
+    index_file
+        .write_all(index_file_content.as_bytes())
+        .unwrap_or_else(|err| {
+            exit_with(
+                &format!("Could not write to index file: {}", err),
+                COULD_NOT_WRITE_TO_OS_FILE,
+            )
+        });
+
+    println!("Creating {} folders", folders.len());
+    for folder in folders {
+        let path = backup_directory.join(PathBuf::from(folder));
+        fs::create_dir_all(&path).unwrap_or_else(|err| {
+            exit_with(
+                &format!(
+                    "Could not create {:?} directory! Error: {}",
+                    path.to_str(),
+                    err
+                ),
+                COULD_NOT_CREATE_OS_DIRECTORY,
+            )
+        });
+    }
+
+    println!("Writing {} documents", docs.len());
+    for doc in docs {
+        let path = backup_directory.join(PathBuf::from(&doc));
+
+        let mut document = File::create(&path).unwrap_or_else(|err| {
+            exit_with(
+                &format!("Could not create index file, error: {}", err),
+                COULD_NOT_WRITE_TO_OS_FILE,
+            )
+        });
+
+        let document_metadata =
+            get_file_by_path(&get_config(), &doc).unwrap_or_else(|err| match err {
+                GetFileByPathError::NoFileAtThatPath | GetFileByPathError::UnexpectedError(_) => {
+                    exit_with(
+                        &format!("Could not get file metadata for: {} error: {:?}", &doc, err),
+                        UNEXPECTED_ERROR,
+                    )
+                }
+            });
+
+        let document_content = read_document(&get_config(), document_metadata.id).unwrap_or_else(|err| match err {
+            ReadDocumentError::TreatedFolderAsDocument |
+            ReadDocumentError::NoAccount |
+            ReadDocumentError::FileDoesNotExist |
+            ReadDocumentError::UnexpectedError(_) => exit_with(
+                &format!("Could not read file: {} error: {:?}", &doc, err),
+                UNEXPECTED_ERROR,
+            ),
+        }).secret;
+
+        document
+            .write_all(document_content.as_bytes())
+            .unwrap_or_else(|err| {
+                exit_with(
+                    &format!("Could not write to file: {}, error: {}", &doc, err),
+                    COULD_NOT_WRITE_TO_OS_FILE,
+                )
+            });
+    }
+}

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -1,18 +1,18 @@
 use std::fs;
 use std::path::PathBuf;
 
+use lockbook_core::{create_file_at_path, CreateFileAtPathError, write_document};
 use lockbook_core::model::crypto::DecryptedValue;
-use lockbook_core::{create_file_at_path, write_document, CreateFileAtPathError};
 
-use crate::utils::{exit_with, exit_with_no_account, get_account_or_exit, get_config};
 use crate::{
     COULD_NOT_GET_OS_ABSOLUTE_PATH, COULD_NOT_READ_OS_FILE, COULD_NOT_READ_OS_METADATA,
     DOCUMENT_TREATED_AS_FOLDER, FILE_ALREADY_EXISTS, NO_ROOT, PATH_CONTAINS_EMPTY_FILE,
     PATH_NO_ROOT, SUCCESS, UNEXPECTED_ERROR, UNIMPLEMENTED,
 };
+use crate::utils::{exit_with, exit_with_no_account, get_account_or_exit, get_config};
 
-pub fn copy(path: PathBuf) {
-    let account = get_account_or_exit();
+pub fn copy(path: PathBuf, import_dest: &str) {
+    get_account_or_exit();
 
     let metadata = fs::metadata(&path).unwrap_or_else(|err| {
         exit_with(
@@ -36,19 +36,22 @@ pub fn copy(path: PathBuf) {
             )
         });
 
-        let absolute_path_string = absolute_path_maybe.to_str().unwrap_or_else(|| {
-            exit_with(
-                "Absolute path not a valid utf-8 sequence!",
-                UNEXPECTED_ERROR,
-            )
-        });
+        let import_dest_with_filename = if import_dest.ends_with('/') {
+            match absolute_path_maybe.file_name() {
+                Some(name) => match name.to_os_string().into_string() {
+                    Ok(string) => string,
+                    Err(err) => exit_with(
+                        format!("Unexpected error while trying to convert an OsString -> Rust String: {:?}", err).as_str(),
+                        UNEXPECTED_ERROR,
+                    ),
+                },
+                None => exit_with("Import target does not contain a file name!", UNEXPECTED_ERROR),
+            }
+        } else {
+            import_dest.to_string()
+        };
 
-        let import_dest = format!(
-            "{}/imported/cli-copy{}",
-            account.username, absolute_path_string
-        );
-
-        let file_metadata = match create_file_at_path(&get_config(), &import_dest) {
+        let file_metadata = match create_file_at_path(&get_config(), import_dest_with_filename.as_str()) {
             Ok(file_metadata) => file_metadata,
             Err(err) => match err {
                 CreateFileAtPathError::FileAlreadyExists => exit_with(&format!("Input destination {} not available within lockbook!", import_dest), FILE_ALREADY_EXISTS),
@@ -56,7 +59,7 @@ pub fn copy(path: PathBuf) {
                 CreateFileAtPathError::NoRoot => exit_with("No root folder, have you synced yet?", NO_ROOT),
                 CreateFileAtPathError::DocumentTreatedAsFolder => exit_with(&format!("A file along the target destination is a document that cannot be used as a folder: {}", import_dest), DOCUMENT_TREATED_AS_FOLDER),
                 CreateFileAtPathError::PathContainsEmptyFile => exit_with(&format!("Input destination {} contains an empty file!", import_dest), PATH_CONTAINS_EMPTY_FILE),
-                CreateFileAtPathError::PathDoesntStartWithRoot => exit_with("Unexpected: PathDoesntStartWithRoot", PATH_NO_ROOT),
+                CreateFileAtPathError::PathDoesntStartWithRoot => exit_with("Import destination doesn't start with your root folder.", PATH_NO_ROOT),
                 CreateFileAtPathError::UnexpectedError(msg) => exit_with(&msg, UNEXPECTED_ERROR),
             },
         };

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -1,15 +1,15 @@
 use std::fs;
 use std::path::PathBuf;
 
-use lockbook_core::{create_file_at_path, CreateFileAtPathError, write_document};
 use lockbook_core::model::crypto::DecryptedValue;
+use lockbook_core::{create_file_at_path, write_document, CreateFileAtPathError};
 
+use crate::utils::{exit_with, exit_with_no_account, get_account_or_exit, get_config};
 use crate::{
     COULD_NOT_GET_OS_ABSOLUTE_PATH, COULD_NOT_READ_OS_FILE, COULD_NOT_READ_OS_METADATA,
     DOCUMENT_TREATED_AS_FOLDER, FILE_ALREADY_EXISTS, NO_ROOT, PATH_CONTAINS_EMPTY_FILE,
     PATH_NO_ROOT, SUCCESS, UNEXPECTED_ERROR, UNIMPLEMENTED,
 };
-use crate::utils::{exit_with, exit_with_no_account, get_account_or_exit, get_config};
 
 pub fn copy(path: PathBuf, import_dest: &str) {
     get_account_or_exit();

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -1,15 +1,18 @@
 use std::fs;
 use std::path::PathBuf;
 
-use lockbook_core::{create_file_at_path, CreateFileAtPathError, get_file_by_path, GetFileByPathError, write_document};
 use lockbook_core::model::crypto::DecryptedValue;
+use lockbook_core::{
+    create_file_at_path, get_file_by_path, write_document, CreateFileAtPathError,
+    GetFileByPathError,
+};
 
+use crate::utils::{exit_with, exit_with_no_account, get_account_or_exit, get_config};
 use crate::{
     COULD_NOT_GET_OS_ABSOLUTE_PATH, COULD_NOT_READ_OS_FILE, COULD_NOT_READ_OS_METADATA,
     DOCUMENT_TREATED_AS_FOLDER, FILE_ALREADY_EXISTS, NO_ROOT, PATH_CONTAINS_EMPTY_FILE,
     PATH_NO_ROOT, SUCCESS, UNEXPECTED_ERROR, UNIMPLEMENTED,
 };
-use crate::utils::{exit_with, exit_with_no_account, get_account_or_exit, get_config};
 
 pub fn copy(path: PathBuf, import_dest: &str, edit: bool) {
     get_account_or_exit();
@@ -81,7 +84,10 @@ pub fn copy(path: PathBuf, import_dest: &str, edit: bool) {
             file_metadata.id,
             &DecryptedValue::from(content_to_import),
         ) {
-            Ok(_) => exit_with(&format!("imported to {}", import_dest_with_filename), SUCCESS),
+            Ok(_) => exit_with(
+                &format!("imported to {}", import_dest_with_filename),
+                SUCCESS,
+            ),
             Err(err) => exit_with(&format!("Unexpected error: {:#?}", err), UNEXPECTED_ERROR),
         }
     } else {

--- a/clients/cli/src/export_private_key.rs
+++ b/clients/cli/src/export_private_key.rs
@@ -3,7 +3,7 @@ use lockbook_core::{export_account, AccountExportError};
 use crate::utils::{exit_with, exit_with_no_account, get_config};
 use crate::UNEXPECTED_ERROR;
 
-pub fn export() {
+pub fn export_private_key() {
     match export_account(&get_config()) {
         Ok(account_string) => {
             if atty::is(atty::Stream::Stdout) {

--- a/clients/cli/src/import_private_key.rs
+++ b/clients/cli/src/import_private_key.rs
@@ -8,7 +8,7 @@ use crate::{
     SUCCESS, UNEXPECTED_ERROR, USERNAME_PK_MISMATCH,
 };
 
-pub fn import() {
+pub fn import_private_key() {
     if atty::is(atty::Stream::Stdin) {
         exit_with(
             "To import an existing Lockbook, pipe your account string into this command, \

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
             file,
             destination,
             edit,
-        } => copy::copy(file, &destination),
+        } => copy::copy(file, &destination, edit),
         Lockbook::Edit { path } => edit::edit(&path.trim()),
         Lockbook::ExportPrivateKey => export_private_key::export_private_key(),
         Lockbook::ImportPrivateKey => import_private_key::import_private_key(),

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -24,8 +24,8 @@ mod whoami;
 #[derive(Debug, PartialEq, StructOpt)]
 #[structopt(about = "A secure and intuitive notebook.")]
 enum Lockbook {
-    /// Bring a file from your computer into your Lockbook
-    Copy { file: PathBuf },
+    /// Bring a file from your computer into a target destination inside your Lockbook. If your Lockbook target destination is a Folder, the file name will be taken from the file-system file.
+    Copy { file: PathBuf, destination: String },
 
     /// Open a document for editing
     Edit { path: String },
@@ -86,7 +86,7 @@ fn main() {
 
     let args: Lockbook = Lockbook::from_args();
     match args {
-        Lockbook::Copy { file } => copy::copy(file),
+        Lockbook::Copy { file, destination} => copy::copy(file, &destination),
         Lockbook::Edit { path } => edit::edit(&path.trim()),
         Lockbook::ExportPrivateKey => export_private_key::export_private_key(),
         Lockbook::ImportPrivateKey => import_private_key::import_private_key(),

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -7,9 +7,9 @@ use lockbook_core::repo::file_metadata_repo::Filter::{DocumentsOnly, FoldersOnly
 
 mod copy;
 mod edit;
-mod export;
-mod import;
-mod init;
+mod export_private_key;
+mod import_private_key;
+mod new_account;
 mod list;
 mod move_file;
 mod new;
@@ -31,13 +31,13 @@ enum Lockbook {
     Edit { path: String },
 
     /// Export your private key
-    Export,
+    ExportPrivateKey,
 
     /// Import an existing Lockbook
-    Import,
+    ImportPrivateKey,
 
     /// Create a new Lockbook account
-    Init,
+    NewAccount,
 
     /// List all your paths
     List,
@@ -88,9 +88,9 @@ fn main() {
     match args {
         Lockbook::Copy { file } => copy::copy(file),
         Lockbook::Edit { path } => edit::edit(&path.trim()),
-        Lockbook::Export => export::export(),
-        Lockbook::Import => import::import(),
-        Lockbook::Init => init::init(),
+        Lockbook::ExportPrivateKey => export_private_key::export_private_key(),
+        Lockbook::ImportPrivateKey => import_private_key::import_private_key(),
+        Lockbook::NewAccount => new_account::new_account(),
         Lockbook::List => list::list(Some(LeafNodesOnly)),
         Lockbook::ListAll => list::list(None),
         Lockbook::ListDocs => list::list(Some(DocumentsOnly)),

--- a/clients/cli/src/new_account.rs
+++ b/clients/cli/src/new_account.rs
@@ -16,6 +16,8 @@ pub fn new_account() {
         .expect("Failed to read from stdin");
     username.retain(|c| c != '\n');
 
+    println!("Generating keys and checking for username availability...");
+
     match create_account(&get_config(), &username) {
         Ok(_) => exit_with("Account created successfully", SUCCESS),
         Err(error) => match error {

--- a/clients/cli/src/new_account.rs
+++ b/clients/cli/src/new_account.rs
@@ -6,7 +6,7 @@ use lockbook_core::{create_account, CreateAccountError};
 use crate::utils::{exit_with, exit_with_offline, exit_with_upgrade_required, get_config};
 use crate::{ACCOUNT_ALREADY_EXISTS, SUCCESS, UNEXPECTED_ERROR, USERNAME_INVALID, USERNAME_TAKEN};
 
-pub fn init() {
+pub fn new_account() {
     print!("Enter a Username: ");
     io::stdout().flush().unwrap();
 


### PR DESCRIPTION
# Backup

You can now `lockbook backup`. This will create a folder named `LOCKBOOK_BACKUP_2020-09-26` in your `pwd`. It will create all your content in this directory, folders and all. It will also create a `lockbook.index`, this makes restoring via `lockbook copy` much more straightforward.

```
[~/test]: lockbook backup 
Creating an index to keep track of 6 files
Creating 4 folders
Writing 5 documents
```

# Make Copy more powerful

Restore is implemented by making `copy` more powerful. 
+ `lockbook copy` now takes a target file on your local file system *and a target location within your lockbook for where you want this file to end up*. 
+ It also takes an optional `--edit` flag which tells CLI to overwrite the content of this this file if it already exists. 
+ If your specified lockbook destination is a folder it will take the name of the file from the local file.

```
[~]: lockbook copy cargo.toml $(lockbook whoami)/
imported to parth2334/Cargo.toml
[~]: lockbook copy cargo.toml $(lockbook whoami)/
Input destination parth2334/Cargo.toml not available within lockbook, use --edit to overwrite the contents of this file!
[~]: lockbook copy --edit cargo.toml $(lockbook whoami)/
imported to parth2334/Cargo.toml
```

# How to restore

When we nuke prod and our team needs to restore, I will provide a script that will `copy` a `LOCKBOOK_BACKUP` into a fresh account. ~I won't bother with the specifics of the script because it's 1:43am, but the pseudocode for this bash script is something like this,~ here you go, it's copy-pastable:

```bash
function restore() {
    cd $1
    cat lockbook.index | while read line 
    do
        lockbook copy --edit $(pwd)/$line $line
    done
}
```

closes #309 
closes #183 