### PR TITLE
windows cli: usability

### DIFF
--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -9,8 +9,8 @@ use lockbook_core::{
 
 use crate::error::CliResult;
 use crate::utils::{
-    edit_file_with_editor, get_account_or_exit, get_config, save_temp_file_contents,
-    set_up_auto_save, stop_auto_save, get_directory_location
+    edit_file_with_editor, get_account_or_exit, get_config, get_directory_location,
+    save_temp_file_contents, set_up_auto_save, stop_auto_save,
 };
 use crate::{err, err_unexpected};
 

--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -3,8 +3,6 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use uuid::Uuid;
-
 use lockbook_core::{
     get_file_by_path, read_document, Error as CoreError, GetFileByPathError, ReadDocumentError,
 };
@@ -12,7 +10,7 @@ use lockbook_core::{
 use crate::error::CliResult;
 use crate::utils::{
     edit_file_with_editor, get_account_or_exit, get_config, save_temp_file_contents,
-    set_up_auto_save, stop_auto_save,
+    set_up_auto_save, stop_auto_save, get_directory_location
 };
 use crate::{err, err_unexpected};
 
@@ -35,11 +33,7 @@ pub fn edit(file_name: &str) -> CliResult<()> {
         | CoreError::Unexpected(_) => err_unexpected!("reading encrypted doc: {:#?}", err),
     })?;
 
-    let directory_location = format!("/tmp/{}", Uuid::new_v4().to_string());
-    fs::create_dir(&directory_location)
-        .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;
-
-    let file_location = format!("{}/{}", directory_location, file_metadata.name);
+    let file_location = format!("{}/{}", get_directory_location()?, file_metadata.name);
     let temp_file_path = Path::new(file_location.as_str());
     let mut file_handle = File::create(&temp_file_path)
         .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -3,12 +3,11 @@ use lockbook_models::file_metadata::FileType::Folder;
 use std::fs;
 use std::fs::File;
 use std::path::Path;
-use uuid::Uuid;
 
 use crate::error::CliResult;
 use crate::utils::{
     edit_file_with_editor, exit_success, get_account_or_exit, get_config, save_temp_file_contents,
-    set_up_auto_save, stop_auto_save,
+    set_up_auto_save, stop_auto_save, get_directory_location
 };
 use crate::{err, err_unexpected};
 
@@ -36,21 +35,7 @@ pub fn new(file_name: &str) -> CliResult<()> {
         CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
     })?;
 
-    let directory_location = if cfg!(target_os = "windows") {
-        let result = format!("/Temp/{}", Uuid::new_v4().to_string());
-        fs::create_dir(&result).map_err(|err| {
-            err_unexpected!("couldn't open temporary file for writing: {:#?}", err)
-        })?;
-        result
-    } else {
-        let result = format!("/tmp/{}", Uuid::new_v4().to_string());
-        fs::create_dir(&result).map_err(|err| {
-            err_unexpected!("couldn't open temporary file for writing: {:#?}", err)
-        })?;
-        result
-    };
-
-    let file_location = format!("{}/{}", directory_location, file_metadata.name);
+    let file_location = format!("{}/{}", get_directory_location()?, file_metadata.name);
     let temp_file_path = Path::new(file_location.as_str());
     let _ = File::create(&temp_file_path)
         .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -36,9 +36,17 @@ pub fn new(file_name: &str) -> CliResult<()> {
         CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
     })?;
 
-    let directory_location = format!("/tmp/{}", Uuid::new_v4().to_string());
-    fs::create_dir(&directory_location)
+    let directory_location = if cfg!(target_os = "windows") {
+        let result = format!("/Temp/{}", Uuid::new_v4().to_string());
+        fs::create_dir(&result)
         .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;
+        result
+    } else {
+        let result = format!("/tmp/{}", Uuid::new_v4().to_string());
+        fs::create_dir(&result)
+        .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;
+        result
+    };
 
     let file_location = format!("{}/{}", directory_location, file_metadata.name);
     let temp_file_path = Path::new(file_location.as_str());

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 
 use crate::error::CliResult;
 use crate::utils::{
-    edit_file_with_editor, exit_success, get_account_or_exit, get_config, save_temp_file_contents,
-    set_up_auto_save, stop_auto_save, get_directory_location
+    edit_file_with_editor, exit_success, get_account_or_exit, get_config, get_directory_location,
+    save_temp_file_contents, set_up_auto_save, stop_auto_save,
 };
 use crate::{err, err_unexpected};
 

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -38,13 +38,15 @@ pub fn new(file_name: &str) -> CliResult<()> {
 
     let directory_location = if cfg!(target_os = "windows") {
         let result = format!("/Temp/{}", Uuid::new_v4().to_string());
-        fs::create_dir(&result)
-        .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;
+        fs::create_dir(&result).map_err(|err| {
+            err_unexpected!("couldn't open temporary file for writing: {:#?}", err)
+        })?;
         result
     } else {
         let result = format!("/tmp/{}", Uuid::new_v4().to_string());
-        fs::create_dir(&result)
-        .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;
+        fs::create_dir(&result).map_err(|err| {
+            err_unexpected!("couldn't open temporary file for writing: {:#?}", err)
+        })?;
         result
     };
 

--- a/clients/cli/src/new_account.rs
+++ b/clients/cli/src/new_account.rs
@@ -15,7 +15,7 @@ pub fn new_account() -> CliResult<()> {
     io::stdin()
         .read_line(&mut username)
         .expect("Failed to read from stdin");
-    username.retain(|c| c != '\n');
+    username.retain(|c| c != '\n' && c != '\r');
 
     let api_location =
         env::var("API_URL").unwrap_or_else(|_| lockbook_core::DEFAULT_API_LOCATION.to_string());

--- a/clients/cli/src/remove.rs
+++ b/clients/cli/src/remove.rs
@@ -46,7 +46,7 @@ pub fn remove(path: &str, force: bool) -> CliResult<()> {
         io::stdin()
             .read_line(&mut answer)
             .expect("Failed to read from stdin");
-        answer.retain(|c| c != '\n');
+        answer.retain(|c| c != '\n' && c != '\r');
 
         if answer != "y" && answer != "Y" {
             exit_success("Aborted.")

--- a/clients/cli/src/utils.rs
+++ b/clients/cli/src/utils.rs
@@ -139,9 +139,8 @@ pub fn get_directory_location() -> CliResult<String> {
     } else {
         format!("/tmp/{}", Uuid::new_v4().to_string())
     };
-    fs::create_dir(&result).map_err(|err| {
-        err_unexpected!("couldn't open temporary file for writing: {:#?}", err)
-    })?;
+    fs::create_dir(&result)
+        .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;
     Ok(result)
 }
 

--- a/clients/cli/src/utils.rs
+++ b/clients/cli/src/utils.rs
@@ -18,6 +18,7 @@ use lockbook_core::service::drawing_service::SupportedImageFormats::{
 use lockbook_models::account::Account;
 use lockbook_models::file_metadata::FileMetadata;
 use std::path::Path;
+use uuid::Uuid;
 
 #[macro_export]
 macro_rules! path_string {
@@ -100,7 +101,7 @@ pub fn exit_success(msg: &str) -> ! {
     std::process::exit(0)
 }
 
-// In order of superiority
+// In ascending order of superiority
 pub enum SupportedEditors {
     Vim,
     Emacs,
@@ -130,6 +131,18 @@ pub fn get_editor() -> SupportedEditors {
             Vim
         }
     }
+}
+
+pub fn get_directory_location() -> CliResult<String> {
+    let result = if cfg!(target_os = "windows") {
+        format!("/Temp/{}", Uuid::new_v4().to_string())
+    } else {
+        format!("/tmp/{}", Uuid::new_v4().to_string())
+    };
+    fs::create_dir(&result).map_err(|err| {
+        err_unexpected!("couldn't open temporary file for writing: {:#?}", err)
+    })?;
+    Ok(result)
 }
 
 pub fn get_image_format(image_format: &str) -> SupportedImageFormats {


### PR DESCRIPTION
Adds windows support for the CLI. Terminal editors are not supported because of difficulty directing controlling terminal's standard in to the editor (Windows does not have an equivalent for `/dev/tty`).

Sample output:
```
C:\Users\tvand\code\lockbook\clients\cli>lockbook new test123/testy-test8
LOCKBOOK_EDITOR not set, assuming vim
Terminal editors are not supported on windows! Set LOCKBOOK_EDITOR to a visual editor.
Your editor indicated a problem, aborting and cleaning up
```

Closes #409
Closes #410 