### PR TITLE
android: correct darkmode theme for setting dialogs

### DIFF
--- a/clients/android/app/src/main/res/values/styles.xml
+++ b/clients/android/app/src/main/res/values/styles.xml
@@ -32,6 +32,10 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Main.Button.Borderless.Colored</item>
+        <item name="android:buttonBarPositiveButtonStyle">@style/Main.Button.Borderless.Colored</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Main.Button.Borderless.Colored</item>
+        <item name="android:buttonBarNegativeButtonStyle">@style/Main.Button.Borderless.Colored</item>
     </style>
 
     <style name="Main.Widget.Dialog.Alert" parent="Theme.AppCompat.DayNight.Dialog.Alert">
@@ -39,6 +43,10 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Main.Button.Borderless.Colored</item>
+        <item name="android:buttonBarPositiveButtonStyle">@style/Main.Button.Borderless.Colored</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Main.Button.Borderless.Colored</item>
+        <item name="android:buttonBarNegativeButtonStyle">@style/Main.Button.Borderless.Colored</item>
     </style>
 
     <style name="Main.Widget.SnackBar" parent="Widget.MaterialComponents.Snackbar">

--- a/clients/android/app/src/main/res/values/styles.xml
+++ b/clients/android/app/src/main/res/values/styles.xml
@@ -1,18 +1,25 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Main" parent="Theme.MaterialComponents.DayNight">
-        <item name="android:windowBackground">@color/colorPrimaryDark</item>
-        <item name="android:navigationBarColor">@color/navigationBarColor</item>
-        <item name="snackbarStyle">@style/Main.Widget.SnackBar</item>
-        <item name="snackbarTextViewStyle">@style/Main.Widget.SnackBar.TextView</item>
         <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="android:windowLightStatusBar" tools:targetApi="23">@bool/windowLightStatusBar</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="windowActionBar">false</item>
+
+        <item name="android:windowBackground">@color/colorPrimaryDark</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="23">@bool/windowLightStatusBar</item>
         <item name="windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+
         <item name="android:actionBarStyle">@style/Main.Widget.Actionbar</item>
-        <item name="titleTextStyle">@style/Main.Title</item>
         <item name="android:actionOverflowButtonStyle">@style/Main.Overflow</item>
+
+        <item name="android:navigationBarColor">@color/navigationBarColor</item>
+        <item name="titleTextStyle">@style/Main.Title</item>
+
+        <item name="snackbarStyle">@style/Main.Widget.SnackBar</item>
+        <item name="snackbarTextViewStyle">@style/Main.Widget.SnackBar.TextView</item>
+
+        <item name="dialogTheme">@style/Main.Widget.Dialog</item>
+        <item name="alertDialogTheme">@style/Main.Widget.Dialog.Alert</item>
     </style>
 
     <style name="Main.FullScreen" parent="Main">
@@ -21,6 +28,13 @@
     </style>
 
     <style name="Main.Widget.Dialog" parent="Theme.AppCompat.DayNight.Dialog">
+        <item name="android:background">@color/windowBackground</item>
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+    </style>
+
+    <style name="Main.Widget.Dialog.Alert" parent="Theme.AppCompat.DayNight.Dialog.Alert">
         <item name="android:background">@color/windowBackground</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>


### PR DESCRIPTION
In this PR, the dark themes for the settings dialogs were corrected. Originally, in darkmode these dialogs would have grey backgrounds. This is because they could not be themed the same way as the other dialogs, like move file and rename, so they defaulted to global theme which did not specifically account for these dialogs.

## Before

<details>

![Screenshot_20210327-141117.png](https://user-images.githubusercontent.com/20663038/112730188-94906980-8f06-11eb-96fb-394b180f44c5.png)

![Screenshot_20210327-141125.png](https://user-images.githubusercontent.com/20663038/112730192-98bc8700-8f06-11eb-85a8-0904b038c1ca.png)
</details>

## After

<details>

![Screenshot_20210327-140932.png](https://user-images.githubusercontent.com/20663038/112730195-9bb77780-8f06-11eb-8597-8d6e93994b18.png)

![Screenshot_20210327-140943.png](https://user-images.githubusercontent.com/20663038/112730197-9e19d180-8f06-11eb-9a15-bbec67dc7fed.png)
</details>


fixes #656 