### PR TITLE
android: fixed bad allocation error while drawing

### DIFF
--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -6,10 +6,7 @@
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
 
     <uses-permission android:name="android.permission.INTERNET" />
-
-    <uses-feature
-        android:name="android.hardware.camera"
-        android:required="false" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
     <!--
         allowBackup is set to false because it may backup keys in plaintext to google drive
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
@@ -47,9 +47,7 @@ class DrawingActivity : AppCompatActivity() {
         ) {
         }
 
-        override fun surfaceDestroyed(holder: SurfaceHolder) {
-            holder.surface.release()
-        }
+        override fun surfaceDestroyed(holder: SurfaceHolder) {}
     }
 
     private var autoSaveTimer = Timer()
@@ -58,7 +56,6 @@ class DrawingActivity : AppCompatActivity() {
     private lateinit var gestureDetector: GestureDetector
 
     override fun onCreate(savedInstanceState: Bundle?) {
-
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_drawing)
 
@@ -125,22 +122,24 @@ class DrawingActivity : AppCompatActivity() {
 
     override fun onRestart() {
         super.onRestart()
-        drawing_view.restartThread()
+        drawing_view.startThread()
     }
 
     override fun onPause() {
         super.onPause()
-        drawing_view.endThread()
+        if (!isFirstLaunch) {
+            drawing_view.pauseThread()
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        drawing_view.endThread()
         autoSaveTimer.cancel()
         autoSaveTimer.purge()
+        drawing_view.holder.surface.release()
         if (!isFirstLaunch) {
             drawingViewModel.backupDrawing = drawing_view.drawing
-            drawingViewModel.saveDrawing(drawing_view.drawing)
+            drawingViewModel.saveDrawing(drawing_view.drawing.clone())
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
@@ -48,6 +48,7 @@ class DrawingActivity : AppCompatActivity() {
         }
 
         override fun surfaceDestroyed(holder: SurfaceHolder) {
+            holder.surface.release()
         }
     }
 
@@ -136,6 +137,7 @@ class DrawingActivity : AppCompatActivity() {
         super.onDestroy()
         drawing_view.endThread()
         autoSaveTimer.cancel()
+        autoSaveTimer.purge()
         if (!isFirstLaunch) {
             drawingViewModel.backupDrawing = drawing_view.drawing
             drawingViewModel.saveDrawing(drawing_view.drawing)

--- a/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
@@ -8,7 +8,6 @@ import android.os.Handler
 import android.os.Looper
 import android.view.GestureDetector
 import android.view.MotionEvent
-import android.view.SurfaceHolder
 import android.view.View
 import android.widget.SeekBar
 import androidx.appcompat.app.AppCompatActivity
@@ -24,7 +23,6 @@ import app.lockbook.ui.DrawingView
 import app.lockbook.util.*
 import kotlinx.android.synthetic.main.activity_drawing.*
 import kotlinx.android.synthetic.main.toolbar_drawing.*
-import timber.log.Timber
 import java.util.*
 
 class DrawingActivity : AppCompatActivity() {
@@ -104,8 +102,6 @@ class DrawingActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        Timber.e("RESUMED")
-
         drawing_view.startThread()
     }
 
@@ -252,7 +248,6 @@ class DrawingActivity : AppCompatActivity() {
 
     private fun startDrawing() {
         drawing_progress_bar.visibility = View.VISIBLE
-
 
         if (drawingViewModel.backupDrawing == null) {
             drawingViewModel.getDrawing(id)

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -20,6 +20,7 @@ import app.lockbook.util.ColorAlias
 import app.lockbook.util.Drawing
 import app.lockbook.util.Stroke
 import kotlinx.android.synthetic.main.activity_drawing.*
+import java.lang.IllegalStateException
 import java.util.*
 import kotlin.math.pow
 import kotlin.math.roundToInt
@@ -30,9 +31,10 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
     var drawing: Drawing = Drawing()
     private lateinit var canvasBitmap: Bitmap
     private lateinit var tempCanvas: Canvas
+    private lateinit var thread: Thread
+
 
     private var erasePoints = Pair(PointF(Float.NaN, Float.NaN), PointF(Float.NaN, Float.NaN)) // Shouldn't these be NAN
-    private var thread = Thread(this)
     private var isThreadRunning = false
     private var penSizeMultiplier = 7
     private var strokeAlpha = 255
@@ -544,17 +546,21 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
         penSizeMultiplier = penSize
     }
 
-    fun endThread() {
-        isThreadRunning = false
-    }
-
-    fun restartThread() {
-        thread = Thread(this)
-    }
-
     fun startThread() {
+        thread = Thread(this)
         isThreadRunning = true
         thread.start()
+    }
+
+    fun pauseThread() {
+        isThreadRunning = false
+        while(thread.isAlive) {
+            try {
+                thread.join(10)
+            } catch (e: Exception) {
+
+            }
+        }
     }
 
     override fun run() {
@@ -568,7 +574,8 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
                 }
                 render(canvas)
             } finally {
-                holder.unlockCanvasAndPost(canvas)
+
+                    holder.unlockCanvasAndPost(canvas)
             }
         }
     }

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -63,7 +63,6 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
 
         const val PRESSURE_SAMPLES_AVERAGED = 5
         const val SPEN_ACTION_DOWN = 211
-        const val MIN_TIME_PER_FRAME = (1000.0 / 60.0).toInt()
     }
 
     private val scaleGestureDetector =
@@ -565,15 +564,10 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
     }
 
     override fun run() {
-        var frameStartTime: Long
-        var frameTime: Long
-
         while (isThreadAvailable && isDrawingAvailable) {
             if (holder == null) {
                 return
             }
-
-            frameStartTime = System.nanoTime()
 
             var canvas: Canvas? = null
             try {
@@ -585,14 +579,6 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
                 render(canvas)
             } finally {
                 holder.unlockCanvasAndPost(canvas)
-            }
-
-            frameTime = (System.nanoTime() - frameStartTime) / 1000000L
-
-            if (frameTime < MIN_TIME_PER_FRAME) {
-                try {
-                    Thread.sleep(MIN_TIME_PER_FRAME - frameTime)
-                } catch (e: InterruptedException) {}
             }
         }
     }

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -19,7 +19,6 @@ import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
-
 class DrawingView(context: Context, attributeSet: AttributeSet?) :
     SurfaceView(context, attributeSet), Runnable, SurfaceHolder.Callback {
     lateinit var drawing: Drawing

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -124,6 +124,9 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
         )
 
     init {
+        holder.setKeepScreenOn(true)
+
+
         setUpPaint()
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -19,7 +19,6 @@ import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
-private const val MAX_FRAME_TIME = (1000.0 / 60.0).toInt()
 
 class DrawingView(context: Context, attributeSet: AttributeSet?) :
     SurfaceView(context, attributeSet), Runnable, SurfaceHolder.Callback {
@@ -65,6 +64,7 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
 
         const val PRESSURE_SAMPLES_AVERAGED = 5
         const val SPEN_ACTION_DOWN = 211
+        const val MAX_FRAME_TIME = (1000.0 / 60.0).toInt()
     }
 
     private val scaleGestureDetector =

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -64,7 +64,7 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
 
         const val PRESSURE_SAMPLES_AVERAGED = 5
         const val SPEN_ACTION_DOWN = 211
-        const val MAX_FRAME_TIME = (1000.0 / 60.0).toInt()
+        const val MIN_TIME_PER_FRAME = (1000.0 / 60.0).toInt()
     }
 
     private val scaleGestureDetector =
@@ -590,9 +590,9 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
 
             frameTime = (System.nanoTime() - frameStartTime) / 1000000L
 
-            if (frameTime < MAX_FRAME_TIME) {
+            if (frameTime < MIN_TIME_PER_FRAME) {
                 try {
-                    Thread.sleep(MAX_FRAME_TIME - frameTime)
+                    Thread.sleep(MIN_TIME_PER_FRAME - frameTime)
                 } catch (e: InterruptedException) {}
             }
         }


### PR DESCRIPTION
In this PR, I fix a long time issue involving the drawing view. If you keep rotating and getting in and out of the app while in the drawing screen, then you may crash due to this bug. This was due to the improper handling of the drawing thread whenever it was being ended. I ended up having to get rid of all the old thread logic and replaced it with something that is more concise and cleaner the long run. Its important to note, **I do not entirely know what caused this error**, this was only present on my tablet, my mobile device (Google Pixel 3) had nothing of the sort. What I did know is that it happened while the thread was closing and I must have improperly handled it, possibly in a way that only offended the tablet (the log messages were different too), that of which was solved after the new logic was implemented.

fixes #642 