### PR TITLE
server: less nonsense, better logging

### DIFF
--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -9,18 +9,20 @@ use lockbook_models::file_metadata::FileType;
 
 pub async fn new_account(
     context: &mut RequestContext<'_, NewAccountRequest>,
-) -> Result<NewAccountResponse, Option<NewAccountError>> {
+) -> Result<NewAccountResponse, Result<NewAccountError, String>> {
     let request = &context.request;
     let server_state = &mut context.server_state;
     if !username_is_valid(&request.username) {
-        return Err(Some(NewAccountError::InvalidUsername));
+        return Err(Ok(NewAccountError::InvalidUsername));
     }
 
     let mut transaction = match server_state.index_db_client.begin().await {
         Ok(t) => t,
         Err(e) => {
-            error!("Internal server error! Cannot begin transaction: {:?}", e);
-            return Err(None);
+            return Err(Err(format!(
+                "Internal server error! Cannot begin transaction: {:?}",
+                e
+            )));
         }
     };
 
@@ -28,14 +30,11 @@ pub async fn new_account(
         file_index_repo::new_account(&mut transaction, &request.username, &request.public_key)
             .await;
     new_account_result.map_err(|e| match e {
-        file_index_repo::NewAccountError::UsernameTaken => Some(NewAccountError::UsernameTaken),
-        _ => {
-            error!(
-                "Internal server error! Cannot create account in Postgres: {:?}",
-                e
-            );
-            None
-        }
+        file_index_repo::NewAccountError::UsernameTaken => Ok(NewAccountError::UsernameTaken),
+        _ => Err(format!(
+            "Internal server error! Cannot create account in Postgres: {:?}",
+            e
+        )),
     })?;
 
     let create_folder_result = file_index_repo::create_file(
@@ -50,14 +49,11 @@ pub async fn new_account(
     )
     .await;
     let new_version = create_folder_result.map_err(|e| match e {
-        file_index_repo::CreateFileError::IdTaken => Some(NewAccountError::FileIdTaken),
-        _ => {
-            error!(
-                "Internal server error! Cannot create account root folder in Postgres: {:?}",
-                e
-            );
-            None
-        }
+        file_index_repo::CreateFileError::IdTaken => Ok(NewAccountError::FileIdTaken),
+        _ => Err(format!(
+            "Internal server error! Cannot create account root folder in Postgres: {:?}",
+            e
+        )),
     })?;
     let new_user_access_key_result = file_index_repo::create_user_access_key(
         &mut transaction,
@@ -67,82 +63,76 @@ pub async fn new_account(
     )
     .await;
     new_user_access_key_result.map_err(|e| {
-        error!(
+        Err(format!(
             "Internal server error! Cannot create access keys for user in Postgres: {:?}",
             e
-        );
-        None
+        ))
     })?;
 
     match transaction.commit().await {
         Ok(()) => Ok(NewAccountResponse {
             folder_metadata_version: new_version,
         }),
-        Err(e) => {
-            error!("Internal server error! Cannot commit transaction: {:?}", e);
-            Err(None)
-        }
+        Err(e) => Err(Err(format!(
+            "Internal server error! Cannot commit transaction: {:?}",
+            e
+        ))),
     }
 }
 
 pub async fn get_public_key(
     context: &mut RequestContext<'_, GetPublicKeyRequest>,
-) -> Result<GetPublicKeyResponse, Option<GetPublicKeyError>> {
+) -> Result<GetPublicKeyResponse, Result<GetPublicKeyError, String>> {
     let request = &context.request;
     let server_state = &mut context.server_state;
     let mut transaction = match server_state.index_db_client.begin().await {
         Ok(t) => t,
         Err(e) => {
-            error!("Internal server error! Cannot begin transaction: {:?}", e);
-            return Err(None);
+            return Err(Err(format!(
+                "Internal server error! Cannot begin transaction: {:?}",
+                e
+            )));
         }
     };
     let result = file_index_repo::get_public_key(&mut transaction, &request.username).await;
     let key = result.map_err(|e| match e {
-        file_index_repo::PublicKeyError::UserNotFound => Some(GetPublicKeyError::UserNotFound),
-        _ => {
-            error!(
-                "Internal server error! Cannot get public key from Postgres: {:?}",
-                e
-            );
-            None
-        }
+        file_index_repo::PublicKeyError::UserNotFound => Ok(GetPublicKeyError::UserNotFound),
+        _ => Err(format!(
+            "Internal server error! Cannot get public key from Postgres: {:?}",
+            e
+        )),
     })?;
 
     match transaction.commit().await {
         Ok(()) => Ok(GetPublicKeyResponse { key: key }),
-        Err(e) => {
-            error!("Internal server error! Cannot commit transaction: {:?}", e);
-            Err(None)
-        }
+        Err(e) => Err(Err(format!(
+            "Internal server error! Cannot commit transaction: {:?}",
+            e
+        ))),
     }
 }
 
 pub async fn get_usage(
     context: &mut RequestContext<'_, GetUsageRequest>,
-) -> Result<GetUsageResponse, Option<GetUsageError>> {
+) -> Result<GetUsageResponse, Result<GetUsageError, String>> {
     let server_state = &mut context.server_state;
     let mut transaction = match server_state.index_db_client.begin().await {
         Ok(t) => t,
         Err(e) => {
-            error!("Internal server error! Cannot begin transaction: {:#?}", e);
-            return Err(None);
+            return Err(Err(format!(
+                "Internal server error! Cannot begin transaction: {:#?}",
+                e
+            )));
         }
     };
 
     let usages = file_index_repo::get_file_usages(&mut transaction, &context.public_key)
         .await
-        .map_err(|e| {
-            error!("Usage calculation error: {:#?}", e);
-            None
-        })?;
+        .map_err(|e| Err(format!("Usage calculation error: {:#?}", e)))?;
 
     let cap = file_index_repo::get_account_data_cap(&mut transaction, &context.public_key)
         .await
-        .map_err(|e| {
-            error!("Data cap calculation error: {:#?}", e);
-            None
-        })?;
+        .map_err(|e| Err(format!("Data cap calculation error: {:#?}", e)))?;
 
     Ok(GetUsageResponse { usages, cap })
 }

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -10,8 +10,6 @@ use lockbook_models::file_metadata::FileType;
 pub async fn new_account(
     context: &mut RequestContext<'_, NewAccountRequest>,
 ) -> Result<NewAccountResponse, Result<NewAccountError, String>> {
-    return Err(Err(String::from("testy test")));
-
     let request = &context.request;
     let server_state = &mut context.server_state;
     if !username_is_valid(&request.username) {

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -10,6 +10,8 @@ use lockbook_models::file_metadata::FileType;
 pub async fn new_account(
     context: &mut RequestContext<'_, NewAccountRequest>,
 ) -> Result<NewAccountResponse, Result<NewAccountError, String>> {
+    return Err(Err(String::from("testy test")));
+
     let request = &context.request;
     let server_state = &mut context.server_state;
     if !username_is_valid(&request.username) {
@@ -19,10 +21,7 @@ pub async fn new_account(
     let mut transaction = match server_state.index_db_client.begin().await {
         Ok(t) => t,
         Err(e) => {
-            return Err(Err(format!(
-                "Internal server error! Cannot begin transaction: {:?}",
-                e
-            )));
+            return Err(Err(format!("Cannot begin transaction: {:?}", e)));
         }
     };
 
@@ -31,10 +30,7 @@ pub async fn new_account(
             .await;
     new_account_result.map_err(|e| match e {
         file_index_repo::NewAccountError::UsernameTaken => Ok(NewAccountError::UsernameTaken),
-        _ => Err(format!(
-            "Internal server error! Cannot create account in Postgres: {:?}",
-            e
-        )),
+        _ => Err(format!("Cannot create account in Postgres: {:?}", e)),
     })?;
 
     let create_folder_result = file_index_repo::create_file(
@@ -51,7 +47,7 @@ pub async fn new_account(
     let new_version = create_folder_result.map_err(|e| match e {
         file_index_repo::CreateFileError::IdTaken => Ok(NewAccountError::FileIdTaken),
         _ => Err(format!(
-            "Internal server error! Cannot create account root folder in Postgres: {:?}",
+            "Cannot create account root folder in Postgres: {:?}",
             e
         )),
     })?;
@@ -64,7 +60,7 @@ pub async fn new_account(
     .await;
     new_user_access_key_result.map_err(|e| {
         Err(format!(
-            "Internal server error! Cannot create access keys for user in Postgres: {:?}",
+            "Cannot create access keys for user in Postgres: {:?}",
             e
         ))
     })?;
@@ -73,10 +69,7 @@ pub async fn new_account(
         Ok(()) => Ok(NewAccountResponse {
             folder_metadata_version: new_version,
         }),
-        Err(e) => Err(Err(format!(
-            "Internal server error! Cannot commit transaction: {:?}",
-            e
-        ))),
+        Err(e) => Err(Err(format!("Cannot commit transaction: {:?}", e))),
     }
 }
 
@@ -88,27 +81,18 @@ pub async fn get_public_key(
     let mut transaction = match server_state.index_db_client.begin().await {
         Ok(t) => t,
         Err(e) => {
-            return Err(Err(format!(
-                "Internal server error! Cannot begin transaction: {:?}",
-                e
-            )));
+            return Err(Err(format!("Cannot begin transaction: {:?}", e)));
         }
     };
     let result = file_index_repo::get_public_key(&mut transaction, &request.username).await;
     let key = result.map_err(|e| match e {
         file_index_repo::PublicKeyError::UserNotFound => Ok(GetPublicKeyError::UserNotFound),
-        _ => Err(format!(
-            "Internal server error! Cannot get public key from Postgres: {:?}",
-            e
-        )),
+        _ => Err(format!("Cannot get public key from Postgres: {:?}", e)),
     })?;
 
     match transaction.commit().await {
         Ok(()) => Ok(GetPublicKeyResponse { key: key }),
-        Err(e) => Err(Err(format!(
-            "Internal server error! Cannot commit transaction: {:?}",
-            e
-        ))),
+        Err(e) => Err(Err(format!("Cannot commit transaction: {:?}", e))),
     }
 }
 
@@ -119,10 +103,7 @@ pub async fn get_usage(
     let mut transaction = match server_state.index_db_client.begin().await {
         Ok(t) => t,
         Err(e) => {
-            return Err(Err(format!(
-                "Internal server error! Cannot begin transaction: {:#?}",
-                e
-            )));
+            return Err(Err(format!("Cannot begin transaction: {:#?}", e)));
         }
     };
 

--- a/server/server/src/config.rs
+++ b/server/server/src/config.rs
@@ -71,6 +71,7 @@ impl ServerConfig {
 
 #[derive(Clone)]
 pub struct Config {
+    pub build: String,
     pub index_db: IndexDbConfig,
     pub files_db: FilesDbConfig,
     pub server: ServerConfig,
@@ -79,6 +80,7 @@ pub struct Config {
 impl Config {
     pub fn from_env_vars() -> Config {
         Config {
+            build: env_or_panic("CARGO_PKG_VERSION"),
             index_db: IndexDbConfig::from_env_vars(),
             files_db: FilesDbConfig::from_env_vars(),
             server: ServerConfig::from_env_vars(),

--- a/server/server/src/config.rs
+++ b/server/server/src/config.rs
@@ -80,7 +80,7 @@ pub struct Config {
 impl Config {
     pub fn from_env_vars() -> Config {
         Config {
-            build: env_or_panic("CARGO_PKG_VERSION"),
+            build: String::from(env!("CARGO_PKG_VERSION")),
             index_db: IndexDbConfig::from_env_vars(),
             files_db: FilesDbConfig::from_env_vars(),
             server: ServerConfig::from_env_vars(),

--- a/server/server/src/config.rs
+++ b/server/server/src/config.rs
@@ -71,7 +71,6 @@ impl ServerConfig {
 
 #[derive(Clone)]
 pub struct Config {
-    pub build: String,
     pub index_db: IndexDbConfig,
     pub files_db: FilesDbConfig,
     pub server: ServerConfig,
@@ -80,7 +79,6 @@ pub struct Config {
 impl Config {
     pub fn from_env_vars() -> Config {
         Config {
-            build: String::from(env!("CARGO_PKG_VERSION")),
             index_db: IndexDbConfig::from_env_vars(),
             files_db: FilesDbConfig::from_env_vars(),
             server: ServerConfig::from_env_vars(),

--- a/server/server/src/config.rs
+++ b/server/server/src/config.rs
@@ -93,9 +93,6 @@ fn env_or_panic(var_name: &str) -> String {
 fn env_or_empty(var_name: &str) -> Option<String> {
     match env::var(var_name) {
         Ok(var) => Some(var),
-        Err(_) => {
-            println!("Missing environment variable {}", var_name);
-            None
-        }
+        Err(_) => None,
     }
 }

--- a/server/server/src/file_content_client.rs
+++ b/server/server/src/file_content_client.rs
@@ -50,7 +50,6 @@ pub fn create_client(config: &FilesDbConfig) -> Result<S3Client, Error> {
     match (&config.scheme, &config.host, &config.port) {
         (Some(scheme), Some(host), Some(port)) => {
             let url = format!("{}://{}:{}", scheme, host, port);
-            println!("Url {}", url);
             S3Client::new_with_path_style(
                 &config.bucket,
                 Region::Custom {

--- a/server/server/src/file_index_repo.rs
+++ b/server/server/src/file_index_repo.rs
@@ -5,7 +5,7 @@ use lockbook_models::crypto::{EncryptedUserAccessKey, FolderAccessInfo, UserAcce
 use lockbook_models::file_metadata::FileMetadata;
 use lockbook_models::file_metadata::FileType;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
-use sqlx::{PgPool, Postgres, Transaction};
+use sqlx::{ConnectOptions, PgPool, Postgres, Transaction};
 use std::array::IntoIter;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -28,6 +28,7 @@ pub async fn connect(config: &IndexDbConfig) -> Result<PgPool, ConnectError> {
         .port(config.port)
         .database(&config.db)
         .application_name("lockbook-server");
+    pool_options.log_statements(log::LevelFilter::Debug);
 
     if config.cert.as_str() != "" {
         pool_options = pool_options.ssl_root_cert_from_pem(config.cert.clone().into_bytes());

--- a/server/server/src/file_index_repo.rs
+++ b/server/server/src/file_index_repo.rs
@@ -28,7 +28,7 @@ pub async fn connect(config: &IndexDbConfig) -> Result<PgPool, ConnectError> {
         .port(config.port)
         .database(&config.db)
         .application_name("lockbook-server");
-    pool_options.log_statements(log::LevelFilter::Debug);
+    pool_options.disable_statement_logging();
 
     if config.cert.as_str() != "" {
         pool_options = pool_options.ssl_root_cert_from_pem(config.cert.clone().into_bytes());

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -181,8 +181,8 @@ pub async fn delete_document(
     let single_index_response = if let Some(result) = index_responses.iter().last() {
         result
     } else {
-        return Err(Err(format!(
-            "Internal server error! Unexpected zero or multiple postgres rows"
+        return Err(Err(String::from(
+            "Internal server error! Unexpected zero or multiple postgres rows during delete document"
         )));
     };
 
@@ -413,7 +413,9 @@ pub async fn delete_folder(
     {
         result
     } else {
-        return Err(Err(format!("Internal server error! Unexpected zero or multiple postgres rows for delete folder root")));
+        return Err(Err(String::from(
+            "Internal server error! Unexpected zero or multiple postgres rows during delete folder",
+        )));
     };
 
     for r in index_responses.iter() {

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -408,15 +408,14 @@ pub async fn delete_folder(
         )),
     })?;
 
-    let root_result = if let Some(result) =
-        index_responses.iter().filter(|r| r.id == request.id).last()
-    {
-        result
-    } else {
-        return Err(Err(String::from(
+    let root_result =
+        if let Some(result) = index_responses.iter().filter(|r| r.id == request.id).last() {
+            result
+        } else {
+            return Err(Err(String::from(
             "Internal server error! Unexpected zero or multiple postgres rows during delete folder",
         )));
-    };
+        };
 
     for r in index_responses.iter() {
         if !r.is_folder {

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -11,7 +11,6 @@ extern crate log;
 
 use libsecp256k1::PublicKey;
 
-#[derive(Clone)]
 pub struct ServerState {
     pub config: config::Config,
     pub index_db_client: sqlx::PgPool,
@@ -19,7 +18,7 @@ pub struct ServerState {
 }
 
 pub struct RequestContext<'a, TRequest> {
-    pub server_state: &'a mut ServerState,
+    pub server_state: &'a ServerState,
     pub request: TRequest,
     pub public_key: PublicKey,
 }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -6,7 +6,6 @@ pub mod file_service;
 pub mod loggers;
 pub mod utils;
 
-#[macro_use]
 extern crate log;
 
 use libsecp256k1::PublicKey;

--- a/server/server/src/loggers.rs
+++ b/server/server/src/loggers.rs
@@ -13,11 +13,11 @@ use tokio::runtime::Handle;
 
 pub fn init(
     log_path: &Path,
-    log_name: String,
+    log_name: &str,
     std_colors: bool,
     pd_api_key: &Option<String>,
     handle: Handle,
-    build: &String,
+    build: &str,
 ) -> Result<Dispatch, io::Error> {
     let colors_level = ColoredLevelConfig::new()
         .error(Color::Red)
@@ -141,7 +141,7 @@ impl Log for PDLogger {
                             build: self.build.to_string(),
                         }),
                     },
-                    dedup_key: Some(dedup_key(record, self.build.to_string())),
+                    dedup_key: None,
                     images: None,
                     links: None,
                     client: None,
@@ -161,21 +161,6 @@ fn level_to_severity(level: Level) -> Severity {
         Level::Info => Severity::Info,
         Level::Debug => Severity::Info,
         Level::Trace => Severity::Info,
-    }
-}
-
-fn dedup_key(record: &Record, build: String) -> String {
-    match (record.file(), record.line()) {
-        (Some(file), Some(line)) => {
-            format!("{}-{}#{}", build, file, line)
-        }
-        (_, _) => build
-            .chars()
-            .chain(record.target().chars().take(30))
-            .chain("::".chars())
-            .chain(record.args().to_string().chars())
-            .take(255)
-            .collect(),
     }
 }
 

--- a/server/server/src/loggers.rs
+++ b/server/server/src/loggers.rs
@@ -74,17 +74,17 @@ pub fn init(
     })
 }
 
-fn pd_logger(build: &String, pd_api_key: &String, handle: Handle) -> Dispatch {
-    let _ = notify(
+fn pd_logger(build: &str, pd_api_key: &str, handle: Handle) -> Dispatch {
+    notify(
         pd_api_key,
         &handle,
         Event::Change(Change {
             payload: ChangePayload {
-                summary: "Lockbook Server is starting up...".to_string(),
+                summary: String::from("Lockbook Server is starting up..."),
                 timestamp: SystemTime::now().into(),
-                source: Some("localhost".to_string()), // TODO: Hostname
+                source: Some(String::from("localhost")), // TODO: Hostname
                 custom_details: Some(ChangeDetail {
-                    build: build.to_string(),
+                    build: String::from(build),
                 }),
             },
             links: None,
@@ -92,9 +92,9 @@ fn pd_logger(build: &String, pd_api_key: &String, handle: Handle) -> Dispatch {
     );
 
     let pdl = PDLogger {
-        key: pd_api_key.to_string(),
+        key: String::from(pd_api_key),
         handle: handle,
-        build: build.to_string(),
+        build: String::from(build),
     };
 
     fern::Dispatch::new()
@@ -123,7 +123,11 @@ impl Log for PDLogger {
                 Event::AlertTrigger(AlertTrigger {
                     payload: AlertTriggerPayload {
                         severity: level_to_severity(record.level()),
-                        summary: record.args().to_string(),
+                        summary: {
+                            let mut s = String::from(&record.args().to_string()[..1021]);
+                            s.push_str("...");
+                            s
+                        },
                         source: "localhost".to_string(), // TODO: Hostname
                         timestamp: Some(SystemTime::now().into()),
                         component: None,
@@ -190,11 +194,11 @@ struct ChangeDetail {
 }
 
 fn notify<T: serde::Serialize + std::marker::Send + std::marker::Sync + 'static>(
-    api_key: &String,
+    api_key: &str,
     handle: &Handle,
     event: Event<T>,
 ) {
-    let events = EventsV2::new(api_key.to_string(), Some("lockbook-server".to_string())).unwrap();
+    let events = EventsV2::new(String::from(api_key), Some("lockbook-server".to_string())).unwrap();
 
     // https://github.com/neonphog/tokio_safe_block_on/blob/074d40929ccab649b0dcc83a4ebdbdcb70b317fb/src/lib.rs#L72-L86
     tokio::task::block_in_place(move || {

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -27,22 +27,21 @@ static LOG_FILE: &str = "lockbook_server.log";
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let handle = Handle::current();
     let config = Config::from_env_vars();
-    let build = option_env!("SERVER_BUILD").unwrap_or("MISSING");
 
     loggers::init(
         Path::new(&config.server.log_path),
-        LOG_FILE.to_string(),
+        LOG_FILE,
         true,
         &config.server.pd_api_key,
         handle,
-        &build.to_string(),
+        &config.build,
     )
     .expect(format!("Logger failed to initialize at {}", &config.server.log_path).as_str())
     .level(log::LevelFilter::Info)
     .level_for("lockbook_server", log::LevelFilter::Debug)
     .apply()
     .expect("Failed setting logger!");
-    info!("Server starting with build: {}", build);
+    info!("Server starting with build: {}", &config.build);
 
     debug!("Connecting to index_db...");
     let index_db_client = file_index_repo::connect(&config.index_db)

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use tokio::runtime::Handle;
 
 static LOG_FILE: &str = "lockbook_server.log";
+static CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -34,14 +35,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         true,
         &config.server.pd_api_key,
         handle,
-        &config.build,
+        CARGO_PKG_VERSION,
     )
     .expect(format!("Logger failed to initialize at {}", &config.server.log_path).as_str())
     .level(log::LevelFilter::Info)
     .level_for("lockbook_server", log::LevelFilter::Debug)
     .apply()
     .expect("Failed setting logger!");
-    info!("Server starting with build: {}", &config.build);
+    info!("Server starting with build: {}", CARGO_PKG_VERSION);
 
     debug!("Connecting to index_db...");
     let index_db_client = file_index_repo::connect(&config.index_db)

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -101,8 +101,7 @@ macro_rules! route_handler {
         pack::<$TRequest>(match unpack(&$server_state, $hyper_request).await {
             Ok((request, public_key)) => {
                 let request_string = format!("{:?}", request);
-                let result = 
-                $handler(&mut RequestContext {
+                let result = $handler(&mut RequestContext {
                     server_state: &$server_state,
                     request,
                     public_key,
@@ -112,7 +111,7 @@ macro_rules! route_handler {
                     error!("Internal error! Request: {}, Error: {}", request_string, e);
                 }
                 wrap_err::<$TRequest>(result)
-            },
+            }
             Err(e) => Err(e),
         })
     }};


### PR DESCRIPTION
I came here to fix the logging. What I found was that the entire server state was being cloned multiple times per request, including the postgres connection pool. I don't really know how that worked at all.

* let the postgres connection pool handle reconnecting
* makes server state immutable and unclonable
* fixes pagerduty logging
* bubbles up internal errors to single point
* only logs request if response is internal error

Fixes #757 