### PR TITLE
android: use metadata version in file descriptions to show when the file was updated synced

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -166,6 +166,10 @@ object CoreModel {
         return Err(SetLastSyncedError.Unexpected("setLastSyncedConverter was unable to be called!"))
     }
 
+    fun getLastUpdated(
+        metadataVersion: Long
+    ): String = app.lockbook.core.getLastUpdated(metadataVersion)
+
     fun getLastSyncedHumanString(
         config: Config,
     ): Result<String, GetLastSynced> {

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -166,9 +166,9 @@ object CoreModel {
         return Err(SetLastSyncedError.Unexpected("setLastSyncedConverter was unable to be called!"))
     }
 
-    fun getLastUpdated(
+    fun convertToHumanDuration(
         metadataVersion: Long
-    ): String = app.lockbook.core.getLastUpdated(metadataVersion)
+    ): String = app.lockbook.core.convertToHumanDuration(metadataVersion)
 
     fun getLastSyncedHumanString(
         config: Config,

--- a/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
@@ -41,7 +41,7 @@ class LinearRecyclerViewAdapter(listFilesClickInterface: ListFilesClickInterface
         holder.cardView.linear_file_name.text = item.name
         holder.cardView.linear_file_description.text = holder.cardView.resources.getString(
             R.string.last_synced,
-            CoreModel.getLastUpdated(item.metadataVersion)
+            CoreModel.convertToHumanDuration(item.metadataVersion)
         )
 
         when {

--- a/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
@@ -1,20 +1,14 @@
 package app.lockbook.model
 
-import android.content.res.Resources
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.cardview.widget.CardView
 import androidx.core.content.res.ResourcesCompat
 import app.lockbook.App
 import app.lockbook.R
+import app.lockbook.core.getLastUpdatedFile
 import app.lockbook.util.*
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
 import kotlinx.android.synthetic.main.linear_layout_file_item.view.*
-import timber.log.Timber
-import java.sql.Date
-import java.sql.Timestamp
 
 class LinearRecyclerViewAdapter(listFilesClickInterface: ListFilesClickInterface, filesDir: String) :
     GeneralViewAdapter(listFilesClickInterface) {
@@ -41,30 +35,16 @@ class LinearRecyclerViewAdapter(listFilesClickInterface: ListFilesClickInterface
 
     override fun getItemCount(): Int = files.size
 
-    private fun setReadableLastSynced(description: TextView, resources: Resources, metadataVersion: Long) {
-        when (val getLastSyncedHumanStringResult = CoreModel.getLastSyncedHumanString(config)) {
-            is Ok -> description.text = resources.getString(
-                R.string.last_synced,
-                getLastSyncedHumanStringResult.value
-            )
-            is Err -> when (val error = getLastSyncedHumanStringResult.error) {
-                is GetLastSynced.Unexpected -> {
-                    description.text = resources.getString(
-                        R.string.last_synced,
-                        if (metadataVersion != 0L) Date(Timestamp(metadataVersion).time) else resources.getString(R.string.never_synced)
-                    )
-                    Timber.e("Unable to calculate last synced: ${error.error}")
-                }
-            }
-        }.exhaustive
-    }
-
     override fun onBindViewHolder(holder: FileViewHolder, position: Int) {
         val item = files[position]
 
         holder.fileMetadata = item
         holder.cardView.linear_file_name.text = item.name
-        setReadableLastSynced(holder.cardView.linear_file_description, holder.cardView.resources, item.metadataVersion)
+        holder.cardView.linear_file_description.text = holder.cardView.resources.getString(
+            R.string.last_synced,
+            getLastUpdatedFile(item.metadataVersion)
+        )
+
         when {
             selectedFiles[position] -> {
                 holder.cardView.background.setTint(

--- a/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/LinearRecyclerViewAdapter.kt
@@ -6,7 +6,6 @@ import androidx.cardview.widget.CardView
 import androidx.core.content.res.ResourcesCompat
 import app.lockbook.App
 import app.lockbook.R
-import app.lockbook.core.getLastUpdatedFile
 import app.lockbook.util.*
 import kotlinx.android.synthetic.main.linear_layout_file_item.view.*
 
@@ -42,7 +41,7 @@ class LinearRecyclerViewAdapter(listFilesClickInterface: ListFilesClickInterface
         holder.cardView.linear_file_name.text = item.name
         holder.cardView.linear_file_description.text = holder.cardView.resources.getString(
             R.string.last_synced,
-            getLastUpdatedFile(item.metadataVersion)
+            CoreModel.getLastUpdated(item.metadataVersion)
         )
 
         when {

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -1,6 +1,5 @@
 package app.lockbook.model
 
-import android.app.Activity.RESULT_CANCELED
 import android.app.Application
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.lifecycle.AndroidViewModel
@@ -224,8 +223,9 @@ class ListFilesViewModel(path: String, application: Application) :
         uiScope.launch {
             withContext(Dispatchers.IO) {
                 when (requestCode) {
-                    TEXT_EDITOR_REQUEST_CODE, HANDWRITING_EDITOR_REQUEST_CODE -> syncBasedOnPreferences()
-                    RESULT_CANCELED -> {}
+                    TEXT_EDITOR_REQUEST_CODE, HANDWRITING_EDITOR_REQUEST_CODE -> {
+                        syncBasedOnPreferences()
+                    }
                     else -> {
                         Timber.e("Unable to recognize match requestCode: $requestCode.")
                         _errorHasOccurred.postValue(UNEXPECTED_CLIENT_ERROR)

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -93,15 +93,15 @@ class ListFilesFragment : Fragment() {
         }
 
         updatedLastSyncedDescription.schedule(
-                object : TimerTask() {
-                    override fun run() {
-                        handler.post {
-                            adapter.notifyDataSetChanged()
-                        }
+            object : TimerTask() {
+                override fun run() {
+                    handler.post {
+                        adapter.notifyDataSetChanged()
                     }
-                },
-                30000,
-                30000
+                }
+            },
+            30000,
+            30000
         )
 
         listFilesViewModel.files.observe(

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -30,9 +32,12 @@ import com.google.android.material.snackbar.Snackbar
 import com.tingyik90.snackprogressbar.SnackProgressBar
 import com.tingyik90.snackprogressbar.SnackProgressBarManager
 import kotlinx.android.synthetic.main.fragment_list_files.*
+import java.util.*
 
 class ListFilesFragment : Fragment() {
     lateinit var listFilesViewModel: ListFilesViewModel
+    private var updatedLastSyncedDescription = Timer()
+    private val handler = Handler(requireNotNull(Looper.myLooper()))
     private val fragmentFinishedCallback = object : FragmentManager.FragmentLifecycleCallbacks() {
         override fun onFragmentDestroyed(fm: FragmentManager, f: Fragment) {
             if (f is CreateFileDialogFragment) {
@@ -86,6 +91,18 @@ class ListFilesFragment : Fragment() {
         binding.listFilesRefresh.setOnRefreshListener {
             listFilesViewModel.onSwipeToRefresh()
         }
+
+        updatedLastSyncedDescription.schedule(
+                object : TimerTask() {
+                    override fun run() {
+                        handler.post {
+                            adapter.notifyDataSetChanged()
+                        }
+                    }
+                },
+                30000,
+                30000
+        )
 
         listFilesViewModel.files.observe(
             viewLifecycleOwner,

--- a/clients/android/app/src/main/res/values/strings.xml
+++ b/clients/android/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="popup_info_file_type">File Type: %s</string>
     <string name="popup_info_metadata_version">Metadata Version: %s</string>
 
-    <string name="last_synced">Last updated: %s</string>
+    <string name="last_synced">Last synced: %s</string>
     <string name="never_synced">never</string>
     <string name="pop_up_info_never_synced">never synced</string>
 

--- a/clients/android/app/src/main/res/values/strings.xml
+++ b/clients/android/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="popup_info_file_type">File Type: %s</string>
     <string name="popup_info_metadata_version">Metadata Version: %s</string>
 
-    <string name="last_synced">Last synced: %s</string>
+    <string name="last_synced">Last updated: %s</string>
     <string name="never_synced">never</string>
     <string name="pop_up_info_never_synced">never synced</string>
 

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -9,7 +9,7 @@ external fun importAccount(config: String, account: String): String
 external fun exportAccount(config: String): String
 external fun getAccount(config: String): String
 external fun setLastSynced(config: String, lastSynced: Long): String
-external fun getLastUpdatedFile(metadataVersion: Long): String
+external fun getLastUpdated(metadataVersion: Long): String
 external fun getLastSyncedHumanString(config: String): String
 external fun getUsageHumanString(config: String, exact: Boolean): String
 external fun getRoot(config: String): String

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -9,6 +9,7 @@ external fun importAccount(config: String, account: String): String
 external fun exportAccount(config: String): String
 external fun getAccount(config: String): String
 external fun setLastSynced(config: String, lastSynced: Long): String
+external fun getLastUpdatedFile(metadataVersion: Long): String
 external fun getLastSyncedHumanString(config: String): String
 external fun getUsageHumanString(config: String, exact: Boolean): String
 external fun getRoot(config: String): String

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -9,7 +9,7 @@ external fun importAccount(config: String, account: String): String
 external fun exportAccount(config: String): String
 external fun getAccount(config: String): String
 external fun setLastSynced(config: String, lastSynced: Long): String
-external fun getLastUpdated(metadataVersion: Long): String
+external fun convertToHumanDuration(metadataVersion: Long): String
 external fun getLastSyncedHumanString(config: String): String
 external fun getUsageHumanString(config: String, exact: Boolean): String
 external fun getRoot(config: String): String

--- a/clients/android/lint.xml
+++ b/clients/android/lint.xml
@@ -2,4 +2,5 @@
 <lint>
         <issue id="UnusedResources" severity="ignore" />
         <issue id="AlwaysShowAction" severity="ignore" />
+        <issue id="GradleDependency" severity="ignore" />
 </lint>

--- a/core/src/java_interface.rs
+++ b/core/src/java_interface.rs
@@ -411,7 +411,7 @@ pub extern "system" fn Java_app_lockbook_core_CoreKt_createFile(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_app_lockbook_core_CoreKt_getLastUpdatedFile(
+pub extern "system" fn Java_app_lockbook_core_CoreKt_getLastUpdated(
     env: JNIEnv,
     _: JClass,
     metadata_version: jlong,

--- a/core/src/java_interface.rs
+++ b/core/src/java_interface.rs
@@ -411,7 +411,7 @@ pub extern "system" fn Java_app_lockbook_core_CoreKt_createFile(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_app_lockbook_core_CoreKt_getLastUpdated(
+pub extern "system" fn Java_app_lockbook_core_CoreKt_convertToHumanDuration(
     env: JNIEnv,
     _: JClass,
     metadata_version: jlong,


### PR DESCRIPTION
This PR, I fix a previous error where I used get last synced human string, and instead utilize the metadata version for the date.

fixes #592 