### PR TITLE
android: erasing will take into account the stroke's width

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/SettingsFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/SettingsFragment.kt
@@ -49,7 +49,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun setUpPreferences() {
-        findPreference<Preference>(BIOMETRIC_OPTION_KEY)?.setOnPreferenceChangeListener { preference, newValue ->
+        findPreference<Preference>(BIOMETRIC_OPTION_KEY)?.setOnPreferenceChangeListener { _, newValue ->
             if (newValue is String) {
                 newValueForPref = newValue
 

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -209,7 +209,7 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
 
                 val pointWidth1 = stroke.pointsGirth[pointIndex]
                 val pointWidth2 = stroke.pointsGirth[pointIndex + 1]
-                if (pointIndex == 3) {
+                if (pointIndex == 0) {
                     strokesBounds.last().set(x1 - pointWidth1, y1 - pointWidth1, x1 + pointWidth1, y1 + pointWidth1)
                     updateLastStrokeBounds(x2, y2, pointWidth2)
                 } else {
@@ -229,13 +229,6 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
                 tempCanvas.drawPath(strokePath, strokePaint)
                 strokePath.reset()
             }
-
-            strokePaint.color = Color.WHITE
-
-            tempCanvas.drawRect(
-                    strokesBounds.last(),
-                    strokePaint
-            )
 
             strokePath.reset()
         }
@@ -430,7 +423,12 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
     }
 
     private fun lineTo(point: PointF, pressure: Float) {
+        if (lastPoint.equals(Float.NaN, Float.NaN)) { // if you start drawing after just erasing, and the pen was never lifted, this will compensate for it
+            return moveTo(point, pressure)
+        }
+
         val adjustedCurrentPressure = getAdjustedPressure(pressure)
+
         rollingAveragePressure = approximateRollingAveragePressure(rollingAveragePressure, adjustedCurrentPressure)
         updateLastStrokeBounds(point.x, point.y, rollingAveragePressure)
 
@@ -473,6 +471,10 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
             }
         }
 
+        if (!lastPoint.equals(Float.NaN, Float.NaN)) {
+            lastPoint.set(Float.NaN, Float.NaN)
+        }
+
         val drawingClone = drawing.clone()
         var refreshScreen = false
 
@@ -488,7 +490,7 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
                 if (pointIndex < stroke.pointsX.size - 1) {
                     var roundedPressure = stroke.pointsGirth[pointIndex].toInt()
 
-                    if(roundedPressure < 5) {
+                    if (roundedPressure < 5) {
                         roundedPressure = 5
                     }
 


### PR DESCRIPTION
In this PR, a stroke's width is now used in determining whether something can be erasing. Before, there would be a fixed distance around a stroke point, and only when you entered that would you erase it. This fixed distance was hardwired at `20`, but now this distance around the point is based on stroke girth. This gives a predictable and normal erasing feeling.

fixes #658 