### PR TITLE
Apple Move/Rename

### DIFF
--- a/clients/apple/Shared/Components/FileCell.swift
+++ b/clients/apple/Shared/Components/FileCell.swift
@@ -33,13 +33,12 @@ struct FileCell: View {
 struct SyntheticFileCell: View {
     let parent: FileMetadata
     let type: FileType
-    @Binding var nameField: String
-    @Binding var fileExtension: String
+    @Binding var name: String
     let onCommit: () -> Void
     let onCancel: () -> Void
     
     var newWhat: String {
-        if fileExtension == ".draw" && type == .Document {
+        if name.hasSuffix(".draw") && type == .Document {
             return "Drawing"
         } else {
             return type.rawValue
@@ -49,18 +48,10 @@ struct SyntheticFileCell: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 5) {
-                HStack {
-                    TextField(type == .Folder ? "folder name" : "document name", text: $nameField,
-                              onCommit: onCommit)
+                ZStack {
+                    TextField(type == .Folder ? "folder name" : "document name", text: $name, onCommit: onCommit)
                         .autocapitalization(.none)
                         .font(.title3)
-                    if type == .Document {
-                        TextField("File Extension", text: $fileExtension,
-                                  onCommit: onCommit)
-                            .autocapitalization(.none)
-                            .font(.title3)
-                            .frame(width: 50)
-                    }
                 }
                 HStack {
                     Image(systemName: type == .Folder ? "folder" : "doc")
@@ -68,14 +59,13 @@ struct SyntheticFileCell: View {
                     Text("New \(newWhat) in \(parent.name)")
                         .foregroundColor(.gray)
                 }.font(.footnote)
-            }.padding(.vertical, 5)
-            
+            }
+
             Button(action: onCancel) {
                 Image(systemName: "xmark")
                     .foregroundColor(.red)
             }.padding(.trailing, 10)
-        }
-        
+        }.padding(.vertical, 5)
     }
 }
 
@@ -83,13 +73,13 @@ struct FileCell_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             FileCell(meta: GlobalState().files[0])
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".md"), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {})
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".text"), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {})
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".draw"), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {})
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Folder, nameField: .constant(""), fileExtension: .constant(".md"), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Folder, name: .constant(""), onCommit: {}, onCancel: {})
             
         }
         .previewLayout(.fixed(width: 300, height: 50))

--- a/clients/apple/Shared/Components/FileCell.swift
+++ b/clients/apple/Shared/Components/FileCell.swift
@@ -35,7 +35,7 @@ struct SyntheticFileCell: View {
     let type: FileType
     @Binding var nameField: String
     @Binding var fileExtension: String
-    let onCreate: () -> Void
+    let onCommit: () -> Void
     let onCancel: () -> Void
     
     var newWhat: String {
@@ -51,12 +51,12 @@ struct SyntheticFileCell: View {
             VStack(alignment: .leading, spacing: 5) {
                 HStack {
                     TextField(type == .Folder ? "folder name" : "document name", text: $nameField,
-                              onCommit: onCreate)
+                              onCommit: onCommit)
                         .autocapitalization(.none)
                         .font(.title3)
                     if type == .Document {
                         TextField("File Extension", text: $fileExtension,
-                                  onCommit: onCreate)
+                                  onCommit: onCommit)
                             .autocapitalization(.none)
                             .font(.title3)
                             .frame(width: 50)
@@ -83,13 +83,13 @@ struct FileCell_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             FileCell(meta: GlobalState().files[0])
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".md"), onCreate: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".md"), onCommit: {}, onCancel: {})
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".text"), onCreate: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".text"), onCommit: {}, onCancel: {})
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".draw"), onCreate: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, nameField: .constant(""), fileExtension: .constant(".draw"), onCommit: {}, onCancel: {})
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Folder, nameField: .constant(""), fileExtension: .constant(".md"), onCreate: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Folder, nameField: .constant(""), fileExtension: .constant(".md"), onCommit: {}, onCancel: {})
             
         }
         .previewLayout(.fixed(width: 300, height: 50))

--- a/clients/apple/Shared/Components/FileCell.swift
+++ b/clients/apple/Shared/Components/FileCell.swift
@@ -36,6 +36,7 @@ struct SyntheticFileCell: View {
     @Binding var name: String
     let onCommit: () -> Void
     let onCancel: () -> Void
+    let renaming: Bool
     
     var newWhat: String {
         if name.hasSuffix(".draw") && type == .Document {
@@ -56,7 +57,7 @@ struct SyntheticFileCell: View {
                 HStack {
                     Image(systemName: type == .Folder ? "folder" : "doc")
                         .foregroundColor(type == .Folder ? .blue : .secondary)
-                    Text("New \(newWhat) in \(parent.name)")
+                    Text(renaming ? "Renaming \(parent.name)" : "New \(newWhat) in \(parent.name)")
                         .foregroundColor(.gray)
                 }.font(.footnote)
             }
@@ -73,13 +74,13 @@ struct FileCell_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             FileCell(meta: GlobalState().files[0])
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {}, renaming: false)
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {}, renaming: false)
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Document, name: .constant(""), onCommit: {}, onCancel: {}, renaming: false)
             
-            SyntheticFileCell(parent: GlobalState().files[0], type: .Folder, name: .constant(""), onCommit: {}, onCancel: {})
+            SyntheticFileCell(parent: GlobalState().files[0], type: .Folder, name: .constant(""), onCommit: {}, onCancel: {}, renaming: false)
             
         }
         .previewLayout(.fixed(width: 300, height: 50))

--- a/clients/apple/Shared/Components/NestedList.swift
+++ b/clients/apple/Shared/Components/NestedList.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import SwiftLockbookCore
+
+struct NestedList<T: Identifiable, V: View>: View {
+    let node: WithChild<T>
+    let row: (T) -> V
+    @State var expanded: Bool
+
+    init(node: WithChild<T>, row: @escaping (T) -> V) {
+        self.node = node
+        self.row = row
+        // Start expanded up to 3 levels deep!
+        self._expanded = .init(initialValue: node.level < 3)
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack {
+                row(node.value)
+                Spacer()
+                if (!node.children.isEmpty) {
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(expanded ? .degrees(90) : .zero)
+                        .onTapGesture {
+                            withAnimation {
+                                expanded.toggle()
+                            }
+                        }
+                }
+            }
+            if (expanded) {
+                ForEach(node.children) { c in
+                    NestedList(node: c, row: row).padding(.leading, 30)
+                }
+            }
+        }
+    }
+}
+
+struct WithChild<T>: Identifiable where T: Identifiable {
+    var id: T.ID {
+        value.id
+    }
+
+    let value: T
+    let children: [WithChild<T>]
+    let level: Int
+
+    init(_ value: T, _ children: [WithChild<T>], level: Int = 0) {
+        self.value = value
+        self.children = children
+        self.level = level
+    }
+
+    init(_ value: T, _ ts: [T], _ desc: (T, T) -> Bool, level: Int = 0) {
+        self.value = value
+        self.level = level
+        self.children = ts.compactMap {
+            if (desc(value, $0)) {
+                return Self($0, ts, desc, level: level+1)
+            } else {
+                return nil
+            }
+        }
+    }
+}
+
+struct NestedList_Previews: PreviewProvider {
+    static var previews: some View {
+        NestedList(
+            node: .init(FakeApi.root, FakeApi.fileMetas, { $0.id == $1.parent && $0.id != $1.id && $1.fileType == .Folder }),
+            row: {
+                Label($0.name, systemImage: "folder")
+            }
+        )
+    }
+}

--- a/clients/apple/Shared/Stateful Logic/GlobalState.swift
+++ b/clients/apple/Shared/Stateful Logic/GlobalState.swift
@@ -80,7 +80,6 @@ class GlobalState: ObservableObject {
     }
     
     func updateFiles() {
-        print("Updating files!")
         if (account != nil) {
             switch api.getRoot() {
             case .success(let root):

--- a/clients/apple/Shared/Views/BookView.swift
+++ b/clients/apple/Shared/Views/BookView.swift
@@ -6,11 +6,15 @@ struct BookView: View {
     @ObservedObject var core: GlobalState
     let currentFolder: FileMetadata
     let account: Account
+    @State var moving: FileMetadata?
     
     var body: some View {
         NavigationView {
+            #if os(iOS)
+            FileListView(core: core, currentFolder: currentFolder, account: account, moving: $moving)
+            #else
             FileListView(core: core, currentFolder: currentFolder, account: account)
-
+            #endif
         }
     }
 }

--- a/clients/apple/Shared/Views/EditorView.swift
+++ b/clients/apple/Shared/Views/EditorView.swift
@@ -143,7 +143,7 @@ extension NSTextField {
 struct EditorView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            EditorLoader(content: GlobalState().openDocument, meta: FakeApi().fileMetas[0], files: FakeApi().fileMetas)
+            EditorLoader(content: GlobalState().openDocument, meta: FakeApi.fileMetas[0], files: FakeApi.fileMetas)
         }
         .preferredColorScheme(.dark)
     }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
@@ -97,6 +97,10 @@ public struct CoreApi: LockbookApi {
     public func renameFile(id: UUID, name: String) -> FfiResult<Empty, RenameFileError> {
         fromPrimitiveResult(result: rename_file(documentsDirectory, id.uuidString, name))
     }
+
+    public func moveFile(id: UUID, newParent: UUID) -> FfiResult<Empty, MoveFileError> {
+        fromPrimitiveResult(result: move_file(documentsDirectory, id.uuidString, newParent.uuidString))
+    }
     
     public func getState() -> FfiResult<DbState, GetStateError> {
         fromPrimitiveResult(result: get_db_state(documentsDirectory))

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
@@ -91,6 +91,10 @@ Vestibulum ante ipsum primis in vel.
     public func renameFile(id: UUID, name: String) -> FfiResult<Empty, RenameFileError> {
         .failure(.init(unexpected: "LAZY"))
     }
+
+    public func moveFile(id: UUID, newParent: UUID) -> FfiResult<Empty, MoveFileError> {
+        .failure(.init(unexpected: "LAZY"))
+    }
     
     public func getState() -> FfiResult<DbState, GetStateError> {
         .failure(.init(unexpected: "LAZY"))

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
@@ -115,5 +115,6 @@ Vestibulum ante ipsum primis in vel.
         FileMetadata(fileType: .Document, id: UUID(uuidString: "7578bedd-6429-47ad-b03d-a8d9eebaec0c").unsafelyUnwrapped, parent: UUID(uuidString: "53470907-5628-49eb-a8b0-8212cf9c8a91").unsafelyUnwrapped, name: "nice_1.txt", owner: "jeff", contentVersion: 1587384000000, metadataVersion: 1587384000000, deleted: false),
         FileMetadata(fileType: .Document, id: UUID(uuidString: "c27e3c81-a2cb-4638-8ab5-c395bc119b92").unsafelyUnwrapped, parent: UUID(uuidString: "53470907-5628-49eb-a8b0-8212cf9c8a91").unsafelyUnwrapped, name: "nice_2.txt", owner: "jeff", contentVersion: 1587384000000, metadataVersion: 1587384000000, deleted: false),
         FileMetadata(fileType: .Folder, id: UUID(uuidString: "7ca0d23a-4d17-478c-9152-c37683761ce2").unsafelyUnwrapped, parent: UUID(uuidString: "aa9c473b-79d3-4d11-b6c7-7c82d6fb94cc").unsafelyUnwrapped, name: "other_stuff", owner: "jeff", contentVersion: 1587384000000, metadataVersion: 1587384000000, deleted: false),
+        FileMetadata(fileType: .Folder, id: UUID(uuidString: "5e828f37-4695-477d-8157-7434cea29474").unsafelyUnwrapped, parent: UUID(uuidString: "7ca0d23a-4d17-478c-9152-c37683761ce2").unsafelyUnwrapped, name: "deep_other_stuff", owner: "jeff", contentVersion: 1587384000000, metadataVersion: 1587384000000, deleted: false),
     ]
 }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
@@ -46,7 +46,7 @@ public struct FakeApi: LockbookApi {
     }
     
     public func listFiles() -> FfiResult<[FileMetadata], ListMetadatasError> {
-        return .success(fileMetas)
+        return .success(FakeApi.fileMetas)
     }
     
     public func getFile(id: UUID) -> FfiResult<String, ReadDocumentError> {
@@ -106,7 +106,7 @@ Vestibulum ante ipsum primis in vel.
     
     public let username: Account.Username = "jeff"
     public static let root = FileMetadata(fileType: .Folder, id: UUID(uuidString: "aa9c473b-79d3-4d11-b6c7-7c82d6fb94cc").unsafelyUnwrapped, parent: UUID(uuidString: "aa9c473b-79d3-4d11-b6c7-7c82d6fb94cc").unsafelyUnwrapped, name: "jeff", owner: "jeff", contentVersion: 1587384000000, metadataVersion: 1587384000000, deleted: false)
-    public let fileMetas = [
+    public static let fileMetas = [
         root,
         FileMetadata(fileType: .Document, id: UUID(uuidString: "e956c7a2-db7f-4f9d-98c3-217847acf23a").unsafelyUnwrapped, parent: UUID(uuidString: "aa9c473b-79d3-4d11-b6c7-7c82d6fb94cc").unsafelyUnwrapped, name: "first_file.md", owner: "jeff", contentVersion: 1587384000000, metadataVersion: 1587384000000, deleted: false),
         FileMetadata(fileType: .Document, id: UUID(uuidString: "644d1d56-8e24-4a32-8304-e906435f95db").unsafelyUnwrapped, parent: UUID(uuidString: "aa9c473b-79d3-4d11-b6c7-7c82d6fb94cc").unsafelyUnwrapped, name: "another_file.md", owner: "jeff", contentVersion: 1587384000000, metadataVersion: 1587384000000, deleted: false),

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
@@ -24,6 +24,7 @@ public protocol LockbookApi {
     func updateFile(id: UUID, content: String) -> FfiResult<Empty, WriteToDocumentError>
     func deleteFile(id: UUID) -> FfiResult<Empty, FileDeleteError>
     func renameFile(id: UUID, name: String) -> FfiResult<Empty, RenameFileError>
+    func moveFile(id: UUID, newParent: UUID) -> FfiResult<Empty, MoveFileError>
     func readDrawing(id: UUID) -> FfiResult<Drawing, ReadDocumentError>
     func writeDrawing(id: UUID, content: Drawing) -> FfiResult<Empty, WriteToDocumentError>
 

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FileMetadata.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FileMetadata.swift
@@ -11,6 +11,7 @@ public struct FileMetadata: Codable, Identifiable, Equatable {
     public var deleted: Bool
     public var userAccessKeys: [Account.Username : UserAccessInfo] = .init()
     public var folderAccessKeys: FolderAccessInfo = FolderAccessInfo(folderId: .init(), accessKey: .init(value: [], nonce: []))
+    public var isRoot: Bool { parent == id }
     
     public static func == (lhs: FileMetadata, rhs: FileMetadata) -> Bool {
         return lhs.fileType == rhs.fileType &&

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FileMetadata.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FileMetadata.swift
@@ -19,7 +19,8 @@ public struct FileMetadata: Codable, Identifiable, Equatable {
             lhs.contentVersion == rhs.contentVersion &&
             lhs.parent == rhs.parent &&
             lhs.owner == rhs.owner &&
-            lhs.deleted == rhs.deleted
+            lhs.deleted == rhs.deleted &&
+            lhs.name == rhs.name
     }
 }
 

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -7,7 +7,6 @@ struct FileListView: View {
     @State var showingAccount: Bool = false
     @State var creating: FileType?
     @State var creatingName: String = ""
-    @State var creatingFileExtension = ""
     let currentFolder: FileMetadata
     let account: Account
     @Binding var moving: FileMetadata?
@@ -22,7 +21,7 @@ struct FileListView: View {
         ScrollView {
             VStack {
                 creating.map { type in
-                    SyntheticFileCell(parent: currentFolder, type: type, nameField: $creatingName, fileExtension: $creatingFileExtension, onCommit: {
+                    SyntheticFileCell(parent: currentFolder, type: type, name: $creatingName, onCommit: {
                         handleCreate(meta: currentFolder, type: type)
                     }, onCancel: doneCreating)
                 }
@@ -128,7 +127,7 @@ struct FileListView: View {
     }
     
     func handleCreate(meta: FileMetadata, type: FileType) {
-        switch core.api.createFile(name: creatingName + creatingFileExtension, dirId: meta.id, isFolder: type == .Folder) {
+        switch core.api.createFile(name: creatingName, dirId: meta.id, isFolder: type == .Folder) {
         case .success(_):
             doneCreating()
             core.updateFiles()
@@ -147,16 +146,14 @@ struct FileListView: View {
     func newDocument() {
         withAnimation {
             creating = .Document
-            creatingName = ""
-            creatingFileExtension = ".md"
+            creatingName = ".md"
         }
     }
     
     func newDrawing() {
         withAnimation {
             creating = .Document
-            creatingName = ""
-            creatingFileExtension = ".draw"
+            creatingName = ".draw"
         }
     }
     

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -22,7 +22,7 @@ struct FileListView: View {
         ScrollView {
             VStack {
                 creating.map { type in
-                    SyntheticFileCell(parent: currentFolder, type: type, nameField: $creatingName, fileExtension: $creatingFileExtension, onCreate: {
+                    SyntheticFileCell(parent: currentFolder, type: type, nameField: $creatingName, fileExtension: $creatingFileExtension, onCommit: {
                         handleCreate(meta: currentFolder, type: type)
                     }, onCancel: doneCreating)
                 }

--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		EA380B212561FA2C0021C4FA /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA380B1F2561FA2C0021C4FA /* AccountView.swift */; };
 		EA380B262561FAEF0021C4FA /* FileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA380B242561FAEF0021C4FA /* FileListView.swift */; };
 		EA4559BE25169F7D003AD80A /* CodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4559BD25169F7D003AD80A /* CodeScannerView.swift */; };
+		EA5979A126040DB1007B9357 /* NestedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5979A026040DB1007B9357 /* NestedList.swift */; };
+		EA5979A226040DB1007B9357 /* NestedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5979A026040DB1007B9357 /* NestedList.swift */; };
 		EA5C7D7B2516606100F7F358 /* LockbookApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C7D682516605F00F7F358 /* LockbookApp.swift */; };
 		EA5C7D7C2516606100F7F358 /* LockbookApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C7D682516605F00F7F358 /* LockbookApp.swift */; };
 		EA5C7D7F2516606100F7F358 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EA5C7D6A2516606000F7F358 /* Assets.xcassets */; };
@@ -90,6 +92,7 @@
 		EA380B1F2561FA2C0021C4FA /* AccountView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountView.swift; sourceTree = "<group>"; };
 		EA380B242561FAEF0021C4FA /* FileListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileListView.swift; sourceTree = "<group>"; };
 		EA4559BD25169F7D003AD80A /* CodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeScannerView.swift; sourceTree = "<group>"; };
+		EA5979A026040DB1007B9357 /* NestedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedList.swift; sourceTree = "<group>"; };
 		EA5C7D682516605F00F7F358 /* LockbookApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockbookApp.swift; sourceTree = "<group>"; };
 		EA5C7D6A2516606000F7F358 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		EA5C7D6F2516606000F7F358 /* Lockbook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lockbook.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -237,6 +240,7 @@
 				EA30B54C25298B0800D2FE22 /* UsageIndicator.swift */,
 				EA349F0A25BE6BD80016241E /* ActivityIndicator.swift */,
 				EAD401CC25E311320083A236 /* NotepadView.swift */,
+				EA5979A026040DB1007B9357 /* NestedList.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -385,6 +389,7 @@
 				1F7E4FBF2521297D0045F606 /* Colors.swift in Sources */,
 				EA831A5A2534E5020048CE26 /* SettingsView.swift in Sources */,
 				B2B7E2E225C6411800B9EFAD /* OnboardingState.swift in Sources */,
+				EA5979A126040DB1007B9357 /* NestedList.swift in Sources */,
 				EAD401CD25E311320083A236 /* NotepadView.swift in Sources */,
 				EA9079C32569960A00E04F5D /* FileCell.swift in Sources */,
 				8741E8E425AAA524005B7B01 /* BottomBar.swift in Sources */,
@@ -412,6 +417,7 @@
 			files = (
 				87206EBD25C61DF300870A42 /* CreateAccountView.swift in Sources */,
 				B2B7E2E325C6411800B9EFAD /* OnboardingState.swift in Sources */,
+				EA5979A226040DB1007B9357 /* NestedList.swift in Sources */,
 				EA831A562534E3C80048CE26 /* AppView.swift in Sources */,
 				EA5C9F4D25E4C4D500DA7C6D /* NotepadView.swift in Sources */,
 				B2B7E2EC25C669C400B9EFAD /* NotificationButton.swift in Sources */,

--- a/clients/apple/macOS/OutlineRow.swift
+++ b/clients/apple/macOS/OutlineRow.swift
@@ -63,15 +63,16 @@ struct OutlineRow: View {
 struct SyntheticOutlineRow: View {
     let fileType: FileType
     var level: CGFloat
-    let onCreate: (String) -> Void
+    let onCommit: (String) -> Void
     let onCancel: () -> Void
+    let pendingImage: Image
 
     @State var nameField: String = ""
 
     var body: some View {
         HStack {
             Group {
-                Image(systemName: "plus")
+                pendingImage
             }
             .frame(width: 16, height: 16)
             Image(systemName: fileType == .Folder ? "folder" : "doc")
@@ -81,7 +82,7 @@ struct SyntheticOutlineRow: View {
 
             TextField("\(fileType.rawValue.lowercased()) name", text: $nameField, onCommit: {
                 if (!nameField.isEmpty) {
-                    onCreate(nameField)
+                    onCommit(nameField)
                 } else {
                     onCancel()
                 }

--- a/clients/apple/macOS/OutlineRow.swift
+++ b/clients/apple/macOS/OutlineRow.swift
@@ -7,6 +7,7 @@ struct OutlineRow: View {
     var file: FileMetadata
     var level: CGFloat
     @Binding var open: Bool
+    @Binding var dragging: FileMetadata?
 
     var children: [FileMetadata] {
         core.files.filter {
@@ -52,6 +53,10 @@ struct OutlineRow: View {
         .padding(.vertical, 4)
         .contentShape(Rectangle())
         .padding(.leading, level * 20)
+        .onDrag {
+            self.dragging = file
+            return NSItemProvider(object: self.file.id.uuidString as NSString)
+        }
     }
 }
 


### PR DESCRIPTION
- Modifies iOS `SyntheticCell` to be more generic (removes weird double `TextField` for just a pre-populated suffix)
- iOS move dialog
- macOS drag & drop move
- macOS `SyntheticCell` rename



https://user-images.githubusercontent.com/2370497/111727744-e15aad00-8841-11eb-8e5b-bf9e0a0b80de.mov


https://user-images.githubusercontent.com/2370497/111727491-5b3e6680-8841-11eb-90a4-cc738129e435.mov

fixes #509 
fixes #511 
fixes #510 