### PR TITLE
Apple Crash on New Account

### DIFF
--- a/clients/android/lint.xml
+++ b/clients/android/lint.xml
@@ -4,4 +4,5 @@
         <issue id="SwitchIntDef" severity="ignore" />
         <issue id="UselessParent" severity="ignore" />
         <issue id="ObsoleteLintCustomCheck" severity="ignore" />
+        <issue id="GradleDependency" severity="ignore" />
 </lint>

--- a/clients/apple/Shared/Book/BookView.swift
+++ b/clients/apple/Shared/Book/BookView.swift
@@ -44,22 +44,16 @@ struct FileCell: View {
 struct FileListView: View {
     @ObservedObject var core: Core
     let account: Account
-    @State var selectedFolder: FileMetadataWithChildren
+    @State var selectedFolder: FileMetadataWithChildren?
     @State var showingCreate: Bool = false
     @State var showingAccount: Bool = false
-    
-//    init(core: Core, account: Account, root: FileMetadataWithChildren) {
-//        self.core = core
-//        self.account = account
-//        self.selectedFolder = root
-//    }
     
     var body: some View {
         let baseView = List {
             OutlineGroup(core.grouped, children: \.children) { meta in
                 if meta.meta.fileType == .Folder {
                     FileCell(meta: meta.meta)
-                        .foregroundColor(meta.id == selectedFolder.id ? .accentColor : .primary)
+                        .foregroundColor(selectedFolder.map({ $0.id == meta.id }) ?? false ? .accentColor : .primary)
                         .onTapGesture {
                             selectedFolder = meta
                         }


### PR DESCRIPTION
A force unwrap optional is causing a crash when creating a new account, because at some dubstep there are no items so force-getting the head of a list fails. Solved with optionals! 