### PR TITLE
apple: Fixing file deletion, view drawings as image, fixing markdown bounds

### DIFF
--- a/clients/apple/Notepad/Sources/NotepadSwift/Markdown/MarkdownEngine.swift
+++ b/clients/apple/Notepad/Sources/NotepadSwift/Markdown/MarkdownEngine.swift
@@ -14,12 +14,13 @@ public class MarkdownEngine {
         if let type = MarkdownNode.MarkdownType(rawValue: Int(p.type)) {
             let s = lines[Int(p.start_line) - 1] + Int(p.start_column) - 1
             let e = lines[Int(p.end_line) - 1] + Int(p.end_column) - 1
+            let l = e-s
 
             let fromIdx = text.index(text.startIndex, offsetBy: s)
-            let range = text
-                .index(text.startIndex, offsetBy: e, limitedBy: text.endIndex)
+            let toIdx = text.utf8.index(fromIdx, offsetBy: l, limitedBy: text.utf8.endIndex)
+            let range = toIdx
                 .flatMap {
-                    if ($0 < text.endIndex) { return NSRange(fromIdx...$0, in: text) } else { return nil }
+                    if ($0 < text.utf8.endIndex) { return NSRange(fromIdx...$0, in: text) } else { return nil }
                 } ?? NSRange(fromIdx..<text.endIndex, in: text)
             return MarkdownNode(range: range, type: type, headingLevel: node.cmarkNode.headingLevel)
         } else {

--- a/clients/apple/Shared/Components/NotepadView.swift
+++ b/clients/apple/Shared/Components/NotepadView.swift
@@ -13,6 +13,7 @@ struct NotepadView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UITextView {
         let np = Notepad(frame: frame, theme: theme)
+        np.smartQuotesType = .no
         np.onTextChange = onTextChange
         np.storage.markdowner = { engine.render($0) }
         np.storage.applyMarkdown = { m in applyMarkdown(markdown: m) }
@@ -38,6 +39,7 @@ struct NotepadView: NSViewRepresentable {
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSTextView.scrollableTextView()
         let np = Notepad(frame: frame)
+        np.isAutomaticQuoteSubstitutionEnabled = false
         np.onTextChange = onTextChange
         np.storage.markdowner = { engine.render($0) }
         np.storage.applyMarkdown = { m in applyMarkdown(markdown: m) }

--- a/clients/apple/Shared/Config/Colors.swift
+++ b/clients/apple/Shared/Config/Colors.swift
@@ -46,4 +46,30 @@ extension UniversalColor {
         return x
         #endif
     }
+
+    #if os(iOS)
+    func addColor(_ color1: UniversalColor, with color2: UniversalColor) -> UniversalColor {
+        var (r1, g1, b1, a1) = (CGFloat(0), CGFloat(0), CGFloat(0), CGFloat(0))
+        var (r2, g2, b2, a2) = (CGFloat(0), CGFloat(0), CGFloat(0), CGFloat(0))
+        color1.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+        color2.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+        return UniversalColor(red: min(r1 + r2, 1), green: min(g1 + g2, 1), blue: min(b1 + b2, 1), alpha: (a1 + a2) / 2)
+    }
+    func multiplyColor(_ color: UniversalColor, by multiplier: CGFloat) -> UniversalColor {
+        var (r, g, b, a) = (CGFloat(0), CGFloat(0), CGFloat(0), CGFloat(0))
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return UniversalColor(red: r * multiplier, green: g * multiplier, blue: b * multiplier, alpha: a)
+    }
+
+    func blendColors(_ color: UniversalColor, by multiplier: CGFloat) -> UniversalColor {
+        let base = multiplyColor(self, by: 1 - multiplier)
+        let other = multiplyColor(color, by: multiplier)
+        return addColor(base, with: other)
+    }
+    #else
+    func blendColors(_ color: UniversalColor, by multiplier: CGFloat) -> UniversalColor {
+        return self.blended(withFraction: multiplier, of: color)!
+    }
+    #endif
+
 }

--- a/clients/apple/Shared/Config/LockbookMarkdownConfig.swift
+++ b/clients/apple/Shared/Config/LockbookMarkdownConfig.swift
@@ -37,8 +37,8 @@ func applyMarkdown(markdown: MarkdownNode) -> [NSAttributedString.Key : Any] {
     switch markdown.type {
     case .header:
         return [
-            .foregroundColor : UniversalColor.fromColorAlias(from: .Red),
-            .font : systemFontWithTraits(headingTraits, fontSize*(10.0-CGFloat(markdown.headingLevel))/3),
+            .foregroundColor : UniversalColor.fromColorAlias(from: .Red).blendColors(UniversalColor.label, by: (CGFloat(markdown.headingLevel-1)/10)),
+            .font : systemFontWithTraits(headingTraits),
         ]
     case .italic:
         return [

--- a/clients/apple/Shared/Stateful Logic/GlobalState.swift
+++ b/clients/apple/Shared/Stateful Logic/GlobalState.swift
@@ -27,6 +27,8 @@ class GlobalState: ObservableObject {
     let serialQueue = DispatchQueue(label: "syncQueue")
     #if os(iOS)
     @Published var openDrawing: DrawingModel
+    #else
+    @Published var openImage: ImageModel
     #endif
     @Published var openDocument: Content
 
@@ -172,6 +174,8 @@ class GlobalState: ObservableObject {
         #if os(iOS)
         self.openDrawing = DrawingModel(write: api.writeDrawing, read: api.readDrawing)
         openDrawing.writeListener = documentChangeHappened
+        #else
+        self.openImage = ImageModel(read: api.exportDrawing)
         #endif
         openDocument.writeListener = documentChangeHappened
         updateFiles()
@@ -211,6 +215,8 @@ class GlobalState: ObservableObject {
         self.account = Account(username: "testy", apiUrl: "ftp://lockbook.gov", keys: .empty)
         #if os(iOS)
         self.openDrawing = DrawingModel(write: { _, _ in .failure(.init(unexpected: "LAZY")) }, read: { _ in .failure(.init(unexpected: "LAZY")) })
+        #else
+        self.openImage = ImageModel(read: { _ in .failure(.init(unexpected: "LAZY"))})
         #endif
         self.openDocument = Content(write: { _, _ in .failure(.init(unexpected: "LAZY")) }, read: { _ in .failure(.init(unexpected: "LAZY")) })
         if case .success(let root) = api.getRoot(), case .success(let metas) = api.listFiles() {

--- a/clients/apple/Shared/Stateful Logic/GlobalState.swift
+++ b/clients/apple/Shared/Stateful Logic/GlobalState.swift
@@ -30,6 +30,7 @@ class GlobalState: ObservableObject {
     #endif
     @Published var openDocument: Content
 
+    var deleteChannel = PassthroughSubject<FileMetadata, Never>()
     private var syncChannel = PassthroughSubject<FfiResult<SwiftLockbookCore.Empty, SyncAllError>, Never>()
     private var cancellableSet: Set<AnyCancellable> = []
 

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
@@ -84,6 +84,11 @@ public struct CoreApi: LockbookApi {
             return .failure(.init(unexpected: err.localizedDescription))
         }
     }
+
+    public func exportDrawing(id: UUID) -> FfiResult<Data, ExportDrawingError> {
+        let res: FfiResult<[UInt8], ExportDrawingError> = fromPrimitiveResult(result: export_drawing(documentsDirectory, id.uuidString))
+        return res.map(transform: { Data($0) })
+    }
     
     public func createFile(name: String, dirId: UUID, isFolder: Bool) -> FfiResult<FileMetadata, CreateFileError> {
         let fileType = isFolder ? "Folder" : "Document"

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
@@ -78,6 +78,10 @@ Vestibulum ante ipsum primis in vel.
     public func writeDrawing(id: UUID, content: Drawing) -> FfiResult<Empty, WriteToDocumentError> {
         .failure(.init(unexpected: "LAZY"))
     }
+
+    public func exportDrawing(id: UUID) -> FfiResult<Data, ExportDrawingError> {
+        .failure(.init(unexpected: "LAZY"))
+    }
     
     public func createFile(name: String, dirId: UUID, isFolder: Bool) -> FfiResult<FileMetadata, CreateFileError> {
         let now = Date().timeIntervalSince1970

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
@@ -30,6 +30,7 @@ public protocol LockbookApi {
     func moveFile(id: UUID, newParent: UUID) -> FfiResult<Empty, MoveFileError>
     func readDrawing(id: UUID) -> FfiResult<Drawing, ReadDocumentError>
     func writeDrawing(id: UUID, content: Drawing) -> FfiResult<Empty, WriteToDocumentError>
+    func exportDrawing(id: UUID) -> FfiResult<Data, ExportDrawingError>
 
     // State
     func getState() -> FfiResult<DbState, GetStateError>

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FfiError.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FfiError.swift
@@ -201,3 +201,24 @@ public enum FileDeleteError: String, UiError {
 public enum GetLocalChangesError: String, UiError {
     case Stub
 }
+
+public enum GetDrawingError: String, UiError {
+    case NoAccount
+    case FolderTreatedAsDrawing
+    case InvalidDrawing
+    case FileDoesNotExist
+}
+
+public enum SaveDrawingError: String, UiError {
+    case NoAccount
+    case FileDoesNotExist
+    case FolderTreatedAsDrawing
+    case InvalidDrawing
+}
+
+public enum ExportDrawingError: String, UiError {
+    case FolderTreatedAsDrawing
+    case FileDoesNotExist
+    case NoAccount
+    case InvalidDrawing
+}

--- a/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/Contracts/ErrorEnumTests.swift
+++ b/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/Contracts/ErrorEnumTests.swift
@@ -30,6 +30,9 @@ class ErrorEnumTests: XCTestCase {
         let GetLastSyncedError: [GetLastSyncedError]
         let GetUsageError: [GetUsageError]
         let FileDeleteError: [FileDeleteError]
+        let GetDrawingError: [GetDrawingError]
+        let SaveDrawingError: [SaveDrawingError]
+        let ExportDrawingError: [ExportDrawingError]
 
         func noneEmpty() -> Bool {
             !GetStateError.isEmpty
@@ -58,6 +61,9 @@ class ErrorEnumTests: XCTestCase {
                 && !GetLastSyncedError.isEmpty
                 && !GetUsageError.isEmpty
                 && !FileDeleteError.isEmpty
+                && !GetDrawingError.isEmpty
+                && !SaveDrawingError.isEmpty
+                && !ExportDrawingError.isEmpty
         }
     }
     

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -160,7 +160,7 @@ struct FileListView: View {
                         FileCell(meta: meta)
                     })
                 } else {
-                    let el = EditorLoader(content: core.openDocument, meta: meta, files: core.files)
+                    let el = EditorLoader(content: core.openDocument, meta: meta, files: core.files, deleteChannel: core.deleteChannel)
                     return AnyView (NavigationLink(destination: el) {
                         FileCell(meta: meta)
                     })
@@ -172,6 +172,7 @@ struct FileListView: View {
     func handleDelete(meta: FileMetadata) {
         switch core.api.deleteFile(id: meta.id) {
         case .success(_):
+            core.deleteChannel.send(meta)
             core.updateFiles()
             core.checkForLocalWork()
         case .failure(let err):

--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		B2B7E2E325C6411800B9EFAD /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B7E2E125C6411800B9EFAD /* OnboardingState.swift */; };
 		B2B7E2EB25C669C400B9EFAD /* NotificationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B7E2EA25C669C400B9EFAD /* NotificationButton.swift */; };
 		B2B7E2EC25C669C400B9EFAD /* NotificationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B7E2EA25C669C400B9EFAD /* NotificationButton.swift */; };
+		EA20B52B2611278B00421F48 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA20B52A2611278B00421F48 /* ImageLoader.swift */; };
 		EA30B54D25298B0800D2FE22 /* UsageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA30B54C25298B0800D2FE22 /* UsageIndicator.swift */; };
 		EA30B54E25298B0800D2FE22 /* UsageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA30B54C25298B0800D2FE22 /* UsageIndicator.swift */; };
 		EA349F0725BC7C360016241E /* OutlineRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA349F0125BC7C110016241E /* OutlineRow.swift */; };
@@ -86,6 +87,7 @@
 		87C118E925C5E20200D28A04 /* ImportAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportAccountView.swift; sourceTree = "<group>"; };
 		B2B7E2E125C6411800B9EFAD /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
 		B2B7E2EA25C669C400B9EFAD /* NotificationButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationButton.swift; sourceTree = "<group>"; };
+		EA20B52A2611278B00421F48 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		EA30B54C25298B0800D2FE22 /* UsageIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageIndicator.swift; sourceTree = "<group>"; };
 		EA349F0125BC7C110016241E /* OutlineRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineRow.swift; sourceTree = "<group>"; };
 		EA349F0A25BE6BD80016241E /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				87C118E125C5E1BA00D28A04 /* OnboardingView.swift */,
 				87C118E925C5E20200D28A04 /* ImportAccountView.swift */,
 				87206EBC25C61DF300870A42 /* CreateAccountView.swift */,
+				EA20B52A2611278B00421F48 /* ImageLoader.swift */,
 			);
 			path = macOS;
 			sourceTree = "<group>";
@@ -432,6 +435,7 @@
 				EA5C7D7C2516606100F7F358 /* LockbookApp.swift in Sources */,
 				8741E8FA25ACBCF9005B7B01 /* FileListView.swift in Sources */,
 				87C118E225C5E1BA00D28A04 /* OnboardingView.swift in Sources */,
+				EA20B52B2611278B00421F48 /* ImageLoader.swift in Sources */,
 				EA349F0C25BE6BD80016241E /* ActivityIndicator.swift in Sources */,
 				EAAA10D925B3FD58005140EE /* BottomBar.swift in Sources */,
 				8741E92825AD9B02005B7B01 /* LockbookMarkdownConfig.swift in Sources */,

--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios";
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
 				PRODUCT_NAME = Lockbook;
 				SDKROOT = iphoneos;
@@ -603,7 +603,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios";
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
 				PRODUCT_NAME = Lockbook;
 				SDKROOT = iphoneos;
@@ -634,7 +634,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
 				PRODUCT_NAME = Lockbook;
 				SDKROOT = macosx;
@@ -663,7 +663,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
 				PRODUCT_NAME = Lockbook;
 				SDKROOT = macosx;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios";
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
 				PRODUCT_NAME = Lockbook;
 				SDKROOT = iphoneos;
@@ -777,7 +777,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
 				PRODUCT_NAME = Lockbook;
 				SDKROOT = macosx;

--- a/clients/apple/lockbook.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/clients/apple/lockbook.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/johnxnguyen/Down.git",
         "state": {
           "branch": "master",
-          "revision": "f83e9a2566bb060f7a4e0cff682c63b625b9dcc9",
+          "revision": "2524b6247081451083f82d64f1a6d3eb95468870",
           "version": null
         }
       }

--- a/clients/apple/macOS/FileListView.swift
+++ b/clients/apple/macOS/FileListView.swift
@@ -23,7 +23,11 @@ struct FileListView: View {
             }
         }
         if let item = selectedItem {
-            EditorLoader(content: core.openDocument, meta: item, files: core.files, deleteChannel: core.deleteChannel)
+            if (item.name.hasSuffix(".draw")) {
+                ImageLoader(model: core.openImage, meta: item)
+            } else {
+                EditorLoader(content: core.openDocument, meta: item, files: core.files, deleteChannel: core.deleteChannel)
+            }
         }
     }
 }

--- a/clients/apple/macOS/FileListView.swift
+++ b/clients/apple/macOS/FileListView.swift
@@ -23,7 +23,7 @@ struct FileListView: View {
             }
         }
         if let item = selectedItem {
-            EditorLoader(content: core.openDocument, meta: item, files: core.files)
+            EditorLoader(content: core.openDocument, meta: item, files: core.files, deleteChannel: core.deleteChannel)
         }
     }
 }

--- a/clients/apple/macOS/ImageLoader.swift
+++ b/clients/apple/macOS/ImageLoader.swift
@@ -1,0 +1,20 @@
+//
+//  ImageLoader.swift
+//  Lockbook (macOS)
+//
+//  Created by Raayan Pillai on 3/28/21.
+//
+
+import SwiftUI
+
+struct ImageLoader: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct ImageLoader_Previews: PreviewProvider {
+    static var previews: some View {
+        ImageLoader()
+    }
+}

--- a/clients/windows/core/CoreModel.cs
+++ b/clients/windows/core/CoreModel.cs
@@ -420,4 +420,50 @@ namespace Core {
         public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
         public class UnexpectedError : Core.UnexpectedError, IResult { }
     }
+
+
+    namespace GetDrawing {
+            public interface IResult { }
+            public class Success : IResult {
+                public string content;
+            }
+            public enum PossibleErrors {
+                NoAccount,
+                FolderTreatedAsDrawing,
+                InvalidDrawing,
+                FileDoesNotExist,
+            }
+            public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
+            public class UnexpectedError : Core.UnexpectedError, IResult { }
+    }
+
+    namespace SaveDrawing {
+            public interface IResult { }
+            public class Success : IResult {
+                public string content;
+            }
+            public enum PossibleErrors {
+                NoAccount,
+                FileDoesNotExist,
+                FolderTreatedAsDrawing,
+                InvalidDrawing,
+            }
+            public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
+            public class UnexpectedError : Core.UnexpectedError, IResult { }
+    }
+
+    namespace ExportDrawing {
+            public interface IResult { }
+            public class Success : IResult {
+                public string content;
+            }
+            public enum PossibleErrors {
+                FolderTreatedAsDrawing,
+                FileDoesNotExist,
+                NoAccount,
+                InvalidDrawing,
+            }
+            public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
+            public class UnexpectedError : Core.UnexpectedError, IResult { }
+    }
 }

--- a/clients/windows/test/CoreServiceTest.cs
+++ b/clients/windows/test/CoreServiceTest.cs
@@ -799,6 +799,9 @@ namespace test {
                 {"SetLastSyncedError", typeof(Core.SetLastSynced.PossibleErrors)},
                 {"SyncAllError", typeof(Core.SyncAll.PossibleErrors)},
                 {"WriteToDocumentError", typeof(Core.WriteDocument.PossibleErrors)},
+                {"GetDrawingError", typeof(Core.GetDrawing.PossibleErrors)},
+                {"SaveDrawingError", typeof(Core.SaveDrawing.PossibleErrors)},
+                {"ExportDrawingError", typeof(Core.ExportDrawing.PossibleErrors)},
             };
 
             var variants = CoreService.GetVariants().WaitResult();

--- a/core/src/c_interface.rs
+++ b/core/src/c_interface.rs
@@ -10,6 +10,7 @@ use crate::model::file_metadata::FileType;
 use crate::model::state::Config;
 use crate::model::work_unit::WorkUnit;
 use crate::repo::file_metadata_repo::{filter_from_str, Filter};
+use crate::service::drawing_service::SupportedImageFormats;
 use crate::{get_all_error_variants, Error, ExecuteWorkError};
 use serde::Serialize;
 
@@ -207,6 +208,18 @@ pub unsafe extern "C" fn read_document(
         crate::read_document(&config_from_ptr(writeable_path), uuid_from_ptr(id))
             .map(|d| String::from(String::from_utf8_lossy(&d))),
     ))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn export_drawing(
+    writeable_path: *const c_char,
+    id: *const c_char,
+) -> *const c_char {
+    c_string(translate(crate::export_drawing(
+        &config_from_ptr(writeable_path),
+        uuid_from_ptr(id),
+        SupportedImageFormats::Png,
+    )))
 }
 
 #[no_mangle]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1103,6 +1103,9 @@ impl_get_variants!(
     SetLastSyncedError,
     GetLastSyncedError,
     GetUsageError,
+    GetDrawingError,
+    SaveDrawingError,
+    ExportDrawingError,
 );
 
 pub mod c_interface;


### PR DESCRIPTION

fixes #649

You can view drawings as image in macOS

https://user-images.githubusercontent.com/2370497/112770078-d696d980-8ff2-11eb-86dd-a4ebfe578c05.mov

fixes #648 

Smart quotes and other **wonk-AF** characters will not busk the render with their dirty bounds!

<img width="450" alt="Screen Shot 2021-03-31 at 8 28 59 PM" src="https://user-images.githubusercontent.com/2370497/113227090-c2a3df80-925f-11eb-8d6b-bb0ba181acf4.png">

fixes #645