### PR TITLE
linux: Show Account usage in a dialog.

### DIFF
--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -10,8 +10,8 @@ use lockbook_core::service::sync_service::WorkCalculated;
 use lockbook_core::{
     calculate_work, create_account, create_file_at_path, execute_work, export_account, get_account,
     get_children, get_db_state, get_file_by_id, get_file_by_path, get_last_synced, get_root,
-    import_account, list_paths, migrate_db, read_document, set_last_synced, write_document,
-    AccountExportError, CalculateWorkError, CreateAccountError, Error as CoreError,
+    get_usage, import_account, list_paths, migrate_db, read_document, set_last_synced,
+    write_document, AccountExportError, CalculateWorkError, CreateAccountError, Error as CoreError,
     ExecuteWorkError, GetAccountError, SetLastSyncedError,
 };
 
@@ -269,6 +269,13 @@ impl LbCore {
     pub fn get_last_synced(&self) -> Result<u64, String> {
         match get_last_synced(&self.config) {
             Ok(last) => Ok(last),
+            Err(err) => Err(format!("{:?}", err)),
+        }
+    }
+
+    pub fn usage(&self) -> Result<u64, String> {
+        match get_usage(&self.config) {
+            Ok(u) => Ok(u.into_iter().map(|usage| usage.byte_secs).sum()),
             Err(err) => Err(format!("{:?}", err)),
         }
     }

--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -14,6 +14,7 @@ mod intro;
 mod menubar;
 mod messages;
 mod settings;
+mod util;
 
 use std::env;
 use std::sync::Arc;

--- a/clients/linux/src/menubar.rs
+++ b/clients/linux/src/menubar.rs
@@ -122,6 +122,7 @@ impl Menubar {
                     self.acct,
                     self.items,
                     &Item::AccountSync,
+                    &Item::AccountUsage,
                     &Item::AccountExport
                 );
             }
@@ -160,6 +161,7 @@ enum Item {
     EditPreferences,
 
     AccountSync,
+    AccountUsage,
     AccountExport,
 
     HelpAbout,
@@ -196,6 +198,7 @@ impl Item {
             (Self::FileQuit, ("Quit", "", || Msg::Quit)),
             (Self::EditPreferences, ("Preferences", "", || Msg::ShowDialogPreferences)),
             (Self::AccountSync, ("Sync", "", || Msg::PerformSync)),
+            (Self::AccountUsage, ("Usage", "", || Msg::ShowDialogUsage)),
             (Self::AccountExport, ("Export", "", || Msg::ExportAccount)),
             (Self::HelpAbout, ("About", "", || Msg::ShowDialogAbout)),
         ]

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -21,6 +21,7 @@ pub enum Msg {
     ShowDialogNew,
     ShowDialogOpen,
     ShowDialogPreferences,
+    ShowDialogUsage,
     ShowDialogAbout,
 
     UnexpectedErr(String, String),

--- a/clients/linux/src/util.rs
+++ b/clients/linux/src/util.rs
@@ -1,0 +1,24 @@
+pub const BYTE: u64 = 1;
+pub const KILOBYTE: u64 = BYTE * 1024;
+pub const MEGABYTE: u64 = KILOBYTE * 1024;
+pub const GIGABYTE: u64 = MEGABYTE * 1024;
+pub const TERABYTE: u64 = GIGABYTE * 1024;
+
+const KILOBYTE_PLUS_ONE: u64 = KILOBYTE + 1;
+const MEGABYTE_PLUS_ONE: u64 = MEGABYTE + 1;
+const GIGABYTE_PLUS_ONE: u64 = GIGABYTE + 1;
+const TERABYTE_PLUS_ONE: u64 = TERABYTE + 1;
+
+pub struct Util;
+impl Util {
+    pub fn human_readable_bytes(v: u64) -> String {
+        let (unit, abbr) = match v {
+            0..=KILOBYTE => (BYTE, ""),
+            KILOBYTE_PLUS_ONE..=MEGABYTE => (KILOBYTE, "K"),
+            MEGABYTE_PLUS_ONE..=GIGABYTE => (MEGABYTE, "M"),
+            GIGABYTE_PLUS_ONE..=TERABYTE => (GIGABYTE, "G"),
+            TERABYTE_PLUS_ONE..=u64::MAX => (TERABYTE, "T"),
+        };
+        format!("{:.3} {}B", v as f64 / unit as f64, abbr)
+    }
+}


### PR DESCRIPTION
* Create a util mod (for now just has bytes to human readable string function).
* Add method on `LbCore` to use core `get_usage` function.
* Create the usage dialog interface.
* Add a `Msg` and Menubar item for opening the new usage dialog.

Closes #306.