### PR TITLE
core: Refactor to return Account when creating or importing one. 

### DIFF
--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -70,7 +70,7 @@ impl LbCore {
         }
     }
 
-    pub fn create_account(&self, uname: &str) -> LbResult<()> {
+    pub fn create_account(&self, uname: &str) -> LbResult<Account> {
         create_account(&self.config, &uname, &api_url())
             .map_err(|err| errs::create_account::to_lb_error(err, uname))
     }


### PR DESCRIPTION
This also now makes the switch to using `map_err` for the `create_account` and `import_account` functions.