### PR TITLE
infra: android and kotlin interface tests dockerfiles start with a gradle image

### DIFF
--- a/containers/Dockerfile.android
+++ b/containers/Dockerfile.android
@@ -1,8 +1,9 @@
 ARG HASH
-FROM ubuntu:20.04 AS android-build
+
+FROM gradle:6.7-jdk8 AS android-build
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV ANDROID_HOME /opt/android-sdk-linux
-RUN apt update && apt install -y build-essential openjdk-8-jdk wget curl unzip
 
 # Install android things
 RUN wget -q https://dl.google.com/android/repository/android-ndk-r21c-linux-x86_64.zip -O android-ndk-r21c-linux-x86_64.zip
@@ -17,13 +18,13 @@ RUN yes | sdkmanager --licenses
 # Copy android in
 COPY clients/android clients/android
 WORKDIR clients/android
-RUN ./gradlew assemble
+RUN gradle assemble
 
 
 # Check formatting
 FROM android:${HASH} AS android-fmt
-RUN ./gradlew lintKotlin 
+RUN gradle lintKotlin 
 
 # Check lint
 FROM android:${HASH} AS android-lint
-RUN ./gradlew lint
+RUN gradle lint

--- a/containers/Dockerfile.kotlin_interface_tests
+++ b/containers/Dockerfile.kotlin_interface_tests
@@ -1,12 +1,11 @@
 ARG HASH
 
-FROM core:$HASH as core-build
+FROM core:$HASH AS core-build
 
-FROM ubuntu:20.04 AS kotlin-interface-tests
+FROM gradle:6.7-jdk8 AS kotlin-interface-tests
 
 ENV ANDROID_HOME /opt/android-sdk-linux
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y build-essential openjdk-8-jdk wget curl unzip
 
 # Install android things
 RUN cd /opt \
@@ -25,4 +24,4 @@ WORKDIR /clients/android
 COPY --from=core-build /core/target/release/liblockbook_core.so /clients/android/core/src/main/jniLibs/desktop/liblockbook_core.so
 
 # Build android
-RUN ./gradlew assemble
+RUN gradle assemble

--- a/containers/docker-compose-integration-tests.yml
+++ b/containers/docker-compose-integration-tests.yml
@@ -112,7 +112,7 @@ services:
     entrypoint: >
       /bin/sh -c '\
         sleep 5 && \
-        ./gradlew test \
+        gradle test \
       '
 
   performance_bench:


### PR DESCRIPTION
In this PR, both the android and kotlin interface tests dockerfiles now start with a gradle image.

This is good since... 
- Gradle will always be cached
- There is no need to install java since it comes with the gradle image

fixes #485 