### PR TITLE
linux: Redesigned account screen header, enhanced search, redesign Export Account dialog, and other misc refactors.

### DIFF
--- a/clients/linux/Cargo.lock
+++ b/clients/linux/Cargo.lock
@@ -575,6 +575,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1083,7 @@ dependencies = [
 name = "lockbook"
 version = "0.1.0"
 dependencies = [
+ "fuzzy-matcher",
  "gdk",
  "gdk-pixbuf",
  "gio",
@@ -1871,6 +1881,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]

--- a/clients/linux/Cargo.lock
+++ b/clients/linux/Cargo.lock
@@ -908,6 +908,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtk-source-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010ad29f87606c4bc91fe4ab6762cab3d5155af7100e59c1af9c6d9aba5df689"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "gtk-sys"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1247,7 @@ dependencies = [
  "qrcode-generator",
  "serde",
  "serde_yaml",
+ "sourceview",
  "uuid",
 ]
 
@@ -1977,6 +1996,30 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "sourceview"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6197ca40c697b552b8d27cfa9d8ee15267037ac071f4c1010749625ba2fc8f79"
+dependencies = [
+ "bitflags",
+ "cairo-rs",
+ "gdk",
+ "gdk-pixbuf",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio",
+ "gio-sys",
+ "glib",
+ "glib-sys",
+ "gobject-sys",
+ "gtk",
+ "gtk-source-sys",
+ "gtk-sys",
+ "libc",
+ "pango",
 ]
 
 [[package]]

--- a/clients/linux/Cargo.lock
+++ b/clients/linux/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,9 +153,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.2",
  "object",
  "rustc-demangle",
 ]
@@ -225,6 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytemuck"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41aa2ec95ca3b5c54cf73c91acf06d24f4495d5f1b1c12506ae3483d646177ac"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +319,12 @@ checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colored"
@@ -327,12 +351,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -342,10 +393,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.0",
+ "lazy_static",
  "memoffset",
  "scopeguard",
 ]
@@ -357,8 +422,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+dependencies = [
+ "autocfg 1.0.1",
+ "cfg-if 1.0.0",
+ "const_fn",
+ "lazy_static",
+]
+
+[[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder",
 ]
 
 [[package]]
@@ -397,7 +484,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -672,7 +759,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -684,6 +771,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
 dependencies = [
  "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02efba560f227847cb41463a7395c514d127d4f74fff12ef0137fff1b84b96c4"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -872,6 +969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d348900ce941b7474395ba922ed3735a517df4546a2939ddb416ce85eeaa988e"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1062,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f0a8345b33b082aedec2f4d7d4a926b845cee184cbe78b703413066564431b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif",
+ "jpeg-decoder",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+ "png",
+ "scoped_threadpool",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,7 +1096,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1023,6 +1148,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc797adac5f083b8ff0ca6f6294a999393d76e197c36488e2ef732c4715f6fa3"
+dependencies = [
+ "byteorder",
+ "rayon",
+]
 
 [[package]]
 name = "js-sys"
@@ -1091,6 +1226,7 @@ dependencies = [
  "gtk",
  "lockbook_core",
  "pango",
+ "qrcode-generator",
  "serde",
  "serde_yaml",
  "uuid",
@@ -1128,7 +1264,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1176,6 +1312,15 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
@@ -1190,7 +1335,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1221,7 +1366,7 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -1260,6 +1405,17 @@ name = "num-iter"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -1347,7 +1503,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "instant",
  "libc",
@@ -1401,12 +1557,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
+name = "png"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe7f9f1c730833200b134370e1d5098964231af8450bce9b78ee3ab5278b970"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide 0.3.7",
+]
+
+[[package]]
 name = "polyval"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "universal-hash",
 ]
 
@@ -1471,6 +1639,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode-generator"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af6f834f95e6f4183e6ce671fdc0ecb43c5fa5640d58d5a22fc53996ab638dc"
+dependencies = [
+ "html-escape",
+ "image",
+ "qrcodegen",
+]
+
+[[package]]
+name = "qrcodegen"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24ea38b2345f15533e6668104bec0136883404287e095f15f9ea2522e2b4b6c"
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1703,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg 1.0.1",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils 0.8.0",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1641,6 +1851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,8 +1952,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f72c064e63fbca3138ad07f3588c58093f1684f3a99f60dcfa6d46b87e60fde7"
 dependencies = [
  "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
  "fs2",
  "fxhash",
  "libc",
@@ -1757,7 +1973,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1855,7 +2071,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -1890,6 +2106,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tiff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abeb4e3f32a8973722c0254189e6890358e72b1bf11becb287ee0b23c595a41d"
+dependencies = [
+ "jpeg-decoder",
+ "miniz_oxide 0.4.2",
+ "weezl",
 ]
 
 [[package]]
@@ -1974,7 +2201,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
  "pin-project-lite",
  "tracing-core",
@@ -2077,6 +2304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
+
+[[package]]
 name = "uuid"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,7 +2376,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -2170,7 +2403,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2233,6 +2466,12 @@ checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2bb9fc8309084dd7cd651336673844c1d47f8ef6d2091ec160b27f5c4aa277"
 
 [[package]]
 name = "winapi"

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -13,6 +13,7 @@ glib = "0.10"
 gtk = { version = "0.9.0", features = ["v3_16"] }
 gio = { version = "", features = ["v2_44"] }
 pango = "0.9.1"
+qrcode-generator = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -16,4 +16,5 @@ pango = "0.9.1"
 qrcode-generator = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
+sourceview = "0.9.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["steverusso <steverusso@pm.me"]
 edition = "2018"
 
 [dependencies]
+fuzzy-matcher = "*"
 lockbook_core = { path = "../../core" }
 gdk = "0.13.2"
 gdk-pixbuf = "0.9.0"

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -10,7 +10,7 @@ lockbook_core = { path = "../../core" }
 gdk = "0.13.2"
 gdk-pixbuf = "0.9.0"
 glib = "0.10"
-gtk = { version = "0.9.0", features = ["v3_16"] }
+gtk = { version = "0.9.0", features = ["v3_22"] }
 gio = { version = "", features = ["v2_44"] }
 pango = "0.9.1"
 qrcode-generator = "*"

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -170,9 +170,15 @@ impl Header {
         search.set_placeholder_text(Some("Enter a file location..."));
 
         let m = msngr.clone();
+        search.connect_focus_out_event(move |_, _| {
+            m.send(Msg::SearchFieldBlur(false));
+            gtk::Inhibit(false)
+        });
+
+        let m = msngr.clone();
         search.connect_key_press_event(move |_, key| {
             if key.get_hardware_keycode() == ESC {
-                m.send(Msg::SearchFieldBlur);
+                m.send(Msg::SearchFieldBlur(true));
             }
             gtk::Inhibit(false)
         });

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -1,11 +1,12 @@
-use glib::clone;
 use gtk::prelude::*;
 use gtk::Orientation::{Horizontal, Vertical};
 use gtk::{
     Adjustment as GtkAdjustment, Align as GtkAlign, Box as GtkBox, Button as GtkBtn,
-    Grid as GtkGrid, HeaderBar as GtkHeaderBar, Image as GtkImage, Label as GtkLabel,
-    Paned as GtkPaned, ScrolledWindow as GtkScrolledWindow, Separator as GtkSeparator,
-    Spinner as GtkSpinner, Stack as GtkStack, TextView as GtkTextView, WrapMode as GtkWrapMode,
+    Entry as GtkEntry, EntryCompletion as GtkEntryCompletion,
+    EntryIconPosition as GtkEntryIconPosition, Grid as GtkGrid, Image as GtkImage,
+    Label as GtkLabel, Paned as GtkPaned, ScrolledWindow as GtkScrolledWindow,
+    Separator as GtkSeparator, Spinner as GtkSpinner, Stack as GtkStack, TextView as GtkTextView,
+    WrapMode as GtkWrapMode,
 };
 
 use lockbook_core::model::file_metadata::FileMetadata;
@@ -17,21 +18,30 @@ use crate::messages::{Messenger, Msg};
 use crate::settings::Settings;
 
 pub struct AccountScreen {
-    pub sidebar: Sidebar,
+    header: Header,
+    sidebar: Sidebar,
     editor: Editor,
-    pub cntr: GtkPaned,
+    pub cntr: GtkBox,
 }
 
 impl AccountScreen {
     pub fn new(m: &Messenger, s: &Settings) -> Self {
-        let sidebar = Sidebar::new(m, &s);
+        let header = Header::new(&m);
+        let sidebar = Sidebar::new(&m, &s);
         let editor = Editor::new();
 
-        let cntr = GtkPaned::new(Horizontal);
-        cntr.add1(&sidebar.cntr);
-        cntr.add2(&editor.cntr);
+        let paned = GtkPaned::new(Horizontal);
+        paned.add1(&sidebar.cntr);
+        paned.add2(&editor.cntr);
+        paned.set_position(300);
+
+        let cntr = GtkBox::new(Vertical, 0);
+        cntr.add(&header.cntr);
+        cntr.add(&GtkSeparator::new(Horizontal));
+        cntr.pack_start(&paned, true, true, 0);
 
         Self {
+            header,
             sidebar,
             editor,
             cntr,
@@ -40,7 +50,7 @@ impl AccountScreen {
 
     pub fn fill(&self, core: &LbCore) {
         self.sidebar.fill(&core);
-        self.set_sync_status(&core);
+        self.sidebar.sync.set_status(&core);
     }
 
     pub fn add_file(&self, b: &LbCore, f: &FileMetadata) {
@@ -49,70 +59,154 @@ impl AccountScreen {
 
     pub fn show(&self, mode: &EditMode) {
         match mode {
-            EditMode::PlainText { meta, content } => {
+            EditMode::PlainText {
+                path,
+                meta,
+                content,
+            } => {
+                self.header.set_file(&path);
                 self.sidebar.tree.select(&meta.id);
-                self.editor.set_file(&meta, &content);
+                self.editor.set_file(&content);
             }
             EditMode::Folder {
                 path,
                 meta,
                 n_children,
             } => {
+                self.header.set_file(path);
                 self.sidebar.tree.focus();
-                self.editor.show_folder_info(&path, &meta, *n_children);
+                self.editor.show_folder_info(&meta, *n_children);
             }
-            EditMode::None => self.editor.clear(),
+            EditMode::None => {
+                self.header.set_file("");
+                self.editor.show("empty");
+            }
         }
     }
 
     pub fn text_content(&self) -> String {
-        let buf = self.editor.workspace.textarea.get_buffer().unwrap();
-        buf.get_text(&buf.get_start_iter(), &buf.get_end_iter(), true)
-            .unwrap()
-            .to_string()
+        let buf = self.editor.textarea.get_buffer().unwrap();
+        let start = buf.get_start_iter();
+        let end = buf.get_end_iter();
+        buf.get_text(&start, &end, true).unwrap().to_string()
     }
 
     pub fn set_saving(&self, is_saving: bool) {
         if is_saving {
-            self.editor.headerbar.show_spinner();
+            self.header.show_spinner();
         } else {
-            self.editor.headerbar.hide_spinner();
+            self.header.hide_spinner();
         }
     }
 
-    pub fn set_syncing(&self, is_syncing: bool) {
-        if is_syncing {
-            self.sidebar.sync.syncing();
-        } else {
-            self.sidebar.sync.done();
+    pub fn sync(&self) -> &SyncPanel {
+        &self.sidebar.sync
+    }
+
+    pub fn get_search_field_text(&self) -> String {
+        self.header.search.get_text().to_string()
+    }
+
+    pub fn set_search_field_text(&self, txt: &str) {
+        self.header.search.set_text(txt);
+    }
+
+    pub fn set_search_field_icon(&self, icon_name: &str, tooltip: Option<&str>) {
+        entry_set_primary_icon(&self.header.search, icon_name);
+        entry_set_primary_icon_tooltip(&self.header.search, tooltip);
+    }
+
+    pub fn set_search_field_completion(&self, comp: &GtkEntryCompletion) {
+        self.header.search.set_completion(Some(comp));
+        self.header.search.grab_focus();
+    }
+
+    pub fn deselect_search_field(&self) {
+        self.header.search.select_region(0, 0);
+    }
+
+    pub fn tree(&self) -> &FileTree {
+        &self.sidebar.tree
+    }
+}
+
+struct Header {
+    search: GtkEntry,
+    spinner: GtkSpinner,
+    cntr: GtkBox,
+}
+
+impl Header {
+    fn new(m: &Messenger) -> Self {
+        let search = Self::new_search_field(&m);
+
+        let spinner = GtkSpinner::new();
+        spinner.set_margin_start(6);
+        spinner.set_margin_end(3);
+
+        let cntr = GtkBox::new(Horizontal, 0);
+        cntr.set_margin_top(6);
+        cntr.set_margin_bottom(6);
+        cntr.set_margin_start(3);
+        cntr.set_margin_end(3);
+        cntr.pack_start(&search, true, true, 0);
+
+        Self {
+            search,
+            spinner,
+            cntr,
         }
     }
 
-    pub fn set_sync_status(&self, core: &LbCore) {
-        match core.get_last_synced() {
-            Ok(last) => match last {
-                0 => self.sidebar.sync.status.set_markup("✘  Never synced."),
-                _ => match core.calculate_work() {
-                    Ok(work) => {
-                        let n_files = work.work_units.len();
-                        let txt = match n_files {
-                            0 => "✔  Synced.".to_string(),
-                            1 => "<b>1</b>  file not synced.".to_string(),
-                            _ => format!("<b>{}</b>  files not synced.", n_files),
-                        };
-                        self.sidebar.sync.status.set_markup(&txt);
-                    }
-                    Err(err) => println!("{:?}", err),
-                },
-            },
-            Err(err) => panic!(err),
-        }
+    fn new_search_field(msngr: &Messenger) -> GtkEntry {
+        let search = GtkEntry::new();
+        entry_set_primary_icon(&search, "edit-find-symbolic");
+        search.set_placeholder_text(Some("Enter a file location..."));
+
+        let m = msngr.clone();
+        search.connect_key_press_event(move |_, key| {
+            if key.get_hardware_keycode() == ESC {
+                m.send(Msg::SearchFieldBlur);
+            }
+            gtk::Inhibit(false)
+        });
+
+        let m = msngr.clone();
+        search.connect_key_release_event(move |_, key| {
+            let k = key.get_hardware_keycode();
+            if k != ARROW_UP && k != ARROW_DOWN {
+                m.send(Msg::SearchFieldUpdate);
+            }
+            gtk::Inhibit(false)
+        });
+
+        let m = msngr.clone();
+        search.connect_changed(move |_| m.send(Msg::SearchFieldUpdateIcon));
+
+        let m = msngr.clone();
+        search.connect_activate(move |_| m.send(Msg::SearchFieldExec(None)));
+        search
+    }
+
+    fn set_file(&self, path: &str) {
+        self.search.set_text(path);
+    }
+
+    fn show_spinner(&self) {
+        self.cntr.pack_end(&self.spinner, false, false, 0);
+        self.cntr.show_all();
+        self.spinner.start();
+    }
+
+    fn hide_spinner(&self) {
+        self.spinner.stop();
+        self.cntr.remove(&self.spinner);
     }
 }
 
 pub struct Sidebar {
-    pub tree: FileTree,
-    pub sync: SyncPanel,
+    tree: FileTree,
+    sync: SyncPanel,
     cntr: GtkBox,
 }
 
@@ -122,20 +216,14 @@ impl Sidebar {
         let sync = SyncPanel::new(&m);
 
         let cntr = GtkBox::new(Vertical, 0);
-        cntr.add(&{
-            let hb = GtkHeaderBar::new();
-            hb.set_title(Some("My Files:"));
-            hb
-        });
-        cntr.add(&GtkSeparator::new(Horizontal));
-        cntr.pack_start(&tree.tree, true, true, 0);
+        cntr.pack_start(tree.widget(), true, true, 0);
         cntr.add(&GtkSeparator::new(Horizontal));
         cntr.add(&sync.cntr);
 
         Self { tree, sync, cntr }
     }
 
-    pub fn fill(&self, core: &LbCore) {
+    fn fill(&self, core: &LbCore) {
         self.tree.fill(core);
     }
 }
@@ -175,10 +263,9 @@ impl SyncPanel {
         let status = GtkLabel::new(None);
         status.set_halign(GtkAlign::Start);
 
+        let m = m.clone();
         let button = GtkBtn::with_label("Sync");
-        button.connect_clicked(clone!(@strong m => move |_| {
-            m.send(Msg::PerformSync);
-        }));
+        button.connect_clicked(move |_| m.send(Msg::PerformSync));
 
         let spinner = GtkSpinner::new();
         spinner.set_margin_top(4);
@@ -194,148 +281,59 @@ impl SyncPanel {
         (status, button, spinner, center)
     }
 
-    pub fn doing(&self, txt: &str) {
-        self.status.set_text(txt);
+    pub fn set_syncing(&self, is_syncing: bool) {
+        if is_syncing {
+            self.center.remove(&self.button);
+            self.center.pack_end(&self.spinner, false, false, 0);
+            self.spinner.show();
+            self.spinner.start();
+        } else {
+            self.spinner.stop();
+            self.center.remove(&self.spinner);
+            self.center.pack_end(&self.button, false, false, 0);
+            self.status.set_text("");
+        }
+    }
+
+    pub fn set_status(&self, core: &LbCore) {
+        match core.get_last_synced() {
+            Ok(last) => match last {
+                0 => self.status.set_markup("✘  Never synced."),
+                _ => match core.calculate_work() {
+                    Ok(work) => {
+                        let n_files = work.work_units.len();
+                        let txt = match n_files {
+                            0 => "✔  Synced.".to_string(),
+                            1 => "<b>1</b>  file not synced.".to_string(),
+                            _ => format!("<b>{}</b>  files not synced.", n_files),
+                        };
+                        self.status.set_markup(&txt);
+                    }
+                    Err(err) => println!("{:?}", err),
+                },
+            },
+            Err(err) => panic!(err),
+        }
+    }
+
+    pub fn doing(&self, work: &str) {
+        self.status.set_text(work);
     }
 
     pub fn error(&self, txt: &str) {
         self.cntr.pack_start(&self.errlbl, false, false, 0);
         self.errlbl.set_text(txt);
     }
-
-    fn syncing(&self) {
-        self.center.remove(&self.button);
-        self.center.pack_end(&self.spinner, false, false, 0);
-        self.spinner.show();
-        self.spinner.start();
-    }
-
-    fn done(&self) {
-        self.spinner.stop();
-        self.center.remove(&self.spinner);
-        self.center.pack_end(&self.button, false, false, 0);
-        self.status.set_text("");
-    }
 }
 
 struct Editor {
-    headerbar: EditorHeaderBar,
-    workspace: EditorWorkSpace,
-    cntr: GtkBox,
-}
-
-impl Editor {
-    fn new() -> Self {
-        let headerbar = EditorHeaderBar::new();
-        let workspace = EditorWorkSpace::new();
-
-        let cntr = GtkBox::new(Vertical, 0);
-        cntr.add(&headerbar.cntr);
-        cntr.add(&GtkSeparator::new(Horizontal));
-        cntr.pack_start(&workspace.cntr, true, true, 0);
-
-        Self {
-            headerbar,
-            workspace,
-            cntr,
-        }
-    }
-
-    fn set_file(&self, f: &FileMetadata, content: &str) {
-        self.headerbar.set_file(&f);
-
-        let ws = &self.workspace;
-        ws.show("textarea");
-        ws.textarea.grab_focus();
-        ws.textarea.get_buffer().unwrap().set_text(content);
-    }
-
-    fn show_folder_info(&self, full_path: &str, f: &FileMetadata, n_children: usize) {
-        let name = GtkLabel::new(None);
-        name.set_markup(&format!("<span><big>{}/</big></span>", f.name));
-        name.set_margin_end(64);
-        name.set_margin_bottom(16);
-
-        let grid = GtkGrid::new();
-        grid.set_halign(GtkAlign::Center);
-
-        let rows = vec![
-            ("ID", f.id.to_string()),
-            ("Owner", f.owner.clone()),
-            ("Children", n_children.to_string()),
-        ];
-        for (row, (key, val)) in rows.into_iter().enumerate() {
-            grid.attach(&text_right(key), 0, row as i32, 1, 1);
-            grid.attach(&text_left(&val), 1, row as i32, 1, 1);
-        }
-
-        let info = &self.workspace.info;
-        info.foreach(|w| info.remove(w));
-        info.add(&name);
-        info.add(&grid);
-        info.show_all();
-
-        self.headerbar.cntr.set_title(Some(full_path));
-        self.workspace.show("folderinfo");
-    }
-
-    fn clear(&self) {
-        self.headerbar.cntr.set_title(Some(""));
-        self.workspace.show("empty");
-    }
-}
-
-pub fn text_right(txt: &str) -> GtkLabel {
-    let l = GtkLabel::new(Some(txt));
-    l.set_halign(GtkAlign::End);
-    l.set_margin_end(4);
-    l
-}
-
-pub fn text_left(txt: &str) -> GtkLabel {
-    let l = GtkLabel::new(Some(txt));
-    l.set_halign(GtkAlign::Start);
-    l.set_margin_start(4);
-    l
-}
-
-struct EditorHeaderBar {
-    spinner: GtkSpinner,
-    cntr: GtkHeaderBar,
-}
-
-impl EditorHeaderBar {
-    fn new() -> Self {
-        Self {
-            spinner: GtkSpinner::new(),
-            cntr: GtkHeaderBar::new(),
-        }
-    }
-
-    fn set_file(&self, f: &FileMetadata) {
-        self.cntr.set_title(Some(&f.name));
-    }
-
-    fn show_spinner(&self) {
-        self.cntr.pack_end(&self.spinner);
-        self.cntr.show_all();
-        self.spinner.start();
-    }
-
-    fn hide_spinner(&self) {
-        self.spinner.stop();
-        self.cntr.remove(&self.spinner);
-    }
-}
-
-struct EditorWorkSpace {
     info: GtkBox,
     textarea: GtkTextView,
     stack: GtkStack,
     cntr: GtkScrolledWindow,
 }
 
-impl EditorWorkSpace {
+impl Editor {
     fn new() -> Self {
         let empty = GtkBox::new(Vertical, 0);
         empty.set_valign(GtkAlign::Center);
@@ -366,7 +364,65 @@ impl EditorWorkSpace {
         }
     }
 
+    fn set_file(&self, content: &str) {
+        self.show("textarea");
+        self.textarea.grab_focus();
+        self.textarea.get_buffer().unwrap().set_text(content);
+    }
+
+    fn show_folder_info(&self, f: &FileMetadata, n_children: usize) {
+        let name = GtkLabel::new(None);
+        name.set_markup(&format!("<span><big>{}/</big></span>", f.name));
+        name.set_margin_end(64);
+        name.set_margin_bottom(16);
+
+        let grid = GtkGrid::new();
+        grid.set_halign(GtkAlign::Center);
+
+        let rows = vec![
+            ("ID", f.id.to_string()),
+            ("Owner", f.owner.clone()),
+            ("Children", n_children.to_string()),
+        ];
+        for (row, (key, val)) in rows.into_iter().enumerate() {
+            grid.attach(&text_right(key), 0, row as i32, 1, 1);
+            grid.attach(&text_left(&val), 1, row as i32, 1, 1);
+        }
+
+        self.info.foreach(|w| self.info.remove(w));
+        self.info.add(&name);
+        self.info.add(&grid);
+        self.info.show_all();
+        self.show("folderinfo");
+    }
+
     fn show(&self, name: &str) {
         self.stack.set_visible_child_name(name);
     }
 }
+
+fn entry_set_primary_icon(entry: &GtkEntry, name: &str) {
+    entry.set_icon_from_icon_name(GtkEntryIconPosition::Primary, Some(name));
+}
+
+fn entry_set_primary_icon_tooltip(entry: &GtkEntry, tooltip: Option<&str>) {
+    entry.set_icon_tooltip_text(GtkEntryIconPosition::Primary, tooltip);
+}
+
+pub fn text_right(txt: &str) -> GtkLabel {
+    let l = GtkLabel::new(Some(txt));
+    l.set_halign(GtkAlign::End);
+    l.set_margin_end(4);
+    l
+}
+
+pub fn text_left(txt: &str) -> GtkLabel {
+    let l = GtkLabel::new(Some(txt));
+    l.set_halign(GtkAlign::Start);
+    l.set_margin_start(4);
+    l
+}
+
+const ESC: u16 = 9;
+const ARROW_UP: u16 = 111;
+const ARROW_DOWN: u16 = 116;

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -5,9 +5,11 @@ use gtk::{
     Entry as GtkEntry, EntryCompletion as GtkEntryCompletion,
     EntryIconPosition as GtkEntryIconPosition, Grid as GtkGrid, Image as GtkImage,
     Label as GtkLabel, Paned as GtkPaned, ScrolledWindow as GtkScrolledWindow,
-    Separator as GtkSeparator, Spinner as GtkSpinner, Stack as GtkStack, TextView as GtkTextView,
-    WrapMode as GtkWrapMode,
+    Separator as GtkSeparator, Spinner as GtkSpinner, Stack as GtkStack, WrapMode as GtkWrapMode,
 };
+use sourceview::prelude::*;
+use sourceview::Buffer as GtkSourceViewBuffer;
+use sourceview::View as GtkSourceView;
 
 use lockbook_core::model::file_metadata::FileMetadata;
 
@@ -328,7 +330,7 @@ impl SyncPanel {
 
 struct Editor {
     info: GtkBox,
-    textarea: GtkTextView,
+    textarea: GtkSourceView,
     stack: GtkStack,
     cntr: GtkScrolledWindow,
 }
@@ -343,10 +345,11 @@ impl Editor {
         info.set_vexpand(false);
         info.set_valign(GtkAlign::Center);
 
-        let textarea = GtkTextView::new();
+        let textarea = GtkSourceView::new();
         textarea.set_property_monospace(true);
         textarea.set_wrap_mode(GtkWrapMode::Word);
         textarea.set_left_margin(4);
+        textarea.set_tab_width(4);
 
         let stack = GtkStack::new();
         stack.add_named(&empty, "empty");
@@ -365,9 +368,14 @@ impl Editor {
     }
 
     fn set_file(&self, content: &str) {
+        let tvb = self.textarea.get_buffer().unwrap();
+        let svb = tvb.downcast::<GtkSourceViewBuffer>().unwrap();
+        svb.begin_not_undoable_action();
+        svb.set_text(content);
+        svb.end_not_undoable_action();
+
         self.show("textarea");
         self.textarea.grab_focus();
-        self.textarea.get_buffer().unwrap().set_text(content);
     }
 
     fn show_folder_info(&self, f: &FileMetadata, n_children: usize) {

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -33,9 +33,9 @@ impl AccountScreen {
         let editor = Editor::new();
 
         let paned = GtkPaned::new(Horizontal);
+        paned.set_position(350);
         paned.add1(&sidebar.cntr);
         paned.add2(&editor.cntr);
-        paned.set_position(300);
 
         let cntr = GtkBox::new(Vertical, 0);
         cntr.add(&header.cntr);
@@ -125,6 +125,10 @@ impl AccountScreen {
 
     pub fn deselect_search_field(&self) {
         self.header.search.select_region(0, 0);
+    }
+
+    pub fn focus_editor(&self) {
+        self.editor.textarea.grab_focus();
     }
 
     pub fn tree(&self) -> &FileTree {

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+
+use qrcode_generator::QrCodeEcc;
 use uuid::Uuid;
 
 use lockbook_core::model::account::Account;
@@ -98,13 +101,27 @@ impl LbCore {
 
     pub fn export_account(&self) -> Result<String, String> {
         match export_account(&self.config) {
-            Ok(acct_str) => Ok(acct_str),
+            Ok(privkey) => Ok(privkey),
             Err(err) => match err {
                 CoreError::UiError(AccountExportError::NoAccount) => {
                     Err("Unable to load account".to_string())
                 }
                 CoreError::Unexpected(msg) => Err(msg),
             },
+        }
+    }
+
+    pub fn account_qrcode(&self, chan: &glib::Sender<Result<String, String>>) {
+        match self.export_account() {
+            Ok(privkey) => {
+                let path = format!("{}/account-qr.png", self.config.writeable_path);
+                if !Path::new(&path).exists() {
+                    let bytes = privkey.as_bytes();
+                    qrcode_generator::to_png_to_file(bytes, QrCodeEcc::Low, 400, &path).unwrap();
+                }
+                chan.send(Ok(path)).unwrap();
+            }
+            Err(err) => chan.send(Err(format!("{:?}", err))).unwrap(),
         }
     }
 

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -241,8 +241,8 @@ impl LbCore {
         }
     }
 
-    pub fn delete(&self, id: Uuid) -> Result<(), String> {
-        match delete_file(&self.config, id) {
+    pub fn delete(&self, id: &Uuid) -> Result<(), String> {
+        match delete_file(&self.config, *id) {
             Ok(_) => Ok(()),
             Err(err) => Err(format!("{:?}", err)),
         }

--- a/clients/linux/src/editmode.rs
+++ b/clients/linux/src/editmode.rs
@@ -8,6 +8,7 @@ pub enum EditMode {
     },
 
     PlainText {
+        path: String,
         meta: FileMetadata,
         content: String,
     },

--- a/clients/linux/src/gui.rs
+++ b/clients/linux/src/gui.rs
@@ -764,7 +764,7 @@ impl Gui {
         }
         w.add(&{
             let base = GtkBox::new(Vertical, 0);
-            base.add(&menubar.cntr);
+            base.add(menubar.widget());
             base.pack_start(&screens, true, true, 0);
             base
         });

--- a/clients/linux/src/gui.rs
+++ b/clients/linux/src/gui.rs
@@ -1,11 +1,11 @@
 use std::cell::RefCell;
+use std::cmp::Ordering;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use uuid::Uuid;
 
 use gio::prelude::*;
-use glib::clone;
 use gtk::prelude::*;
 use gtk::Orientation::Vertical;
 use gtk::{
@@ -13,9 +13,14 @@ use gtk::{
     ApplicationWindow as GtkAppWindow, Box as GtkBox, CheckButton as GtkCheckBox,
     Dialog as GtkDialog, Entry as GtkEntry, EntryCompletion as GtkEntryCompletion,
     Expander as GtkExpander, Label as GtkLabel, ListStore as GtkListStore, Notebook as GtkNotebook,
-    ResponseType as GtkResponseType, Stack as GtkStack, Widget as GtkWidget,
-    WidgetExt as GtkWidgetExt, WindowPosition as GtkWindowPosition,
+    ProgressBar as GtkProgressBar, ResponseType as GtkResponseType, SortColumn as GtkSortColumn,
+    SortType as GtkSortType, Stack as GtkStack, TreeIter as GtkTreeIter, TreeModel as GtkTreeModel,
+    TreeModelSort as GtkTreeModelSort, Widget as GtkWidget, WidgetExt as GtkWidgetExt,
+    WindowPosition as GtkWindowPosition,
 };
+
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
 
 use lockbook_core::model::file_metadata::{FileMetadata, FileType};
 
@@ -29,18 +34,6 @@ use crate::messages::{Messenger, Msg, MsgReceiver};
 use crate::settings::Settings;
 use crate::tree_iter_value;
 use crate::util::{Util, KILOBYTE};
-
-macro_rules! widgetize {
-    ($w:expr) => {
-        $w.upcast::<GtkWidget>()
-    };
-}
-
-macro_rules! lblopt {
-    ($txt:expr) => {
-        Some(&GtkLabel::new(Some($txt)))
-    };
-}
 
 pub fn run_gtk(sr: Rc<RefCell<Settings>>, core: Arc<LbCore>) {
     let gtkapp = GtkApp::new(None, Default::default()).unwrap();
@@ -87,7 +80,7 @@ fn make_glib_chan<T, F: FnMut(T) -> glib::Continue + 'static>(func: F) -> glib::
 #[derive(Clone)]
 struct LockbookApp {
     settings: Rc<RefCell<Settings>>,
-    model: Rc<RefCell<Model>>,
+    state: Rc<RefCell<LbState>>,
     core: Arc<LbCore>,
     gui: Rc<Gui>,
     messenger: Messenger,
@@ -98,11 +91,11 @@ impl LockbookApp {
         let gui = Gui::new(&a, &m, &s.borrow());
 
         Self {
+            settings: s,
+            state: Rc::new(RefCell::new(LbState::default())),
             core,
             gui: Rc::new(gui),
-            model: Rc::new(RefCell::new(Model::default())),
             messenger: m,
-            settings: s,
         }
     }
 
@@ -124,8 +117,13 @@ impl LockbookApp {
 
                 Msg::ToggleTreeCol(col) => lb.toggle_tree_col(col),
 
+                Msg::SearchFieldFocus => lb.search_field_focus(),
+                Msg::SearchFieldBlur => lb.search_field_blur(),
+                Msg::SearchFieldUpdate => lb.search_field_update(),
+                Msg::SearchFieldUpdateIcon => lb.search_field_update_icon(),
+                Msg::SearchFieldExec(vopt) => lb.search_field_exec(vopt),
+
                 Msg::ShowDialogNew => lb.show_dialog_new(),
-                Msg::ShowDialogOpen => lb.show_dialog_open(),
                 Msg::ShowDialogPreferences => lb.show_dialog_preferences(),
                 Msg::ShowDialogUsage => lb.show_dialog_usage(),
                 Msg::ShowDialogAbout => lb.show_dialog_about(),
@@ -175,7 +173,7 @@ impl LockbookApp {
                             LbSyncMsg::Doing(work) => gui.intro.doing_status(&work),
                             LbSyncMsg::Done => {
                                 gui.show_account_screen(&cc);
-                                gui.account.set_sync_status(&cc);
+                                gui.account.sync().set_status(&cc);
                             }
                             _ => {}
                         }
@@ -202,18 +200,18 @@ impl LockbookApp {
     }
 
     fn perform_sync(&self) {
-        let acctscr = self.gui.account.clone();
-        acctscr.set_syncing(true);
-
         let core = self.core.clone();
+        let acctscr = self.gui.account.clone();
+        acctscr.sync().set_syncing(true);
 
         let ch = make_glib_chan(move |msg| {
+            let sync_ui = acctscr.sync();
             match msg {
-                LbSyncMsg::Doing(work) => acctscr.sidebar.sync.doing(&work),
-                LbSyncMsg::Error(err) => acctscr.sidebar.sync.error(&format!("error: {}", err)),
+                LbSyncMsg::Doing(work) => sync_ui.doing(&work),
+                LbSyncMsg::Error(err) => sync_ui.error(&format!("error: {}", err)),
                 LbSyncMsg::Done => {
-                    acctscr.set_syncing(false);
-                    acctscr.set_sync_status(&core);
+                    sync_ui.set_syncing(false);
+                    sync_ui.set_status(&core);
                 }
             }
             glib::Continue(true)
@@ -231,7 +229,7 @@ impl LockbookApp {
         match self.core.create_file_at_path(&path) {
             Ok(file) => {
                 self.gui.account.add_file(&self.core, &file);
-                self.gui.account.set_sync_status(&self.core);
+                self.gui.account.sync().set_status(&self.core);
                 self.open_file(file.id);
             }
             Err(err) => println!("error creating '{}': {}", path, err),
@@ -241,7 +239,7 @@ impl LockbookApp {
     fn open_file(&self, id: Uuid) {
         match self.core.file_by_id(id) {
             Ok(meta) => {
-                self.model.borrow_mut().set_opened_file(Some(meta.clone()));
+                self.state.borrow_mut().set_opened_file(Some(meta.clone()));
                 match meta.file_type {
                     FileType::Document => self.open_document(meta.id),
                     FileType::Folder => self.open_folder(&meta),
@@ -253,7 +251,14 @@ impl LockbookApp {
 
     fn open_document(&self, id: Uuid) {
         match self.core.open(&id) {
-            Ok((meta, content)) => self.edit(&EditMode::PlainText { meta, content }),
+            Ok((meta, content)) => {
+                let path = self.core.full_path_for(&meta);
+                self.edit(&EditMode::PlainText {
+                    path,
+                    meta,
+                    content,
+                })
+            }
             Err(err) => println!("error opening '{}': {}", id, err),
         }
     }
@@ -275,7 +280,7 @@ impl LockbookApp {
     }
 
     fn save(&self) {
-        if let Some(f) = &self.model.borrow().get_opened_file() {
+        if let Some(f) = &self.state.borrow().get_opened_file() {
             if f.file_type == FileType::Document {
                 let acctscr = self.gui.account.clone();
                 acctscr.set_saving(true);
@@ -288,7 +293,7 @@ impl LockbookApp {
                     match result {
                         Ok(_) => {
                             acctscr.set_saving(false);
-                            acctscr.set_sync_status(&core);
+                            acctscr.sync().set_status(&core);
                         }
                         Err(err) => {
                             println!("error saving: {}", err);
@@ -304,7 +309,7 @@ impl LockbookApp {
     }
 
     fn close(&self) {
-        if self.model.borrow().get_opened_file().is_some() {
+        if self.state.borrow().get_opened_file().is_some() {
             self.edit(&EditMode::None);
         }
     }
@@ -327,7 +332,7 @@ impl LockbookApp {
 
         if d.run() == GtkResponseType::Yes {
             match self.core.delete(id) {
-                Ok(_) => self.gui.account.sidebar.tree.remove(&meta.id),
+                Ok(_) => self.gui.account.tree().remove(&meta.id),
                 Err(err) => println!("{}", err),
             }
         }
@@ -336,72 +341,89 @@ impl LockbookApp {
     }
 
     fn toggle_tree_col(&self, c: FileTreeCol) {
-        self.gui.account.sidebar.tree.toggle_col(&c);
+        self.gui.account.tree().toggle_col(&c);
         self.settings.borrow_mut().toggle_tree_col(c.name());
     }
 
     fn show_dialog_new(&self) {
+        let entry = GtkEntry::new();
+        entry.set_activates_default(true);
+
         let d = self.gui.new_dialog("New...");
-
-        let path_entry = GtkEntry::new();
-        path_entry.connect_activate(clone!(@strong d => move |_| {
-            d.response(GtkResponseType::Ok);
-        }));
-
-        d.get_content_area().add(&path_entry);
+        d.get_content_area().add(&entry);
         d.add_button("Ok", GtkResponseType::Ok);
-        d.connect_response(
-            clone!(@strong self.messenger as m, @strong path_entry => move |d, resp| {
-                if let GtkResponseType::Ok = resp {
-                    let path = path_entry.get_buffer().get_text();
-                    m.send(Msg::NewFile(path));
-                    d.close();
-                }
-            }),
-        );
+        d.set_default_response(GtkResponseType::Ok);
         d.show_all();
+
+        if d.run() == GtkResponseType::Ok {
+            let path = entry.get_buffer().get_text();
+            self.messenger.send(Msg::NewFile(path));
+            d.close();
+        }
     }
 
-    fn show_dialog_open(&self) {
-        let d = self.gui.new_dialog("Open");
-        let entry = GtkEntry::new();
+    fn search_field_focus(&self) {
+        let search = SearchComponents::new(&self.core);
 
-        let completion = GtkEntryCompletion::new();
-        completion.set_model(Some(&list_model_for_open(&self.core)));
-        completion.set_text_column(0);
-        completion.set_popup_completion(true);
-        completion.set_match_func(|this, val, iter| {
-            let iter_val = tree_iter_value!(this.get_model().unwrap(), iter, 0, String);
-            iter_val.contains(&val)
-        });
-        completion.connect_match_selected(
-            clone!(@strong d, @strong entry => move |_, model, iter| {
-                let iter_val = tree_iter_value!(model, iter, 0, String);
-                entry.set_text(&iter_val);
-                d.response(GtkResponseType::Ok);
-                gtk::Inhibit(false)
-            }),
-        );
+        let comp = GtkEntryCompletion::new();
+        comp.set_model(Some(&search.sort_model));
+        comp.set_popup_completion(true);
+        comp.set_inline_selection(true);
+        comp.set_text_column(1);
+        comp.set_match_func(|_, _, _| true);
 
-        entry.set_completion(Some(&completion));
-        entry.connect_activate(clone!(@strong d => move |_| {
-            d.response(GtkResponseType::Ok);
-        }));
-
-        let core = self.core.clone();
         let m = self.messenger.clone();
-        d.connect_response(clone!(@strong entry => move |d, resp| {
-            if let GtkResponseType::Ok = resp {
-                let path = entry.get_buffer().get_text();
-                match core.file_by_path(&path) {
-                    Ok(meta) => m.send(Msg::OpenFile(meta.id)),
-                    Err(err) => println!("{}", err),
-                }
-                d.close();
-            }
-        }));
-        d.get_content_area().add(&entry);
-        d.show_all();
+        comp.connect_match_selected(move |_, model, iter| {
+            let iter_val = tree_iter_value!(model, iter, 1, String);
+            m.send(Msg::SearchFieldExec(Some(iter_val)));
+            gtk::Inhibit(false)
+        });
+
+        self.gui.account.set_search_field_completion(&comp);
+        self.state.borrow_mut().set_search_components(search);
+    }
+
+    fn search_field_update(&self) {
+        if let Some(search) = self.state.borrow().search_ref() {
+            let input = self.gui.account.get_search_field_text();
+            search.update_for(&input);
+        }
+    }
+
+    fn search_field_update_icon(&self) {
+        let input = self.gui.account.get_search_field_text();
+        let icon_name = if input.ends_with(".md") || input.ends_with(".txt") {
+            "text-x-generic-symbolic"
+        } else if input.ends_with('/') {
+            "folder-symbolic"
+        } else {
+            "edit-find-symbolic"
+        };
+        self.gui.account.set_search_field_icon(icon_name, None);
+    }
+
+    fn search_field_blur(&self) {
+        let path = match self.state.borrow().get_opened_file() {
+            Some(meta) => self.core.full_path_for(meta),
+            None => "".to_string(),
+        };
+        self.gui.account.set_search_field_text(&path);
+        self.gui.account.deselect_search_field();
+        self.gui.account.tree().focus();
+    }
+
+    fn search_field_exec(&self, explicit: Option<String>) {
+        let entry_text = self.gui.account.get_search_field_text();
+        let best_match = self.state.borrow().get_first_search_match();
+        let path = explicit.unwrap_or_else(|| best_match.unwrap_or(entry_text));
+
+        match self.core.file_by_path(&path) {
+            Ok(meta) => self.messenger.send(Msg::OpenFile(meta.id)),
+            Err(_) => self.gui.account.set_search_field_icon(
+                "dialog-error-symbolic",
+                Some(&format!("The file '{}' does not exist", path)),
+            ),
+        }
     }
 
     fn show_dialog_preferences(&self) {
@@ -411,7 +433,7 @@ impl LockbookApp {
         d.set_default_size(300, 400);
         d.get_content_area().add(&tabs);
         d.add_button("Ok", GtkResponseType::Ok);
-        d.connect_response(move |d, resp| {
+        d.connect_response(|d, resp| {
             if let GtkResponseType::Ok = resp {
                 d.close();
             }
@@ -431,7 +453,7 @@ impl LockbookApp {
         d.set_authors(&["The Lockbook Team"]);
         d.set_license(Some(LICENSE));
         d.set_comments(Some(COMMENTS));
-        d.connect_response(move |d, resp| {
+        d.connect_response(|d, resp| {
             if let GtkResponseType::DeleteEvent = resp {
                 d.close();
             }
@@ -480,13 +502,116 @@ impl LockbookApp {
     }
 }
 
-struct Model {
+struct SearchComponents {
+    possibs: Vec<String>,
+    list_store: GtkListStore,
+    sort_model: GtkTreeModelSort,
+    matcher: SkimMatcherV2,
+}
+
+impl SearchComponents {
+    fn new(core: &LbCore) -> Self {
+        let root = core.account().unwrap().unwrap().username;
+        let root_len = root.len();
+        let mut possibs = Vec::new();
+        for mut p in core.list_paths().ok().unwrap() {
+            if p.starts_with(&root) {
+                p.replace_range(..root_len, "");
+            }
+            possibs.push(p);
+        }
+
+        let list_store = GtkListStore::new(&[glib::Type::I64, glib::Type::String]);
+        let sort_model = GtkTreeModelSort::new(&list_store);
+        sort_model.set_sort_column_id(GtkSortColumn::Index(0), GtkSortType::Descending);
+        sort_model.set_sort_func(GtkSortColumn::Index(0), Self::compare_possibs);
+
+        Self {
+            possibs,
+            list_store,
+            sort_model,
+            matcher: SkimMatcherV2::default(),
+        }
+    }
+
+    fn compare_possibs(model: &GtkTreeModel, it1: &GtkTreeIter, it2: &GtkTreeIter) -> Ordering {
+        let score1 = tree_iter_value!(model, it1, 0, i64);
+        let score2 = tree_iter_value!(model, it2, 0, i64);
+
+        match score1.cmp(&score2) {
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+            Ordering::Equal => {
+                let text1 = tree_iter_value!(model, it1, 1, String);
+                let text2 = model
+                    .get_value(&it2, 1)
+                    .get::<String>()
+                    .unwrap_or_default()
+                    .unwrap_or_default();
+                if text2 == "" {
+                    return Ordering::Less;
+                }
+
+                let chars1: Vec<char> = text1.chars().collect();
+                let chars2: Vec<char> = text2.chars().collect();
+
+                let n_chars1 = chars1.len();
+                let n_chars2 = chars2.len();
+
+                for i in 0..std::cmp::min(n_chars1, n_chars2) {
+                    let ord = chars1[i].cmp(&chars2[i]);
+                    if ord != Ordering::Equal {
+                        return ord.reverse();
+                    }
+                }
+
+                n_chars1.cmp(&n_chars2)
+            }
+        }
+    }
+
+    fn update_for(&self, pattern: &str) {
+        let list = &self.list_store;
+        list.clear();
+
+        for p in &self.possibs {
+            if let Some(score) = self.matcher.fuzzy_match(&p, &pattern) {
+                let values: [&dyn ToValue; 2] = [&score, &p];
+                list.set(&list.append(), &[0, 1], &values);
+            }
+        }
+    }
+}
+
+struct LbState {
+    search: Option<SearchComponents>,
     opened_file: Option<FileMetadata>,
 }
 
-impl Model {
+impl LbState {
     fn default() -> Self {
-        Self { opened_file: None }
+        Self {
+            search: None,
+            opened_file: None,
+        }
+    }
+
+    fn set_search_components(&mut self, search: SearchComponents) {
+        self.search = Some(search);
+    }
+
+    fn search_ref(&self) -> Option<&SearchComponents> {
+        self.search.as_ref()
+    }
+
+    fn get_first_search_match(&self) -> Option<String> {
+        if let Some(search) = self.search.as_ref() {
+            let model = &search.sort_model;
+            if let Some(iter) = model.get_iter_first() {
+                return Some(tree_iter_value!(model, &iter, 1, String));
+            }
+        }
+        None
     }
 
     fn get_opened_file(&self) -> Option<&FileMetadata> {
@@ -498,6 +623,9 @@ impl Model {
 
     fn set_opened_file(&mut self, f: Option<FileMetadata>) {
         self.opened_file = f;
+        if self.opened_file.is_some() {
+            self.search = None;
+        }
     }
 }
 
@@ -526,8 +654,8 @@ impl Gui {
         // Window.
         let w = GtkAppWindow::new(app);
         w.set_title("Lockbook");
-        w.set_default_size(1300, 700);
         w.add_accel_group(&accels);
+        w.set_default_size(1300, 700);
         if s.window_maximize {
             w.maximize();
         }
@@ -571,6 +699,7 @@ impl Gui {
         self.menubar.for_account_screen();
         self.account.cntr.show_all();
         self.account.fill(&core);
+        self.account.tree().focus();
         self.screens.set_visible_child_name("account");
     }
 
@@ -587,12 +716,14 @@ struct GuiUtil;
 impl GuiUtil {
     fn settings(s: &Rc<RefCell<Settings>>, m: &Messenger) -> GtkNotebook {
         let tabs = GtkNotebook::new();
-        for tab in vec![
+        for tab_data in vec![
             ("File Tree", settings_filetree(&s, &m)),
             ("Window", settings_window(&s)),
         ] {
-            let (name, page) = tab;
-            tabs.append_page(&page, lblopt!(name));
+            let (title, content) = tab_data;
+            let tab_btn = GtkLabel::new(Some(title));
+            let tab_page = content.upcast::<GtkWidget>();
+            tabs.append_page(&tab_page, Some(&tab_btn));
         }
         tabs
     }
@@ -603,8 +734,8 @@ impl GuiUtil {
         lbl.set_max_width_chars(80);
         lbl.set_line_wrap(true);
         lbl.set_line_wrap_mode(pango::WrapMode::Char);
-        lbl.connect_button_release_event(|this, _| {
-            this.select_region(0, -1);
+        lbl.connect_button_release_event(|lbl, _| {
+            lbl.select_region(0, -1);
             gtk::Inhibit(false)
         });
         lbl
@@ -613,7 +744,7 @@ impl GuiUtil {
     fn usage(usage: u64) -> GtkBox {
         let limit = KILOBYTE as f64 * 20.0;
 
-        let pbar = gtk::ProgressBar::new();
+        let pbar = GtkProgressBar::new();
         pbar.set_size_request(300, -1);
         pbar.set_margin_start(16);
         pbar.set_margin_end(16);
@@ -634,50 +765,34 @@ impl GuiUtil {
     }
 }
 
-fn settings_filetree(s: &Rc<RefCell<Settings>>, m: &Messenger) -> GtkWidget {
+fn settings_filetree(s: &Rc<RefCell<Settings>>, m: &Messenger) -> GtkBox {
     let s = s.borrow();
     let chbxs = GtkBox::new(Vertical, 0);
 
     for col in FileTreeCol::removable() {
+        let m = m.clone();
+
         let ch = GtkCheckBox::with_label(&col.name());
         ch.set_active(!s.hidden_tree_cols.contains(&col.name()));
-        ch.connect_toggled(clone!(@strong m => move |_| {
-            m.send(Msg::ToggleTreeCol(col));
-        }));
+        ch.connect_toggled(move |_| m.send(Msg::ToggleTreeCol(col)));
         chbxs.add(&ch);
     }
 
-    widgetize!(chbxs)
+    chbxs
 }
 
-fn settings_window(s: &Rc<RefCell<Settings>>) -> GtkWidget {
+fn settings_window(s: &Rc<RefCell<Settings>>) -> GtkBox {
     let s = s.clone();
 
     let ch = GtkCheckBox::with_label("Maximize on startup");
     ch.set_active(s.borrow().window_maximize);
-    ch.connect_toggled(move |this| {
-        s.borrow_mut().window_maximize = this.get_active();
+    ch.connect_toggled(move |chbox| {
+        s.borrow_mut().window_maximize = chbox.get_active();
     });
 
     let chbxs = GtkBox::new(Vertical, 0);
     chbxs.add(&ch);
-    widgetize!(chbxs)
-}
-
-fn list_model_for_open(b: &LbCore) -> GtkListStore {
-    let paths = b.list_paths().ok().unwrap();
-
-    let store = GtkListStore::new(&[glib::Type::String]);
-    for mut p in paths {
-        let uname = b.account().unwrap().unwrap().username;
-        if p.contains(&uname) {
-            p.replace_range(..uname.len(), "");
-        }
-
-        let values: [&dyn ToValue; 1] = [&p];
-        store.set(&store.append(), &[0], &values);
-    }
-    store
+    chbxs
 }
 
 const STYLE: &str = "

--- a/clients/linux/src/gui.rs
+++ b/clients/linux/src/gui.rs
@@ -119,7 +119,7 @@ impl LockbookApp {
                 Msg::ToggleTreeCol(col) => lb.toggle_tree_col(col),
 
                 Msg::SearchFieldFocus => lb.search_field_focus(),
-                Msg::SearchFieldBlur => lb.search_field_blur(),
+                Msg::SearchFieldBlur(escaped) => lb.search_field_blur(escaped),
                 Msg::SearchFieldUpdate => lb.search_field_update(),
                 Msg::SearchFieldUpdateIcon => lb.search_field_update_icon(),
                 Msg::SearchFieldExec(vopt) => lb.search_field_exec(vopt),
@@ -506,17 +506,22 @@ impl LockbookApp {
         self.gui.account.set_search_field_icon(icon_name, None);
     }
 
-    fn search_field_blur(&self) {
-        let txt = match self.state.borrow().get_opened_file() {
-            Some(meta) => {
-                self.gui.account.focus_editor();
-                self.core.full_path_for(meta)
+    fn search_field_blur(&self, escaped: bool) {
+        let state = self.state.borrow();
+        let opened_file = state.get_opened_file();
+
+        if escaped {
+            match opened_file {
+                Some(_) => self.gui.account.focus_editor(),
+                None => self.gui.account.tree().focus(),
             }
-            None => {
-                self.gui.account.tree().focus();
-                "".to_string()
-            }
+        }
+
+        let txt = match opened_file {
+            Some(meta) => self.core.full_path_for(meta),
+            None => "".to_string(),
         };
+
         self.gui.account.deselect_search_field();
         self.gui.account.set_search_field_text(&txt);
     }

--- a/clients/linux/src/intro.rs
+++ b/clients/linux/src/intro.rs
@@ -1,4 +1,3 @@
-use glib::clone;
 use gtk::prelude::*;
 use gtk::Orientation::{Horizontal, Vertical};
 use gtk::{
@@ -109,12 +108,13 @@ struct IntroInput {
 
 impl IntroInput {
     fn new(m: &Messenger, msg: fn(String) -> Msg, desc: &str) -> Self {
+        let m = m.clone();
         let entry = GtkEntry::new();
         entry.set_placeholder_text(Some(desc));
-        entry.connect_activate(clone!(@strong m => move |this| {
-            let value = this.get_buffer().get_text();
+        entry.connect_activate(move |entry| {
+            let value = entry.get_buffer().get_text();
             m.send(msg(value));
-        }));
+        });
 
         let error = GtkLabel::new(None);
         error.set_margin_top(16);

--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -5,6 +5,7 @@ extern crate glib;
 extern crate gtk;
 extern crate pango;
 extern crate qrcode_generator;
+extern crate sourceview;
 
 mod account;
 mod backend;

--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -4,6 +4,7 @@ extern crate gio;
 extern crate glib;
 extern crate gtk;
 extern crate pango;
+extern crate qrcode_generator;
 
 mod account;
 mod backend;

--- a/clients/linux/src/menubar.rs
+++ b/clients/linux/src/menubar.rs
@@ -94,6 +94,7 @@ impl Menubar {
                 );
             }
             EditMode::PlainText {
+                path: _,
                 meta: _,
                 content: _,
             } => {
@@ -192,7 +193,7 @@ impl Item {
     fn data() -> Vec<(Self, ItemData)> {
         vec![
             (Self::FileNew, ("New", "<Primary>N", || Msg::ShowDialogNew)),
-            (Self::FileOpen, ("Open", "<Primary>O", || Msg::ShowDialogOpen)),
+            (Self::FileOpen, ("Open", "<Primary>L", || Msg::SearchFieldFocus)),
             (Self::FileSave, ("Save", "<Primary>S", || Msg::SaveFile)),
             (Self::FileClose, ("Close File", "<Primary>W", || Msg::CloseFile)),
             (Self::FileQuit, ("Quit", "", || Msg::Quit)),

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 use crate::filetree::FileTreeCol;
 
 pub type MsgReceiver = glib::Receiver<Msg>;
+pub type MsgFn = fn() -> Msg;
 
 pub enum Msg {
     CreateAccount(String),
@@ -15,7 +16,7 @@ pub enum Msg {
     OpenFile(Uuid),
     SaveFile,
     CloseFile,
-    DeleteFile(Uuid),
+    DeleteFiles,
 
     SearchFieldFocus,
     SearchFieldBlur,

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -17,10 +17,15 @@ pub enum Msg {
     CloseFile,
     DeleteFile(Uuid),
 
+    SearchFieldFocus,
+    SearchFieldBlur,
+    SearchFieldUpdate,
+    SearchFieldUpdateIcon,
+    SearchFieldExec(Option<String>),
+
     ToggleTreeCol(FileTreeCol),
 
     ShowDialogNew,
-    ShowDialogOpen,
     ShowDialogPreferences,
     ShowDialogUsage,
     ShowDialogAbout,

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -19,7 +19,7 @@ pub enum Msg {
     DeleteFiles,
 
     SearchFieldFocus,
-    SearchFieldBlur,
+    SearchFieldBlur(bool),
     SearchFieldUpdate,
     SearchFieldUpdateIcon,
     SearchFieldExec(Option<String>),

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -13,7 +13,7 @@ pub enum Msg {
     Quit,
 
     NewFile(String),
-    OpenFile(Uuid),
+    OpenFile(Option<Uuid>),
     SaveFile,
     CloseFile,
     DeleteFiles,

--- a/containers/Dockerfile.linux
+++ b/containers/Dockerfile.linux
@@ -1,7 +1,7 @@
 FROM ubuntu:20.10
 
 RUN apt update -y
-RUN apt-get install -y build-essential curl libgtk-3-dev
+RUN apt-get install -y build-essential curl libgtk-3-dev gtksourceview-3.0
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 RUN apt update -y
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
This PR primarily concerns the redesign of the Account screen header and the enhancements made to Open (aka. "search") by using fuzzy finding as well as a better Export Account and Delete Files UX. Some notes:
* The Account screen before, at the topmost level, was broken into two parts: the Sidebar and Editor. It is now broken into three parts: the Header, Sidebar, and Editor.
  * The Header contains a text field, which can be focused via the `Ctrl-L` shortcut.
  * The text field completion uses fuzzy finding. The results are sorted in descending order of fuzzy scoring (higher score means closer match).
  * The Open dialog code is therefore gone now.
* The Export Account dialog is redesigned:
  * A QR code is generated now. It takes enough time to do so that a loader is necessary, so it is shown while the QR is being made. The image is shown when done, which might be a security flaw (maybe in the future, we want to have a button so the user explicitly chooses to show it?).
  * The label that displayed the account private key is replaced with a button that will copy the private key to the clipboard.
* The Delete UX was just a confirmation dialog with a simple message for deleting a single file. Now, a user can delete multiple files at once, and the dialog (regardless of how many files) will show a table of each file that is about to be deleted along with how many children it has if it is a directory.
<br>

On top of the primary changes detailed above, there were also the following smaller / unrelated changes:
* misc refactors / clean ups:
  * removed the `widgetize!` and `lblopt!` macros from `gui.rs` as the code they contained is currently, and for the foreseeable future, only used in one spot.
  * dropped the last unnecessary uses of the `glib::clone!` macro.
  * cleaned up the code for the "New" dialog and started using `activates_default` functionality.
  * fixed struct field visibility for the SyncPanel and FileTree: there were random `pub` fields that now are accessed with a `pub` getter method.
* minor UI:
  * use a GTK SourceView for the Editor's textarea input instead of a plain GTK TextView. The SourceView comes with essential features such as undo and redo, as well as nice features such as opening/closing bracket highlighting.
  * disable TreeView search: this was annoying since the FileTree is the default focused widget, so any typing would trigger the default search. It is also unnecessary as we now have the search header.
  * add a right click menu for tree items! (just one item, "Delete", for now). the items are always in the menu, but are enabled / disabled based on their necessary conditions (ex: Open requires exactly 1 item to be selected, Delete requires _at least_ one item to be selected).
  * double clicking a folder no longer opens its info (that was too clumsy). opening the info is still available via the Right Click -> Open menu item.
<br>

Closes #379.
Closes #393.
Closes #394.
Closes #396.
Closes #397.