### PR TITLE
android: extraneous drawing stroke points are rounded to their nearest max or min

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/ui/HandwritingEditorView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/HandwritingEditorView.kt
@@ -13,7 +13,6 @@ import app.lockbook.App
 import app.lockbook.R
 import app.lockbook.util.*
 import app.lockbook.util.Point
-import timber.log.Timber
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
@@ -217,13 +216,13 @@ class HandwritingEditorView(context: Context, attributeSet: AttributeSet?) :
         modelX = (modelX * 100).roundToInt() / 100f
         modelY = (modelY * 100).roundToInt() / 100f
 
-        if(modelX < 0) {
+        if (modelX < 0) {
             modelX = 0f
         } else if (modelX > CANVAS_WIDTH) {
             modelX = CANVAS_WIDTH.toFloat()
         }
 
-        if(modelY < 0) {
+        if (modelY < 0) {
             modelY = 0f
         } else if (modelY > CANVAS_HEIGHT) {
             modelY = CANVAS_HEIGHT.toFloat()
@@ -297,13 +296,13 @@ class HandwritingEditorView(context: Context, attributeSet: AttributeSet?) :
     private fun lineTo(point: PointF, pressure: Float) {
         strokePaint.strokeWidth = pressure
         strokePath.moveTo(
-                lastPoint.x,
-                lastPoint.y
+            lastPoint.x,
+            lastPoint.y
         )
 
         strokePath.lineTo(
-                point.x,
-                point.y
+            point.x,
+            point.y
         )
 
         tempCanvas.drawPath(strokePath, strokePaint)


### PR DESCRIPTION
Instead of saving strokes and points that happen outside of the drawable canvas, we now round them to their nearest max or min. 

For this PR I was originally planning to not save any points at all that left, but that had some unintended consequences with the way the strokes were being logged already. Fast strokes composed of few points that went off the edge of the drawable canvas would disappear many pixels before the edge since their last point would disappear. The fix may not be that difficult, but there are other instances that would have to be accounted for in that format. To get past this, I would have to add a lot of unneeded complexity, for something that isn't better imo.

fixes #532 