### PR TITLE
android: drawingview's white and black color values switch depending on device theme

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
@@ -3,6 +3,7 @@ package app.lockbook.screen
 import android.animation.Animator
 import android.annotation.SuppressLint
 import android.content.res.ColorStateList
+import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -211,8 +212,7 @@ class DrawingActivity : AppCompatActivity() {
             return
         }
 
-        drawing_view.theme = drawing.theme ?: DEFAULT_THEME
-        val colorAliasInARGB = EnumMap(Drawing.themeToARGBColors(drawing_view.theme, resources.configuration.uiMode))
+        val colorAliasInARGB = EnumMap(drawing.themeToARGBColors(resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK))
 
         val white = colorAliasInARGB[ColorAlias.White]
         val black = colorAliasInARGB[ColorAlias.Black]

--- a/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/DrawingActivity.kt
@@ -212,7 +212,7 @@ class DrawingActivity : AppCompatActivity() {
         }
 
         drawing_view.theme = drawing.theme ?: DEFAULT_THEME
-        val colorAliasInARGB = EnumMap(Drawing.themeToARGBColors(drawing_view.theme))
+        val colorAliasInARGB = EnumMap(Drawing.themeToARGBColors(drawing_view.theme, resources.configuration.uiMode))
 
         val white = colorAliasInARGB[ColorAlias.White]
         val black = colorAliasInARGB[ColorAlias.Black]

--- a/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/ui/DrawingView.kt
@@ -33,7 +33,6 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
     private var strokeAlpha = 255
     var isErasing = false
     var strokeColor = ColorAlias.White
-    var theme = DEFAULT_THEME
     lateinit var colorAliasInARGB: EnumMap<ColorAlias, Int?>
 
     // Current drawing stroke state
@@ -182,7 +181,7 @@ class DrawingView(context: Context, attributeSet: AttributeSet?) :
         return if (alphaAsInt == 255) {
             colorAliasInARGB[colorAlias]
         } else {
-            Drawing.getARGBColor(theme, colorAlias, alphaAsInt)
+            drawing.getARGBColor(resources.configuration.uiMode, colorAlias, alphaAsInt)
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
@@ -1,5 +1,6 @@
 package app.lockbook.util
 
+import android.content.res.Configuration
 import android.graphics.Color
 import com.beust.klaxon.Json
 import java.util.LinkedHashMap
@@ -20,11 +21,13 @@ data class Drawing(
             return Color.argb(alpha, colorRGB.r, colorRGB.g, colorRGB.b)
         }
 
-        fun themeToARGBColors(theme: LinkedHashMap<String, ColorRGB>): LinkedHashMap<ColorAlias, Int?> {
+        fun themeToARGBColors(theme: LinkedHashMap<String, ColorRGB>, uiMode: Int): LinkedHashMap<ColorAlias, Int?> {
+            val white = Pair(ColorAlias.White, getARGBColor(theme, ColorAlias.White, 255))
+            val black = Pair(ColorAlias.Black, getARGBColor(theme, ColorAlias.Black, 255))
 
             return linkedMapOf(
-                Pair(ColorAlias.White, getARGBColor(theme, ColorAlias.White, 255)),
-                Pair(ColorAlias.Black, getARGBColor(theme, ColorAlias.Black, 255)),
+                if (uiMode == Configuration.UI_MODE_NIGHT_NO) white else black,
+                if (uiMode == Configuration.UI_MODE_NIGHT_NO) black else white,
                 Pair(ColorAlias.Red, getARGBColor(theme, ColorAlias.Red, 255)),
                 Pair(ColorAlias.Green, getARGBColor(theme, ColorAlias.Green, 255)),
                 Pair(ColorAlias.Yellow, getARGBColor(theme, ColorAlias.Yellow, 255)),

--- a/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
@@ -15,27 +15,28 @@ data class Drawing(
     var theme: LinkedHashMap<String, ColorRGB>? = null
 ) {
 
-    companion object {
-        fun getARGBColor(theme: LinkedHashMap<String, ColorRGB>, colorAlias: ColorAlias, alpha: Int): Int? {
-            val colorRGB = theme.get(colorAlias.name) ?: return null
-            return Color.argb(alpha, colorRGB.r, colorRGB.g, colorRGB.b)
+    fun getARGBColor(uiMode: Int, colorAlias: ColorAlias, alpha: Int = 255): Int? {
+        val modifiedColorAlias = when (colorAlias) {
+            ColorAlias.White -> if (uiMode == Configuration.UI_MODE_NIGHT_NO) ColorAlias.White else ColorAlias.Black
+            ColorAlias.Black -> if (uiMode == Configuration.UI_MODE_NIGHT_NO) ColorAlias.Black else ColorAlias.White
+            else -> colorAlias
         }
 
-        fun themeToARGBColors(theme: LinkedHashMap<String, ColorRGB>, uiMode: Int): LinkedHashMap<ColorAlias, Int?> {
-            val white = Pair(ColorAlias.White, getARGBColor(theme, ColorAlias.White, 255))
-            val black = Pair(ColorAlias.Black, getARGBColor(theme, ColorAlias.Black, 255))
+        val colorRGB = (theme ?: DEFAULT_THEME)[modifiedColorAlias.name] ?: return null
+        return Color.argb(alpha, colorRGB.r, colorRGB.g, colorRGB.b)
+    }
 
-            return linkedMapOf(
-                if (uiMode == Configuration.UI_MODE_NIGHT_NO) white else black,
-                if (uiMode == Configuration.UI_MODE_NIGHT_NO) black else white,
-                Pair(ColorAlias.Red, getARGBColor(theme, ColorAlias.Red, 255)),
-                Pair(ColorAlias.Green, getARGBColor(theme, ColorAlias.Green, 255)),
-                Pair(ColorAlias.Yellow, getARGBColor(theme, ColorAlias.Yellow, 255)),
-                Pair(ColorAlias.Blue, getARGBColor(theme, ColorAlias.Blue, 255)),
-                Pair(ColorAlias.Magenta, getARGBColor(theme, ColorAlias.Magenta, 255)),
-                Pair(ColorAlias.Cyan, getARGBColor(theme, ColorAlias.Cyan, 255))
-            )
-        }
+    fun themeToARGBColors(uiMode: Int): LinkedHashMap<ColorAlias, Int?> {
+        return linkedMapOf(
+            Pair(ColorAlias.White, getARGBColor(uiMode, ColorAlias.White)),
+            Pair(ColorAlias.Black, getARGBColor(uiMode, ColorAlias.Black)),
+            Pair(ColorAlias.Red, getARGBColor(uiMode, ColorAlias.Red)),
+            Pair(ColorAlias.Green, getARGBColor(uiMode, ColorAlias.Green)),
+            Pair(ColorAlias.Yellow, getARGBColor(uiMode, ColorAlias.Yellow)),
+            Pair(ColorAlias.Blue, getARGBColor(uiMode, ColorAlias.Blue)),
+            Pair(ColorAlias.Magenta, getARGBColor(uiMode, ColorAlias.Magenta)),
+            Pair(ColorAlias.Cyan, getARGBColor(uiMode, ColorAlias.Cyan))
+        )
     }
 
     fun clone(): Drawing {


### PR DESCRIPTION
In this PR, white and black will switch values in the `drawingview` depending on whether the device is in darkmode or lightmode. This means that if you are in lightmode and drawing with the black `ColorAlias`, it will become the white `ColorAlias` in darkmode. Effectively allowing strokes to visible regardless of the theme.

Recorded Example:
<details>

https://user-images.githubusercontent.com/20663038/119876015-696dca80-bef5-11eb-9c6a-46ca5fb2f4a4.mp4
</details>

fixes #668 