### PR TITLE
linux: end user default settings and enable syntax highlighting

### DIFF
--- a/clients/linux/src/settings.rs
+++ b/clients/linux/src/settings.rs
@@ -20,7 +20,7 @@ pub struct Settings {
 impl Settings {
     pub fn default() -> Self {
         Self {
-            hidden_tree_cols: vec![],
+            hidden_tree_cols: vec!["Id".to_string(), "Type".to_string()],
             window_maximize: false,
             path: "".to_string(),
         }


### PR DESCRIPTION
+ By default the file tree opens without showing debugging related columns (id & type)
+ Use `SourceView`'s syntax highlighting based on file name:
![image](https://user-images.githubusercontent.com/821972/113512288-f0c04280-9531-11eb-8d84-e3b3f350559a.png)
