### PR TITLE
android: new FABs appear horizontally on small screens

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -2,11 +2,12 @@ package app.lockbook.screen
 
 import android.content.Intent
 import android.content.res.Configuration
-import android.content.res.Configuration.ORIENTATION_PORTRAIT
+import android.content.res.Configuration.*
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout.HORIZONTAL
 import androidx.appcompat.app.AlertDialog
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -265,6 +266,10 @@ class ListFilesFragment : Fragment() {
                 listFilesViewModel.handleRefreshAtParent(position)
             }
         })
+
+        if (resources.configuration.orientation == ORIENTATION_LANDSCAPE && resources.configuration.screenLayout == SCREENLAYOUT_SIZE_SMALL) {
+            list_files_fab_holder.orientation = HORIZONTAL
+        }
     }
 
     private fun setFileAdapter(binding: FragmentListFilesBinding, filesDir: String): GeneralViewAdapter {
@@ -290,7 +295,7 @@ class ListFilesFragment : Fragment() {
             val adapter = GridRecyclerViewAdapter(listFilesViewModel)
             binding.filesList.adapter = adapter
 
-            val displayMetrics = requireContext().resources.displayMetrics
+            val displayMetrics = resources.displayMetrics
             val noOfColumns = (((displayMetrics.widthPixels / displayMetrics.density) / 90)).toInt()
 
             if (orientation == ORIENTATION_PORTRAIT) {

--- a/clients/android/app/src/main/res/layout/fragment_list_files.xml
+++ b/clients/android/app/src/main/res/layout/fragment_list_files.xml
@@ -75,7 +75,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|end"
-                android:gravity="center_horizontal"
+                android:gravity="center"
                 android:orientation="vertical">
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/clients/android/app/src/main/res/layout/fragment_list_files.xml
+++ b/clients/android/app/src/main/res/layout/fragment_list_files.xml
@@ -71,6 +71,7 @@
                 android:text="@string/empty_folder" />
 
             <LinearLayout
+                android:id="@+id/list_files_fab_holder"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|end"
@@ -105,7 +106,7 @@
                     android:id="@+id/list_files_fab"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_margin="18dp"
+                    android:layout_margin="10dp"
                     app:backgroundTint="@color/colorPrimary"
                     android:contentDescription="@string/list_files_create_file"
                     android:onClick="@{() -> listFilesViewModel.collapseExpandFAB()}"

--- a/clients/android/app/src/main/res/values/styles.xml
+++ b/clients/android/app/src/main/res/values/styles.xml
@@ -70,7 +70,7 @@
     <style name="Main.Widget.FAB" parent="Widget.MaterialComponents.FloatingActionButton">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_margin">10dp</item>
+        <item name="android:layout_margin">5dp</item>
         <item name="backgroundTint">@color/colorPrimary</item>
         <item name="rippleColor">@color/light</item>
         <item name="tint">@null</item>

--- a/clients/android/lint.xml
+++ b/clients/android/lint.xml
@@ -2,4 +2,5 @@
 <lint>
         <issue id="UnusedResources" severity="ignore" />
         <issue id="AlwaysShowAction" severity="ignore" />
+        <issue id="GradleDependency" severity="ignore" />
 </lint>


### PR DESCRIPTION
In this PR, FABs will appear horizontally on small screens that are landscape. I chose to do this since there will be multiple visual glitches if the screen is too small to fit the FABs. So to circumvent this, I wanted the FABs to appear along the larger side, in portrait it will stay the same (appear vertically), in landscape it will be horizontally.

I also shrunk the distance between the FABs a bit to help out.

Screenshot of a small device in landscape using this PR:
<details>

![Screenshot_20210213_111756](https://user-images.githubusercontent.com/20663038/107854908-2af04c00-6ded-11eb-8ccc-bbf9d5c68170.png)
</details>

fixes #548 