### PR TITLE
infra: fix cacheing problems for kotlin and csharp prep images

### DIFF
--- a/containers/Dockerfile.csharp_interface_tests
+++ b/containers/Dockerfile.csharp_interface_tests
@@ -1,5 +1,8 @@
 ARG HASH
-FROM core:${HASH} AS csharp-interface-tests
+
+FROM core:$HASH as core-build
+
+FROM ubuntu:20.04 AS csharp-interface-tests
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install essentials
@@ -21,14 +24,14 @@ RUN apt-get install -y apt-transport-https
 RUN apt-get update
 RUN apt-get install -y dotnet-sdk-3.1
 
-WORKDIR /
-
 # Copy code
 COPY clients/windows clients/windows
 RUN mkdir -p /clients/windows/core/
-RUN cp /core/target/release/liblockbook_core.so  /clients/windows/core
+
+WORKDIR /clients/windows/test 
+ENV API_URL=http://lockbook_server:8000
+
+COPY --from=core-build /core/target/release/liblockbook_core.so /clients/windows/core
 
 # Build tests
-ENV API_URL=http://lockbook_server:8000
-WORKDIR /clients/windows/test 
 RUN dotnet build

--- a/containers/Dockerfile.kotlin_interface_tests
+++ b/containers/Dockerfile.kotlin_interface_tests
@@ -1,31 +1,28 @@
 ARG HASH
-FROM core:${HASH}  AS kotlin-interface-tests
+
+FROM core:$HASH as core-build
+
+FROM ubuntu:20.04 AS kotlin-interface-tests
 
 ENV ANDROID_HOME /opt/android-sdk-linux
-RUN apt-get update && apt-get -y install software-properties-common
-RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' && apt-get update
-RUN apt-get -y install openjdk-8-jdk
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y build-essential openjdk-8-jdk wget curl unzip
 
 # Install android things
-RUN wget -q https://dl.google.com/android/repository/android-ndk-r21c-linux-x86_64.zip -O android-ndk-r21c-linux-x86_64.zip
-RUN unzip -q android-ndk-r21c-linux-x86_64.zip
-ENV ANDROID_NDK_HOME=/android-ndk-r21c
 RUN cd /opt \
     && wget -q https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O android-sdk-tools.zip \
     && unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}
 ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 RUN yes | sdkmanager --licenses
 
-WORKDIR /
-
 # Copy android in
-COPY clients/android clients/android
+COPY clients/android /clients/android
 ENV API_URL=http://lockbook_server:8000
 
 # Move binaries for tests
 RUN mkdir -p /clients/android/core/src/main/jniLibs/desktop
-RUN mv /core/target/release/liblockbook_core.so /clients/android/core/src/main/jniLibs/desktop/liblockbook_core.so
+WORKDIR /clients/android
+COPY --from=core-build /core/target/release/liblockbook_core.so /clients/android/core/src/main/jniLibs/desktop/liblockbook_core.so
 
 # Build android
-WORKDIR /clients/android
 RUN ./gradlew assemble


### PR DESCRIPTION
When originally running the csharp and kotlin test prep images, they would take minutes to finish building. This was due to the starting image, core. Core would cause both of these to recompile, though the reason is not directly known why. In this pull request, rather than the starting image being core, it is now ubuntu for both and core is only used on one of the last steps to pull the binary from.

<img width="960" alt="Screen Shot 2020-12-25 at 3 01 52 PM" src="https://user-images.githubusercontent.com/20663038/103141426-239ca400-46c2-11eb-8098-16af43c31895.png">

fixes #465