### PR TITLE
android: UI refinements

### DIFF
--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -25,21 +25,18 @@
         <activity
             android:name=".screen.InitialLaunchFigureOuter"
             android:noHistory="true"
-            android:theme="@style/Main.NoActionBar">
+            android:theme="@style/Main">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity
-            android:name=".screen.WelcomeActivity"
-            android:theme="@style/Main.NoActionBar" />
+            android:name=".screen.WelcomeActivity" />
         <activity
-            android:name=".screen.NewAccountActivity"
-            android:theme="@style/Main.NoActionBar" />
+            android:name=".screen.NewAccountActivity" />
         <activity
-            android:name=".screen.ImportAccountActivity"
-            android:theme="@style/Main.NoActionBar" />
+            android:name=".screen.ImportAccountActivity" />
         <activity
             android:name=".screen.HandwritingEditorActivity"
             android:theme="@style/Main.FullScreen" />

--- a/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
@@ -15,7 +15,6 @@ import com.github.michaelbull.result.Ok
 import timber.log.Timber
 
 class FileModel(path: String) {
-    private val _setToolbarTitle = MutableLiveData<String>()
     private val _files = MutableLiveData<List<FileMetadata>>()
     private val _updateBreadcrumbBar = SingleMutableLiveData<List<BreadCrumb>>()
     private val _errorHasOccurred = SingleMutableLiveData<String>()
@@ -24,9 +23,6 @@ class FileModel(path: String) {
     lateinit var lastDocumentAccessed: FileMetadata
     private val filePath: MutableList<FileMetadata> = mutableListOf()
     val config = Config(path)
-
-    val setToolbarTitle: LiveData<String>
-        get() = _setToolbarTitle
 
     val files: LiveData<List<FileMetadata>>
         get() = _files
@@ -96,7 +92,6 @@ class FileModel(path: String) {
                 parentFileMetadata = getRootResult.value
                 filePath.add(getRootResult.value)
                 updateBreadCrumbWithLatest()
-                _setToolbarTitle.postValue("${getRootResult.value.name}'s Lockbook")
                 refreshFiles()
             }
             is Err -> when (val error = getRootResult.error) {

--- a/clients/android/app/src/main/java/app/lockbook/model/GridRecyclerViewAdapter.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/GridRecyclerViewAdapter.kt
@@ -37,7 +37,7 @@ class GridRecyclerViewAdapter(listFilesClickInterface: ListFilesClickInterface) 
     override fun onBindViewHolder(holder: FileViewHolder, position: Int) {
         val item = files[position]
         holder.fileMetadata = item
-        holder.cardView.grid_file_name.text = item.name.removeSuffix(".draw")
+        holder.cardView.grid_file_name.text = item.name
 
         when {
             selectedFiles[position] -> {

--- a/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
@@ -41,7 +41,7 @@ class LinearRecyclerViewAdapter(listFilesClickInterface: ListFilesClickInterface
 
         val date = Date(Timestamp(item.metadataVersion).time)
         holder.fileMetadata = item
-        holder.cardView.linear_file_name.text = item.name.removeSuffix(".draw")
+        holder.cardView.linear_file_name.text = item.name
         holder.cardView.linear_file_description.text = holder.cardView.resources.getString(
             R.string.last_synced,
             if (item.metadataVersion != 0L) date else holder.cardView.resources.getString(R.string.never_synced)

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -66,9 +66,6 @@ class ListFilesViewModel(path: String, application: Application) :
     private val _errorHasOccurred = SingleMutableLiveData<String>()
     private val _unexpectedErrorHasOccurred = SingleMutableLiveData<String>()
 
-    val setToolbarTitle: LiveData<String>
-        get() = fileModel.setToolbarTitle
-
     val files: LiveData<List<FileMetadata>>
         get() = fileModel.files
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/HandwritingEditorActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/HandwritingEditorActivity.kt
@@ -386,7 +386,7 @@ class HandwritingEditorActivity : AppCompatActivity() {
     }
 
     private fun unexpectedErrorHasOccurred(error: String) {
-        AlertDialog.Builder(this, R.style.Main_Dialog)
+        AlertDialog.Builder(this, R.style.Main_Widget_Dialog)
             .setTitle(UNEXPECTED_ERROR)
             .setMessage(error)
             .setOnCancelListener {

--- a/clients/android/app/src/main/java/app/lockbook/screen/ImportAccountActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ImportAccountActivity.kt
@@ -112,7 +112,7 @@ class ImportAccountActivity : AppCompatActivity() {
                             Snackbar.LENGTH_SHORT
                         ).show()
                         is ImportError.Unexpected -> {
-                            AlertDialog.Builder(this@ImportAccountActivity, R.style.Main_Dialog)
+                            AlertDialog.Builder(this@ImportAccountActivity, R.style.Main_Widget_Dialog)
                                 .setTitle(UNEXPECTED_ERROR)
                                 .setMessage(error.error)
                                 .show()

--- a/clients/android/app/src/main/java/app/lockbook/screen/InitialLaunchFigureOuter.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/InitialLaunchFigureOuter.kt
@@ -72,7 +72,7 @@ class InitialLaunchFigureOuter : AppCompatActivity() {
             }
             is Err -> when (val error = getDBStateResult.error) {
                 is GetStateError.Unexpected -> {
-                    AlertDialog.Builder(this, R.style.Main_Dialog)
+                    AlertDialog.Builder(this, R.style.Main_Widget_Dialog)
                         .setTitle(UNEXPECTED_ERROR)
                         .setMessage(error.error)
                         .show()
@@ -129,7 +129,7 @@ class InitialLaunchFigureOuter : AppCompatActivity() {
                                 migrate_progress_bar.visibility = View.GONE
                                 AlertDialog.Builder(
                                     this@InitialLaunchFigureOuter,
-                                    R.style.Main_Dialog
+                                    R.style.Main_Widget_Dialog
                                 )
                                     .setTitle(UNEXPECTED_ERROR)
                                     .setMessage(error.error)

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
@@ -143,10 +143,6 @@ class ListFilesActivity : AppCompatActivity() {
         }.exhaustive
     }
 
-    fun setToolbarTitle(title: String) {
-        list_files_toolbar.title = title
-    }
-
     fun switchMenu() {
         val fragment = getFragment().component1()
         if (fragment is ListFilesFragment) {

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -82,13 +82,6 @@ class ListFilesFragment : Fragment() {
             listFilesViewModel.onSwipeToRefresh()
         }
 
-        listFilesViewModel.setToolbarTitle.observe(
-            viewLifecycleOwner,
-            { toolbarTitle ->
-                setToolbarTitle(toolbarTitle)
-            }
-        )
-
         listFilesViewModel.files.observe(
             viewLifecycleOwner,
             { files ->
@@ -451,14 +444,6 @@ class ListFilesFragment : Fragment() {
         }
     }
 
-    private fun setToolbarTitle(title: String) {
-        if (activity is ListFilesActivity) {
-            (activity as ListFilesActivity).setToolbarTitle(title)
-        } else {
-            errorHasOccurred(fragment_list_files, UNEXPECTED_CLIENT_ERROR)
-        }
-    }
-
     private fun navigateToHandwritingEditor(editableFile: EditableFile) {
         val intent = Intent(context, HandwritingEditorActivity::class.java)
         intent.putExtra("name", editableFile.name)
@@ -471,7 +456,7 @@ class ListFilesFragment : Fragment() {
     }
 
     private fun unexpectedErrorHasOccurred(error: String) {
-        AlertDialog.Builder(requireContext(), R.style.Main_Dialog)
+        AlertDialog.Builder(requireContext(), R.style.Main_Widget_Dialog)
             .setTitle(UNEXPECTED_ERROR)
             .setMessage(error)
             .show()

--- a/clients/android/app/src/main/java/app/lockbook/screen/NewAccountActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/NewAccountActivity.kt
@@ -90,7 +90,7 @@ class NewAccountActivity : AppCompatActivity() {
                             Snackbar.LENGTH_SHORT
                         ).show()
                         is CreateAccountError.Unexpected -> {
-                            AlertDialog.Builder(this@NewAccountActivity, R.style.Main_Dialog)
+                            AlertDialog.Builder(this@NewAccountActivity, R.style.Main_Widget_Dialog)
                                 .setTitle(UNEXPECTED_ERROR)
                                 .setMessage(error.error)
                                 .show()

--- a/clients/android/app/src/main/java/app/lockbook/screen/SettingsActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/SettingsActivity.kt
@@ -8,7 +8,6 @@ class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
-        title = "Settings"
 
         supportFragmentManager
             .beginTransaction()

--- a/clients/android/app/src/main/java/app/lockbook/screen/SettingsFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/SettingsFragment.kt
@@ -112,7 +112,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                         "Update required."
                 }
                 is GetUsageError.Unexpected -> {
-                    AlertDialog.Builder(requireContext(), R.style.Main_Dialog)
+                    AlertDialog.Builder(requireContext(), R.style.Main_Widget_Dialog)
                         .setTitle(UNEXPECTED_ERROR)
                         .setMessage(error.error)
                         .show()
@@ -275,7 +275,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                         Snackbar.LENGTH_SHORT
                     ).show()
                     is AccountExportError.Unexpected -> {
-                        AlertDialog.Builder(requireContext(), R.style.Main_Dialog)
+                        AlertDialog.Builder(requireContext(), R.style.Main_Widget_Dialog)
                             .setTitle(UNEXPECTED_ERROR)
                             .setMessage(error.error)
                             .show()
@@ -306,7 +306,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     Snackbar.LENGTH_SHORT
                 ).show()
                 is AccountExportError.Unexpected -> {
-                    AlertDialog.Builder(requireContext(), R.style.Main_Dialog)
+                    AlertDialog.Builder(requireContext(), R.style.Main_Widget_Dialog)
                         .setTitle(UNEXPECTED_ERROR)
                         .setMessage(error.error)
                         .show()

--- a/clients/android/app/src/main/java/app/lockbook/screen/TextEditorActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/TextEditorActivity.kt
@@ -108,7 +108,7 @@ class TextEditorActivity : AppCompatActivity() {
     }
 
     private fun unexpectedErrorHasOccurred(error: String) {
-        AlertDialog.Builder(this, R.style.Main_Dialog)
+        AlertDialog.Builder(this, R.style.Main_Widget_Dialog)
             .setTitle(UNEXPECTED_ERROR)
             .setMessage(error)
             .setOnCancelListener {

--- a/clients/android/app/src/main/java/app/lockbook/ui/CreateFileDialogFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/CreateFileDialogFragment.kt
@@ -113,60 +113,46 @@ class CreateFileDialogFragment : DialogFragment() {
                 create_file_title.setText(R.string.create_file_title_folder)
                 create_file_text.setHint(R.string.create_file_hint_folder)
             }
-            Klaxon().toJsonString(FileType.Document) ->
-                if (isDrawing) {
-                    create_file_extension.visibility = View.GONE
-                    create_file_text_part.visibility = View.GONE
-                    create_file_text.visibility = View.VISIBLE
-
-                    create_file_text.setOnEditorActionListener { _, actionId, _ ->
-                        if (actionId == EditorInfo.IME_ACTION_DONE) {
-                            handleCreateFileRequest(create_file_text.text.toString() + ".draw")
+            Klaxon().toJsonString(FileType.Document) -> {
+                create_file_text_part.setOnEditorActionListener { _, actionId, _ ->
+                    if (actionId == EditorInfo.IME_ACTION_NEXT) {
+                        create_file_extension.requestFocus()
+                        val extension = create_file_extension.text.toString()
+                        if (extension.isEmpty()) {
+                            create_file_extension.setText(".")
+                            create_file_extension.setSelection(1)
+                        } else {
+                            create_file_extension.setSelection(extension.length)
                         }
-
-                        true
                     }
 
-                    create_file_create.setOnClickListener {
-                        handleCreateFileRequest(create_file_text.text.toString())
-                    }
+                    true
+                }
 
-                    create_file_create.setOnClickListener {
-                        handleCreateFileRequest(create_file_text.text.toString() + ".draw")
-                    }
-
-                    create_file_text.setHint(R.string.create_file_hint_drawing)
-                    create_file_title.setText(R.string.create_file_title_drawing)
-                } else {
-                    create_file_text_part.setOnEditorActionListener { _, actionId, _ ->
-                        if (actionId == EditorInfo.IME_ACTION_NEXT) {
-                            create_file_extension.requestFocus()
-                            val extension = create_file_extension.text.toString()
-                            if (extension.isEmpty()) {
-                                create_file_extension.setText(".")
-                                create_file_extension.setSelection(1)
-                            } else {
-                                create_file_extension.setSelection(extension.length)
-                            }
-                        }
-
-                        true
-                    }
-
-                    create_file_extension.setOnEditorActionListener { _, actionId, _ ->
-                        if (actionId == EditorInfo.IME_ACTION_DONE) {
-                            handleCreateFileRequest(create_file_text_part.text.toString() + create_file_extension.text.toString())
-                        }
-
-                        true
-                    }
-
-                    create_file_create.setOnClickListener {
+                create_file_extension.setOnEditorActionListener { _, actionId, _ ->
+                    if (actionId == EditorInfo.IME_ACTION_DONE) {
                         handleCreateFileRequest(create_file_text_part.text.toString() + create_file_extension.text.toString())
                     }
 
-                    create_file_title.setText(R.string.create_file_title_document)
+                    true
                 }
+
+                create_file_create.setOnClickListener {
+                    handleCreateFileRequest(create_file_text_part.text.toString() + create_file_extension.text.toString())
+                }
+
+                if (isDrawing) {
+                    create_file_title.setText(R.string.create_file_title_drawing)
+                    create_file_text_part.setHint(R.string.create_file_hint_drawing)
+                    create_file_extension.setHint(R.string.create_file_hint_drawing_extension)
+                    create_file_extension.setText(R.string.create_file_dialog_drawing_extension)
+                } else {
+                    create_file_title.setText(R.string.create_file_title_document)
+                    create_file_text_part.setHint(R.string.create_file_hint_document)
+                    create_file_extension.setHint(R.string.create_file_hint_document_extension)
+                    create_file_extension.setText(R.string.create_file_dialog_document_extension)
+                }
+            }
             else -> {
                 Snackbar.make(create_file_layout, Messages.UNEXPECTED_CLIENT_ERROR, Snackbar.LENGTH_SHORT)
                     .addCallback(object : Snackbar.Callback() {
@@ -244,7 +230,7 @@ class CreateFileDialogFragment : DialogFragment() {
 
     private suspend fun unexpectedErrorHasOccurred(error: String) {
         withContext(Dispatchers.Main) {
-            AlertDialog.Builder(requireContext(), R.style.Main_Dialog)
+            AlertDialog.Builder(requireContext(), R.style.Main_Widget_Dialog)
                 .setTitle(Messages.UNEXPECTED_ERROR)
                 .setMessage(error)
                 .setOnCancelListener {

--- a/clients/android/app/src/main/java/app/lockbook/ui/MoveFileDialogFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/MoveFileDialogFragment.kt
@@ -132,7 +132,7 @@ class MoveFileDialogFragment : DialogFragment() {
     }
 
     private fun unexpectedErrorHasOccurred(error: String) {
-        AlertDialog.Builder(requireContext(), R.style.Main_Dialog)
+        AlertDialog.Builder(requireContext(), R.style.Main_Widget_Dialog)
             .setTitle(Messages.UNEXPECTED_ERROR)
             .setMessage(error)
             .setOnCancelListener {

--- a/clients/android/app/src/main/java/app/lockbook/ui/RenameFileDialogFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/RenameFileDialogFragment.kt
@@ -150,7 +150,7 @@ class RenameFileDialogFragment : DialogFragment() {
 
     private suspend fun unexpectedErrorHasOccurred(error: String) {
         withContext(Dispatchers.Main) {
-            AlertDialog.Builder(requireContext(), R.style.Main_Dialog)
+            AlertDialog.Builder(requireContext(), R.style.Main_Widget_Dialog)
                 .setTitle(Messages.UNEXPECTED_ERROR)
                 .setMessage(error)
                 .setOnCancelListener {

--- a/clients/android/app/src/main/res/layout/activity_handwriting_editor.xml
+++ b/clients/android/app/src/main/res/layout/activity_handwriting_editor.xml
@@ -54,44 +54,44 @@
 
                 <ImageButton
                     android:id="@+id/drawing_erase"
-                    style="@style/Main.DrawingImageButton"
+                    style="@style/Main.Widget.DrawingImageButton"
                     android:src="@drawable/ic_eraser_outline"
                     android:contentDescription="@string/handwriting_editor_eraser_description" />
 
                 <ImageButton
                     android:id="@+id/drawing_pen"
-                    style="@style/Main.DrawingImageButton"
+                    style="@style/Main.Widget.DrawingImageButton"
                     android:src="@drawable/ic_pencil_outline"
                     android:contentDescription="@string/handwriting_editor_pen_description" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/drawing_color_white"
-                    style="@style/Main.DrawingButton"
+                    style="@style/Main.Widget.DrawingButton"
                     app:backgroundTint="@android:color/white" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/drawing_color_blue"
-                    style="@style/Main.DrawingButton"
+                    style="@style/Main.Widget.DrawingButton"
                     app:backgroundTint="@android:color/holo_blue_light" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/drawing_color_red"
-                    style="@style/Main.DrawingButton"
+                    style="@style/Main.Widget.DrawingButton"
                     app:backgroundTint="@android:color/holo_red_light" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/drawing_color_green"
-                    style="@style/Main.DrawingButton"
+                    style="@style/Main.Widget.DrawingButton"
                     app:backgroundTint="@android:color/holo_green_light" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/drawing_color_orange"
-                    style="@style/Main.DrawingButton"
+                    style="@style/Main.Widget.DrawingButton"
                     app:backgroundTint="@android:color/holo_orange_light" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/drawing_color_purple"
-                    style="@style/Main.DrawingButton"
+                    style="@style/Main.Widget.DrawingButton"
                     app:backgroundTint="@android:color/holo_purple" />
 
                 <TextView

--- a/clients/android/app/src/main/res/layout/activity_handwriting_editor.xml
+++ b/clients/android/app/src/main/res/layout/activity_handwriting_editor.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/handwriting_editor_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/handwriting_editor_layout"
+    <ProgressBar
+        android:id="@+id/handwriting_editor_progress_bar"
+        style="?android:attr/progressBarStyleHorizontal"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:orientation="vertical"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:minHeight="20dp"
+        android:visibility="gone"
+        android:background="@color/black"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <app.lockbook.ui.HandwritingEditorView
+        android:id="@+id/handwriting_editor"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@+id/handwriting_editor_progress_bar" />
 
-        <ProgressBar
-            android:id="@+id/handwriting_editor_progress_bar"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="-4dp"
-            android:layout_marginBottom="-8dp"
-            android:indeterminate="true"
-            android:minHeight="20dp"
-            android:visibility="gone" />
-
-        <app.lockbook.ui.HandwritingEditorView
-            android:id="@+id/handwriting_editor"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-
-    </LinearLayout>
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:translationZ="-1dp"
+        android:background="@color/drawingUntouchableBackground" />
 
     <FrameLayout
         android:id="@+id/handwriting_editor_frame_layout"

--- a/clients/android/app/src/main/res/layout/activity_import_account.xml
+++ b/clients/android/app/src/main/res/layout/activity_import_account.xml
@@ -38,8 +38,7 @@
 
     <Button
         android:id="@+id/import_lockbook"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+
         style="@style/Main.Button.Borderless.Colored"
         android:text="@string/import_account_import_button" />
 

--- a/clients/android/app/src/main/res/layout/activity_list_files.xml
+++ b/clients/android/app/src/main/res/layout/activity_list_files.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:theme="@style/Main.Actionbar" />
+        android:theme="@style/Main.Widget.Actionbar" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/files_fragment"

--- a/clients/android/app/src/main/res/layout/activity_main.xml
+++ b/clients/android/app/src/main/res/layout/activity_main.xml
@@ -26,15 +26,11 @@
     <Button
         android:id="@+id/welcome_new_lockbook"
         style="@style/Main.Button.Borderless.Colored"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:layout_marginBottom="15dp"
         android:text="@string/lockbook_new_account" />
 
     <Button
         android:id="@+id/welcome_import_lockbook"
         style="@style/Main.Button.Borderless.Colored"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/lockbook_import" />
 </LinearLayout>

--- a/clients/android/app/src/main/res/layout/activity_new_account.xml
+++ b/clients/android/app/src/main/res/layout/activity_new_account.xml
@@ -64,8 +64,6 @@
     <Button
         android:id="@+id/new_account_create_lockbook"
         style="@style/Main.Button.Borderless.Colored"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/new_account_submit" />
 
     <ProgressBar

--- a/clients/android/app/src/main/res/layout/activity_settings.xml
+++ b/clients/android/app/src/main/res/layout/activity_settings.xml
@@ -1,7 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge>
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/settings_toolbar"
+        style="@style/Main.Widget.Actionbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/settings_title" />
+
+    <FrameLayout
         android:id="@+id/settings_preference_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</merge>
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/settings_toolbar" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/clients/android/app/src/main/res/layout/activity_text_editor.xml
+++ b/clients/android/app/src/main/res/layout/activity_text_editor.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:theme="@style/Main.Actionbar"
+        android:theme="@style/Main.Widget.Actionbar"
         app:layout_constraintTop_toTopOf="parent"
         tools:layout_editor_absoluteX="5dp" />
 
@@ -59,7 +59,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
-                style="@style/Main.RegularImageButton"
+                style="@style/Main.Widget.RegularImageButton"
                 android:contentDescription="@string/menu_markdown_title"
                 android:src="@drawable/ic_baseline_title_24" />
 
@@ -68,7 +68,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
-                style="@style/Main.RegularImageButton"
+                style="@style/Main.Widget.RegularImageButton"
                 android:contentDescription="@string/menu_markdown_bold"
                 android:src="@drawable/ic_baseline_format_bold_24" />
 
@@ -78,7 +78,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
                 android:contentDescription="@string/menu_markdown_italics"
-                style="@style/Main.RegularImageButton"
+                style="@style/Main.Widget.RegularImageButton"
                 android:src="@drawable/ic_baseline_format_italic_24" />
 
             <ImageButton
@@ -87,7 +87,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
                 android:contentDescription="@string/menu_markdown_image"
-                style="@style/Main.RegularImageButton"
+                style="@style/Main.Widget.RegularImageButton"
                 android:src="@drawable/ic_baseline_image_24" />
 
             <ImageButton
@@ -96,7 +96,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
                 android:contentDescription="@string/menu_markdown_link"
-                style="@style/Main.RegularImageButton"
+                style="@style/Main.Widget.RegularImageButton"
                 android:src="@drawable/ic_baseline_link_24" />
 
             <ImageButton
@@ -104,7 +104,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
-                style="@style/Main.RegularImageButton"
+                style="@style/Main.Widget.RegularImageButton"
                 android:contentDescription="@string/menu_markdown_code"
                 android:src="@drawable/ic_baseline_code_24" />
 

--- a/clients/android/app/src/main/res/layout/dialog_create_file.xml
+++ b/clients/android/app/src/main/res/layout/dialog_create_file.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:id="@+id/create_file_layout"
-    style="@style/Main.Dialog"
+    style="@style/Main.Widget.Dialog"
     android:orientation="vertical">
 
     <TextView
@@ -45,7 +45,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:hint="@string/dialog_file_extension"
-            android:text="@string/create_file_dialog_default_extension"
             style="@style/Main.Text.Small"
             android:inputType="text"
             android:layout_weight="0.4"
@@ -78,15 +77,11 @@
         <Button
             android:id="@+id/create_file_cancel"
             style="@style/Main.Button.Borderless.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="@string/cancel" />
 
         <Button
             android:id="@+id/create_file_create"
             style="@style/Main.Button.Borderless.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="@string/create_file_create" />
     </LinearLayout>
 

--- a/clients/android/app/src/main/res/layout/dialog_file_info.xml
+++ b/clients/android/app/src/main/res/layout/dialog_file_info.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="5dp"
-    style="@style/Main.Dialog"
+    style="@style/Main.Widget.Dialog"
     android:orientation="vertical">
 
     <TextView

--- a/clients/android/app/src/main/res/layout/dialog_move_file.xml
+++ b/clients/android/app/src/main/res/layout/dialog_move_file.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    style="@style/Main.Dialog"
+    style="@style/Main.Widget.Dialog"
     android:padding="10dp">
 
     <ProgressBar
@@ -42,15 +42,11 @@
         <Button
             android:id="@+id/move_file_cancel"
             style="@style/Main.Button.Borderless.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="@string/cancel" />
 
         <Button
             android:id="@+id/move_file_confirm"
             style="@style/Main.Button.Borderless.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="@string/move_file_confirm" />
 
     </LinearLayout>

--- a/clients/android/app/src/main/res/layout/dialog_rename_file.xml
+++ b/clients/android/app/src/main/res/layout/dialog_rename_file.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:id="@+id/rename_file_layout"
-    style="@style/Main.Dialog"
+    style="@style/Main.Widget.Dialog"
     android:orientation="vertical">
 
     <TextView
@@ -41,15 +41,11 @@
         <Button
             android:id="@+id/rename_file_cancel"
             style="@style/Main.Button.Borderless.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="@string/cancel" />
 
         <Button
             android:id="@+id/rename_file_rename"
             style="@style/Main.Button.Borderless.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="@string/rename_file_rename" />
     </LinearLayout>
 

--- a/clients/android/app/src/main/res/layout/fragment_list_files.xml
+++ b/clients/android/app/src/main/res/layout/fragment_list_files.xml
@@ -79,27 +79,27 @@
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/list_files_fab_drawing"
-                    style="@style/Main.FAB"
+                    style="@style/Main.Widget.FAB"
                     android:contentDescription="@string/list_files_create_document"
                     android:onClick="@{() -> listFilesViewModel.onNewDocumentFABClicked(true)}"
                     android:visibility="gone"
                     android:src="@drawable/ic_baseline_border_color_24" />
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/list_files_fab_folder"
-                    style="@style/Main.FAB"
-                    android:contentDescription="@string/list_files_create_folder"
-                    android:onClick="@{() -> listFilesViewModel.onNewFolderFABClicked()}"
-                    android:visibility="gone"
-                    android:src="@drawable/round_folder_white_18dp" />
-
-                <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/list_files_fab_document"
-                    style="@style/Main.FAB"
+                    style="@style/Main.Widget.FAB"
                     android:contentDescription="@string/list_files_create_document"
                     android:onClick="@{() -> listFilesViewModel.onNewDocumentFABClicked(false)}"
                     android:visibility="gone"
                     android:src="@drawable/ic_baseline_insert_drive_file_24" />
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/list_files_fab_folder"
+                    style="@style/Main.Widget.FAB"
+                    android:contentDescription="@string/list_files_create_folder"
+                    android:onClick="@{() -> listFilesViewModel.onNewFolderFABClicked()}"
+                    android:visibility="gone"
+                    android:src="@drawable/round_folder_white_18dp" />
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/list_files_fab"

--- a/clients/android/app/src/main/res/menu/menu_list_files.xml
+++ b/clients/android/app/src/main/res/menu/menu_list_files.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    app:popupTheme="@style/Main.Actionbar"
+    app:popupTheme="@style/Main.Widget.Actionbar"
     tools:context="app.lockbook.screen.WelcomeActivity">
     <item
         android:id="@+id/menu_list_files_sort"

--- a/clients/android/app/src/main/res/values-night/colors.xml
+++ b/clients/android/app/src/main/res/values-night/colors.xml
@@ -15,8 +15,7 @@
   <color name="white">#FFFFFF</color>
   <color name="grey">#787878</color>
 
-  <color name="transparent_black">#94000000</color>
-  <color name="transparent_white">#94E3E5EB</color>
+  <color name="drawingUntouchableBackground">@color/dark</color>
 
   <color name="selectedFileBackground">#64B5F6</color>
   <color name="navigationBarColor">@color/black</color>
@@ -24,7 +23,6 @@
   <color name="colorPrimary">@color/blue</color>
   <color name="colorAccent">@color/blue</color>
   <color name="colorPrimaryDark">@color/black</color>
-  <color name="drawingToolbarBackground">@color/transparent_black</color>
   <color name="windowBackground">@color/black</color>
   <color name="textColor">@color/light</color>
   <color name="iconColor">@color/light</color>

--- a/clients/android/app/src/main/res/values/colors.xml
+++ b/clients/android/app/src/main/res/values/colors.xml
@@ -15,8 +15,7 @@
   <color name="white">#FFFFFF</color>
   <color name="grey">#787878</color>
 
-  <color name="transparent_black">#94000000</color>
-  <color name="transparent_white">#94E3E5EB</color>
+  <color name="drawingUntouchableBackground">@color/grey</color>
 
   <color name="selectedFileBackground">#64B5F6</color>
   <color name="navigationBarColor">@color/white</color>
@@ -24,7 +23,6 @@
   <color name="colorPrimary">@color/blue</color>
   <color name="colorAccent">@color/blue</color>
   <color name="colorPrimaryDark">@color/white</color>
-  <color name="drawingToolbarBackground">@color/transparent_white</color>
   <color name="windowBackground">@color/white</color>
   <color name="textColor">@color/black</color>
   <color name="iconColor">@color/black</color>

--- a/clients/android/app/src/main/res/values/strings.xml
+++ b/clients/android/app/src/main/res/values/strings.xml
@@ -164,7 +164,8 @@
     <string name="empty_folder">There are no files, please click the bottom right button to create a new file, folder, or drawing.</string>
     <string name="krumbs_start_item">Root</string>
     <string name="create_file_default_file_hint">ERROR, hint not correctly configured.</string>
-    <string name="create_file_dialog_default_extension">.md</string>
+    <string name="create_file_dialog_document_extension">.md</string>
+    <string name="create_file_dialog_drawing_extension">.draw</string>
     <string name="bread_crumb_folder">Folder</string>
 
     <string name="create_file_title_folder">New Folder</string>
@@ -174,6 +175,10 @@
     <string name="create_file_hint_folder">Folder name</string>
     <string name="create_file_hint_document">Document name</string>
     <string name="create_file_hint_drawing">Drawing name</string>
+
+    <string name="create_file_hint_document_extension">Document Ext.</string>
+    <string name="create_file_hint_drawing_extension">Drawing Ext.</string>
+
     <string name="handwriting_editor_eraser_description">Eraser</string>
     <string name="handwriting_editor_pen_description">Pen</string>
     <string name="handwriting_editor_pen_small_description">Small</string>

--- a/clients/android/app/src/main/res/values/styles.xml
+++ b/clients/android/app/src/main/res/values/styles.xml
@@ -2,15 +2,15 @@
     <style name="Main" parent="Theme.MaterialComponents.DayNight">
         <item name="android:windowBackground">@color/colorPrimaryDark</item>
         <item name="android:navigationBarColor">@color/navigationBarColor</item>
-        <item name="snackbarStyle">@style/Main.SnackBar</item>
-        <item name="snackbarTextViewStyle">@style/Main.SnackBar.TextView</item>
+        <item name="snackbarStyle">@style/Main.Widget.SnackBar</item>
+        <item name="snackbarTextViewStyle">@style/Main.Widget.SnackBar.TextView</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="android:windowLightStatusBar" tools:targetApi="23">@bool/windowLightStatusBar</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:actionBarStyle">@style/Main.Actionbar</item>
+        <item name="android:actionBarStyle">@style/Main.Widget.Actionbar</item>
         <item name="titleTextStyle">@style/Main.Title</item>
         <item name="android:actionOverflowButtonStyle">@style/Main.Overflow</item>
     </style>
@@ -20,41 +20,37 @@
         <item name="android:windowContentOverlay">@null</item>
     </style>
 
-    <style name="Main.Dialog" parent="Theme.AppCompat.DayNight.Dialog">
+    <style name="Main.Widget.Dialog" parent="Theme.AppCompat.DayNight.Dialog">
         <item name="android:background">@color/windowBackground</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     </style>
 
-    <style name="Main.SnackBar" parent="Widget.MaterialComponents.Snackbar">
+    <style name="Main.Widget.SnackBar" parent="Widget.MaterialComponents.Snackbar">
         <item name="backgroundTint">@color/background</item>
         <item name="android:textColor">@color/white</item>
     </style>
 
-    <style name="Main.SnackBar.TextView" parent="Widget.MaterialComponents.Snackbar.TextView">
+    <style name="Main.Widget.SnackBar.TextView" parent="Widget.MaterialComponents.Snackbar.TextView">
         <item name="android:textColor">@color/white</item>
     </style>
 
-    <style name="Main.NoActionBar" parent="Main">
-        <item name="background">@color/windowBackground</item>
-    </style>
-
-    <style name="Main.Actionbar" parent="Widget.AppCompat.ActionBar">
+    <style name="Main.Widget.Actionbar" parent="Widget.AppCompat.ActionBar">
         <item name="backgroundColor">@color/windowBackground</item>
         <item name="android:textColorPrimary">@color/textColor</item>
         <item name="android:textColorSecondary">@color/textColor</item>
         <item name="actionMenuTextColor">@color/textColor</item>
     </style>
 
-    <style name="Main.RegularImageButton" parent="Widget.AppCompat.ImageButton">
+    <style name="Main.Widget.RegularImageButton" parent="Widget.AppCompat.ImageButton">
         <item name="android:background">?android:selectableItemBackgroundBorderless</item>
         <item name="android:backgroundTint">?attr/colorPrimaryDark</item>
         <item name="android:clickable">true</item>
         <item name="android:focusable">true</item>
     </style>
 
-    <style name="Main.DrawingImageButton" parent="Widget.AppCompat.ImageButton">
+    <style name="Main.Widget.DrawingImageButton" parent="Widget.AppCompat.ImageButton">
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_margin">10dp</item>
@@ -64,24 +60,20 @@
         <item name="android:focusable">true</item>
     </style>
 
-    <style name="Main.DrawingButton" parent="Widget.MaterialComponents.ExtendedFloatingActionButton">
+    <style name="Main.Widget.DrawingButton" parent="Widget.MaterialComponents.ExtendedFloatingActionButton">
         <item name="android:layout_width">40dp</item>
         <item name="android:layout_height">40dp</item>
         <item name="android:layout_margin">10dp</item>
         <item name="cornerRadius">100dp</item>
     </style>
 
-    <style name="Main.FAB" parent="Widget.MaterialComponents.FloatingActionButton">
+    <style name="Main.Widget.FAB" parent="Widget.MaterialComponents.FloatingActionButton">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_margin">10dp</item>
         <item name="backgroundTint">@color/colorPrimary</item>
         <item name="rippleColor">@color/light</item>
-        <item name="tint">@color/iconColor</item>
-    </style>
-
-    <style name="Main.Toolbar">
-        <item name="backgroundColor">@color/windowBackground</item>
+        <item name="tint">@null</item>
     </style>
 
     <style name="Main.Overflow">
@@ -156,6 +148,8 @@
     <style name="Main.Button.Borderless" parent="Widget.AppCompat.Button.Borderless" />
 
     <style name="Main.Button.Borderless.Colored" parent="Widget.AppCompat.Button.Borderless.Colored">
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">wrap_content</item>
         <item name="android:textColor">@color/colorPrimary</item>
     </style>
 </resources>


### PR DESCRIPTION
## Removed username from actionbar
<details>

Before:

![Screenshot_20210115-194050.png](https://user-images.githubusercontent.com/20663038/104821151-f302e280-5807-11eb-81cf-1dcb4764f356.png)

After:

![Screenshot_20210116-142745.png](https://user-images.githubusercontent.com/20663038/104821116-a8816600-5807-11eb-9be9-6ba229738211.png)

</details>

## Canvas background design change
<details>

![Screenshot_20210116-142346.png](https://user-images.githubusercontent.com/20663038/104820983-aa96f500-5806-11eb-8b7d-c1976ec233d0.png)

![Screenshot_20210116-142353.png](https://user-images.githubusercontent.com/20663038/104820986-acf94f00-5806-11eb-83dd-92a81571bb8f.png)

</details>

## The settings screen should have an action bar
<details>

![Screenshot_20210116-142221.png](https://user-images.githubusercontent.com/20663038/104821092-7d971200-5807-11eb-9d77-c3a1d28af38c.png)

![Screenshot_20210116-142547.png](https://user-images.githubusercontent.com/20663038/104820997-c26e7900-5806-11eb-932a-39b98e264de0.png)

</details>

## Two separate EditText fields for a new drawing
<details>

![Screenshot_20210116-142145.png](https://user-images.githubusercontent.com/20663038/104821002-c8fcf080-5806-11eb-96b7-40f89a364f0f.png)

</details>

## Create file dialogs should reflect their file type in the title and hint
<details>

![Screenshot_20210116-142212.png](https://user-images.githubusercontent.com/20663038/104821006-cdc1a480-5806-11eb-921d-dbd56ff0ec30.png)

![Screenshot_20210116-142145.png](https://user-images.githubusercontent.com/20663038/104821009-d0bc9500-5806-11eb-89ab-c4523125e677.png)

</details>

## The main FAB (the plus button) should be white regardless of theme
<details>

![Screenshot_20210116-142745.png](https://user-images.githubusercontent.com/20663038/104821068-504a6400-5807-11eb-90e4-0251f61c3c80.png)

![Screenshot_20210116-142234.png](https://user-images.githubusercontent.com/20663038/104821017-dc0fc080-5806-11eb-8649-1352dbdea532.png)

</details>

## The folder FAB should be the lowermost icon in the expanded FAB
<details>

![Screenshot_20210116-142848.png](https://user-images.githubusercontent.com/20663038/104821054-301aa500-5807-11eb-847f-6ca6e3d15b0b.png)

</details>

## File extensions for drawings aren't hidden anymore
<details>

![Screenshot_20210116-142745.png](https://user-images.githubusercontent.com/20663038/104821043-137e6d00-5807-11eb-81df-44202ca05cd2.png)

</details>

## The layout width of border-less buttons aren't the width of the screen anymore

close #530 
close #520 
close #521 
close #524 
close #523  
close #525 
close #526 
close #527 
close #522 
close #489 