### PR TITLE
linux: gtk is initialized before settings and lbcore

### DIFF
--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -38,6 +38,7 @@ use crate::settings::Settings;
 
 fn main() {
     let data_dir = get_data_dir();
+    gtk::init().unwrap();
 
     let core = match LbCore::new(&data_dir) {
         Ok(c) => Arc::new(c),

--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -37,8 +37,9 @@ use crate::backend::LbCore;
 use crate::settings::Settings;
 
 fn main() {
-    let data_dir = get_data_dir();
     gtk::init().unwrap();
+
+    let data_dir = get_data_dir();
 
     let core = match LbCore::new(&data_dir) {
         Ok(c) => Arc::new(c),


### PR DESCRIPTION
If an error occurred while initializing `Settings` or `LbCore`, we call `launch_err` to post a dialog for this error. The problem is, you can't post a dialog if gtk+ is not initialized, and we initialize gtk+ on the very last line of the main function with `gtk_app.run(&[])`. So if an error happens, it will crash when attempting to run the dialog. So `gtk::init().unwrap()` has been added so we can successfully run dialogs before the `GtkApp` itself is run.

fixes #703 