### PR TITLE
linux: syncing a move will refresh the file tree

### DIFF
--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -108,6 +108,7 @@ impl LbApp {
                 Msg::RenameFile => lb.rename_file(),
 
                 Msg::ToggleTreeCol(col) => lb.toggle_tree_col(col),
+                Msg::RefreshTree => lb.refresh_tree(),
 
                 Msg::SearchFieldFocus => lb.search_field_focus(),
                 Msg::SearchFieldBlur(escaped) => lb.search_field_blur(escaped),
@@ -281,6 +282,7 @@ impl LbApp {
             if let Err(err) = c.sync(ch) {
                 m.send_err("syncing", err);
             }
+            m.send(Msg::RefreshTree)
         });
 
         Ok(())
@@ -719,6 +721,10 @@ impl LbApp {
         self.gui.account.sidebar.tree.toggle_col(&c);
         self.settings.borrow_mut().toggle_tree_col(c.name());
         Ok(())
+    }
+
+    fn refresh_tree(&self) -> LbResult<()> {
+        self.gui.account.sidebar.tree.refresh(&self.core)
     }
 
     fn search_field_focus(&self) -> LbResult<()> {

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -25,7 +25,6 @@ use crate::closure;
 use crate::error::LbResult;
 use crate::messages::{Messenger, Msg, MsgFn};
 use crate::util::gui::RIGHT_CLICK;
-use std::sync::Arc;
 
 #[macro_export]
 macro_rules! tree_iter_value {

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -210,7 +210,7 @@ impl FileTree {
 
         if let Some(path) = maybe_path {
             if self.tree.row_expanded(&path) {
-                expanded_paths.push(path.clone());
+                expanded_paths.push(path);
             }
         }
 

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -29,6 +29,7 @@ pub enum Msg {
     SearchFieldExec(Option<String>),
 
     ToggleTreeCol(FileTreeCol),
+    RefreshTree,
 
     AccountScreenShown,
     ShowDialogSyncDetails,


### PR DESCRIPTION
In this PR, if you sync a move it will show on the file tree, all whilst keeping the folders that were already open, open.

fixes #689