### PR TITLE
core: fixed get last synced human string outputting the wrong duration

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -811,11 +811,10 @@ pub fn get_last_synced(config: &Config) -> Result<i64, Error<GetLastSyncedError>
 pub fn get_last_synced_human_string(config: &Config) -> Result<String, Error<GetLastSyncedError>> {
     let last_synced = get_last_synced(config)?;
 
-    Ok(match last_synced {
-        0 => Duration::milliseconds(DefaultClock::get_time() - last_synced)
-            .format_human()
-            .to_string(),
-        _ => "never".to_string(),
+    Ok(if last_synced != 0 {
+        Duration::milliseconds(DefaultClock::get_time() - last_synced).format_human().to_string()
+    } else {
+        "never".to_string()
     })
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -812,7 +812,9 @@ pub fn get_last_synced_human_string(config: &Config) -> Result<String, Error<Get
     let last_synced = get_last_synced(config)?;
 
     Ok(if last_synced != 0 {
-        Duration::milliseconds(DefaultClock::get_time() - last_synced).format_human().to_string()
+        Duration::milliseconds(DefaultClock::get_time() - last_synced)
+            .format_human()
+            .to_string()
     } else {
         "never".to_string()
     })


### PR DESCRIPTION
In this PR I fixed `get_last_synced_human_string`. The function gave a wrong duration due to incorrectly parsing the time it was given.

fix #573 