### PR TITLE
cli: Refactor calculate_usage code.

### DIFF
--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -5,46 +5,40 @@ use crate::UNEXPECTED_ERROR;
 use lockbook_core::{get_usage, Error as CoreError, GetUsageError};
 
 const BYTE: u64 = 1;
-const KILOBYTES: u64 = BYTE * 1000;
-const MEGABYTES: u64 = KILOBYTES * 1000;
-const GIGABYTES: u64 = MEGABYTES * 1000;
-const TERABYTES: u64 = GIGABYTES * 1000;
+const KILOBYTE: u64 = BYTE * 1024;
+const MEGABYTE: u64 = KILOBYTE * 1024;
+const GIGABYTE: u64 = MEGABYTE * 1024;
+const TERABYTE: u64 = GIGABYTE * 1024;
 
-const KILOBYTES_PLUS_ONE: u64 = KILOBYTES + 1;
-const MEGABYTES_PLUS_ONE: u64 = MEGABYTES + 1;
-const GIGABYTES_PLUS_ONE: u64 = GIGABYTES + 1;
-const TERABYTES_PLUS_ONE: u64 = TERABYTES + 1;
+const KILOBYTE_PLUS_ONE: u64 = KILOBYTE + 1;
+const MEGABYTE_PLUS_ONE: u64 = MEGABYTE + 1;
+const GIGABYTE_PLUS_ONE: u64 = GIGABYTE + 1;
+const TERABYTE_PLUS_ONE: u64 = TERABYTE + 1;
 
 pub fn calculate_usage(exact: bool) {
     get_account_or_exit();
 
-    let usages = get_usage(&get_config()).unwrap_or_else(|err| match err {
-        CoreError::UiError(GetUsageError::CouldNotReachServer) => exit_with_offline(),
-        CoreError::UiError(GetUsageError::ClientUpdateRequired) => exit_with_upgrade_required(),
-        CoreError::UiError(GetUsageError::NoAccount) | CoreError::Unexpected(_) => {
-            exit_with(&format!("Unexpected Error: {:?}", err), UNEXPECTED_ERROR)
-        }
-    });
-
-    let usage_in_bytes: u64 = usages.into_iter().map(|usage| usage.byte_secs).sum();
+    let usage_in_bytes = match get_usage(&get_config()) {
+        Ok(usages) => usages.into_iter().map(|usage| usage.byte_secs).sum(),
+        Err(err) => match err {
+            CoreError::UiError(GetUsageError::CouldNotReachServer) => exit_with_offline(),
+            CoreError::UiError(GetUsageError::ClientUpdateRequired) => exit_with_upgrade_required(),
+            CoreError::UiError(GetUsageError::NoAccount) | CoreError::Unexpected(_) => {
+                exit_with(&format!("Unexpected Error: {:?}", err), UNEXPECTED_ERROR)
+            }
+        },
+    };
 
     if exact {
         println!("{}", usage_in_bytes)
     } else {
-        match usage_in_bytes {
-            0..=KILOBYTES => println!("{} B", usage_in_bytes),
-            KILOBYTES_PLUS_ONE..=MEGABYTES => {
-                println!("{:.3} kB", usage_in_bytes as f64 / KILOBYTES as f64)
-            }
-            MEGABYTES_PLUS_ONE..=GIGABYTES => {
-                println!("{:.3} MB", usage_in_bytes as f64 / MEGABYTES as f64)
-            }
-            GIGABYTES_PLUS_ONE..=TERABYTES => {
-                println!("{:.3} GB", usage_in_bytes as f64 / GIGABYTES as f64)
-            }
-            TERABYTES_PLUS_ONE..=u64::MAX => {
-                println!("{:.3} TB", usage_in_bytes as f64 / TERABYTES as f64)
-            }
-        }
+        let (unit, abbr) = match usage_in_bytes {
+            0..=KILOBYTE => (BYTE, ""),
+            KILOBYTE_PLUS_ONE..=MEGABYTE => (KILOBYTE, "K"),
+            MEGABYTE_PLUS_ONE..=GIGABYTE => (MEGABYTE, "M"),
+            GIGABYTE_PLUS_ONE..=TERABYTE => (GIGABYTE, "G"),
+            TERABYTE_PLUS_ONE..=u64::MAX => (TERABYTE, "T"),
+        };
+        println!("{:.3} {}B", usage_in_bytes as f64 / unit as f64, abbr)
     }
 }

--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -5,10 +5,10 @@ use crate::UNEXPECTED_ERROR;
 use lockbook_core::{get_usage, Error as CoreError, GetUsageError};
 
 const BYTE: u64 = 1;
-const KILOBYTE: u64 = BYTE * 1024;
-const MEGABYTE: u64 = KILOBYTE * 1024;
-const GIGABYTE: u64 = MEGABYTE * 1024;
-const TERABYTE: u64 = GIGABYTE * 1024;
+const KILOBYTE: u64 = BYTE * 1000;
+const MEGABYTE: u64 = KILOBYTE * 1000;
+const GIGABYTE: u64 = MEGABYTE * 1000;
+const TERABYTE: u64 = GIGABYTE * 1000;
 
 const KILOBYTE_PLUS_ONE: u64 = KILOBYTE + 1;
 const MEGABYTE_PLUS_ONE: u64 = MEGABYTE + 1;


### PR DESCRIPTION
* The units are in 1000s, changed to 1024s.
* The variable names represent a _single_ unit, so the plurality was dropped.
* A tuple is used to reduce the match statement by only getting the necessary parts and calculating afterwards instead of calculating and printing each in place.