### PR TITLE
android: sync snackbar messages don't always appear

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/model/AlertModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/AlertModel.kt
@@ -21,7 +21,7 @@ object AlertModel {
                 }
             })
         }
-        Timber.e("STEP 15")
+
         snackBar.show()
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/model/AlertModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/AlertModel.kt
@@ -6,11 +6,13 @@ import androidx.appcompat.app.AlertDialog
 import app.lockbook.R
 import app.lockbook.util.UNEXPECTED_ERROR
 import com.google.android.material.snackbar.Snackbar
+import timber.log.Timber
 
 object AlertModel {
     fun notify(view: View, msg: String, onFinishAlert: OnFinishAlert) {
+        Timber.e("STEP 13")
         val snackBar = Snackbar.make(view, msg, Snackbar.LENGTH_SHORT)
-
+        Timber.e("STEP 14")
         if (onFinishAlert is OnFinishAlert.DoSomethingOnFinishAlert) {
             snackBar.addCallback(object : Snackbar.Callback() {
                 override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
@@ -19,7 +21,7 @@ object AlertModel {
                 }
             })
         }
-
+        Timber.e("STEP 15")
         snackBar.show()
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/model/AlertModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/AlertModel.kt
@@ -6,13 +6,11 @@ import androidx.appcompat.app.AlertDialog
 import app.lockbook.R
 import app.lockbook.util.UNEXPECTED_ERROR
 import com.google.android.material.snackbar.Snackbar
-import timber.log.Timber
 
 object AlertModel {
     fun notify(view: View, msg: String, onFinishAlert: OnFinishAlert) {
-        Timber.e("STEP 13")
         val snackBar = Snackbar.make(view, msg, Snackbar.LENGTH_SHORT)
-        Timber.e("STEP 14")
+
         if (onFinishAlert is OnFinishAlert.DoSomethingOnFinishAlert) {
             snackBar.addCallback(object : Snackbar.Callback() {
                 override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {

--- a/clients/android/app/src/main/java/app/lockbook/model/DrawingViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/DrawingViewModel.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import app.lockbook.ui.DrawingView
 import app.lockbook.util.*
 import app.lockbook.util.ColorAlias
@@ -66,8 +67,7 @@ class DrawingViewModel(
     }
 
     fun getDrawing(id: String) {
-        uiScope.launch {
-            withContext(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.IO) {
                 val contents = readDocument(id)
                 if (contents != null && contents.isEmpty()) {
                     backupDrawing = Drawing()
@@ -76,7 +76,6 @@ class DrawingViewModel(
                 }
 
                 _drawableReady.postValue(Unit)
-            }
         }
     }
 
@@ -102,8 +101,7 @@ class DrawingViewModel(
     }
 
     fun saveDrawing(drawing: Drawing) {
-        uiScope.launch {
-            withContext(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.IO) {
                 val writeToDocumentResult = CoreModel.writeContentToDocument(config, id, Klaxon().toJsonString(drawing).replace(" ", ""))
 
                 if (writeToDocumentResult is Err) {
@@ -125,7 +123,6 @@ class DrawingViewModel(
                         }
                     }.exhaustive
                 }
-            }
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/model/DrawingViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/DrawingViewModel.kt
@@ -68,14 +68,14 @@ class DrawingViewModel(
 
     fun getDrawing(id: String) {
         viewModelScope.launch(Dispatchers.IO) {
-                val contents = readDocument(id)
-                if (contents != null && contents.isEmpty()) {
-                    backupDrawing = Drawing()
-                } else if (contents != null) {
-                    backupDrawing = Klaxon().parse<Drawing>(contents)
-                }
+            val contents = readDocument(id)
+            if (contents != null && contents.isEmpty()) {
+                backupDrawing = Drawing()
+            } else if (contents != null) {
+                backupDrawing = Klaxon().parse<Drawing>(contents)
+            }
 
-                _drawableReady.postValue(Unit)
+            _drawableReady.postValue(Unit)
         }
     }
 
@@ -102,27 +102,27 @@ class DrawingViewModel(
 
     fun saveDrawing(drawing: Drawing) {
         viewModelScope.launch(Dispatchers.IO) {
-                val writeToDocumentResult = CoreModel.writeContentToDocument(config, id, Klaxon().toJsonString(drawing).replace(" ", ""))
+            val writeToDocumentResult = CoreModel.writeContentToDocument(config, id, Klaxon().toJsonString(drawing).replace(" ", ""))
 
-                if (writeToDocumentResult is Err) {
-                    when (val error = writeToDocumentResult.error) {
-                        is WriteToDocumentError.FolderTreatedAsDocument -> {
-                            _errorHasOccurred.postValue("Error! Folder is treated as document!")
-                        }
-                        is WriteToDocumentError.FileDoesNotExist -> {
-                            _errorHasOccurred.postValue("Error! File does not exist!")
-                        }
-                        is WriteToDocumentError.NoAccount -> {
-                            _errorHasOccurred.postValue("Error! No account!")
-                        }
-                        is WriteToDocumentError.Unexpected -> {
-                            Timber.e("Unable to write document changes: ${error.error}")
-                            _unexpectedErrorHasOccurred.postValue(
-                                error.error
-                            )
-                        }
-                    }.exhaustive
-                }
+            if (writeToDocumentResult is Err) {
+                when (val error = writeToDocumentResult.error) {
+                    is WriteToDocumentError.FolderTreatedAsDocument -> {
+                        _errorHasOccurred.postValue("Error! Folder is treated as document!")
+                    }
+                    is WriteToDocumentError.FileDoesNotExist -> {
+                        _errorHasOccurred.postValue("Error! File does not exist!")
+                    }
+                    is WriteToDocumentError.NoAccount -> {
+                        _errorHasOccurred.postValue("Error! No account!")
+                    }
+                    is WriteToDocumentError.Unexpected -> {
+                        Timber.e("Unable to write document changes: ${error.error}")
+                        _unexpectedErrorHasOccurred.postValue(
+                            error.error
+                        )
+                    }
+                }.exhaustive
+            }
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
@@ -90,7 +90,6 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
     }
 
     fun refreshFiles() {
-        Timber.e("REFRESHING")
         when (val getChildrenResult = CoreModel.getChildren(config, parentFileMetadata.id)) {
             is Ok -> {
                 updateBreadCrumbWithLatest()
@@ -194,7 +193,7 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
         ).toList()
     }
 
-    private fun sortChildren(files: List<FileMetadata>, isREFRESH: Boolean) {
+    private fun sortChildren(files: List<FileMetadata>) {
         val sortedFiles = when (
             val optionValue = PreferenceManager.getDefaultSharedPreferences(App.instance)
                 .getString(SharedPreferences.SORT_FILES_KEY, SharedPreferences.SORT_FILES_A_Z)
@@ -211,9 +210,6 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
             }
         }.exhaustive
 
-        if(!isREFRESH) {
-
-        }
         _files.postValue(sortedFiles)
     }
 }

--- a/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/FileModel.kt
@@ -63,10 +63,6 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
         }.exhaustive
     }
 
-    fun updateBreadCrumbWithLatest() {
-        _updateBreadcrumbBar.postValue(filePath.map { file -> BreadCrumb(file.name) })
-    }
-
     fun intoFolder(fileMetadata: FileMetadata) {
         parentFileMetadata = fileMetadata
         filePath.add(fileMetadata)
@@ -94,6 +90,7 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
     }
 
     fun refreshFiles() {
+        Timber.e("REFRESHING")
         when (val getChildrenResult = CoreModel.getChildren(config, parentFileMetadata.id)) {
             is Ok -> {
                 updateBreadCrumbWithLatest()
@@ -127,6 +124,10 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
         refreshFiles()
     }
 
+    private fun updateBreadCrumbWithLatest() {
+        _updateBreadcrumbBar.postValue(filePath.map { file -> BreadCrumb(file.name) })
+    }
+
     private fun deleteFile(id: String): Boolean {
         return when (val deleteFileResult = CoreModel.deleteFile(config, id)) {
             is Ok -> true
@@ -147,7 +148,7 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
         }.exhaustive
     }
 
-    private fun sortFilesAlpha(files: List<FileMetadata>, inReverse: Boolean): List<FileMetadata> {
+    private fun sortFilesAlpha(files: List<FileMetadata>, inReverse: Boolean): List<FileMetadata> { // TODO: write less code by just reversing the original
         return if (inReverse) {
             files.sortedByDescending { fileMetadata ->
                 fileMetadata.name
@@ -193,7 +194,7 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
         ).toList()
     }
 
-    private fun sortChildren(files: List<FileMetadata>) {
+    private fun sortChildren(files: List<FileMetadata>, isREFRESH: Boolean) {
         val sortedFiles = when (
             val optionValue = PreferenceManager.getDefaultSharedPreferences(App.instance)
                 .getString(SharedPreferences.SORT_FILES_KEY, SharedPreferences.SORT_FILES_A_Z)
@@ -210,6 +211,9 @@ class FileModel(private val config: Config, private val _errorHasOccurred: Singl
             }
         }.exhaustive
 
+        if(!isREFRESH) {
+
+        }
         _files.postValue(sortedFiles)
     }
 }

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -77,8 +77,8 @@ class ListFilesViewModel(path: String, application: Application) :
     val showSyncSnackBar: LiveData<Int>
         get() = syncModel.showSyncSnackBar
 
-    val showPreSyncSnackBar: LiveData<Int>
-        get() = syncModel.showPreSyncSnackBar
+    val showSyncInfoSnackBar: LiveData<Int>
+        get() = syncModel.showSyncInfoSnackBar
 
     val updateProgressSnackBar: LiveData<Int>
         get() = syncModel.updateProgressSnackBar
@@ -134,9 +134,9 @@ class ListFilesViewModel(path: String, application: Application) :
 
     private fun init() {
         viewModelScope.launch(Dispatchers.IO) {
-                setUpPreferenceChangeListener()
-                isThisAnImport()
-                fileModel.startUpInRoot()
+            setUpPreferenceChangeListener()
+            isThisAnImport()
+            fileModel.startUpInRoot()
         }
     }
 
@@ -154,180 +154,178 @@ class ListFilesViewModel(path: String, application: Application) :
 
     fun onOpenedActivityEnd() {
         viewModelScope.launch(Dispatchers.IO) {
-                syncModel.syncBasedOnPreferences()
-
+            syncModel.syncBasedOnPreferences()
         }
     }
 
     fun onSwipeToRefresh() {
         viewModelScope.launch(Dispatchers.IO) {
-                syncModel.startSync()
-                fileModel.refreshFiles()
-                _stopProgressSpinner.postValue(Unit)
+            syncModel.startSync()
+            fileModel.refreshFiles()
+            _stopProgressSpinner.postValue(Unit)
         }
     }
 
     fun onNewDocumentFABClicked(isDrawing: Boolean) {
         viewModelScope.launch(Dispatchers.IO) {
-                isFABOpen = !isFABOpen
-                _collapseExpandFAB.postValue(false)
-                _showCreateFileDialog.postValue(CreateFileInfo(fileModel.parentFileMetadata.id, Klaxon().toJsonString(FileType.Document), isDrawing))
+            isFABOpen = !isFABOpen
+            _collapseExpandFAB.postValue(false)
+            _showCreateFileDialog.postValue(CreateFileInfo(fileModel.parentFileMetadata.id, Klaxon().toJsonString(FileType.Document), isDrawing))
         }
     }
 
     fun onNewFolderFABClicked() {
         viewModelScope.launch(Dispatchers.IO) {
-                isFABOpen = !isFABOpen
-                _collapseExpandFAB.postValue(false)
-                _showCreateFileDialog.postValue(CreateFileInfo(fileModel.parentFileMetadata.id, Klaxon().toJsonString(FileType.Folder), false))
+            isFABOpen = !isFABOpen
+            _collapseExpandFAB.postValue(false)
+            _showCreateFileDialog.postValue(CreateFileInfo(fileModel.parentFileMetadata.id, Klaxon().toJsonString(FileType.Folder), false))
         }
     }
 
     fun onMenuItemPressed(id: Int) {
         viewModelScope.launch(Dispatchers.IO) {
-                val pref = PreferenceManager.getDefaultSharedPreferences(getApplication()).edit()
-                when (id) {
-                    R.id.menu_list_files_sort_last_changed -> {
-                        pref.putString(
-                            SORT_FILES_KEY,
-                            SORT_FILES_LAST_CHANGED
-                        ).apply()
-                        fileModel.refreshFiles()
-                    }
-                    R.id.menu_list_files_sort_a_z -> {
-                        pref.putString(SORT_FILES_KEY, SORT_FILES_A_Z)
-                            .apply()
-                        fileModel.refreshFiles()
-                    }
-                    R.id.menu_list_files_sort_z_a -> {
-                        pref.putString(SORT_FILES_KEY, SORT_FILES_Z_A)
-                            .apply()
-                        fileModel.refreshFiles()
-                    }
-                    R.id.menu_list_files_sort_first_changed -> {
-                        pref.putString(
-                            SORT_FILES_KEY,
-                            SORT_FILES_FIRST_CHANGED
-                        ).apply()
-                        fileModel.refreshFiles()
-                    }
-                    R.id.menu_list_files_sort_type -> {
-                        pref.putString(
-                            SORT_FILES_KEY,
-                            SORT_FILES_TYPE
-                        ).apply()
-                        fileModel.refreshFiles()
-                    }
-                    R.id.menu_list_files_linear_view -> {
-                        pref.putString(
-                            FILE_LAYOUT_KEY,
-                            LINEAR_LAYOUT
-                        ).apply()
-                        _switchFileLayout.postValue(Unit)
-                    }
-                    R.id.menu_list_files_grid_view -> {
-                        pref.putString(
-                            FILE_LAYOUT_KEY,
-                            GRID_LAYOUT
-                        ).apply()
-                        _switchFileLayout.postValue(Unit)
-                    }
-                    R.id.menu_list_files_rename -> {
-                        files.value?.let { files ->
-                            val checkedFiles = getSelectedFiles(files)
-                            if (checkedFiles.size == 1) {
-                                _showRenameFileDialog.postValue(RenameFileInfo(checkedFiles[0].id, checkedFiles[0].name))
-                            } else {
-                                _errorHasOccurred.postValue(BASIC_ERROR)
-                            }
+            val pref = PreferenceManager.getDefaultSharedPreferences(getApplication()).edit()
+            when (id) {
+                R.id.menu_list_files_sort_last_changed -> {
+                    pref.putString(
+                        SORT_FILES_KEY,
+                        SORT_FILES_LAST_CHANGED
+                    ).apply()
+                    fileModel.refreshFiles()
+                }
+                R.id.menu_list_files_sort_a_z -> {
+                    pref.putString(SORT_FILES_KEY, SORT_FILES_A_Z)
+                        .apply()
+                    fileModel.refreshFiles()
+                }
+                R.id.menu_list_files_sort_z_a -> {
+                    pref.putString(SORT_FILES_KEY, SORT_FILES_Z_A)
+                        .apply()
+                    fileModel.refreshFiles()
+                }
+                R.id.menu_list_files_sort_first_changed -> {
+                    pref.putString(
+                        SORT_FILES_KEY,
+                        SORT_FILES_FIRST_CHANGED
+                    ).apply()
+                    fileModel.refreshFiles()
+                }
+                R.id.menu_list_files_sort_type -> {
+                    pref.putString(
+                        SORT_FILES_KEY,
+                        SORT_FILES_TYPE
+                    ).apply()
+                    fileModel.refreshFiles()
+                }
+                R.id.menu_list_files_linear_view -> {
+                    pref.putString(
+                        FILE_LAYOUT_KEY,
+                        LINEAR_LAYOUT
+                    ).apply()
+                    _switchFileLayout.postValue(Unit)
+                }
+                R.id.menu_list_files_grid_view -> {
+                    pref.putString(
+                        FILE_LAYOUT_KEY,
+                        GRID_LAYOUT
+                    ).apply()
+                    _switchFileLayout.postValue(Unit)
+                }
+                R.id.menu_list_files_rename -> {
+                    files.value?.let { files ->
+                        val checkedFiles = getSelectedFiles(files)
+                        if (checkedFiles.size == 1) {
+                            _showRenameFileDialog.postValue(RenameFileInfo(checkedFiles[0].id, checkedFiles[0].name))
+                        } else {
+                            _errorHasOccurred.postValue(BASIC_ERROR)
                         }
                     }
-                    R.id.menu_list_files_delete -> {
-                        files.value?.let { files ->
-                            val checkedIds = getSelectedFiles(files).map { file -> file.id }
-                            collapseMoreOptionsMenu()
-                            if (fileModel.deleteFiles(checkedIds)) {
-                                _showSnackBar.postValue("Successfully deleted the file(s)")
-                            }
+                }
+                R.id.menu_list_files_delete -> {
+                    files.value?.let { files ->
+                        val checkedIds = getSelectedFiles(files).map { file -> file.id }
+                        collapseMoreOptionsMenu()
+                        if (fileModel.deleteFiles(checkedIds)) {
+                            _showSnackBar.postValue("Successfully deleted the file(s)")
+                        }
 
-                            fileModel.refreshFiles()
+                        fileModel.refreshFiles()
+                    }
+                }
+                R.id.menu_list_files_info -> {
+                    files.value?.let { files ->
+                        val checkedFiles = getSelectedFiles(files)
+                        if (checkedFiles.size == 1) {
+                            collapseMoreOptionsMenu()
+                            _showFileInfoDialog.postValue(checkedFiles[0])
+                        } else {
+                            _errorHasOccurred.postValue(BASIC_ERROR)
                         }
                     }
-                    R.id.menu_list_files_info -> {
-                        files.value?.let { files ->
-                            val checkedFiles = getSelectedFiles(files)
-                            if (checkedFiles.size == 1) {
-                                collapseMoreOptionsMenu()
-                                _showFileInfoDialog.postValue(checkedFiles[0])
-                            } else {
-                                _errorHasOccurred.postValue(BASIC_ERROR)
-                            }
-                        }
-                    }
-                    R.id.menu_list_files_move -> {
-                        files.value?.let { files ->
-                            _showMoveFileDialog.postValue(
-                                MoveFileInfo(
-                                    getSelectedFiles(files)
-                                        .map { fileMetadata -> fileMetadata.id }.toTypedArray(),
-                                    getSelectedFiles(files)
-                                        .map { fileMetadata -> fileMetadata.name }.toTypedArray()
-                                )
+                }
+                R.id.menu_list_files_move -> {
+                    files.value?.let { files ->
+                        _showMoveFileDialog.postValue(
+                            MoveFileInfo(
+                                getSelectedFiles(files)
+                                    .map { fileMetadata -> fileMetadata.id }.toTypedArray(),
+                                getSelectedFiles(files)
+                                    .map { fileMetadata -> fileMetadata.name }.toTypedArray()
                             )
-                        }
+                        )
                     }
-                    else -> {
-                        Timber.e("Unrecognized sort item id.")
-                        _errorHasOccurred.postValue(BASIC_ERROR)
-                    }
-                }.exhaustive
-            }
+                }
+                else -> {
+                    Timber.e("Unrecognized sort item id.")
+                    _errorHasOccurred.postValue(BASIC_ERROR)
+                }
+            }.exhaustive
+        }
     }
 
     override fun onItemClick(position: Int, isSelecting: Boolean, selection: List<Boolean>) {
         viewModelScope.launch(Dispatchers.IO) {
-                when (isSelecting) {
-                    true -> {
-                        selectedFiles = selection
-                        _switchMenu.postValue(Unit)
-                    }
-                    false -> {
-                        fileModel.files.value?.let { files ->
-                            val fileMetadata = files[position]
+            when (isSelecting) {
+                true -> {
+                    selectedFiles = selection
+                    _switchMenu.postValue(Unit)
+                }
+                false -> {
+                    fileModel.files.value?.let { files ->
+                        val fileMetadata = files[position]
 
-                            if (fileMetadata.fileType == FileType.Folder) {
-                                fileModel.intoFolder(fileMetadata)
-                                selectedFiles = MutableList(files.size) {
-                                    false
-                                }
-                            } else {
-                                enterDocument(fileMetadata)
+                        if (fileMetadata.fileType == FileType.Folder) {
+                            fileModel.intoFolder(fileMetadata)
+                            selectedFiles = MutableList(files.size) {
+                                false
                             }
+                        } else {
+                            enterDocument(fileMetadata)
                         }
                     }
+                }
             }
         }
     }
 
     override fun onLongClick(position: Int, selection: List<Boolean>) {
         viewModelScope.launch(Dispatchers.IO) {
-                selectedFiles = selection
-                _switchMenu.postValue(Unit)
-
+            selectedFiles = selection
+            _switchMenu.postValue(Unit)
         }
     }
 
     fun refreshFiles(newDocument: FileMetadata?) {
         viewModelScope.launch(Dispatchers.IO) {
-                collapseMoreOptionsMenu()
-                fileModel.refreshFiles()
+            collapseMoreOptionsMenu()
+            fileModel.refreshFiles()
 
-                if (newDocument != null && PreferenceManager.getDefaultSharedPreferences(getApplication())
-                    .getBoolean(OPEN_NEW_DOC_AUTOMATICALLY_KEY, true)
-                ) {
-                    enterDocument(newDocument)
-                }
+            if (newDocument != null && PreferenceManager.getDefaultSharedPreferences(getApplication())
+                .getBoolean(OPEN_NEW_DOC_AUTOMATICALLY_KEY, true)
+            ) {
+                enterDocument(newDocument)
             }
+        }
     }
 
     fun handleRefreshAtParent(position: Int) {

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -161,7 +161,6 @@ class ListFilesViewModel(path: String, application: Application) :
 
     fun onSwipeToRefresh() {
         viewModelScope.launch(Dispatchers.IO) {
-                Timber.e("STEP 2")
                 syncModel.startSync()
                 fileModel.refreshFiles()
                 _stopProgressSpinner.postValue(Unit)

--- a/clients/android/app/src/main/java/app/lockbook/model/MoveFileViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/MoveFileViewModel.kt
@@ -37,39 +37,39 @@ class MoveFileViewModel(path: String) :
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
-                startInRoot()
+            startInRoot()
         }
     }
 
     private fun startInRoot() {
         viewModelScope.launch(Dispatchers.IO) {
-                when (val rootResult = CoreModel.getRoot(config)) {
-                    is Ok -> {
-                        currentParent = rootResult.value
-                        refreshOverFolder()
-                    }
-                    is Err -> when (val error = rootResult.error) {
-                        is GetRootError.NoRoot -> _errorHasOccurred.postValue("Error! No root!")
-                        is GetRootError.Unexpected -> _unexpectedErrorHasOccurred.postValue(error.error)
-                    }
-                }.exhaustive
+            when (val rootResult = CoreModel.getRoot(config)) {
+                is Ok -> {
+                    currentParent = rootResult.value
+                    refreshOverFolder()
+                }
+                is Err -> when (val error = rootResult.error) {
+                    is GetRootError.NoRoot -> _errorHasOccurred.postValue("Error! No root!")
+                    is GetRootError.Unexpected -> _unexpectedErrorHasOccurred.postValue(error.error)
+                }
+            }.exhaustive
         }
     }
 
     fun moveFilesToFolder() {
         viewModelScope.launch(Dispatchers.IO) {
-                var hasErrorOccurred = false
-                for (id in ids) {
-                    val moveFileResult = moveFileIfSuccessful(id)
-                    if (!moveFileResult) {
-                        hasErrorOccurred = !moveFileResult
-                        break
-                    }
+            var hasErrorOccurred = false
+            for (id in ids) {
+                val moveFileResult = moveFileIfSuccessful(id)
+                if (!moveFileResult) {
+                    hasErrorOccurred = !moveFileResult
+                    break
                 }
+            }
 
-                if (!hasErrorOccurred) {
-                    _closeDialog.postValue(Unit)
-                }
+            if (!hasErrorOccurred) {
+                _closeDialog.postValue(Unit)
+            }
         }
     }
 
@@ -120,15 +120,15 @@ class MoveFileViewModel(path: String) :
 
     override fun onItemClick(position: Int) {
         viewModelScope.launch(Dispatchers.IO) {
-                _files.value?.let { files ->
-                    if (position == 0) {
-                        setParentAsParent()
-                        refreshOverFolder()
-                    } else {
-                        currentParent = files[position]
-                        refreshOverFolder()
-                    }
+            _files.value?.let { files ->
+                if (position == 0) {
+                    setParentAsParent()
+                    refreshOverFolder()
+                } else {
+                    currentParent = files[position]
+                    refreshOverFolder()
                 }
+            }
         }
     }
 }

--- a/clients/android/app/src/main/java/app/lockbook/model/MoveFileViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/MoveFileViewModel.kt
@@ -3,6 +3,7 @@ package app.lockbook.model
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import app.lockbook.util.*
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -12,8 +13,6 @@ class MoveFileViewModel(path: String) :
     ViewModel(),
     RegularClickInterface {
 
-    private var job = Job()
-    private val uiScope = CoroutineScope(Dispatchers.Main + job)
     private val config = Config(path)
     lateinit var currentParent: FileMetadata
     lateinit var ids: Array<String>
@@ -37,16 +36,13 @@ class MoveFileViewModel(path: String) :
         get() = _unexpectedErrorHasOccurred
 
     init {
-        uiScope.launch {
-            withContext(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.IO) {
                 startInRoot()
-            }
         }
     }
 
-    fun startInRoot() {
-        uiScope.launch {
-            withContext(Dispatchers.IO) {
+    private fun startInRoot() {
+        viewModelScope.launch(Dispatchers.IO) {
                 when (val rootResult = CoreModel.getRoot(config)) {
                     is Ok -> {
                         currentParent = rootResult.value
@@ -57,13 +53,11 @@ class MoveFileViewModel(path: String) :
                         is GetRootError.Unexpected -> _unexpectedErrorHasOccurred.postValue(error.error)
                     }
                 }.exhaustive
-            }
         }
     }
 
     fun moveFilesToFolder() {
-        uiScope.launch {
-            withContext(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.IO) {
                 var hasErrorOccurred = false
                 for (id in ids) {
                     val moveFileResult = moveFileIfSuccessful(id)
@@ -76,7 +70,6 @@ class MoveFileViewModel(path: String) :
                 if (!hasErrorOccurred) {
                     _closeDialog.postValue(Unit)
                 }
-            }
         }
     }
 
@@ -126,8 +119,7 @@ class MoveFileViewModel(path: String) :
     }
 
     override fun onItemClick(position: Int) {
-        uiScope.launch {
-            withContext(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.IO) {
                 _files.value?.let { files ->
                     if (position == 0) {
                         setParentAsParent()
@@ -137,7 +129,6 @@ class MoveFileViewModel(path: String) :
                         refreshOverFolder()
                     }
                 }
-            }
         }
     }
 }

--- a/clients/android/app/src/main/java/app/lockbook/model/SyncModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/SyncModel.kt
@@ -33,7 +33,6 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
 
     fun startSync() {
         if (syncStatus is SyncStatus.IsNotSyncing) {
-            Timber.e("STEP 3")
             incrementalSync()
             syncStatus = SyncStatus.IsNotSyncing
         }
@@ -48,7 +47,6 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
     }
 
     private fun incrementalSync() {
-        Timber.e("STEP 4")
         val tempSyncStatus = SyncStatus.IsSyncing(0, 0)
 
         val account = when (val accountResult = CoreModel.getAccount(config)) {
@@ -63,9 +61,9 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
                 }
             }
         }.exhaustive
-        Timber.e("STEP 5")
+
         val syncErrors = hashMapOf<String, ExecuteWorkError>()
-        Timber.e("STEP 6")
+
         var workCalculated =
             when (val syncWorkResult = CoreModel.calculateWork(config)) {
                 is Ok -> syncWorkResult.value
@@ -81,12 +79,10 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
                     }
                 }
             }.exhaustive
-        Timber.e("STEP 7")
+
         if (workCalculated.workUnits.isEmpty()) {
-            Timber.e("STEP 8")
             return _showPreSyncSnackBar.postValue(workCalculated.workUnits.size)
         }
-        Timber.e("SHOULDNT HAPPEN")
 
         _showSyncSnackBar.postValue(workCalculated.workUnits.size)
 

--- a/clients/android/app/src/main/java/app/lockbook/model/SyncModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/SyncModel.kt
@@ -16,7 +16,7 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
 
     private val _stopSyncSnackBar = SingleMutableLiveData<Unit>()
     private val _showSyncSnackBar = SingleMutableLiveData<Int>()
-    private val _showPreSyncSnackBar = SingleMutableLiveData<Int>()
+    private val _showSyncInfoSnackBar = SingleMutableLiveData<Int>()
     private val _updateProgressSnackBar = SingleMutableLiveData<Int>()
 
     val stopSyncSnackBar: LiveData<Unit>
@@ -25,8 +25,8 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
     val showSyncSnackBar: LiveData<Int>
         get() = _showSyncSnackBar
 
-    val showPreSyncSnackBar: LiveData<Int>
-        get() = _showPreSyncSnackBar
+    val showSyncInfoSnackBar: LiveData<Int>
+        get() = _showSyncInfoSnackBar
 
     val updateProgressSnackBar: LiveData<Int>
         get() = _updateProgressSnackBar
@@ -81,7 +81,7 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
             }.exhaustive
 
         if (workCalculated.workUnits.isEmpty()) {
-            return _showPreSyncSnackBar.postValue(workCalculated.workUnits.size)
+            return _showSyncInfoSnackBar.postValue(workCalculated.workUnits.size)
         }
 
         _showSyncSnackBar.postValue(workCalculated.workUnits.size)
@@ -160,7 +160,7 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
                 Timber.e("Unable to set most recent sync date: ${setLastSyncedResult.error}")
                 _errorHasOccurred.postValue(BASIC_ERROR)
             }
-            _showPreSyncSnackBar.postValue(workCalculated.workUnits.size)
+            _showSyncInfoSnackBar.postValue(workCalculated.workUnits.size)
         } else {
             Timber.e("Couldn't resolve all syncErrors: ${Klaxon().toJsonString(syncErrors)}")
             _stopSyncSnackBar.postValue(Unit)

--- a/clients/android/app/src/main/java/app/lockbook/model/TextEditorViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/TextEditorViewModel.kt
@@ -6,6 +6,7 @@ import android.text.TextWatcher
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import app.lockbook.util.*
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -14,8 +15,6 @@ import timber.log.Timber
 
 class TextEditorViewModel(application: Application, private val id: String) :
     AndroidViewModel(application), TextWatcher {
-    private var job = Job()
-    private val uiScope = CoroutineScope(Dispatchers.Main + job)
     private val config = Config(getApplication<Application>().filesDir.absolutePath)
     private var history = mutableListOf<String>()
     private var historyIndex = 0
@@ -109,8 +108,7 @@ class TextEditorViewModel(application: Application, private val id: String) :
     override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
 
     fun saveText(content: String) {
-        uiScope.launch {
-            withContext(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.IO) {
                 val writeToDocumentResult = CoreModel.writeContentToDocument(config, id, content)
                 if (writeToDocumentResult is Err) {
                     when (val error = writeToDocumentResult.error) {
@@ -132,6 +130,5 @@ class TextEditorViewModel(application: Application, private val id: String) :
                     }.exhaustive
                 }
             }
-        }
     }
 }

--- a/clients/android/app/src/main/java/app/lockbook/model/TextEditorViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/TextEditorViewModel.kt
@@ -109,26 +109,26 @@ class TextEditorViewModel(application: Application, private val id: String) :
 
     fun saveText(content: String) {
         viewModelScope.launch(Dispatchers.IO) {
-                val writeToDocumentResult = CoreModel.writeContentToDocument(config, id, content)
-                if (writeToDocumentResult is Err) {
-                    when (val error = writeToDocumentResult.error) {
-                        is WriteToDocumentError.FolderTreatedAsDocument -> {
-                            _errorHasOccurred.postValue("Error! Folder is treated as document!")
-                        }
-                        is WriteToDocumentError.FileDoesNotExist -> {
-                            _errorHasOccurred.postValue("Error! File does not exist!")
-                        }
-                        is WriteToDocumentError.NoAccount -> {
-                            _errorHasOccurred.postValue("Error! No account!")
-                        }
-                        is WriteToDocumentError.Unexpected -> {
-                            Timber.e("Unable to write document changes: ${error.error}")
-                            _unexpectedErrorHasOccurred.postValue(
-                                error.error
-                            )
-                        }
-                    }.exhaustive
-                }
+            val writeToDocumentResult = CoreModel.writeContentToDocument(config, id, content)
+            if (writeToDocumentResult is Err) {
+                when (val error = writeToDocumentResult.error) {
+                    is WriteToDocumentError.FolderTreatedAsDocument -> {
+                        _errorHasOccurred.postValue("Error! Folder is treated as document!")
+                    }
+                    is WriteToDocumentError.FileDoesNotExist -> {
+                        _errorHasOccurred.postValue("Error! File does not exist!")
+                    }
+                    is WriteToDocumentError.NoAccount -> {
+                        _errorHasOccurred.postValue("Error! No account!")
+                    }
+                    is WriteToDocumentError.Unexpected -> {
+                        Timber.e("Unable to write document changes: ${error.error}")
+                        _unexpectedErrorHasOccurred.postValue(
+                            error.error
+                        )
+                    }
+                }.exhaustive
             }
+        }
     }
 }

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
@@ -26,6 +26,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import kotlinx.android.synthetic.main.activity_list_files.*
 import kotlinx.android.synthetic.main.dialog_create_file.*
+import kotlinx.android.synthetic.main.fragment_list_files.*
 import timber.log.Timber
 
 class ListFilesActivity : AppCompatActivity() {

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -25,11 +25,9 @@ import app.lockbook.screen.RequestResultCodes.DRAWING_REQUEST_CODE
 import app.lockbook.screen.RequestResultCodes.TEXT_EDITOR_REQUEST_CODE
 import app.lockbook.ui.*
 import app.lockbook.util.*
-import com.google.android.material.snackbar.Snackbar
 import com.tingyik90.snackprogressbar.SnackProgressBar
 import com.tingyik90.snackprogressbar.SnackProgressBarManager
 import kotlinx.android.synthetic.main.fragment_list_files.*
-import timber.log.Timber
 import java.util.*
 
 class ListFilesFragment : Fragment() {
@@ -64,12 +62,11 @@ class ListFilesFragment : Fragment() {
 
     private val syncInfoSnackBar by lazy {
         SnackProgressBar(
-                SnackProgressBar.TYPE_NORMAL,
-                ""
+            SnackProgressBar.TYPE_NORMAL,
+            ""
         )
-                .setSwipeToDismiss(true)
-                .setAllowUserInput(true)
-
+            .setSwipeToDismiss(true)
+            .setAllowUserInput(true)
     }
 
     override fun onCreateView(
@@ -140,10 +137,10 @@ class ListFilesFragment : Fragment() {
             }
         )
 
-        listFilesViewModel.showPreSyncSnackBar.observe(
+        listFilesViewModel.showSyncInfoSnackBar.observe(
             viewLifecycleOwner,
             { amountToSync ->
-                showPreSyncSnackBar(amountToSync)
+                showSyncInfoSnackBar(amountToSync)
             }
         )
 
@@ -374,16 +371,18 @@ class ListFilesFragment : Fragment() {
         )
     }
 
-    private fun showPreSyncSnackBar(amountToSync: Int) {
+    private fun showSyncInfoSnackBar(amountToSync: Int) {
         snackProgressBarManager.dismiss()
         if (amountToSync == 0) {
             syncInfoSnackBar.setMessage(resources.getString(R.string.list_files_sync_finished_snackbar))
             snackProgressBarManager.show(syncInfoSnackBar, SnackProgressBarManager.LENGTH_SHORT)
         } else {
-            syncInfoSnackBar.setMessage(resources.getString(
-                    R.string.list_files_presync_snackbar,
+            syncInfoSnackBar.setMessage(
+                resources.getString(
+                    R.string.list_files_sync_info_snackbar,
                     amountToSync.toString()
-            ))
+                )
+            )
             snackProgressBarManager.show(syncInfoSnackBar, SnackProgressBarManager.LENGTH_SHORT)
         }
     }

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -35,7 +35,6 @@ import java.util.*
 class ListFilesFragment : Fragment() {
     lateinit var listFilesViewModel: ListFilesViewModel
     private var updatedLastSyncedDescription = Timer()
-    var value = 1
     private val handler = Handler(requireNotNull(Looper.myLooper()))
     private val fragmentFinishedCallback = object : FragmentManager.FragmentLifecycleCallbacks() {
         override fun onFragmentDestroyed(fm: FragmentManager, f: Fragment) {
@@ -63,6 +62,16 @@ class ListFilesFragment : Fragment() {
             .setAllowUserInput(true)
     }
 
+    private val syncInfoSnackBar by lazy {
+        SnackProgressBar(
+                SnackProgressBar.TYPE_NORMAL,
+                ""
+        )
+                .setSwipeToDismiss(true)
+                .setAllowUserInput(true)
+
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -88,8 +97,6 @@ class ListFilesFragment : Fragment() {
         binding.lifecycleOwner = this
 
         binding.listFilesRefresh.setOnRefreshListener {
-            Timber.e("----------------------------")
-            Timber.e("$value: FIRST STEP")
             listFilesViewModel.onSwipeToRefresh()
         }
 
@@ -136,7 +143,6 @@ class ListFilesFragment : Fragment() {
         listFilesViewModel.showPreSyncSnackBar.observe(
             viewLifecycleOwner,
             { amountToSync ->
-                Timber.e("STEP 9")
                 showPreSyncSnackBar(amountToSync)
             }
         )
@@ -369,25 +375,16 @@ class ListFilesFragment : Fragment() {
     }
 
     private fun showPreSyncSnackBar(amountToSync: Int) {
-        Timber.e("STEP 10")
         snackProgressBarManager.dismiss()
-        Timber.e("STEP 11")
         if (amountToSync == 0) {
-            Timber.e("STEP 12")
-            AlertModel.notify(
-                fragment_list_files,
-                value.toString(),  OnFinishAlert.DoNothingOnFinishAlert
-            )
-            value += 1
+            syncInfoSnackBar.setMessage(resources.getString(R.string.list_files_sync_finished_snackbar))
+            snackProgressBarManager.show(syncInfoSnackBar, SnackProgressBarManager.LENGTH_SHORT)
         } else {
-            AlertModel.notify(
-                fragment_list_files,
-                resources.getString(
+            syncInfoSnackBar.setMessage(resources.getString(
                     R.string.list_files_presync_snackbar,
                     amountToSync.toString()
-                ),
-                OnFinishAlert.DoNothingOnFinishAlert
-            )
+            ))
+            snackProgressBarManager.show(syncInfoSnackBar, SnackProgressBarManager.LENGTH_SHORT)
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -25,14 +25,17 @@ import app.lockbook.screen.RequestResultCodes.DRAWING_REQUEST_CODE
 import app.lockbook.screen.RequestResultCodes.TEXT_EDITOR_REQUEST_CODE
 import app.lockbook.ui.*
 import app.lockbook.util.*
+import com.google.android.material.snackbar.Snackbar
 import com.tingyik90.snackprogressbar.SnackProgressBar
 import com.tingyik90.snackprogressbar.SnackProgressBarManager
 import kotlinx.android.synthetic.main.fragment_list_files.*
+import timber.log.Timber
 import java.util.*
 
 class ListFilesFragment : Fragment() {
     lateinit var listFilesViewModel: ListFilesViewModel
     private var updatedLastSyncedDescription = Timer()
+    var value = 1
     private val handler = Handler(requireNotNull(Looper.myLooper()))
     private val fragmentFinishedCallback = object : FragmentManager.FragmentLifecycleCallbacks() {
         override fun onFragmentDestroyed(fm: FragmentManager, f: Fragment) {
@@ -85,6 +88,8 @@ class ListFilesFragment : Fragment() {
         binding.lifecycleOwner = this
 
         binding.listFilesRefresh.setOnRefreshListener {
+            Timber.e("----------------------------")
+            Timber.e("$value: FIRST STEP")
             listFilesViewModel.onSwipeToRefresh()
         }
 
@@ -131,6 +136,7 @@ class ListFilesFragment : Fragment() {
         listFilesViewModel.showPreSyncSnackBar.observe(
             viewLifecycleOwner,
             { amountToSync ->
+                Timber.e("STEP 9")
                 showPreSyncSnackBar(amountToSync)
             }
         )
@@ -256,6 +262,8 @@ class ListFilesFragment : Fragment() {
             }
         })
 
+        snackProgressBarManager.useRoundedCornerBackground(true)
+
         if (resources.configuration.orientation == ORIENTATION_LANDSCAPE && resources.configuration.screenLayout == SCREENLAYOUT_SIZE_SMALL) {
             list_files_fab_holder.orientation = HORIZONTAL
         }
@@ -361,12 +369,16 @@ class ListFilesFragment : Fragment() {
     }
 
     private fun showPreSyncSnackBar(amountToSync: Int) {
+        Timber.e("STEP 10")
         snackProgressBarManager.dismiss()
+        Timber.e("STEP 11")
         if (amountToSync == 0) {
+            Timber.e("STEP 12")
             AlertModel.notify(
                 fragment_list_files,
-                resources.getString(R.string.list_files_sync_finished_snackbar), OnFinishAlert.DoNothingOnFinishAlert
+                value.toString(),  OnFinishAlert.DoNothingOnFinishAlert
             )
+            value += 1
         } else {
             AlertModel.notify(
                 fragment_list_files,
@@ -413,8 +425,6 @@ class ListFilesFragment : Fragment() {
         files: List<FileMetadata>,
         adapter: GeneralViewAdapter
     ) {
-        listFilesViewModel.updateBreadcrumbWithLatest()
-
         adapter.files = files
         if (!listFilesViewModel.selectedFiles.contains(true)) {
             listFilesViewModel.selectedFiles = MutableList(files.size) { false }

--- a/clients/android/app/src/main/res/values/strings.xml
+++ b/clients/android/app/src/main/res/values/strings.xml
@@ -106,7 +106,7 @@
     </array>
 
     <string name="list_files_offline_snackbar">You are offline</string>
-    <string name="list_files_presync_snackbar">%s items to sync</string>
+    <string name="list_files_sync_info_snackbar">%s items to sync</string>
     <string name="list_files_sync_snackbar">Syncing %s items…</string>
     <string name="list_files_sync_finished_snackbar">Up to date</string>
     <string name="settings_preference_logs">View logs</string>


### PR DESCRIPTION
In this PR, I resolved a long standing error involving sync messages. Whenever a user would try to sync using the swipe to refresh functionality, the sync info message did not always appear. This was due android itself lacking a queue functionality. So when snackbars appeared in succession, like they did with syncing, then it did guarantee that the message would always be shown. Luckily, a library we already used called snackprogressbar (which can be forked in need be), implemented this functionality already. So I just utilized it and fixed the bug.

fixes: #567 