### PR TITLE
android: fixed drawing deletion bug involved with paused activities

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/model/HandwritingEditorViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/HandwritingEditorViewModel.kt
@@ -12,7 +12,6 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import kotlinx.coroutines.*
 import timber.log.Timber
-import java.util.*
 
 class HandwritingEditorViewModel(
     application: Application,
@@ -21,7 +20,7 @@ class HandwritingEditorViewModel(
     private var job = Job()
     private val uiScope = CoroutineScope(Dispatchers.Main + job)
     private val config = Config(getApplication<Application>().filesDir.absolutePath)
-    var lockBookDrawable: Drawing? = null
+    var backupDrawing: Drawing? = null
 
     private var selectedColor = android.R.color.white
     private var selectedTool = HandwritingEditorView.Tool.PEN
@@ -75,9 +74,9 @@ class HandwritingEditorViewModel(
             withContext(Dispatchers.IO) {
                 val contents = readDocument(id)
                 if (contents != null && contents.isEmpty()) {
-                    lockBookDrawable = Drawing()
+                    backupDrawing = Drawing()
                 } else if (contents != null) {
-                    lockBookDrawable = Klaxon().parse<Drawing>(contents)
+                    backupDrawing = Klaxon().parse<Drawing>(contents)
                 }
 
                 _drawableReady.postValue(Unit)

--- a/clients/android/app/src/main/java/app/lockbook/screen/HandwritingEditorActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/HandwritingEditorActivity.kt
@@ -29,7 +29,7 @@ class HandwritingEditorActivity : AppCompatActivity() {
     private val surfaceViewReadyCallback = object : SurfaceHolder.Callback {
         override fun surfaceCreated(holder: SurfaceHolder?) {
             if (!firstLaunch) {
-                handwriting_editor.initializeWithDrawing(null)
+                handwriting_editor.startThread()
             } else {
                 addDrawingToView()
             }

--- a/clients/android/app/src/main/java/app/lockbook/ui/HandwritingEditorView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/HandwritingEditorView.kt
@@ -225,8 +225,7 @@ class HandwritingEditorView(context: Context, attributeSet: AttributeSet?) :
             this.drawingModel = maybeDrawing
         }
         restoreFromModel()
-        isThreadRunning = true
-        thread.start()
+        startThread()
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -429,6 +428,11 @@ class HandwritingEditorView(context: Context, attributeSet: AttributeSet?) :
 
     fun restartThread() {
         thread = Thread(this)
+    }
+
+    fun startThread() {
+        isThreadRunning = true
+        thread.start()
     }
 
     override fun run() {

--- a/clients/android/app/src/main/java/app/lockbook/ui/HandwritingEditorView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/HandwritingEditorView.kt
@@ -445,6 +445,5 @@ class HandwritingEditorView(context: Context, attributeSet: AttributeSet?) :
                 holder.unlockCanvasAndPost(canvas)
             }
         }
-        thread.interrupt()
     }
 }


### PR DESCRIPTION
Drawings were being reset when a user exited the drawing screen of the app, without fully closing it, and then reentered it through android's task manager (not sure about the official name).

This turned out to be a bug involving a callback that would repeatedly bring back the state of the drawing to the backup drawing's state. This backup drawing was stored in the viewmodel (which survives configuration changes the activity cannot), and was used during a configuration change like a screen rotation. The callback would be fired on the first launch of an activity, and also when an activity was restarted from a pause (like the senario above). It called a function that would check to see if the backup was occupied and if it was, it would override the main drawing.

fixes #545 