### PR TITLE
cli: touchup errors and docs

### DIFF
--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -12,40 +12,45 @@ use crate::error::{CliResult, Error};
 use crate::utils::{exit_success, get_account_or_exit, get_config};
 use crate::{err, err_extra, err_unexpected, path_string};
 
-pub fn copy(path: PathBuf, import_dest: &str, edit: bool) -> CliResult<()> {
+pub fn copy(filesystem_path: PathBuf, lockbook_path: &str, edit: bool) -> CliResult<()> {
     get_account_or_exit();
 
     let config = get_config();
 
-    if path.is_file() {
-        match copy_file(&path, import_dest, &config, edit) {
+    if filesystem_path.is_file() {
+        match copy_file(&filesystem_path, lockbook_path, &config, edit) {
             Ok(msg) => exit_success(&msg),
             Err(err) => Err(err),
         }
     } else {
-        let import_dir = match import_dest.ends_with('/') {
-            true => import_dest.to_string(),
-            false => format!("{}/", import_dest),
+        let import_dir = match lockbook_path.ends_with('/') {
+            true => lockbook_path.to_string(),
+            false => format!("{}/", lockbook_path),
         };
-        let parent = path
+        let parent = filesystem_path
             .file_name()
             .and_then(|name| name.to_str())
-            .unwrap_or_else(|| err!(OsCouldNotGetFileName(path_string!(path))).exit());
+            .unwrap_or_else(|| err!(OsCouldNotGetFileName(path_string!(filesystem_path))).exit());
         let import_path = format!("{}{}", import_dir, parent);
 
-        recursive_copy_folder(&path, &import_path, &config, edit);
+        recursive_copy_folder(&filesystem_path, &import_path, &config, edit);
         Ok(())
     }
 }
 
-fn recursive_copy_folder(path: &PathBuf, import_dest: &str, config: &Config, edit: bool) {
-    if path.is_file() {
-        match copy_file(&path, import_dest, config, edit) {
+fn recursive_copy_folder(
+    filesystem_path: &PathBuf,
+    lockbook_path: &str,
+    config: &Config,
+    edit: bool,
+) {
+    if filesystem_path.is_file() {
+        match copy_file(&filesystem_path, lockbook_path, config, edit) {
             Ok(msg) => println!("{}", msg),
             Err(err) => err.print(),
         }
     } else {
-        let children: Vec<DirEntry> = read_dir_entries_or_exit(&path);
+        let children: Vec<DirEntry> = read_dir_entries_or_exit(&filesystem_path);
 
         if !children.is_empty() {
             for child in children {
@@ -57,23 +62,23 @@ fn recursive_copy_folder(path: &PathBuf, import_dest: &str, config: &Config, edi
                         err!(OsCouldNotGetFileName(path_string!(child_path))).exit()
                     });
 
-                let lb_child_path = format!("{}/{}", import_dest, child_name);
+                let lb_child_path = format!("{}/{}", lockbook_path, child_name);
 
                 recursive_copy_folder(&child_path, &lb_child_path, config, edit);
             }
-        } else if let Err(err) = create_file_at_path(config, &import_dest) {
+        } else if let Err(err) = create_file_at_path(config, &lockbook_path) {
             match err {
                 CoreError::UiError(err) => match err {
                     CreateFileAtPathError::FileAlreadyExists => {
                         if !edit {
-                            eprintln!("Input destination {} not available within lockbook, use --edit to overwrite the contents of this file!", import_dest)
+                            eprintln!("Input destination {} not available within lockbook, use --edit to overwrite the contents of this file!", lockbook_path)
                         }
                     }
                     CreateFileAtPathError::NoAccount => err!(NoAccount).exit(),
                     CreateFileAtPathError::NoRoot => err!(NoRoot).exit(),
-                    CreateFileAtPathError::DocumentTreatedAsFolder => eprintln!("A file along the target destination is a document that cannot be used as a folder: {}", import_dest),
-                    CreateFileAtPathError::PathContainsEmptyFile => eprintln!("Input destination {} contains an empty file!", import_dest),
-                    CreateFileAtPathError::PathDoesntStartWithRoot => err!(PathNoRoot(import_dest.to_string())).exit(),
+                    CreateFileAtPathError::DocumentTreatedAsFolder => eprintln!("A file along the target destination is a document that cannot be used as a folder: {}", lockbook_path),
+                    CreateFileAtPathError::PathContainsEmptyFile => eprintln!("Input destination {} contains an empty file!", lockbook_path),
+                    CreateFileAtPathError::PathDoesntStartWithRoot => err!(PathNoRoot(lockbook_path.to_string())).exit(),
                 }
                 CoreError::Unexpected(msg) => err_unexpected!("{}", msg).exit(),
             }
@@ -82,27 +87,27 @@ fn recursive_copy_folder(path: &PathBuf, import_dest: &str, config: &Config, edi
 }
 
 fn copy_file(
-    path: &PathBuf,
-    import_dest: &str,
+    filesystem_path: &PathBuf,
+    lockbook_path: &str,
     config: &Config,
     edit: bool,
 ) -> Result<String, Error> {
-    let content = fs::read_to_string(&path)
-        .map_err(|err| err!(OsCouldNotReadFile(path_string!(path), err)))?;
+    let content = fs::read_to_string(&filesystem_path)
+        .map_err(|err| err!(OsCouldNotReadFile(path_string!(filesystem_path), err)))?;
 
-    let absolute_path = fs::canonicalize(&path)
-        .map_err(|err| err!(OsCouldNotGetAbsPath(path_string!(path), err)))?;
+    let absolute_path = fs::canonicalize(&filesystem_path)
+        .map_err(|err| err!(OsCouldNotGetAbsPath(path_string!(filesystem_path), err)))?;
 
-    let import_dest_with_filename = if import_dest.ends_with('/') {
+    let import_dest_with_filename = if lockbook_path.ends_with('/') {
         match absolute_path.file_name() {
             Some(name) => match name.to_os_string().into_string() {
-                Ok(string) => format!("{}{}", &import_dest, string),
+                Ok(string) => format!("{}{}", &lockbook_path, string),
                 Err(err) => err_unexpected!("converting an OsString to String: {:?}", err).exit(),
             },
             None => err_unexpected!("Import target does not contain a file name!").exit(),
         }
     } else {
-        import_dest.to_string()
+        lockbook_path.to_string()
     };
 
     let file_metadata = match create_file_at_path(config, &import_dest_with_filename) {

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -95,11 +95,11 @@ fn copy_file(
     let content = fs::read_to_string(&filesystem_path)
         .map_err(|err| err!(OsCouldNotReadFile(path_string!(filesystem_path), err)))?;
 
-    let absolute_path = fs::canonicalize(&filesystem_path)
+    let fs_absolute_path = fs::canonicalize(&filesystem_path)
         .map_err(|err| err!(OsCouldNotGetAbsPath(path_string!(filesystem_path), err)))?;
 
-    let import_dest_with_filename = if lockbook_path.ends_with('/') {
-        match absolute_path.file_name() {
+    let lb_path_with_filename = if lockbook_path.ends_with('/') {
+        match fs_absolute_path.file_name() {
             Some(name) => match name.to_os_string().into_string() {
                 Ok(string) => format!("{}{}", &lockbook_path, string),
                 Err(err) => err_unexpected!("converting an OsString to String: {:?}", err).exit(),
@@ -110,37 +110,37 @@ fn copy_file(
         lockbook_path.to_string()
     };
 
-    let file_metadata = match create_file_at_path(config, &import_dest_with_filename) {
+    let file_metadata = match create_file_at_path(config, &lb_path_with_filename) {
         Ok(file_metadata) => file_metadata,
         Err(err) => match err {
             CoreError::UiError(err) => match err {
                 CreateFileAtPathError::FileAlreadyExists => {
                     if edit {
-                        get_file_by_path(config, &import_dest_with_filename).unwrap_or_else(
-                            |get_err| match get_err {
+                        get_file_by_path(config, &lb_path_with_filename).unwrap_or_else(|get_err| {
+                            match get_err {
                                 CoreError::UiError(GetFileByPathError::NoFileAtThatPath)
                                 | CoreError::Unexpected(_) => {
                                     err_unexpected!("{:?}", get_err).exit()
                                 }
-                            },
-                        )
+                            }
+                        })
                     } else {
-                        return Err(err_extra!(FileAlreadyExists(import_dest_with_filename), "The input destination is not available within lockbook. Use --edit to overwrite the contents of this file!"));
+                        return Err(err_extra!(FileAlreadyExists(lb_path_with_filename), "The input destination is not available within lockbook. Use --edit to overwrite the contents of this file!"));
                     }
                 }
                 CreateFileAtPathError::NoAccount => err!(NoAccount).exit(),
                 CreateFileAtPathError::NoRoot => err!(NoRoot).exit(),
                 CreateFileAtPathError::DocumentTreatedAsFolder => {
-                    return Err(err!(DocTreatedAsFolder(import_dest_with_filename)));
+                    return Err(err!(DocTreatedAsFolder(lb_path_with_filename)));
                 }
                 CreateFileAtPathError::PathContainsEmptyFile => {
                     return Err(err_extra!(
-                        PathContainsEmptyFile(import_dest_with_filename),
+                        PathContainsEmptyFile(lb_path_with_filename),
                         "The input destination path contains an empty file!"
                     ));
                 }
                 CreateFileAtPathError::PathDoesntStartWithRoot => {
-                    err!(PathNoRoot(import_dest_with_filename.to_string())).exit()
+                    err!(PathNoRoot(lb_path_with_filename.to_string())).exit()
                 }
             },
             CoreError::Unexpected(msg) => err_unexpected!("{}", msg).exit(),
@@ -148,7 +148,7 @@ fn copy_file(
     };
 
     match write_document(config, file_metadata.id, content.as_bytes()) {
-        Ok(_) => Ok(format!("imported to {}", import_dest_with_filename)),
+        Ok(_) => Ok(format!("imported to {}", lb_path_with_filename)),
         Err(err) => Err(err_unexpected!("{:#?}", err)),
     }
 }

--- a/clients/cli/src/error.rs
+++ b/clients/cli/src/error.rs
@@ -76,7 +76,7 @@ make_errkind_enum!(
     // Account (20s)
     20 => NoAccount,
     21 => AccountAlreadyExists,
-    22 => AccountDoesNotExist,
+    22 => AccountDoesNotExistOnServer,
     23 => AccountStringCorrupted,
     24 => UsernameTaken(String),
     25 => UsernameInvalid(String),
@@ -103,10 +103,9 @@ make_errkind_enum!(
     46 => PathContainsEmptyFile(String),
     47 => DocTreatedAsFolder(String),
     48 => CannotMoveFolderIntoItself,
-    49 => CannotDeleteRoot(String),
-    50 => NoRootOps(&'static str),
-    51 => InvalidDrawing(String),
-    52 => FolderTreatedAsDoc(String),
+    49 => NoRootOps(&'static str),
+    50 => InvalidDrawing(String),
+    51 => FolderTreatedAsDoc(String),
 );
 
 impl ErrorKind {
@@ -122,7 +121,7 @@ impl ErrorKind {
 
             Self::NoAccount => "No account! Run 'new-account' or 'import-private-key' to get started!".to_string(),
             Self::AccountAlreadyExists => "Account already exists. Run `lockbook erase-everything` to erase your local state.".to_string(),
-            Self::AccountDoesNotExist => "An account with this username was not found on the server.".to_string(),
+            Self::AccountDoesNotExistOnServer => "An account with this username was not found on the server.".to_string(),
             Self::AccountStringCorrupted => "Account string corrupted, not imported".to_string(),
             Self::UsernameTaken(uname) => format!("username '{}' is already taken.", uname),
             Self::UsernameInvalid(uname) => format!("username '{}' invalid (a-z || 0-9).", uname),
@@ -147,7 +146,6 @@ impl ErrorKind {
             Self::PathContainsEmptyFile(path) => format!("the path '{}' contains an empty file name", path),
             Self::DocTreatedAsFolder(path) => format!("a file in path '{}' is a document being treated as a folder", path),
             Self::CannotMoveFolderIntoItself => "Cannot move file into its self or children.".to_string(),
-            Self::CannotDeleteRoot(path) => format!("Cannot delete '{}' since it is the root folder.", path),
             Self::NoRootOps(op) => format!("cannot {} your root directory!", op),
             Self::InvalidDrawing(name) => format!("'{}' is an invalid drawing", name),
             Self::FolderTreatedAsDoc(path) => format!("a file in path '{}' is a folder being treated as a document", path),

--- a/clients/cli/src/export_drawing.rs
+++ b/clients/cli/src/export_drawing.rs
@@ -4,10 +4,10 @@ use crate::{err, err_unexpected};
 use lockbook_core::{get_file_by_path, Error as CoreError, ExportDrawingError, GetFileByPathError};
 use std::io::{stdout, Write};
 
-pub fn export_drawing(drawing: &str, format: &str) -> CliResult<()> {
-    let file_metadata = get_file_by_path(&get_config(), drawing).map_err(|err| match err {
+pub fn export_drawing(lb_path: &str, format: &str) -> CliResult<()> {
+    let file_metadata = get_file_by_path(&get_config(), lb_path).map_err(|err| match err {
         CoreError::UiError(GetFileByPathError::NoFileAtThatPath) => {
-            err!(FileNotFound(drawing.to_string()))
+            err!(FileNotFound(lb_path.to_string()))
         }
         CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
     })?;
@@ -19,7 +19,7 @@ pub fn export_drawing(drawing: &str, format: &str) -> CliResult<()> {
             |err| match err {
                 CoreError::UiError(ui_err) => match ui_err {
                     ExportDrawingError::FolderTreatedAsDrawing => {
-                        err!(FolderTreatedAsDoc(drawing.to_string()))
+                        err!(FolderTreatedAsDoc(lb_path.to_string()))
                     }
                     ExportDrawingError::NoAccount => err!(NoAccount),
                     ExportDrawingError::InvalidDrawing => err!(InvalidDrawing(file_metadata.name)),

--- a/clients/cli/src/import_private_key.rs
+++ b/clients/cli/src/import_private_key.rs
@@ -25,7 +25,7 @@ pub fn import_private_key() -> CliResult<()> {
             CoreError::UiError(err) => match err {
                 ImportError::AccountStringCorrupted => err!(AccountStringCorrupted),
                 ImportError::AccountExistsAlready => err!(AccountAlreadyExists),
-                ImportError::AccountDoesNotExist => err!(AccountDoesNotExist),
+                ImportError::AccountDoesNotExist => err!(AccountDoesNotExistOnServer),
                 ImportError::UsernamePKMismatch => err!(UsernamePkMismatch),
                 ImportError::CouldNotReachServer => err!(NetworkIssue),
                 ImportError::ClientUpdateRequired => err!(UpdateRequired),

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -29,32 +29,40 @@ mod whoami;
 #[derive(Debug, PartialEq, StructOpt)]
 #[structopt(about = "A secure and intuitive notebook.")]
 enum Lockbook {
-    /// Bring a file from your computer into a target destination inside your Lockbook. If your
-    /// Lockbook target destination is a Folder, the file name will be taken from the file-system
-    /// file.
+    /// Backup your Lockbook files and structure to the current directory
+    Backup,
+
+    /// Copy a file from your file system into your Lockbook
     Copy {
-        /// Edit the file if it exists already
+        /// Overwrite the file if it exists already
         #[structopt(long)]
         edit: bool,
 
-        /// File on your local filesystem to be copied into Lockbook
+        /// Filesystem location, a folder or individual file
         file: PathBuf,
 
-        /// Destination within your Lockbook to put the file
+        /// Lockbook location
         destination: String,
     },
 
     /// Open a document for editing
     Edit { path: String },
 
+    /// Export a drawing from your Lockbook to a specified image format
+    ExportDrawing { drawing: String, format: String },
+
     /// Export your private key
     ExportPrivateKey,
 
+    /// Calculate how much space your Lockbook is occupying
+    GetUsage {
+        /// Show the amount in bytes, don't show a human readable interpretation
+        #[structopt(long)]
+        exact: bool,
+    },
+
     /// Import an existing Lockbook
     ImportPrivateKey,
-
-    /// Create a new Lockbook account
-    NewAccount,
 
     /// List all your paths
     List,
@@ -76,11 +84,11 @@ enum Lockbook {
     /// Create a new document or folder
     New { path: String },
 
+    /// Create a new Lockbook account
+    NewAccount,
+
     /// Print the contents of a file
     Print { path: String },
-
-    /// Rename a file at a path to a target value
-    Rename { path: String, name: String },
 
     /// Move a file to trash TODO
     Remove {
@@ -89,6 +97,9 @@ enum Lockbook {
         #[structopt(short, long)]
         force: bool,
     },
+
+    /// Rename a file at a path to a target value
+    Rename { path: String, name: String },
 
     /// What operations a sync would perform
     Status,
@@ -99,19 +110,6 @@ enum Lockbook {
     /// Display Lockbook username
     #[structopt(name = "whoami")]
     WhoAmI,
-
-    /// Backup your Lockbook files and structure to the current directory
-    Backup,
-
-    /// Calculate how much space your Lockbook is occupying
-    GetUsage {
-        /// Show the amount in bytes, don't show a human readable interpretation
-        #[structopt(long)]
-        exact: bool,
-    },
-
-    /// Export a drawing from your Lockbook to a specified image format
-    ExportDrawing { drawing: String, format: String },
 
     /// Print out what each error code means
     Errors,

--- a/clients/cli/src/remove.rs
+++ b/clients/cli/src/remove.rs
@@ -55,7 +55,7 @@ pub fn remove(path: &str, force: bool) -> CliResult<()> {
 
     delete_file(&config, meta.id).map_err(|err| match err {
         UiError(FileDeleteError::FileDoesNotExist) => err!(FileNotFound(path.to_string())),
-        UiError(FileDeleteError::CannotDeleteRoot) => err!(CannotDeleteRoot(path.to_string())),
+        UiError(FileDeleteError::CannotDeleteRoot) => err!(NoRootOps("delete")),
         UnexpectedError(msg) => err_unexpected!("{}", msg),
     })
 }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytemuck"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +419,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.3",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.3",
+ "crossbeam-utils 0.8.3",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,10 +447,23 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.4",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.3",
+ "lazy_static",
+ "memoffset 0.6.1",
  "scopeguard",
 ]
 
@@ -427,6 +479,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+dependencies = [
+ "autocfg 1.0.0",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +497,26 @@ checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array",
  "subtle 1.0.0",
+]
+
+[[package]]
+name = "deflate"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
+dependencies = [
+ "adler32",
+ "byteorder",
+]
+
+[[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder",
 ]
 
 [[package]]
@@ -516,6 +599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,7 +660,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.3",
 ]
 
 [[package]]
@@ -759,6 +851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
 dependencies = [
  "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a668f699973d0f573d15749b7002a9ac9e1f9c6b220e7b165601334c173d8de"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -981,12 +1083,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif",
+ "jpeg-decoder",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+ "png 0.16.8",
+ "scoped_threadpool",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 dependencies = [
  "autocfg 1.0.0",
+]
+
+[[package]]
+name = "inflate"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -1035,6 +1165,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "js-sys"
@@ -1129,9 +1268,11 @@ dependencies = [
  "diffy",
  "fern",
  "flate2",
+ "image",
  "jni",
  "log",
  "rand",
+ "raqote",
  "reqwest 0.11.1",
  "rsa",
  "serde",
@@ -1152,6 +1293,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9962a2ba81382716b87d7d358493cb71844c1f9165ddad763cd9f4d3f5474df2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
 ]
 
 [[package]]
@@ -1188,6 +1340,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg 1.0.0",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1362,15 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -1362,6 +1532,17 @@ name = "num-iter"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
@@ -1597,6 +1778,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
+name = "png"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef859a23054bbfee7811284275ae522f0434a3c8e7f4b74bd4a35ae7e1c4a283"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate 0.7.20",
+ "inflate",
+]
+
+[[package]]
+name = "png"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate 0.8.6",
+ "miniz_oxide 0.3.7",
+]
+
+[[package]]
 name = "polyval"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1930,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raqote"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501c19caa439857ed7bea975fa4c3c10ee9a24e33c2640030c3ac14b58f39f77"
+dependencies = [
+ "euclid",
+ "lyon_geom",
+ "png 0.15.3",
+ "sw-composite",
+ "typed-arena",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg 1.0.0",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils 0.8.3",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1867,7 +2110,7 @@ dependencies = [
  "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -1949,6 +2192,12 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.8",
 ]
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"
@@ -2112,8 +2361,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbf56c35b0c3f9bc208fab35e45c3bc03137d3c1a4a85bdf0b8db69aecffb45"
 dependencies = [
  "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
  "fs2",
  "fxhash",
  "libc",
@@ -2185,6 +2434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
+name = "sw-composite"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39674047b1748e8bf4865142772a6637bd32d8b4b27e3c2248dd122f637808b"
+
+[[package]]
 name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2494,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
+dependencies = [
+ "jpeg-decoder",
+ "miniz_oxide 0.4.3",
+ "weezl",
 ]
 
 [[package]]
@@ -2434,6 +2700,12 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
@@ -2668,6 +2940,12 @@ checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a32b378380f4e9869b22f0b5177c68a5519f03b3454fde0b291455ddbae266c"
 
 [[package]]
 name = "winapi"


### PR DESCRIPTION
```
lockbook 0.2.20
A secure and intuitive notebook.

USAGE:
    lockbook <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    backup                Backup your Lockbook files and structure to the current directory
    copy                  Copy a file from your file system into your Lockbook
    edit                  Open a document for editing
    errors                Print out what each error code means
    export-drawing        Export a drawing as an image
    export-private-key    Export your private key, if piped, account string, otherwise qr code
    get-usage             How much space does your Lockbook occupy on the server
    help                  Prints this message or the help of the given subcommand(s)
    import-private-key    Import an account string via stdin
    list                  List the absolute path of all Lockbook leaf nodes
    list-all              List the absolute path of all lockbook files and folders
    list-docs             List the absolute path of your documents
    list-folders          List the absolute path of your folders
    move                  Change the parent of a file or folder
    new                   Create a new document or folder
    new-account           Create a new Lockbook account
    print                 Print the contents of a file to stdout
    remove                Delete a file
    rename                Rename a file at a path to a target value
    status                What operations a sync would perform
    sync                  Get updates, push changes
    whoami                Display Lockbook username
```

fixes #586 