### PR TITLE
linux: fixed sync crashes and selection is preserved

### DIFF
--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -425,28 +425,27 @@ impl FileTreePopup {
         let tsel = t.get_selection();
         let tmodel = t.get_model().unwrap();
 
-        let is_root = tsel.iter_is_selected(&match tmodel.get_iter_first() {
-            Some(iter) => iter,
-            None => return, // early return since tree is empty
-        });
+        if let Some(iter) = tmodel.get_iter_first() {
+            let is_root = tsel.iter_is_selected(&iter);
 
-        let (selected_rows, _) = tsel.get_selected_rows();
-        let n_selected = selected_rows.len();
+            let (selected_rows, _) = tsel.get_selected_rows();
+            let n_selected = selected_rows.len();
 
-        let at_least_1 = n_selected > 0;
-        let only_1 = n_selected == 1;
+            let at_least_1 = n_selected > 0;
+            let only_1 = n_selected == 1;
 
-        for (key, is_enabled) in &[
-            (PopupItem::NewFolder, only_1),
-            (PopupItem::NewDocument, only_1),
-            (PopupItem::Rename, only_1 && !is_root),
-            (PopupItem::Open, only_1),
-            (PopupItem::Delete, at_least_1),
-        ] {
-            self.set_enabled(&key, *is_enabled);
+            for (key, is_enabled) in &[
+                (PopupItem::NewFolder, only_1),
+                (PopupItem::NewDocument, only_1),
+                (PopupItem::Rename, only_1 && !is_root),
+                (PopupItem::Open, only_1),
+                (PopupItem::Delete, at_least_1),
+            ] {
+                self.set_enabled(&key, *is_enabled);
+            }
+
+            self.menu.show_all();
         }
-
-        self.menu.show_all();
     }
 
     fn set_enabled(&self, key: &PopupItem, condition: bool) {

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -427,7 +427,7 @@ impl FileTreePopup {
 
         let is_root = tsel.iter_is_selected(&match tmodel.get_iter_first() {
             Some(iter) => iter,
-            None => return, // early return since tree empty
+            None => return, // early return since tree is empty
         });
 
         let (selected_rows, _) = tsel.get_selected_rows();

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -86,7 +86,6 @@ impl FileTree {
             if event.get_button() != RIGHT_CLICK {
                 return GtkInhibit(false);
             }
-
             popup.update(&tree);
             popup.menu.popup_at_pointer(Some(event));
 
@@ -140,10 +139,17 @@ impl FileTree {
         let mut expanded_paths = Vec::<GtkTreePath>::new();
         self.search_expanded(&self.iter(), &mut expanded_paths);
 
+        let sel = self.tree.get_selection();
+        let (selected_paths, _) = sel.get_selected_rows();
+
         self.fill(&c)?;
 
         for path in expanded_paths {
             self.tree.expand_row(&path, false);
+        }
+
+        for path in selected_paths {
+            sel.select_path(&path);
         }
 
         Ok(())
@@ -419,12 +425,16 @@ impl FileTreePopup {
         let tsel = t.get_selection();
         let tmodel = t.get_model().unwrap();
 
+        let is_root = tsel.iter_is_selected(&match tmodel.get_iter_first() {
+            Some(iter) => iter,
+            None => return, // early return since tree empty
+        });
+
         let (selected_rows, _) = tsel.get_selected_rows();
         let n_selected = selected_rows.len();
 
         let at_least_1 = n_selected > 0;
         let only_1 = n_selected == 1;
-        let is_root = tsel.iter_is_selected(&tmodel.get_iter_first().unwrap());
 
         for (key, is_enabled) in &[
             (PopupItem::NewFolder, only_1),


### PR DESCRIPTION
This bug originated from [this](https://github.com/lockbook/lockbook/pull/737). Whenever the file tree was populated, using the `fill` method from the `FileTree` struct, it triggered the `on_selection_change` closure. This closure is meant to modify the availability of the pop up items (the options that appear when you right click a file) since a new file was selected. But it assumed (using an `.unwrap()`) that there was at least one file in the tree. The problem was, when `fill` is used, the filetree was cleared and added back all its children. Usually this was just called once when the app was opened, which was before the `on_selection_change` closure was added to the tree. Now it was being used while the closure was already there. The fix was to just get rid of the unwrap and allow for an early return.

fixes #689