### PR TITLE
linux: editor lifecycle improvements

### DIFF
--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -1,6 +1,8 @@
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use gdk_pixbuf::Pixbuf as GdkPixbuf;
+use glib::SignalHandlerId;
 use gtk::prelude::*;
 use gtk::Orientation::{Horizontal, Vertical};
 use gtk::{
@@ -18,7 +20,6 @@ use sourceview::{Buffer as GtkSourceViewBuffer, LanguageManager};
 use lockbook_models::file_metadata::FileMetadata;
 use lockbook_models::work_unit::WorkUnit;
 
-use crate::app::LbState;
 use crate::backend::{LbCore, LbSyncMsg};
 use crate::closure;
 use crate::editmode::EditMode;
@@ -69,7 +70,7 @@ impl AccountScreen {
         self.sidebar.tree.add(b, f)
     }
 
-    pub fn show(&self, mode: &EditMode, state: &mut LbState) {
+    pub fn show(&self, mode: &EditMode) {
         match mode {
             EditMode::PlainText {
                 path,
@@ -78,7 +79,7 @@ impl AccountScreen {
             } => {
                 self.header.set_file(&path);
                 self.sidebar.tree.select(&meta.id);
-                self.editor.set_file(&meta.name, &content, state);
+                self.editor.set_file(&meta.name, &content);
             }
             EditMode::Folder {
                 path,
@@ -328,6 +329,7 @@ struct Editor {
     info: GtkBox,
     textarea: GtkSourceView,
     highlighter: LanguageManager,
+    change_sig_id: RefCell<Option<SignalHandlerId>>,
     stack: GtkStack,
     cntr: GtkScrolledWindow,
     messenger: Messenger,
@@ -363,17 +365,18 @@ impl Editor {
             info,
             textarea,
             highlighter: LanguageManager::new(),
+            change_sig_id: RefCell::new(None),
             stack,
             cntr,
             messenger: m.clone(),
         }
     }
 
-    fn set_file(&self, name: &str, content: &str, state: &mut LbState) {
+    fn set_file(&self, name: &str, content: &str) {
         let tvb = self.textarea.get_buffer().unwrap();
 
         // Stop listening for changes so that document load doesn't emit FileEdited
-        if let Some(id) = state.get_change_signal() {
+        if let Some(id) = self.change_sig_id.take() {
             tvb.disconnect(id)
         }
 
@@ -383,12 +386,12 @@ impl Editor {
         svb.set_language(self.highlighter.guess_language(Some(name), None).as_ref());
         svb.end_not_undoable_action();
 
+        self.change_sig_id.replace(Some(svb.connect_changed(
+            closure!(self.messenger as m => move |_| m.send(Msg::FileEdited)),
+        )));
+
         self.show("textarea");
         self.textarea.grab_focus();
-
-        let m = &self.messenger;
-        state.change_sig_id =
-            Some(svb.connect_changed(closure!(m => move |_| m.send(Msg::FileEdited))));
     }
 
     fn show_folder_info(&self, f: &FileMetadata, n_children: usize) {

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -141,10 +141,6 @@ impl AccountScreen {
     pub fn focus_editor(&self) {
         self.editor.textarea.grab_focus();
     }
-
-    pub fn tree(&self) -> &FileTree {
-        &self.sidebar.tree
-    }
 }
 
 struct Header {

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -31,7 +31,7 @@ use crate::util::{gui as gui_util, gui::RIGHT_CLICK};
 
 pub struct AccountScreen {
     header: Header,
-    sidebar: Sidebar,
+    pub sidebar: Sidebar,
     editor: Editor,
     pub cntr: GtkBox,
 }
@@ -222,7 +222,7 @@ impl Header {
 }
 
 pub struct Sidebar {
-    tree: FileTree,
+    pub tree: FileTree,
     sync: Rc<SyncPanel>,
     cntr: GtkBox,
 }

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -39,8 +39,6 @@ use crate::messages::{Messenger, Msg};
 use crate::settings::Settings;
 use crate::util;
 use crate::{closure, progerr, tree_iter_value, uerr};
-use glib::translate::{FromGlib, ToGlib};
-use glib::SignalHandlerId;
 
 macro_rules! make_glib_chan {
     ($( $( $vars:ident ).+ $( as $aliases:ident )* ),+ => move |$param:ident :$param_type:ty| $fn:block) => {{
@@ -336,7 +334,7 @@ impl LbApp {
 
     fn edit(&self, mode: &EditMode) -> LbResult<()> {
         self.gui.menubar.set(&mode);
-        self.gui.account.show(&mode, &mut self.state.borrow_mut());
+        self.gui.account.show(&mode);
         Ok(())
     }
 
@@ -720,11 +718,10 @@ impl LbApp {
     }
 }
 
-pub struct LbState {
+struct LbState {
     search: Option<SearchComponents>,
     opened_file: Option<FileMetadata>,
     open_file_dirty: bool,
-    pub change_sig_id: Option<SignalHandlerId>,
 }
 
 impl LbState {
@@ -733,7 +730,6 @@ impl LbState {
             search: None,
             opened_file: None,
             open_file_dirty: false,
-            change_sig_id: None,
         }
     }
 
@@ -759,14 +755,6 @@ impl LbState {
         match &self.opened_file {
             Some(f) => Some(f),
             None => None,
-        }
-    }
-
-    // Because SignalHandlerId doesn't implement clone
-    pub fn get_change_signal(&self) -> Option<SignalHandlerId> {
-        match &self.change_sig_id {
-            None => None,
-            Some(id) => Some(SignalHandlerId::from_glib(id.to_glib())),
         }
     }
 

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -300,6 +300,7 @@ impl LbApp {
 
         if let Some(id) = maybe_id.or(selected) {
             let meta = self.core.file_by_id(id)?;
+            self.gui.win.set_title(&meta.name);
             self.state.borrow_mut().set_opened_file(Some(meta.clone()));
             match meta.file_type {
                 FileType::Document => self.open_document(&meta.id),
@@ -364,6 +365,7 @@ impl LbApp {
     }
 
     fn close_file(&self) -> LbResult<()> {
+        self.gui.win.set_title(DEFAULT_WIN_TITLE);
         let mut state = self.state.borrow_mut();
         if state.get_opened_file().is_some() {
             self.edit(&EditMode::None)?;
@@ -846,7 +848,7 @@ impl Gui {
 
         // Window.
         let win = GtkAppWindow::new(app);
-        win.set_title("Lockbook");
+        win.set_title(DEFAULT_WIN_TITLE);
         win.set_icon(Some(&icon));
         win.add_accel_group(&accels);
         win.set_default_size(1300, 700);
@@ -1026,6 +1028,7 @@ fn usage(usage_string: String) -> LbResult<GtkBox> {
     Ok(cntr)
 }
 
+const DEFAULT_WIN_TITLE: &str = "Lockbook";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const LICENSE: &str = include_str!("../res/UNLICENSE");
 const COMMENTS: &str = "Lockbook is a document editor that is secure, minimal, private, open source, and cross-platform.";

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -318,7 +318,7 @@ impl LbApp {
             }
         }
 
-        let selected = self.gui.account.tree().get_selected_uuid();
+        let selected = self.gui.account.sidebar.tree.get_selected_uuid();
 
         if let Some(id) = maybe_id.or(selected) {
             let meta = self.core.file_by_id(id)?;
@@ -487,7 +487,7 @@ impl LbApp {
     }
 
     fn delete_files(&self) -> LbResult<()> {
-        let (selected_files, tmodel) = self.gui.account.tree().selected_rows();
+        let (selected_files, tmodel) = self.gui.account.sidebar.tree.selected_rows();
         if selected_files.is_empty() {
             return Err(uerr!("No file tree items are selected to delete!"));
         }
@@ -552,7 +552,7 @@ impl LbApp {
             for f in &file_data {
                 let (_, id, _) = f;
                 self.core.delete(&id)?;
-                self.gui.account.tree().remove(&id);
+                self.gui.account.sidebar.tree.remove(&id);
             }
         }
 
@@ -565,7 +565,7 @@ impl LbApp {
 
     fn rename_file(&self) -> LbResult<()> {
         // Get the iterator for the selected tree item.
-        let (selected_tpaths, tmodel) = self.gui.account.tree().selected_rows();
+        let (selected_tpaths, tmodel) = self.gui.account.sidebar.tree.selected_rows();
         let tpath = selected_tpaths.get(0).ok_or_else(|| {
             progerr!("No file tree items selected! At least one file tree item must be selected.")
         })?;
@@ -610,7 +610,7 @@ impl LbApp {
                 Ok(_) => {
                     d.close();
                     let acctscr = &lb.gui.account;
-                    acctscr.tree().set_name(&id, &name);
+                    acctscr.sidebar.tree.set_name(&id, &name);
                     match lb.core.sync_status() {
                         Ok(s) => acctscr.sync().set_status(&s),
                         Err(err) => lb.messenger.send_err("getting sync status", err),
@@ -635,7 +635,7 @@ impl LbApp {
     }
 
     fn toggle_tree_col(&self, c: FileTreeCol) -> LbResult<()> {
-        self.gui.account.tree().toggle_col(&c);
+        self.gui.account.sidebar.tree.toggle_col(&c);
         self.settings.borrow_mut().toggle_tree_col(c.name());
         Ok(())
     }
@@ -707,7 +707,7 @@ impl LbApp {
         if escaped {
             match opened_file {
                 Some(_) => self.gui.account.focus_editor(),
-                None => self.gui.account.tree().focus(),
+                None => self.gui.account.sidebar.tree.focus(),
             }
         }
 
@@ -992,7 +992,7 @@ impl Gui {
         self.menubar.for_account_screen();
         self.account.cntr.show_all();
         self.account.fill(&core)?;
-        self.account.tree().focus();
+        self.account.sidebar.tree.focus();
         self.screens.set_visible_child_name("account");
         Ok(())
     }

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -420,7 +420,7 @@ impl LbApp {
     fn file_edited(&self) -> LbResult<()> {
         let mut state = self.state.borrow_mut();
         if let Some(f) = state.opened_file.as_ref() {
-            self.gui.win.set_title(&format!("+ {}", f.name));
+            self.gui.win.set_title(&format!("{}*", f.name));
             state.open_file_dirty = true;
         }
         Ok(())
@@ -994,6 +994,7 @@ impl SettingsUi {
         for tab_data in vec![
             ("File Tree", Self::filetree(&s, &m)),
             ("Window", Self::window(&s)),
+            ("Editor", Self::editor(&s)),
         ] {
             let (title, content) = tab_data;
             let tab_btn = GtkLabel::new(Some(title));
@@ -1021,6 +1022,18 @@ impl SettingsUi {
         ch.set_active(s.borrow().window_maximize);
         ch.connect_toggled(closure!(s => move |chbox| {
             s.borrow_mut().window_maximize = chbox.get_active();
+        }));
+
+        let chbxs = GtkBox::new(Vertical, 0);
+        chbxs.add(&ch);
+        chbxs
+    }
+
+    fn editor(s: &Rc<RefCell<Settings>>) -> GtkBox {
+        let ch = GtkCheckBox::with_label("Auto-save ");
+        ch.set_active(s.borrow().auto_save);
+        ch.connect_toggled(closure!(s => move |chbox| {
+            s.borrow_mut().auto_save = chbox.get_active();
         }));
 
         let chbxs = GtkBox::new(Vertical, 0);

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -845,15 +845,15 @@ impl Gui {
             .unwrap();
 
         // Window.
-        let w = GtkAppWindow::new(app);
-        w.set_title("Lockbook");
-        w.set_icon(Some(&icon));
-        w.add_accel_group(&accels);
-        w.set_default_size(1300, 700);
+        let win = GtkAppWindow::new(app);
+        win.set_title("Lockbook");
+        win.set_icon(Some(&icon));
+        win.add_accel_group(&accels);
+        win.set_default_size(1300, 700);
         if s.window_maximize {
-            w.maximize();
+            win.maximize();
         }
-        w.add(&{
+        win.add(&{
             let base = GtkBox::new(Vertical, 0);
             base.add(menubar.widget());
             base.pack_start(&screens, true, true, 0);
@@ -861,7 +861,7 @@ impl Gui {
         });
 
         Self {
-            win: w,
+            win,
             menubar,
             screens,
             intro,

--- a/clients/linux/src/auto_save.rs
+++ b/clients/linux/src/auto_save.rs
@@ -1,0 +1,50 @@
+use crate::messages::{Messenger, Msg};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub struct AutoSaveState {
+    pub messenger: Messenger,
+    pub last_change: u128,
+    pub last_save: u128,
+}
+
+impl AutoSaveState {
+    pub fn default(m: &Messenger) -> Self {
+        Self {
+            messenger: m.clone(),
+            last_change: 0,
+            last_save: 0,
+        }
+    }
+
+    pub fn file_changed(&mut self) {
+        self.last_change = Self::current_time();
+    }
+
+    fn current_time() -> u128 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis()
+    }
+
+    pub fn auto_save_loop(state: Arc<Mutex<AutoSaveState>>) {
+        loop {
+            thread::sleep(Duration::from_secs(1));
+            let current_time = Self::current_time();
+
+            let mut auto_save_state = state.lock().unwrap();
+
+            let time_between_edits = current_time - auto_save_state.last_change;
+
+            // Required check to prevent overflow
+            if auto_save_state.last_change > auto_save_state.last_save && time_between_edits > 1000
+            {
+                // There are changes since we last saved
+                auto_save_state.last_save = current_time;
+                auto_save_state.messenger.send(Msg::SaveFile);
+            }
+        }
+    }
+}

--- a/clients/linux/src/auto_save.rs
+++ b/clients/linux/src/auto_save.rs
@@ -29,7 +29,7 @@ impl AutoSaveState {
             .as_millis()
     }
 
-    pub fn auto_save_loop(state: Arc<Mutex<AutoSaveState>>) {
+    pub fn auto_save_loop(state: Arc<Mutex<Self>>) {
         loop {
             thread::sleep(Duration::from_secs(1));
             let current_time = Self::current_time();

--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -9,6 +9,7 @@ extern crate sourceview;
 
 mod account;
 mod app;
+mod auto_save;
 mod backend;
 mod editmode;
 mod error;

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -15,6 +15,7 @@ pub enum Msg {
 
     NewFile(String),
     OpenFile(Option<Uuid>),
+    FileEdited,
     SaveFile,
     CloseFile,
     DeleteFiles,

--- a/clients/linux/src/settings.rs
+++ b/clients/linux/src/settings.rs
@@ -13,6 +13,9 @@ pub struct Settings {
     #[serde(default)]
     pub window_maximize: bool,
 
+    #[serde(default)]
+    pub auto_save: bool,
+
     #[serde(skip_serializing, skip_deserializing)]
     path: String,
 }
@@ -22,6 +25,7 @@ impl Settings {
         Self {
             hidden_tree_cols: vec!["Id".to_string(), "Type".to_string()],
             window_maximize: false,
+            auto_save: true,
             path: "".to_string(),
         }
     }


### PR DESCRIPTION
+ [x] Change window title based on open file
+ [x] Be able to detect when a file is dirty
+ [x] Add a `+` or `*` to the window title if the current file is dirty
+ [x] Warn prior to dirty file changes (fixes #381)
+ [x] Create setting to auto save dirty files after a configurable delay, default to auto save after 2 seconds of being idle
+ [x] Auto save dirty files (fixes #373)