### PR TITLE
android: resolved sync errors involving the snackbar popping in and out

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -5,13 +5,12 @@ import app.lockbook.util.*
 import com.beust.klaxon.Klaxon
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
-import timber.log.Timber
 
 object CoreModel {
 
     private const val QA_API_URL = "http://qa.lockbook.app:8000"
     private const val PROD_API_URL = "http://api.lockbook.app:8000"
-    fun getAPIURL(): String = System.getenv("API_URL") ?: QA_API_URL
+    private fun getAPIURL(): String = System.getenv("API_URL") ?: QA_API_URL
 
     fun setUpInitLogger(path: String): Result<Unit, InitLoggerError> {
         val initLoggerResult: Result<Unit, InitLoggerError>? =
@@ -326,15 +325,13 @@ object CoreModel {
         return Err(MoveFileError.Unexpected("moveFileConverter was unable to be called!"))
     }
 
-    fun calculateFileSyncWork(config: Config): Result<WorkCalculated, CalculateWorkError> {
-        val result = calculateSyncWork(Klaxon().toJsonString(config))
-        Timber.e(result)
-        val calculateSyncWorkResult: Result<WorkCalculated, CalculateWorkError>? =
+    fun calculateWork(config: Config): Result<WorkCalculated, CalculateWorkError> {
+        val calculateWorkResult: Result<WorkCalculated, CalculateWorkError>? =
             Klaxon().converter(calculateSyncWorkConverter)
-                .parse(result)
+                .parse(calculateWork(Klaxon().toJsonString(config)))
 
-        if (calculateSyncWorkResult != null) {
-            return calculateSyncWorkResult
+        if (calculateWorkResult != null) {
+            return calculateWorkResult
         }
 
         return Err(CalculateWorkError.Unexpected("calculateSyncWorkConverter was unable to be called!"))
@@ -347,7 +344,7 @@ object CoreModel {
     ): Result<Unit, ExecuteWorkError> {
         val executeSyncWorkResult: Result<Unit, ExecuteWorkError>? =
             Klaxon().converter(executeSyncWorkConverter).parse(
-                executeSyncWork(
+                executeWork(
                     Klaxon().toJsonString(config),
                     Klaxon().toJsonString(account),
                     Klaxon().toJsonString(workUnit)

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -10,7 +10,7 @@ object CoreModel {
 
     private const val QA_API_URL = "http://qa.lockbook.app:8000"
     private const val PROD_API_URL = "http://api.lockbook.app:8000"
-    private fun getAPIURL(): String = System.getenv("API_URL") ?: QA_API_URL
+    fun getAPIURL(): String = System.getenv("API_URL") ?: QA_API_URL
 
     fun setUpInitLogger(path: String): Result<Unit, InitLoggerError> {
         val initLoggerResult: Result<Unit, InitLoggerError>? =

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -96,7 +96,7 @@ object CoreModel {
         return Err(AccountExportError.Unexpected("exportAccountConverter was unable to be called!"))
     }
 
-    fun syncAllFiles(config: Config): Result<Unit, SyncAllError> {
+    fun syncAll(config: Config): Result<Unit, SyncAllError> {
         val syncResult: Result<Unit, SyncAllError>? =
             Klaxon().converter(syncAllConverter).parse(syncAll(Klaxon().toJsonString(config)))
 
@@ -327,7 +327,7 @@ object CoreModel {
 
     fun calculateWork(config: Config): Result<WorkCalculated, CalculateWorkError> {
         val calculateWorkResult: Result<WorkCalculated, CalculateWorkError>? =
-            Klaxon().converter(calculateSyncWorkConverter)
+            Klaxon().converter(calculateWorkConverter)
                 .parse(calculateWork(Klaxon().toJsonString(config)))
 
         if (calculateWorkResult != null) {
@@ -337,13 +337,13 @@ object CoreModel {
         return Err(CalculateWorkError.Unexpected("calculateSyncWorkConverter was unable to be called!"))
     }
 
-    fun executeFileSyncWork(
+    fun executeWork(
         config: Config,
         account: Account,
         workUnit: WorkUnit
     ): Result<Unit, ExecuteWorkError> {
         val executeSyncWorkResult: Result<Unit, ExecuteWorkError>? =
-            Klaxon().converter(executeSyncWorkConverter).parse(
+            Klaxon().converter(executeWorkConverter).parse(
                 executeWork(
                     Klaxon().toJsonString(config),
                     Klaxon().toJsonString(account),

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -5,6 +5,7 @@ import app.lockbook.util.*
 import com.beust.klaxon.Klaxon
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
+import timber.log.Timber
 
 object CoreModel {
 
@@ -326,9 +327,11 @@ object CoreModel {
     }
 
     fun calculateFileSyncWork(config: Config): Result<WorkCalculated, CalculateWorkError> {
+        val result = calculateSyncWork(Klaxon().toJsonString(config))
+        Timber.e(result)
         val calculateSyncWorkResult: Result<WorkCalculated, CalculateWorkError>? =
             Klaxon().converter(calculateSyncWorkConverter)
-                .parse(calculateSyncWork(Klaxon().toJsonString(config)))
+                .parse(result)
 
         if (calculateSyncWorkResult != null) {
             return calculateSyncWorkResult

--- a/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
@@ -236,7 +236,7 @@ class FileModel(path: String) {
         Worker(appContext, workerParams) {
         override fun doWork(): Result {
             val syncAllResult =
-                CoreModel.syncAllFiles(Config(applicationContext.filesDir.absolutePath))
+                CoreModel.syncAll(Config(applicationContext.filesDir.absolutePath))
             return if (syncAllResult is Err) {
                 when (val error = syncAllResult.error) {
                     is SyncAllError.NoAccount -> {

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -443,7 +443,7 @@ class ListFilesViewModel(path: String, application: Application) :
             for (workUnit in workCalculated.workUnits) {
                 when (
                     val executeFileSyncWorkResult =
-                        CoreModel.executeFileSyncWork(fileModel.config, account, workUnit)
+                        CoreModel.executeWork(fileModel.config, account, workUnit)
                 ) {
                     is Ok -> {
                         currentProgress++

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -219,7 +219,7 @@ class ListFilesFragment : Fragment() {
             viewLifecycleOwner,
             {
                 if (container != null) {
-                    showSuccessfulDeletionSnackbar(container)
+                    showSuccessfulDeletionSnackBar(container)
                 }
             }
         )
@@ -412,7 +412,7 @@ class ListFilesFragment : Fragment() {
         }
     }
 
-    private fun showSuccessfulDeletionSnackbar(view: ViewGroup) {
+    private fun showSuccessfulDeletionSnackBar(view: ViewGroup) {
         Snackbar.make(view, "Successfully deleted the file(s)", Snackbar.LENGTH_SHORT).show()
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -116,6 +116,13 @@ class ListFilesFragment : Fragment() {
             }
         )
 
+        listFilesViewModel.updateSyncSnackBar.observe(
+            viewLifecycleOwner,
+            { maxProgress ->
+                updateSyncSnackBar(maxProgress)
+            }
+        )
+
         listFilesViewModel.showPreSyncSnackBar.observe(
             viewLifecycleOwner,
             { amountToSync ->
@@ -350,6 +357,19 @@ class ListFilesFragment : Fragment() {
         snackProgressBarManager.show(
             syncSnackProgressBar,
             SnackProgressBarManager.LENGTH_INDEFINITE
+        )
+    }
+
+    private fun updateSyncSnackBar(maxProgress: Int) {
+        syncSnackProgressBar.setProgressMax(maxProgress)
+        syncSnackProgressBar.setMessage(
+            resources.getString(
+                R.string.list_files_sync_snackbar,
+                maxProgress.toString()
+            )
+        )
+        snackProgressBarManager.updateTo(
+            syncSnackProgressBar
         )
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -116,13 +116,6 @@ class ListFilesFragment : Fragment() {
             }
         )
 
-        listFilesViewModel.updateSyncSnackBar.observe(
-            viewLifecycleOwner,
-            { maxProgress ->
-                updateSyncSnackBar(maxProgress)
-            }
-        )
-
         listFilesViewModel.showPreSyncSnackBar.observe(
             viewLifecycleOwner,
             { amountToSync ->
@@ -347,6 +340,7 @@ class ListFilesFragment : Fragment() {
 
     private fun showSyncSnackBar(maxProgress: Int) {
         snackProgressBarManager.dismiss()
+        snackProgressBarManager.setProgress(0)
         syncSnackProgressBar.setProgressMax(maxProgress)
         syncSnackProgressBar.setMessage(
             resources.getString(
@@ -357,19 +351,6 @@ class ListFilesFragment : Fragment() {
         snackProgressBarManager.show(
             syncSnackProgressBar,
             SnackProgressBarManager.LENGTH_INDEFINITE
-        )
-    }
-
-    private fun updateSyncSnackBar(maxProgress: Int) {
-        syncSnackProgressBar.setProgressMax(maxProgress)
-        syncSnackProgressBar.setMessage(
-            resources.getString(
-                R.string.list_files_sync_snackbar,
-                maxProgress.toString()
-            )
-        )
-        snackProgressBarManager.updateTo(
-            syncSnackProgressBar
         )
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
@@ -832,7 +832,7 @@ val syncAllConverter = object : Converter {
     override fun toJson(value: Any): String = Klaxon().toJsonString(value)
 }
 
-val calculateSyncWorkConverter = object : Converter {
+val calculateWorkConverter = object : Converter {
     override fun canConvert(cls: Class<*>): Boolean = true
 
     override fun fromJson(jv: JsonValue): Any? = when (jv.obj?.string("tag")) {
@@ -876,7 +876,7 @@ val calculateSyncWorkConverter = object : Converter {
     override fun toJson(value: Any): String = Klaxon().toJsonString(value)
 }
 
-val executeSyncWorkConverter = object : Converter {
+val executeWorkConverter = object : Converter {
     override fun canConvert(cls: Class<*>): Boolean = true
 
     override fun fromJson(jv: JsonValue): Any? = when (jv.obj?.string("tag")) {

--- a/clients/android/app/src/main/java/app/lockbook/util/Structures.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Structures.kt
@@ -107,7 +107,8 @@ data class EditableFile(
 
 data class SyncingStatus(
     var isSyncing: Boolean = false,
-    var maxProgress: Int = 0
+    var maxProgress: Int = 0,
+    var currentProgress: Int = 0
 )
 
 data class MoveFileInfo(

--- a/clients/android/app/src/test/java/app/lockbook/CalculateWorkTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/CalculateWorkTest.kt
@@ -1,6 +1,6 @@
 package app.lockbook
 
-import app.lockbook.core.calculateSyncWork
+import app.lockbook.core.calculateWork
 import app.lockbook.model.CoreModel
 import app.lockbook.util.*
 import com.beust.klaxon.Klaxon
@@ -31,14 +31,14 @@ class CalculateWorkTest {
             CoreModel.generateAccount(config, generateAlphaString()).component1()
         )
         assertType<WorkCalculated>(
-            CoreModel.calculateFileSyncWork(config).component1()
+            CoreModel.calculateWork(config).component1()
         )
     }
 
     @Test
     fun calculateWorkUnexpectedError() {
         val calculateSyncWorkResult: Result<WorkCalculated, CalculateWorkError>? =
-            Klaxon().converter(calculateSyncWorkConverter).parse(calculateSyncWork(""))
+            Klaxon().converter(calculateWorkConverter).parse(calculateWork(""))
 
         assertType<CalculateWorkError.Unexpected>(
             calculateSyncWorkResult?.component2()

--- a/clients/android/app/src/test/java/app/lockbook/ExecuteWorkTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/ExecuteWorkTest.kt
@@ -1,6 +1,6 @@
 package app.lockbook
 
-import app.lockbook.core.executeSyncWork
+import app.lockbook.core.executeWork
 import app.lockbook.model.CoreModel
 import app.lockbook.util.*
 import com.beust.klaxon.Klaxon
@@ -62,12 +62,12 @@ class ExecuteWorkTest {
         )
         repeat(10) {
             val syncWork = assertTypeReturn<WorkCalculated>(
-                CoreModel.calculateFileSyncWork(config).component1()
+                CoreModel.calculateWork(config).component1()
             )
 
             for (workUnit in syncWork.workUnits) {
                 assertType<Unit>(
-                    CoreModel.executeFileSyncWork(
+                    CoreModel.executeWork(
                         config,
                         assertTypeReturn(
                             CoreModel.getAccount(config).component1()
@@ -116,7 +116,7 @@ class ExecuteWorkTest {
         )
 
         assertType<Unit>(
-            CoreModel.syncAllFiles(config).component1()
+            CoreModel.syncAll(config).component1()
         )
 
         val exportAccountString = assertTypeReturn<String>(
@@ -131,12 +131,12 @@ class ExecuteWorkTest {
 
         repeat(10) {
             val syncWork = assertTypeReturn<WorkCalculated>(
-                CoreModel.calculateFileSyncWork(config).component1()
+                CoreModel.calculateWork(config).component1()
             )
 
             for (workUnit in syncWork.workUnits) {
                 assertType<Unit>(
-                    CoreModel.executeFileSyncWork(
+                    CoreModel.executeWork(
                         config,
                         assertTypeReturn(
                             CoreModel.getAccount(config).component1()
@@ -151,7 +151,7 @@ class ExecuteWorkTest {
     @Test
     fun executeWorkUnexpectedError() {
         val executeSyncWorkResult: Result<Unit, ExecuteWorkError>? =
-            Klaxon().converter(executeSyncWorkConverter).parse(executeSyncWork("", "", ""))
+            Klaxon().converter(executeWorkConverter).parse(executeWork("", "", ""))
 
         assertType<ExecuteWorkError.Unexpected>(
             executeSyncWorkResult?.component2()

--- a/clients/android/app/src/test/java/app/lockbook/SyncAllTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/SyncAllTest.kt
@@ -62,14 +62,14 @@ class SyncAllTest {
         )
 
         assertType<Unit>(
-            CoreModel.syncAllFiles(config).component1()
+            CoreModel.syncAll(config).component1()
         )
     }
 
     @Test
     fun syncAllNoAccount() {
         assertType<SyncAllError.NoAccount>(
-            CoreModel.syncAllFiles(config).component2()
+            CoreModel.syncAll(config).component2()
         )
     }
 

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -22,6 +22,6 @@ external fun readDocument(config: String, id: String): String
 external fun writeDocument(config: String, id: String, content: String): String
 external fun moveFile(config: String, id: String, parentId: String): String
 external fun syncAll(config: String): String
-external fun calculateSyncWork(config: String): String
-external fun executeSyncWork(config: String, account: String, workUnit: String): String
+external fun calculateWork(config: String): String
+external fun executeWork(config: String, account: String, workUnit: String): String
 external fun getAllErrorVariants(): String

--- a/core/src/java_interface.rs
+++ b/core/src/java_interface.rs
@@ -514,7 +514,7 @@ pub extern "system" fn Java_app_lockbook_core_CoreKt_syncAll(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_app_lockbook_core_CoreKt_calculateSyncWork(
+pub extern "system" fn Java_app_lockbook_core_CoreKt_calculateWork(
     env: JNIEnv,
     _: JClass,
     jconfig: JString,
@@ -528,7 +528,7 @@ pub extern "system" fn Java_app_lockbook_core_CoreKt_calculateSyncWork(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_app_lockbook_core_CoreKt_executeSyncWork(
+pub extern "system" fn Java_app_lockbook_core_CoreKt_executeWork(
     env: JNIEnv,
     _: JClass,
     jconfig: JString,


### PR DESCRIPTION
In this PR I fixed the a long time error involving the snackbar popping in and out whilst trying to sync. It was discovered this was due to the bad sync algorithm that was out of order, and had the wrong statements altogether. I also did some renaming of CoreModel's sync functions to be more in line with core's.

fix #423 