### PR TITLE
infra: shorten kotlin interface tests prep and run time

### DIFF
--- a/clients/android/lint.xml
+++ b/clients/android/lint.xml
@@ -2,4 +2,5 @@
 <lint>
         <issue id="UnusedResources" severity="ignore" />
         <issue id="AlwaysShowAction" severity="ignore" />
+        <issue id="GradleDependency" severity="ignore" />
 </lint>

--- a/containers/Dockerfile.kotlin_interface_tests
+++ b/containers/Dockerfile.kotlin_interface_tests
@@ -22,3 +22,6 @@ ENV API_URL=http://lockbook_server:8000
 RUN mkdir -p /clients/android/core/src/main/jniLibs/desktop
 WORKDIR /clients/android
 COPY --from=core-build /core/target/release/liblockbook_core.so /clients/android/core/src/main/jniLibs/desktop/liblockbook_core.so
+
+# Build android
+RUN gradle compileDebugUnitTestSources

--- a/containers/Dockerfile.kotlin_interface_tests
+++ b/containers/Dockerfile.kotlin_interface_tests
@@ -22,6 +22,3 @@ ENV API_URL=http://lockbook_server:8000
 RUN mkdir -p /clients/android/core/src/main/jniLibs/desktop
 WORKDIR /clients/android
 COPY --from=core-build /core/target/release/liblockbook_core.so /clients/android/core/src/main/jniLibs/desktop/liblockbook_core.so
-
-# Build android
-RUN gradle compileDebugUnitTestSources

--- a/containers/Dockerfile.kotlin_interface_tests
+++ b/containers/Dockerfile.kotlin_interface_tests
@@ -24,4 +24,4 @@ WORKDIR /clients/android
 COPY --from=core-build /core/target/release/liblockbook_core.so /clients/android/core/src/main/jniLibs/desktop/liblockbook_core.so
 
 # Build android
-RUN gradle assemble
+RUN gradle compileDebugUnitTestSources

--- a/containers/docker-compose-integration-tests.yml
+++ b/containers/docker-compose-integration-tests.yml
@@ -112,7 +112,7 @@ services:
     entrypoint: >
       /bin/sh -c '\
         sleep 5 && \
-        gradle test \
+        gradle testDebugUnitTest \
       '
 
   performance_bench:


### PR DESCRIPTION
In this PR I shortened the prep and test time for kotlin interface tests by only compiling the tests in the prep phase and only running those compiled tests in the test phase.

Before:
![Screenshot_20210209_183036](https://user-images.githubusercontent.com/20663038/107442304-defb8980-6b04-11eb-99a8-afa2ceddae8f.png)

After:
![Screenshot_20210209_183102](https://user-images.githubusercontent.com/20663038/107442325-eae74b80-6b04-11eb-801c-11d4a11d6272.png)

fixes #553

**There may be a way to shorten the time more, I explain what I mean [here](https://github.com/lockbook/lockbook/issues/553#issuecomment-776302414).**