### PR TITLE
linux: use get_usage_human_string

### DIFF
--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -1017,7 +1017,7 @@ fn usage(usage_string: String) -> LbResult<GtkBox> {
     let title = GtkLabel::new(Some("Total Usage"));
     let attr_list = pango::AttrList::new();
     let attr = pango::Attribute::new_weight(pango::Weight::Bold)
-        .ok_or(progerr!("Unable to apply bold attribute to title."))?;
+        .ok_or_else(|| progerr!("Unable to apply bold attribute to title."))?;
 
     attr_list.change(attr);
     title.set_attributes(Some(&attr_list));

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -684,7 +684,7 @@ impl LbApp {
 
     fn show_dialog_usage(&self) -> LbResult<()> {
         let usage_string = self.core.usage_human_string()?;
-        let usage = usage(usage_string);
+        let usage = usage(usage_string)?;
         let d = self.gui.new_dialog("My Lockbook Usage");
         d.get_content_area().add(&usage);
         d.show_all();
@@ -1013,15 +1013,25 @@ fn sync_details(c: &Arc<LbCore>) -> LbResult<GtkBox> {
     Ok(cntr)
 }
 
-fn usage(usage_string: String) -> GtkBox {
+fn usage(usage_string: String) -> LbResult<GtkBox> {
+    let title = GtkLabel::new(Some("Total Usage"));
+    let attr_list = pango::AttrList::new();
+    let attr = pango::Attribute::new_weight(pango::Weight::Bold)
+        .ok_or(progerr!("Unable to apply bold attribute to title."))?;
+
+    attr_list.change(attr);
+    title.set_attributes(Some(&attr_list));
+    title.set_margin_bottom(20);
+
     let lbl = GtkLabel::new(Some(&usage_string));
     lbl.set_margin_bottom(24);
 
     let cntr = GtkBox::new(Vertical, 0);
     util::gui::set_marginy(&cntr, 36);
-    util::gui::set_marginx(&cntr, 120);
+    util::gui::set_marginx(&cntr, 100);
+    cntr.add(&title);
     cntr.add(&lbl);
-    cntr
+    Ok(cntr)
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -14,12 +14,12 @@ use gtk::{
     Application as GtkApp, ApplicationWindow as GtkAppWindow, Box as GtkBox,
     CellRendererText as GtkCellRendererText, CheckButton as GtkCheckBox, Dialog as GtkDialog,
     Entry as GtkEntry, EntryCompletion as GtkEntryCompletion, Image as GtkImage, Label as GtkLabel,
-    ListStore as GtkListStore, Notebook as GtkNotebook, ProgressBar as GtkProgressBar,
-    ResponseType as GtkResponseType, SelectionMode as GtkSelectionMode,
-    SortColumn as GtkSortColumn, SortType as GtkSortType, Spinner as GtkSpinner, Stack as GtkStack,
-    TreeIter as GtkTreeIter, TreeModel as GtkTreeModel, TreeModelSort as GtkTreeModelSort,
-    TreeStore as GtkTreeStore, TreeView as GtkTreeView, TreeViewColumn as GtkTreeViewColumn,
-    Widget as GtkWidget, WidgetExt as GtkWidgetExt, WindowPosition as GtkWindowPosition,
+    ListStore as GtkListStore, Notebook as GtkNotebook, ResponseType as GtkResponseType,
+    SelectionMode as GtkSelectionMode, SortColumn as GtkSortColumn, SortType as GtkSortType,
+    Spinner as GtkSpinner, Stack as GtkStack, TreeIter as GtkTreeIter, TreeModel as GtkTreeModel,
+    TreeModelSort as GtkTreeModelSort, TreeStore as GtkTreeStore, TreeView as GtkTreeView,
+    TreeViewColumn as GtkTreeViewColumn, Widget as GtkWidget, WidgetExt as GtkWidgetExt,
+    WindowPosition as GtkWindowPosition,
 };
 use uuid::Uuid;
 
@@ -683,8 +683,8 @@ impl LbApp {
     }
 
     fn show_dialog_usage(&self) -> LbResult<()> {
-        let (n_bytes, limit) = self.core.usage()?;
-        let usage = usage(n_bytes, limit);
+        let usage_string = self.core.usage_human_string()?;
+        let usage = usage(usage_string);
         let d = self.gui.new_dialog("My Lockbook Usage");
         d.get_content_area().add(&usage);
         d.show_all();
@@ -1013,22 +1013,14 @@ fn sync_details(c: &Arc<LbCore>) -> LbResult<GtkBox> {
     Ok(cntr)
 }
 
-fn usage(usage: u64, limit: f64) -> GtkBox {
-    let human_limit = util::human_readable_bytes(limit as u64);
-    let human_usage = util::human_readable_bytes(usage);
-
-    let lbl = GtkLabel::new(Some(&format!("{} / {}", human_usage, human_limit)));
+fn usage(usage_string: String) -> GtkBox {
+    let lbl = GtkLabel::new(Some(&usage_string));
     lbl.set_margin_bottom(24);
-
-    let pbar = GtkProgressBar::new();
-    util::gui::set_marginx(&pbar, 16);
-    pbar.set_size_request(300, -1);
-    pbar.set_fraction(usage as f64 / limit);
 
     let cntr = GtkBox::new(Vertical, 0);
     util::gui::set_marginy(&cntr, 36);
+    util::gui::set_marginx(&cntr, 120);
     cntr.add(&lbl);
-    cntr.add(&pbar);
     cntr
 }
 

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -16,12 +16,11 @@ use lockbook_core::service::sync_service::WorkCalculated;
 use lockbook_core::{
     calculate_work, create_account, create_file_at_path, delete_file, execute_work, export_account,
     get_account, get_and_get_children_recursively, get_children, get_db_state, get_file_by_id,
-    get_file_by_path, get_last_synced, get_root, get_usage, import_account, list_paths, migrate_db,
-    read_document, rename_file, set_last_synced, write_document,
+    get_file_by_path, get_last_synced, get_root, get_usage_human_string, import_account,
+    list_paths, migrate_db, read_document, rename_file, set_last_synced, write_document,
 };
 
 use crate::error::{LbError, LbResult};
-use crate::util::KILOBYTE;
 use crate::{progerr, uerr};
 
 macro_rules! match_core_err {
@@ -283,14 +282,12 @@ impl LbCore {
         ))
     }
 
-    pub fn usage(&self) -> LbResult<(u64, f64)> {
-        let u = get_usage(&self.config).map_err(map_core_err!(GetUsageError,
+    pub fn usage_human_string(&self) -> LbResult<String> {
+        get_usage_human_string(&self.config, false).map_err(map_core_err!(GetUsageError,
             NoAccount => uerr!("No account found."),
             CouldNotReachServer => uerr!("Unable to connect to the server."),
             ClientUpdateRequired => uerr!("Client upgrade required."),
-        ))?;
-        let total = u.into_iter().map(|usage| usage.byte_secs).sum();
-        Ok((total, FAKE_LIMIT))
+        ))
     }
 
     pub fn has_account(&self) -> LbResult<bool> {
@@ -369,6 +366,5 @@ impl LbCore {
 }
 
 const UNAME_REQS: &str = "letters and numbers only";
-const FAKE_LIMIT: f64 = KILOBYTE as f64 * 20.0;
 const STATE_REQ_CLEAN_MSG: &str =
     "Your local state cannot be migrated, please re-sync with a fresh client.";

--- a/clients/linux/src/util.rs
+++ b/clients/linux/src/util.rs
@@ -1,25 +1,3 @@
-pub const BYTE: u64 = 1;
-pub const KILOBYTE: u64 = BYTE * 1024;
-pub const MEGABYTE: u64 = KILOBYTE * 1024;
-pub const GIGABYTE: u64 = MEGABYTE * 1024;
-pub const TERABYTE: u64 = GIGABYTE * 1024;
-
-const KILOBYTE_PLUS_ONE: u64 = KILOBYTE + 1;
-const MEGABYTE_PLUS_ONE: u64 = MEGABYTE + 1;
-const GIGABYTE_PLUS_ONE: u64 = GIGABYTE + 1;
-const TERABYTE_PLUS_ONE: u64 = TERABYTE + 1;
-
-pub fn human_readable_bytes(v: u64) -> String {
-    let (unit, abbr) = match v {
-        0..=KILOBYTE => (BYTE, ""),
-        KILOBYTE_PLUS_ONE..=MEGABYTE => (KILOBYTE, "K"),
-        MEGABYTE_PLUS_ONE..=GIGABYTE => (MEGABYTE, "M"),
-        GIGABYTE_PLUS_ONE..=TERABYTE => (GIGABYTE, "G"),
-        TERABYTE_PLUS_ONE..=u64::MAX => (TERABYTE, "T"),
-    };
-    format!("{:.3} {}B", v as f64 / unit as f64, abbr)
-}
-
 pub fn make_glib_chan<T, F: FnMut(T) -> glib::Continue + 'static>(func: F) -> glib::Sender<T> {
     let (s, r) = glib::MainContext::channel::<T>(glib::PRIORITY_DEFAULT);
     r.attach(None, func);


### PR DESCRIPTION
In this PR, I utilize `get_usage_human_string`, and get rid of the duplicate logic used to do the same thing.

KDE Screenshot
<details>

![Screenshot_20210317_170527](https://user-images.githubusercontent.com/20663038/111544778-03213a80-8743-11eb-8d4f-edbdf5ff2e0c.png)
</details>

fixes #609 