### PR TITLE
linux: Refactor init code for connecting to core and store the user Account.

### DIFF
--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -41,10 +41,10 @@ use crate::settings::Settings;
 fn main() {
     let data_dir = get_data_dir();
 
-    let core = Arc::new(LbCore::new(&data_dir));
-    if let Err(err) = core.init_db() {
-        launch_err("initializing db", &err);
-    }
+    let core = match LbCore::new(&data_dir) {
+        Ok(c) => Arc::new(c),
+        Err(err) => launch_err("initializing db", &err.msg()),
+    };
 
     let settings = match Settings::from_data_dir(&data_dir) {
         Ok(s) => Rc::new(RefCell::new(s)),


### PR DESCRIPTION
* This moves the db migration check and task into the initialization of a `LbCore` handle.
* Additionally, the user's `Account` is now stored within the `LbCore` handle instead of being read each time it is needed. This is now done in the initialization, as well as when an Account is created or imported.