### PR TITLE
linux: Refactor sync error handling and improve sync ui. 

### DIFF
--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -243,37 +243,14 @@ impl Sidebar {
 }
 
 pub struct SyncPanel {
-    errlbl: GtkLabel,
     status: GtkLabel,
     button: GtkBtn,
     spinner: GtkSpinner,
-    center: GtkBox,
     cntr: GtkBox,
 }
 
 impl SyncPanel {
     fn new(m: &Messenger) -> Self {
-        let errlbl = GtkLabel::new(None);
-        errlbl.set_halign(GtkAlign::Start);
-
-        let (status, button, spinner, center) = Self::center(&m);
-
-        let cntr = GtkBox::new(Vertical, 0);
-        cntr.set_center_widget(Some(&center));
-        cntr.set_margin_start(8);
-        cntr.set_margin_end(8);
-
-        Self {
-            errlbl,
-            status,
-            button,
-            spinner,
-            center,
-            cntr,
-        }
-    }
-
-    fn center(m: &Messenger) -> (GtkLabel, GtkBtn, GtkSpinner, GtkBox) {
         let status = GtkLabel::new(None);
         status.set_halign(GtkAlign::Start);
 
@@ -286,25 +263,29 @@ impl SyncPanel {
         spinner.set_margin_bottom(4);
         spinner.set_size_request(20, 20);
 
-        let center = GtkBox::new(Horizontal, 0);
-        center.set_margin_top(8);
-        center.set_margin_bottom(8);
-        center.pack_start(&status, false, false, 0);
-        center.pack_end(&button, false, false, 0);
+        let cntr = GtkBox::new(Horizontal, 0);
+        util::gui::set_margin(&cntr, 8);
+        cntr.pack_start(&status, false, false, 0);
+        cntr.pack_end(&button, false, false, 0);
 
-        (status, button, spinner, center)
+        Self {
+            status,
+            button,
+            spinner,
+            cntr,
+        }
     }
 
     pub fn set_syncing(&self, is_syncing: bool) {
         if is_syncing {
-            self.center.remove(&self.button);
-            self.center.pack_end(&self.spinner, false, false, 0);
+            self.cntr.remove(&self.button);
+            self.cntr.pack_end(&self.spinner, false, false, 0);
             self.spinner.show();
             self.spinner.start();
         } else {
+            self.cntr.remove(&self.spinner);
+            self.cntr.pack_end(&self.button, false, false, 0);
             self.spinner.stop();
-            self.center.remove(&self.spinner);
-            self.center.pack_end(&self.button, false, false, 0);
             self.status.set_text("");
         }
     }
@@ -323,7 +304,7 @@ impl SyncPanel {
                         };
                         self.status.set_markup(&txt);
                     }
-                    Err(err) => println!("{:?}", err),
+                    Err(err) => println!("{}", err.msg()),
                 },
             },
             Err(err) => panic!(err),
@@ -332,11 +313,6 @@ impl SyncPanel {
 
     pub fn doing(&self, work: &str) {
         self.status.set_text(work);
-    }
-
-    pub fn error(&self, txt: &str) {
-        self.cntr.pack_start(&self.errlbl, false, false, 0);
-        self.errlbl.set_text(txt);
     }
 }
 

--- a/clients/linux/src/intro.rs
+++ b/clients/linux/src/intro.rs
@@ -87,8 +87,9 @@ impl IntroScreen {
         self.doing.start(caption);
     }
 
-    pub fn doing_status(&self, txt: &str) {
-        self.doing.status.set_text(txt);
+    pub fn doing_status(&self, path: &str, i: usize, total: usize) {
+        let status = format!("Syncing :: {} ({}/{})", path, i, total);
+        self.doing.status.set_text(&status);
     }
 
     pub fn error_create(&self, msg: &str) {


### PR DESCRIPTION
Aside from the error handling pattern:
* The sync progress prefix is not customizable since it's not hardcoded in LbCore::sync
* Sync errors from lockbook_core are not specific to each work unit (could not reach server and client needs update). Therefore, those aren't tracked anymore. Sync just returns on one of those errors. If this changes in the future, and there are errors specific to a work unit that shouldn't halt the whole sync process, it's an easy adjustment.
* The work units (as well as the total) are sent down the channel as well with Work (so the specific instances can saying "syncing x (i / total)." This is also necessary for a progress bar (a future possibility).