### PR TITLE
android: changed biometric verification subtitle

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/InitialLaunchFigureOuter.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/InitialLaunchFigureOuter.kt
@@ -245,7 +245,7 @@ class InitialLaunchFigureOuter : AppCompatActivity() {
 
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
                     .setTitle("Lockbook Biometric Verification")
-                    .setSubtitle("Enter your fingerprint to access lockbook.")
+                    .setSubtitle("Verify your identity to access Lockbook.")
                     .setDeviceCredentialAllowed(true)
                     .build()
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/SettingsFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/SettingsFragment.kt
@@ -210,7 +210,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
                     .setTitle("Lockbook Biometric Verification")
-                    .setSubtitle("Enter your fingerprint to modify this biometric sensitive setting.")
+                    .setSubtitle("Verify your identity to access this setting.")
                     .setDeviceCredentialAllowed(true)
                     .build()
 


### PR DESCRIPTION
Biometric subtitle is now more accurate. The rename was prompted by the fact biometric is not always a fingerprint, it can be face unlock or some other type of biometric verification.

fixes #535 