### PR TITLE
android: share documents

### DIFF
--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="app.lockbook"
+            android:authorities="app.lockbook.fileprovider"
             android:grantUriPermissions="true"
             android:exported="false">
             <meta-data

--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,17 @@
         <activity android:name=".screen.SettingsActivity" />
         <activity android:name=".screen.TextEditorActivity" />
         <activity android:name=".screen.LogActivity" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="app.lockbook"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/files_path" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -241,6 +241,24 @@ object CoreModel {
         return Err(ExportDrawingError.Unexpected("exportDrawingConverter was unable to be called!"))
     }
 
+    fun exportDrawingToDisk(
+        config: Config,
+        id: String,
+        format: SupportedImageFormats,
+        location: String
+    ): Result<Unit, ExportDrawingToDiskError> {
+        val klaxon = Klaxon()
+        val exportDrawingToDiskResult: Result<Unit, ExportDrawingToDiskError>? =
+            Klaxon().converter(exportDrawingToDiskConverter)
+                .parse(exportDrawingToDisk(klaxon.toJsonString(config), id, klaxon.toJsonString(format), location))
+
+        if (exportDrawingToDiskResult != null) {
+            return exportDrawingToDiskResult
+        }
+
+        return Err(ExportDrawingToDiskError.Unexpected("exportDrawingConverter was unable to be called!"))
+    }
+
     fun createFile(
         config: Config,
         parentId: String,

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -228,10 +228,11 @@ object CoreModel {
         config: Config,
         id: String,
         format: SupportedImageFormats
-    ): Result<ByteArray, ExportDrawingError> {
-        val exportDrawingResult: Result<ByteArray, ExportDrawingError>? =
+    ): Result<List<Byte>, ExportDrawingError> {
+        val klaxon = Klaxon()
+        val exportDrawingResult: Result<List<Byte>, ExportDrawingError>? =
             Klaxon().converter(exportDrawingConverter)
-                .parse(exportDrawing(Klaxon().toJsonString(config), id, format.name))
+                .parse(exportDrawing(klaxon.toJsonString(config), id, klaxon.toJsonString(format)))
 
         if (exportDrawingResult != null) {
             return exportDrawingResult

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -209,7 +209,7 @@ object CoreModel {
         return Err(GetFileByIdError.Unexpected("getFileByIdConverter was unable to be called!"))
     }
 
-    fun getDocumentContent(
+    fun readDocument(
         config: Config,
         fileId: String
     ): Result<String, ReadDocumentError> {
@@ -222,6 +222,22 @@ object CoreModel {
         }
 
         return Err(ReadDocumentError.Unexpected("readDocumentConverter was unable to be called!"))
+    }
+
+    fun exportDrawing(
+        config: Config,
+        id: String,
+        format: SupportedImageFormats
+    ): Result<ByteArray, ExportDrawingError> {
+        val exportDrawingResult: Result<ByteArray, ExportDrawingError>? =
+            Klaxon().converter(exportDrawingConverter)
+                .parse(exportDrawing(Klaxon().toJsonString(config), id, format.name))
+
+        if (exportDrawingResult != null) {
+            return exportDrawingResult
+        }
+
+        return Err(ExportDrawingError.Unexpected("exportDrawingConverter was unable to be called!"))
     }
 
     fun createFile(

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -224,6 +224,22 @@ object CoreModel {
         return Err(ReadDocumentError.Unexpected("readDocumentConverter was unable to be called!"))
     }
 
+    fun saveDocumentToDisk(
+        config: Config,
+        fileId: String,
+        location: String
+    ): Result<Unit, SaveDocumentToDiskError> {
+        val saveDocumentToDiskResult: Result<Unit, SaveDocumentToDiskError>? =
+            Klaxon().converter(saveDocumentToDiskConverter)
+                .parse(saveDocumentToDisk(Klaxon().toJsonString(config), fileId, location))
+
+        if (saveDocumentToDiskResult != null) {
+            return saveDocumentToDiskResult
+        }
+
+        return Err(SaveDocumentToDiskError.Unexpected("saveDocumentToDiskConverter was unable to be called!"))
+    }
+
     fun exportDrawing(
         config: Config,
         id: String,

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -10,7 +10,7 @@ object CoreModel {
 
     private const val QA_API_URL = "http://qa.lockbook.app:8000"
     private const val PROD_API_URL = "http://api.lockbook.app:8000"
-    fun getAPIURL(): String = "http://10.0.0.225:8000"
+    fun getAPIURL(): String = System.getenv("API_URL") ?: PROD_API_URL
 
     fun setUpInitLogger(path: String): Result<Unit, InitLoggerError> {
         val initLoggerResult: Result<Unit, InitLoggerError>? =

--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -10,7 +10,7 @@ object CoreModel {
 
     private const val QA_API_URL = "http://qa.lockbook.app:8000"
     private const val PROD_API_URL = "http://api.lockbook.app:8000"
-    fun getAPIURL(): String = System.getenv("API_URL") ?: QA_API_URL
+    fun getAPIURL(): String = "http://10.0.0.225:8000"
 
     fun setUpInitLogger(path: String): Result<Unit, InitLoggerError> {
         val initLoggerResult: Result<Unit, InitLoggerError>? =

--- a/clients/android/app/src/main/java/app/lockbook/model/DrawingViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/DrawingViewModel.kt
@@ -80,7 +80,7 @@ class DrawingViewModel(
     }
 
     private fun readDocument(id: String): String? {
-        when (val documentResult = CoreModel.getDocumentContent(config, id)) {
+        when (val documentResult = CoreModel.readDocument(config, id)) {
             is Ok -> {
                 return documentResult.value
             }

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -2,7 +2,6 @@ package app.lockbook.model
 
 import android.app.Application
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
-import androidx.activity.result.ActivityResult
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
@@ -169,7 +168,7 @@ class ListFilesViewModel(path: String, application: Application) :
         else -> false
     }
 
-    fun onOpenedActivityEnd(activityResult: ActivityResult) {
+    fun onOpenedActivityEnd() {
         viewModelScope.launch(Dispatchers.IO) {
             syncModel.syncBasedOnPreferences()
         }

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -174,10 +174,6 @@ class ListFilesViewModel(path: String, application: Application) :
         }
     }
 
-    fun clearShareStorage() {
-        ShareModel.clearShareStorage()
-    }
-
     fun onSwipeToRefresh() {
         viewModelScope.launch(Dispatchers.IO) {
             syncModel.trySync()

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -175,9 +175,7 @@ class ListFilesViewModel(path: String, application: Application) :
     }
 
     fun clearShareStorage() {
-        viewModelScope.launch(Dispatchers.IO) {
-            shareModel.clearShareStorage()
-        }
+        ShareModel.clearShareStorage()
     }
 
     fun onSwipeToRefresh() {
@@ -316,7 +314,7 @@ class ListFilesViewModel(path: String, application: Application) :
                     val selectedFiles =
                         getSelected() ?: return@launch _errorHasOccurred.postValue(BASIC_ERROR)
 
-                    shareModel.shareDocument(selectedFiles)
+                    shareModel.shareDocuments(selectedFiles)
                 }
                 else -> {
                     Timber.e("Unrecognized sort item id.")
@@ -423,7 +421,7 @@ class ListFilesViewModel(path: String, application: Application) :
         selectedFiles[index]
     }
 
-    private fun collapseMoreOptionsMenu() {
+    fun collapseMoreOptionsMenu() {
         selectedFiles = MutableList(files.value?.size ?: 0) { false }
         _switchMenu.postValue(Unit)
         _uncheckAllFiles.postValue(Unit)

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -151,11 +151,13 @@ class ListFilesViewModel(path: String, application: Application) :
             setUpPreferenceChangeListener()
             isThisAnImport()
             fileModel.startUpInRoot()
-            shareModel.clearStorage()
         }
     }
 
     fun onBackPress(): Boolean = when {
+        shareModel.isLoadingOverlayVisible -> {
+            true
+        }
         selectedFiles.contains(true) -> {
             collapseMoreOptionsMenu()
             true
@@ -175,7 +177,7 @@ class ListFilesViewModel(path: String, application: Application) :
 
     fun clearShareStorage() {
         viewModelScope.launch(Dispatchers.IO) {
-            shareModel.clearStorage()
+            shareModel.clearShareStorage()
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ListFilesViewModel.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.activity.result.ActivityResult
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
 import androidx.work.WorkManager
@@ -66,7 +65,7 @@ class ListFilesViewModel(path: String, application: Application) :
     private val _showSnackBar = SingleMutableLiveData<String>()
     private val _showSyncSnackBar = SingleMutableLiveData<Unit>()
     private val _updateSyncSnackBar = SingleMutableLiveData<Pair<Int, Int>>()
-    private val _showHideProgressOverlay = MutableLiveData<Boolean>()
+    private val _showHideProgressOverlay = SingleMutableLiveData<Boolean>()
     private val _errorHasOccurred = SingleMutableLiveData<String>()
     private val _unexpectedErrorHasOccurred = SingleMutableLiveData<String>()
 
@@ -131,7 +130,7 @@ class ListFilesViewModel(path: String, application: Application) :
         get() = _unexpectedErrorHasOccurred
 
     private val fileModel = FileModel(config, _errorHasOccurred, _unexpectedErrorHasOccurred)
-    private val shareModel = ShareModel(
+    val shareModel = ShareModel(
         config,
         _shareDocument,
         _showHideProgressOverlay,
@@ -152,6 +151,7 @@ class ListFilesViewModel(path: String, application: Application) :
             setUpPreferenceChangeListener()
             isThisAnImport()
             fileModel.startUpInRoot()
+            shareModel.clearStorage()
         }
     }
 
@@ -170,6 +170,12 @@ class ListFilesViewModel(path: String, application: Application) :
     fun onOpenedActivityEnd(activityResult: ActivityResult) {
         viewModelScope.launch(Dispatchers.IO) {
             syncModel.syncBasedOnPreferences()
+        }
+    }
+
+    fun clearShareStorage() {
+        viewModelScope.launch(Dispatchers.IO) {
+            shareModel.clearStorage()
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
@@ -1,6 +1,5 @@
 package app.lockbook.model
 
-import androidx.lifecycle.MutableLiveData
 import app.lockbook.App
 import app.lockbook.util.*
 import com.github.michaelbull.result.Err
@@ -11,22 +10,35 @@ import java.io.File
 class ShareModel(
     private val config: Config,
     private val _shareDocument: SingleMutableLiveData<ArrayList<File>>,
-    private val _showHideProgressOverlay: MutableLiveData<Boolean>,
+    private val _showHideProgressOverlay: SingleMutableLiveData<Boolean>,
     private val _errorHasOccurred: SingleMutableLiveData<String>,
     private val _unexpectedErrorHasOccurred: SingleMutableLiveData<String>
 ) {
+    var isLoadingOverlayVisible = false
+
+    private fun getShareStorageFolders(): List<File> = listOf(
+        File(App.instance.applicationContext.cacheDir, "images/"),
+        File(App.instance.applicationContext.cacheDir, "docs/")
+    )
+
+    fun clearStorage() {
+        val (imagesFolder, docsFolder) = getShareStorageFolders()
+
+        imagesFolder.deleteRecursively()
+        docsFolder.deleteRecursively()
+    }
+
     fun shareDocument(selectedFiles: List<FileMetadata>) {
-        _showHideProgressOverlay.postValue(true)
+        isLoadingOverlayVisible = true
+        _showHideProgressOverlay.postValue(isLoadingOverlayVisible)
 
         val documents = mutableListOf<FileMetadata>()
-        getFilesToShare(selectedFiles, documents)
+        retreiveSelectedDocuments(selectedFiles, documents)
 
-        val files = ArrayList<File>()
-        val imagesPath = File(App.instance.applicationContext.cacheDir, "images/")
-        imagesPath.mkdirs()
-
-        val docsPath = File(App.instance.applicationContext.cacheDir, "docs/")
-        docsPath.mkdirs()
+        val filesToShare = ArrayList<File>()
+        val (imagesFolder, docsFolder) = getShareStorageFolders()
+        imagesFolder.mkdirs()
+        docsFolder.mkdirs()
 
         for (file in documents) {
             if (file.name.endsWith(".draw")) {
@@ -36,12 +48,12 @@ class ShareModel(
                 ) {
                     is Ok -> {
                         val image = File(
-                            imagesPath,
+                            imagesFolder,
                             file.name.replace(".draw", ".${IMAGE_EXPORT_TYPE.name.lowercase()}")
                         )
                         image.createNewFile()
                         image.writeBytes(exportDrawingResult.value.toByteArray())
-                        files.add(image)
+                        filesToShare.add(image)
                     }
                     is Err -> return when (val error = exportDrawingResult.error) {
                         ExportDrawingError.FileDoesNotExist -> _errorHasOccurred.postValue("Error! File does not exist!")
@@ -57,10 +69,10 @@ class ShareModel(
             } else {
                 when (val readDocumentResult = CoreModel.readDocument(config, file.id)) {
                     is Ok -> {
-                        val doc = File(docsPath, file.name)
+                        val doc = File(docsFolder, file.name)
                         doc.createNewFile()
                         doc.writeText(readDocumentResult.value)
-                        files.add(doc)
+                        filesToShare.add(doc)
                     }
                     is Err -> return when (val error = readDocumentResult.error) {
                         is ReadDocumentError.TreatedFolderAsDocument -> _errorHasOccurred.postValue(
@@ -79,10 +91,10 @@ class ShareModel(
             }
         }
 
-        _shareDocument.postValue(files)
+        _shareDocument.postValue(filesToShare)
     }
 
-    private fun getFilesToShare(
+    private fun retreiveSelectedDocuments(
         selectedFiles: List<FileMetadata>,
         documents: MutableList<FileMetadata>
     ): Boolean {
@@ -94,7 +106,7 @@ class ShareModel(
                         val getChildrenResult =
                             CoreModel.getChildren(config, file.id)
                     ) {
-                        is Ok -> if (!getFilesToShare(getChildrenResult.value, documents)) {
+                        is Ok -> if (!retreiveSelectedDocuments(getChildrenResult.value, documents)) {
                             return false
                         }
                         is Err -> when (val error = getChildrenResult.error) {

--- a/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
@@ -21,7 +21,7 @@ class ShareModel(
         File(App.instance.applicationContext.cacheDir, "docs/")
     )
 
-    fun clearStorage() {
+    fun clearShareStorage() {
         val (imagesFolder, docsFolder) = getShareStorageFolders()
 
         imagesFolder.deleteRecursively()

--- a/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
@@ -1,0 +1,112 @@
+package app.lockbook.model
+
+import androidx.lifecycle.MutableLiveData
+import app.lockbook.App
+import app.lockbook.util.*
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import timber.log.Timber
+import java.io.File
+
+class ShareModel(
+    private val config: Config,
+    private val _shareDocument: SingleMutableLiveData<ArrayList<File>>,
+    private val _showHideProgressOverlay: MutableLiveData<Boolean>,
+    private val _errorHasOccurred: SingleMutableLiveData<String>,
+    private val _unexpectedErrorHasOccurred: SingleMutableLiveData<String>
+) {
+    fun shareDocument(selectedFiles: List<FileMetadata>) {
+        _showHideProgressOverlay.postValue(true)
+
+        val documents = mutableListOf<FileMetadata>()
+        getFilesToShare(selectedFiles, documents)
+
+        val files = ArrayList<File>()
+        val imagesPath = File(App.instance.applicationContext.cacheDir, "images/")
+        imagesPath.mkdirs()
+
+        val docsPath = File(App.instance.applicationContext.cacheDir, "docs/")
+        docsPath.mkdirs()
+
+        for (file in documents) {
+            if (file.name.endsWith(".draw")) {
+                when (
+                    val exportDrawingResult =
+                        CoreModel.exportDrawing(config, file.id, SupportedImageFormats.Jpeg)
+                ) {
+                    is Ok -> {
+                        val image = File(
+                            imagesPath,
+                            file.name.replace(".draw", ".${IMAGE_EXPORT_TYPE.name.lowercase()}")
+                        )
+                        image.createNewFile()
+                        image.writeBytes(exportDrawingResult.value.toByteArray())
+                        files.add(image)
+                    }
+                    is Err -> return when (val error = exportDrawingResult.error) {
+                        ExportDrawingError.FileDoesNotExist -> _errorHasOccurred.postValue("Error! File does not exist!")
+                        ExportDrawingError.FolderTreatedAsDrawing -> _errorHasOccurred.postValue("Error! Folder treated as document!")
+                        ExportDrawingError.InvalidDrawing -> _errorHasOccurred.postValue("Error! Invalid drawing!")
+                        ExportDrawingError.NoAccount -> _errorHasOccurred.postValue("Error! No account!")
+                        is ExportDrawingError.Unexpected -> {
+                            Timber.e(error.error)
+                            _unexpectedErrorHasOccurred.postValue(error.error)
+                        }
+                    }.exhaustive
+                }
+            } else {
+                when (val readDocumentResult = CoreModel.readDocument(config, file.id)) {
+                    is Ok -> {
+                        val doc = File(docsPath, file.name)
+                        doc.createNewFile()
+                        doc.writeText(readDocumentResult.value)
+                        files.add(doc)
+                    }
+                    is Err -> return when (val error = readDocumentResult.error) {
+                        is ReadDocumentError.TreatedFolderAsDocument -> _errorHasOccurred.postValue(
+                            "Error! Folder treated as document!"
+                        )
+                        is ReadDocumentError.NoAccount -> _errorHasOccurred.postValue("Error! No account!")
+                        is ReadDocumentError.FileDoesNotExist -> _errorHasOccurred.postValue("Error! File does not exist!")
+                        is ReadDocumentError.Unexpected -> {
+                            Timber.e("Unable to get content of file: ${error.error}")
+                            _unexpectedErrorHasOccurred.postValue(
+                                error.error
+                            )
+                        }
+                    }.exhaustive
+                }
+            }
+        }
+
+        _shareDocument.postValue(files)
+    }
+
+    private fun getFilesToShare(
+        selectedFiles: List<FileMetadata>,
+        documents: MutableList<FileMetadata>
+    ): Boolean {
+        selectedFiles.forEach { file ->
+            when (file.fileType) {
+                FileType.Document -> documents.add(file)
+                FileType.Folder ->
+                    when (
+                        val getChildrenResult =
+                            CoreModel.getChildren(config, file.id)
+                    ) {
+                        is Ok -> if (!getFilesToShare(getChildrenResult.value, documents)) {
+                            return false
+                        }
+                        is Err -> when (val error = getChildrenResult.error) {
+                            is GetChildrenError.Unexpected -> {
+                                Timber.e("Unable to get siblings of the parent: ${error.error}")
+                                _unexpectedErrorHasOccurred.postValue(error.error)
+                            }
+                        }.exhaustive
+                    }
+            }
+        }
+
+        return true
+    }
+}

--- a/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/ShareModel.kt
@@ -53,7 +53,7 @@ class ShareModel(
                         _showHideProgressOverlay.postValue(isLoadingOverlayVisible)
 
                         return when (val error = exportDrawingToDiskResult.error) {
-                            ExportDrawingToDiskError.DrawingDoesNotExist -> _errorHasOccurred.postValue("Error! File does not exist!")
+                            ExportDrawingToDiskError.FileDoesNotExist -> _errorHasOccurred.postValue("Error! File does not exist!")
                             ExportDrawingToDiskError.FolderTreatedAsDrawing -> _errorHasOccurred.postValue("Error! Folder treated as document!")
                             ExportDrawingToDiskError.InvalidDrawing -> _errorHasOccurred.postValue("Error! Invalid drawing!")
                             ExportDrawingToDiskError.NoAccount -> _errorHasOccurred.postValue("Error! No account!")

--- a/clients/android/app/src/main/java/app/lockbook/model/SyncModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/SyncModel.kt
@@ -8,11 +8,16 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import timber.log.Timber
 
-class SyncModel(private val config: Config, private val _showSnackBar: SingleMutableLiveData<String>, private val _errorHasOccurred: SingleMutableLiveData<String>, private val _unexpectedErrorHasOccurred: SingleMutableLiveData<String>) {
+class SyncModel(
+    private val config: Config,
+    private val _showSyncSnackBar: SingleMutableLiveData<Unit>,
+    private val _updateSyncSnackBar: SingleMutableLiveData<Pair<Int, Int>>,
+    private val _showSnackBar: SingleMutableLiveData<String>,
+    private val _errorHasOccurred: SingleMutableLiveData<String>,
+    private val _unexpectedErrorHasOccurred: SingleMutableLiveData<String>
+) {
 
     var syncStatus: SyncStatus = SyncStatus.IsNotSyncing
-    val _showSyncSnackBar = SingleMutableLiveData<Unit>()
-    val _updateSyncSnackBar = SingleMutableLiveData<Pair<Int, Int>>()
 
     fun trySync() {
         if (syncStatus is SyncStatus.IsNotSyncing
@@ -43,7 +48,8 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
     }
 
     private fun sync() {
-        val upToDateMsg = App.instance.resources.getString(R.string.list_files_sync_finished_snackbar)
+        val upToDateMsg =
+            App.instance.resources.getString(R.string.list_files_sync_finished_snackbar)
 
         when (val workCalculatedResult = CoreModel.calculateWork(config)) {
             is Ok -> {
@@ -53,7 +59,11 @@ class SyncModel(private val config: Config, private val _showSnackBar: SingleMut
             }
             is Err -> return when (val error = workCalculatedResult.error) {
                 is CalculateWorkError.NoAccount -> _errorHasOccurred.postValue("Error! No account!")
-                is CalculateWorkError.CouldNotReachServer -> _showSnackBar.postValue(App.instance.resources.getString(R.string.list_files_offline_snackbar))
+                is CalculateWorkError.CouldNotReachServer -> _showSnackBar.postValue(
+                    App.instance.resources.getString(
+                        R.string.list_files_offline_snackbar
+                    )
+                )
                 is CalculateWorkError.ClientUpdateRequired -> _errorHasOccurred.postValue("Update required.")
                 is CalculateWorkError.Unexpected -> {
                     Timber.e("Unable to calculate syncWork: ${error.error}")

--- a/clients/android/app/src/main/java/app/lockbook/model/TextEditorViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/TextEditorViewModel.kt
@@ -44,7 +44,7 @@ class TextEditorViewModel(application: Application, private val id: String) :
     }
 
     fun readDocument(id: String): String? {
-        when (val documentResult = CoreModel.getDocumentContent(config, id)) {
+        when (val documentResult = CoreModel.readDocument(config, id)) {
             is Ok -> {
                 return documentResult.value
             }

--- a/clients/android/app/src/main/java/app/lockbook/screen/ImportAccountActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ImportAccountActivity.kt
@@ -37,8 +37,8 @@ class ImportAccountActivity : AppCompatActivity() {
         if (result.resultCode == Activity.RESULT_OK) {
             uiScope.launch {
                 withContext(Dispatchers.IO) {
-                    val intentResult =
-                        IntentIntegrator.parseActivityResult(result.resultCode, result.resultCode, result.data)
+                    val intentResult = IntentIntegrator.parseActivityResult(result.resultCode, result.data)
+
                     if (intentResult != null) {
                         intentResult.contents?.let { account ->
                             handleImportResult(

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
@@ -214,9 +214,9 @@ class ListFilesActivity : AppCompatActivity() {
 
     fun showHideProgressOverlay(show: Boolean) {
         if (show) {
-            Animate.animateVisibility(binding.progressOverlay.root, View.VISIBLE, 0.4f, 500)
+            Animate.animateVisibility(binding.progressOverlay.root, View.VISIBLE, 102, 500)
         } else {
-            Animate.animateVisibility(binding.progressOverlay.root, View.GONE, 0f, 500)
+            Animate.animateVisibility(binding.progressOverlay.root, View.GONE, 0, 500)
         }
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
@@ -27,8 +27,25 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import timber.log.Timber
 
+private val menuItemsNoneSelected = listOf(
+    R.id.menu_list_files_sort,
+    R.id.menu_list_files_file_layout,
+)
+
+private val menuItemsOneOrMoreSelected = listOf(
+    R.id.menu_list_files_delete,
+    R.id.menu_list_files_move,
+    R.id.menu_list_files_share
+)
+
+private val menuItemsOneSelected = listOf(
+    R.id.menu_list_files_rename,
+    R.id.menu_list_files_info,
+)
+
 class ListFilesActivity : AppCompatActivity() {
     private var _binding: ActivityListFilesBinding? = null
+
     // This property is only valid between onCreateView and
     // onDestroyView.
     private val binding get() = _binding!!
@@ -46,15 +63,9 @@ class ListFilesActivity : AppCompatActivity() {
         this.menu = menu
         setSelectedMenuOptions()
 
-        val fragment = getFragment().component1()
-        if (fragment is ListFilesFragment) {
-            val selectedFiles = fragment.listFilesViewModel.selectedFiles
-            if (selectedFiles.contains(true)) {
-                openFileMenu(selectedFiles)
-            }
-        } else {
-            Timber.e("Unable to retrieve ListFilesFragment.")
-            AlertModel.errorHasOccurred(binding.listFilesActivityLayout, BASIC_ERROR, OnFinishAlert.DoNothingOnFinishAlert)
+        val selectedFiles = getListFilesFragment()?.listFilesViewModel?.selectedFiles
+        if (selectedFiles != null && selectedFiles.contains(true)) {
+            openFileMenu(selectedFiles)
         }
 
         return true
@@ -80,7 +91,11 @@ class ListFilesActivity : AppCompatActivity() {
             SORT_FILES_TYPE -> menu?.findItem(R.id.menu_list_files_sort_type)?.isChecked = true
             else -> {
                 Timber.e("File sorting shared preference does not match every supposed option: $optionValue")
-                AlertModel.errorHasOccurred(binding.listFilesActivityLayout, BASIC_ERROR, OnFinishAlert.DoNothingOnFinishAlert)
+                AlertModel.errorHasOccurred(
+                    binding.listFilesActivityLayout,
+                    BASIC_ERROR,
+                    OnFinishAlert.DoNothingOnFinishAlert
+                )
             }
         }.exhaustive
 
@@ -100,7 +115,11 @@ class ListFilesActivity : AppCompatActivity() {
             GRID_LAYOUT -> menu?.findItem(R.id.menu_list_files_grid_view)?.isChecked = true
             else -> {
                 Timber.e("File layout shared preference does not match every supposed option: $optionValue")
-                AlertModel.errorHasOccurred(binding.listFilesActivityLayout, BASIC_ERROR, OnFinishAlert.DoNothingOnFinishAlert)
+                AlertModel.errorHasOccurred(
+                    binding.listFilesActivityLayout,
+                    BASIC_ERROR,
+                    OnFinishAlert.DoNothingOnFinishAlert
+                )
             }
         }
     }
@@ -119,23 +138,15 @@ class ListFilesActivity : AppCompatActivity() {
             R.id.menu_list_files_grid_view,
             R.id.menu_list_files_linear_view -> {
                 menu?.findItem(item.itemId)?.isChecked = true
-                val fragment = getFragment().component1()
-                if (fragment is ListFilesFragment) {
-                    fragment.onMenuItemPressed(item.itemId)
-                } else {
-                    Timber.e("Unable to retrieve ListFilesFragment.")
-                    AlertModel.errorHasOccurred(binding.listFilesActivityLayout, BASIC_ERROR, OnFinishAlert.DoNothingOnFinishAlert)
-                }
+                getListFilesFragment()?.onMenuItemPressed(item.itemId)
                 true
             }
-            R.id.menu_list_files_rename, R.id.menu_list_files_delete, R.id.menu_list_files_info, R.id.menu_list_files_move -> {
-                val fragment = getFragment().component1()
-                if (fragment is ListFilesFragment) {
-                    fragment.onMenuItemPressed(item.itemId)
-                } else {
-                    Timber.e("Unable to retrieve ListFilesFragment.")
-                    AlertModel.errorHasOccurred(binding.listFilesActivityLayout, BASIC_ERROR, OnFinishAlert.DoNothingOnFinishAlert)
-                }
+            R.id.menu_list_files_rename,
+            R.id.menu_list_files_delete,
+            R.id.menu_list_files_info,
+            R.id.menu_list_files_move,
+            R.id.menu_list_files_share -> {
+                getListFilesFragment()?.onMenuItemPressed(item.itemId)
                 true
             }
             else -> false
@@ -143,66 +154,64 @@ class ListFilesActivity : AppCompatActivity() {
     }
 
     fun switchMenu() {
-        val fragment = getFragment().component1()
-        if (fragment is ListFilesFragment) {
-            if (fragment.listFilesViewModel.selectedFiles.contains(true)) {
-                openFileMenu(fragment.listFilesViewModel.selectedFiles)
-            } else {
-                closeFileMenu()
-            }
+        val fragment = getListFilesFragment() ?: return
+        if (fragment.listFilesViewModel.selectedFiles.contains(true)) {
+            openFileMenu(fragment.listFilesViewModel.selectedFiles)
         } else {
-            Timber.e("Unable to retrieve ListFilesFragment.")
-            AlertModel.errorHasOccurred(binding.listFilesActivityLayout, BASIC_ERROR, OnFinishAlert.DoNothingOnFinishAlert)
+            closeFileMenu()
         }
     }
 
     private fun openFileMenu(selected: List<Boolean>) {
-        menu?.findItem(R.id.menu_list_files_delete)?.isVisible = true
-        menu?.findItem(R.id.menu_list_files_move)?.isVisible = true
-        menu?.findItem(R.id.menu_list_files_sort)?.isVisible = false
-        menu?.findItem(R.id.menu_list_files_file_layout)?.isVisible = false
+        for (menuItem in menuItemsNoneSelected) {
+            menu?.findItem(menuItem)?.isVisible = false
+        }
+
+        for (menuItem in menuItemsOneOrMoreSelected) {
+            menu?.findItem(menuItem)?.isVisible = true
+        }
+
         if (selected.filter { selectedFile -> selectedFile }.size == 1) {
-            menu?.findItem(R.id.menu_list_files_rename)?.isVisible = true
-            menu?.findItem(R.id.menu_list_files_info)?.isVisible = true
+            for (menuItem in menuItemsOneSelected) {
+                menu?.findItem(menuItem)?.isVisible = true
+            }
         } else {
-            menu?.findItem(R.id.menu_list_files_rename)?.isVisible = false
-            menu?.findItem(R.id.menu_list_files_info)?.isVisible = false
+            for (menuItem in menuItemsOneSelected) {
+                menu?.findItem(menuItem)?.isVisible = false
+            }
         }
     }
 
     private fun closeFileMenu() {
-        menu?.findItem(R.id.menu_list_files_rename)?.isVisible = false
-        menu?.findItem(R.id.menu_list_files_delete)?.isVisible = false
-        menu?.findItem(R.id.menu_list_files_info)?.isVisible = false
-        menu?.findItem(R.id.menu_list_files_move)?.isVisible = false
-        menu?.findItem(R.id.menu_list_files_file_layout)?.isVisible = true
-        menu?.findItem(R.id.menu_list_files_sort)?.isVisible = true
-    }
-
-    private fun getFragment(): Result<ListFilesFragment, Unit> {
-        val fragments = supportFragmentManager.fragments
-        val listFilesFragment = fragments[0]
-        if (listFilesFragment is ListFilesFragment) {
-            return Ok(listFilesFragment)
+        for (menuItem in menuItemsOneOrMoreSelected) {
+            menu?.findItem(menuItem)?.isVisible = false
         }
 
-        return Err(Unit)
+        for (menuItem in menuItemsOneSelected) {
+            menu?.findItem(menuItem)?.isVisible = false
+        }
+    }
+
+    private fun getListFilesFragment(): ListFilesFragment? {
+        val fragments = supportFragmentManager.fragments
+        val listFilesFragment = fragments[0]
+        return if (listFilesFragment is ListFilesFragment) {
+            listFilesFragment
+        } else {
+            Timber.e("Unable to retrieve ListFilesFragment.")
+            AlertModel.errorHasOccurred(
+                binding.listFilesActivityLayout,
+                BASIC_ERROR,
+                OnFinishAlert.DoNothingOnFinishAlert
+            )
+
+            null
+        }
     }
 
     override fun onBackPressed() {
-        when (getFragment().component1()?.onBackPressed()) {
-            false -> super.onBackPressed()
-            true -> {
-            }
-            null -> {
-                Timber.e("Unable to get result of back press.")
-                AlertModel.errorHasOccurred(binding.listFilesActivityLayout, BASIC_ERROR, OnFinishAlert.DoNothingOnFinishAlert)
-            }
-        }.exhaustive
+        if(getListFilesFragment()?.onBackPressed() == false) {
+            super.onBackPressed()
+        }
     }
-}
-
-object RequestResultCodes {
-    const val TEXT_EDITOR_REQUEST_CODE: Int = 102
-    const val DRAWING_REQUEST_CODE: Int = 104
 }

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesActivity.kt
@@ -5,12 +5,14 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceManager
 import app.lockbook.R
 import app.lockbook.databinding.ActivityListFilesBinding
 import app.lockbook.model.AlertModel
 import app.lockbook.model.OnFinishAlert
+import app.lockbook.util.Animate
 import app.lockbook.util.BASIC_ERROR
 import app.lockbook.util.SharedPreferences.FILE_LAYOUT_KEY
 import app.lockbook.util.SharedPreferences.GRID_LAYOUT
@@ -22,9 +24,6 @@ import app.lockbook.util.SharedPreferences.SORT_FILES_LAST_CHANGED
 import app.lockbook.util.SharedPreferences.SORT_FILES_TYPE
 import app.lockbook.util.SharedPreferences.SORT_FILES_Z_A
 import app.lockbook.util.exhaustive
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.Result
 import timber.log.Timber
 
 private val menuItemsNoneSelected = listOf(
@@ -190,6 +189,10 @@ class ListFilesActivity : AppCompatActivity() {
         for (menuItem in menuItemsOneSelected) {
             menu?.findItem(menuItem)?.isVisible = false
         }
+
+        for (menuItem in menuItemsNoneSelected) {
+            menu?.findItem(menuItem)?.isVisible = true
+        }
     }
 
     private fun getListFilesFragment(): ListFilesFragment? {
@@ -209,8 +212,16 @@ class ListFilesActivity : AppCompatActivity() {
         }
     }
 
+    fun showHideProgressOverlay(show: Boolean) {
+        if (show) {
+            Animate.animateVisibility(binding.progressOverlay.root, View.VISIBLE, 0.4f, 500)
+        } else {
+            Animate.animateVisibility(binding.progressOverlay.root, View.GONE, 0f, 500)
+        }
+    }
+
     override fun onBackPressed() {
-        if(getListFilesFragment()?.onBackPressed() == false) {
+        if (getListFilesFragment()?.onBackPressed() == false) {
             super.onBackPressed()
         }
     }

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -40,8 +40,8 @@ class ListFilesFragment : Fragment() {
     private val binding get() = _binding!!
 
     private var onActivityResult =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
-            listFilesViewModel.onOpenedActivityEnd(activityResult)
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            listFilesViewModel.onOpenedActivityEnd()
         }
 
     var onShareResult =

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -2,6 +2,7 @@ package app.lockbook.screen
 
 import android.content.Intent
 import android.content.res.Configuration.*
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -10,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout.HORIZONTAL
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
@@ -25,8 +27,9 @@ import app.lockbook.ui.*
 import app.lockbook.util.*
 import com.tingyik90.snackprogressbar.SnackProgressBar
 import com.tingyik90.snackprogressbar.SnackProgressBarManager
-import kotlinx.coroutines.launch
+import java.io.File
 import java.util.*
+
 
 class ListFilesFragment : Fragment() {
     lateinit var listFilesViewModel: ListFilesViewModel
@@ -239,6 +242,13 @@ class ListFilesFragment : Fragment() {
             }
         )
 
+        listFilesViewModel.shareDocument.observe(
+            viewLifecycleOwner,
+            { files ->
+                shareDocuments(files)
+            }
+        )
+
         listFilesViewModel.updateSyncSnackBar.observe(
             viewLifecycleOwner,
             { progressAndTotal ->
@@ -357,6 +367,30 @@ class ListFilesFragment : Fragment() {
         parentFragmentManager.registerFragmentLifecycleCallbacks(
             fragmentFinishedCallback,
             false
+        )
+    }
+
+    private fun shareDocuments(files: ArrayList<File>) {
+        val uris = ArrayList<Uri>()
+
+        for(file in files) {
+            uris.add(
+                FileProvider.getUriForFile(
+                    requireContext(),
+                    "app.lockbook.fileprovider",
+                    file
+                )
+            )
+        }
+
+        val intent = Intent(Intent.ACTION_SEND_MULTIPLE)
+        intent.type = "*/*"
+        intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+        startActivity(
+            Intent.createChooser(
+                intent,
+                "Send multiple files."
+            )
         )
     }
 

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -39,7 +39,7 @@ class ListFilesFragment : Fragment() {
     // onDestroyView.
     private val binding get() = _binding!!
 
-    var onActivityResult =
+    private var onActivityResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
             listFilesViewModel.onOpenedActivityEnd(activityResult)
         }
@@ -47,6 +47,8 @@ class ListFilesFragment : Fragment() {
     var onShareResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             getListFilesActivity()?.showHideProgressOverlay(false)
+            listFilesViewModel.shareModel.isLoadingOverlayVisible = false
+            listFilesViewModel.clearShareStorage()
         }
 
     private var updatedLastSyncedDescription = Timer()
@@ -366,10 +368,15 @@ class ListFilesFragment : Fragment() {
     private fun setUpAfterConfigChange() {
         collapseExpandFAB(listFilesViewModel.isFABOpen)
 
-        if (listFilesViewModel.syncModel.syncStatus is SyncStatus.IsSyncing) {
-            val status = listFilesViewModel.syncModel.syncStatus as SyncStatus.IsSyncing
+        val syncStatus = listFilesViewModel.syncModel.syncStatus
+        if (syncStatus is SyncStatus.IsSyncing) {
             showSyncSnackBar()
-            updateProgressSnackBar(status.total, status.progress)
+            updateProgressSnackBar(syncStatus.total, syncStatus.progress)
+        }
+
+        val isLoadingOverlayVisible = listFilesViewModel.shareModel.isLoadingOverlayVisible
+        if (isLoadingOverlayVisible) {
+            showHideProgressOverlay(isLoadingOverlayVisible)
         }
 
         parentFragmentManager.registerFragmentLifecycleCallbacks(

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -48,7 +48,6 @@ class ListFilesFragment : Fragment() {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             getListFilesActivity()?.showHideProgressOverlay(false)
             listFilesViewModel.shareModel.isLoadingOverlayVisible = false
-            listFilesViewModel.clearShareStorage()
         }
 
     private var updatedLastSyncedDescription = Timer()
@@ -310,8 +309,9 @@ class ListFilesFragment : Fragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         parentFragmentManager.unregisterFragmentLifecycleCallbacks(fragmentFinishedCallback)
+        listFilesViewModel.clearShareStorage()
+        super.onDestroy()
     }
 
     fun onBackPressed(): Boolean {

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -314,7 +314,6 @@ class ListFilesFragment : Fragment() {
     override fun onDestroy() {
         super.onDestroy()
         parentFragmentManager.unregisterFragmentLifecycleCallbacks(fragmentFinishedCallback)
-        listFilesViewModel.clearShareStorage()
     }
 
     fun onBackPressed(): Boolean {

--- a/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/ListFilesFragment.kt
@@ -289,6 +289,9 @@ class ListFilesFragment : Fragment() {
     }
 
     private fun showHideProgressOverlay(show: Boolean) {
+        if (show) {
+            listFilesViewModel.collapseMoreOptionsMenu()
+        }
         getListFilesActivity()?.showHideProgressOverlay(show)
     }
 
@@ -309,9 +312,9 @@ class ListFilesFragment : Fragment() {
     }
 
     override fun onDestroy() {
+        super.onDestroy()
         parentFragmentManager.unregisterFragmentLifecycleCallbacks(fragmentFinishedCallback)
         listFilesViewModel.clearShareStorage()
-        super.onDestroy()
     }
 
     fun onBackPressed(): Boolean {

--- a/clients/android/app/src/main/java/app/lockbook/util/Animate.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Animate.kt
@@ -3,24 +3,27 @@ package app.lockbook.util
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.view.View
-import timber.log.Timber
 
 object Animate {
-    fun animateVisibility(view: View, toVisibility: Int, toAlpha: Float, duration: Int) {
-        Timber.e("SWITCHING: $toVisibility $toAlpha $duration")
-
+    fun animateVisibility(view: View, toVisibility: Int, toAlpha: Int, duration: Int) {
         val show = toVisibility == View.VISIBLE
+
         if (show) {
             view.alpha = 0f
+            view.background.alpha = toAlpha
         }
 
         view.visibility = View.VISIBLE
         view.animate()
             .setDuration(duration.toLong())
-            .alpha(if (show) toAlpha else 0f)
+            .alpha(if (show) 1f else 0f)
             .setListener(object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
                     view.visibility = toVisibility
+
+                    if (!show) { // may need to file a bug report to android, without this visual glitches will occur
+                        view.background.alpha = 255
+                    }
                 }
             })
     }

--- a/clients/android/app/src/main/java/app/lockbook/util/Animate.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Animate.kt
@@ -1,0 +1,27 @@
+package app.lockbook.util
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.view.View
+import timber.log.Timber
+
+object Animate {
+    fun animateVisibility(view: View, toVisibility: Int, toAlpha: Float, duration: Int) {
+        Timber.e("SWITCHING: $toVisibility $toAlpha $duration")
+
+        val show = toVisibility == View.VISIBLE
+        if (show) {
+            view.alpha = 0f
+        }
+
+        view.visibility = View.VISIBLE
+        view.animate()
+            .setDuration(duration.toLong())
+            .alpha(if (show) toAlpha else 0f)
+            .setListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    view.visibility = toVisibility
+                }
+            })
+    }
+}

--- a/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
@@ -656,6 +656,22 @@ val exportDrawingConverter = object : Converter {
             }
         }
         errTag -> when (val errorTag = jv.obj?.obj("content")?.string("tag")) {
+            uiErrorTag -> {
+                val error = jv.obj?.obj("content")?.string("content")
+                if (error != null) {
+                    Err(
+                        when (error) {
+                            ExportDrawingError.InvalidDrawing::class.simpleName -> ExportDrawingError.InvalidDrawing
+                            ExportDrawingError.NoAccount::class.simpleName -> ExportDrawingError.NoAccount
+                            ExportDrawingError.FileDoesNotExist::class.simpleName -> ExportDrawingError.FileDoesNotExist
+                            ExportDrawingError.FolderTreatedAsDrawing::class.simpleName -> ExportDrawingError.FolderTreatedAsDrawing
+                            else -> ExportDrawingError.Unexpected("exportDrawingConverter $unmatchedUiError $error")
+                        }
+                    )
+                } else {
+                    Err(ExportDrawingError.Unexpected("exportDrawingConverter $unableToGetUiError ${jv.obj?.toJsonString()}"))
+                }
+            }
             unexpectedTag -> {
                 val error = jv.obj?.obj("content")?.string("content")
                 if (error != null) {

--- a/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
@@ -648,19 +648,9 @@ val exportDrawingConverter = object : Converter {
 
     override fun fromJson(jv: JsonValue): Any = when (jv.obj?.string("tag")) {
         okTag -> {
-            val ok = jv.obj?.string("content")
+            val ok = jv.obj?.array<ByteArray>("content")
             if (ok != null) {
-                Ok(
-                    when (ok) {
-                        SupportedImageFormats.Jpeg.name -> SupportedImageFormats.Jpeg
-                        SupportedImageFormats.Png.name -> SupportedImageFormats.Png
-                        SupportedImageFormats.Bmp.name -> SupportedImageFormats.Bmp
-                        SupportedImageFormats.Pnm.name -> SupportedImageFormats.Pnm
-                        SupportedImageFormats.Farbfeld.name -> SupportedImageFormats.Farbfeld
-                        SupportedImageFormats.Tga.name -> SupportedImageFormats.Tga
-                        else -> ExportDrawingError.Unexpected("exportDrawingConverter $unmatchedOkEnum $ok")
-                    }
-                )
+                Ok(Klaxon().parseFromJsonArray<Byte>(ok))
             } else {
                 Err(ExportDrawingError.Unexpected("exportDrawingConverter $unableToGetOk ${jv.obj?.toJsonString()}"))
             }

--- a/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
@@ -740,7 +740,7 @@ val exportDrawingToDiskConverter = object : Converter {
                         when (error) {
                             ExportDrawingToDiskError.InvalidDrawing::class.simpleName -> ExportDrawingToDiskError.InvalidDrawing
                             ExportDrawingToDiskError.NoAccount::class.simpleName -> ExportDrawingToDiskError.NoAccount
-                            ExportDrawingToDiskError.DrawingDoesNotExist::class.simpleName -> ExportDrawingToDiskError.DrawingDoesNotExist
+                            ExportDrawingToDiskError.FileDoesNotExist::class.simpleName -> ExportDrawingToDiskError.FileDoesNotExist
                             ExportDrawingToDiskError.FolderTreatedAsDrawing::class.simpleName -> ExportDrawingToDiskError.FolderTreatedAsDrawing
                             ExportDrawingToDiskError.BadPath::class.simpleName -> ExportDrawingToDiskError.BadPath
                             ExportDrawingToDiskError.FileAlreadyExistsInDisk::class.simpleName -> ExportDrawingToDiskError.FileAlreadyExistsInDisk

--- a/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
@@ -105,3 +105,5 @@ val DEFAULT_THEME = linkedMapOf(
     Pair(ColorAlias.Magenta.name, ColorRGB(0xFF, 0x00, 0xFF)),
     Pair(ColorAlias.Cyan.name, ColorRGB(0x00, 0xFF, 0xFF)),
 )
+
+val IMAGE_EXPORT_TYPE = SupportedImageFormats.Jpeg

--- a/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Drawing.kt
@@ -86,6 +86,15 @@ data class ColorRGB(
     val b: Int,
 )
 
+enum class SupportedImageFormats {
+    Png,
+    Jpeg,
+    Pnm,
+    Tga,
+    Farbfeld,
+    Bmp,
+}
+
 val DEFAULT_THEME = linkedMapOf(
     Pair(ColorAlias.White.name, ColorRGB(0xFF, 0xFF, 0xFF)),
     Pair(ColorAlias.Black.name, ColorRGB(0x00, 0x00, 0x00)),

--- a/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
@@ -106,6 +106,14 @@ sealed class ReadDocumentError : CoreError() {
     data class Unexpected(val error: String) : ReadDocumentError()
 }
 
+sealed class ExportDrawingError : CoreError() {
+    object FolderTreatedAsDrawing : ExportDrawingError()
+    object FileDoesNotExist : ExportDrawingError()
+    object NoAccount : ExportDrawingError()
+    object InvalidDrawing : ExportDrawingError()
+    data class Unexpected(val error: String) : ExportDrawingError()
+}
+
 sealed class RenameFileError : CoreError() {
     object FileDoesNotExist : RenameFileError()
     object NewNameContainsSlash : RenameFileError()

--- a/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
@@ -106,12 +106,31 @@ sealed class ReadDocumentError : CoreError() {
     data class Unexpected(val error: String) : ReadDocumentError()
 }
 
+sealed class SaveDocumentToDisk : CoreError() {
+    object TreatedFolderAsDocument : SaveDocumentToDisk()
+    object NoAccount : SaveDocumentToDisk()
+    object FileDoesNotExist : SaveDocumentToDisk()
+    object BadPath : SaveDocumentToDisk()
+    object FileAlreadyExists : SaveDocumentToDisk()
+    data class Unexpected(val error: String) : SaveDocumentToDisk()
+}
+
 sealed class ExportDrawingError : CoreError() {
     object FolderTreatedAsDrawing : ExportDrawingError()
     object FileDoesNotExist : ExportDrawingError()
     object NoAccount : ExportDrawingError()
     object InvalidDrawing : ExportDrawingError()
     data class Unexpected(val error: String) : ExportDrawingError()
+}
+
+sealed class ExportDrawingToDiskError : CoreError() {
+    object FolderTreatedAsDrawing : ExportDrawingToDiskError()
+    object FileDoesNotExist : ExportDrawingToDiskError()
+    object NoAccount : ExportDrawingToDiskError()
+    object InvalidDrawing : ExportDrawingToDiskError()
+    object BadPath : ExportDrawingToDiskError()
+    object FileAlreadyExists : ExportDrawingToDiskError()
+    data class Unexpected(val error: String) : ExportDrawingToDiskError()
 }
 
 sealed class RenameFileError : CoreError() {

--- a/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
@@ -125,7 +125,7 @@ sealed class ExportDrawingError : CoreError() {
 
 sealed class ExportDrawingToDiskError : CoreError() {
     object FolderTreatedAsDrawing : ExportDrawingToDiskError()
-    object DrawingDoesNotExist : ExportDrawingToDiskError()
+    object FileDoesNotExist : ExportDrawingToDiskError()
     object NoAccount : ExportDrawingToDiskError()
     object InvalidDrawing : ExportDrawingToDiskError()
     object BadPath : ExportDrawingToDiskError()

--- a/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
@@ -106,13 +106,13 @@ sealed class ReadDocumentError : CoreError() {
     data class Unexpected(val error: String) : ReadDocumentError()
 }
 
-sealed class SaveDocumentToDisk : CoreError() {
-    object TreatedFolderAsDocument : SaveDocumentToDisk()
-    object NoAccount : SaveDocumentToDisk()
-    object FileDoesNotExist : SaveDocumentToDisk()
-    object BadPath : SaveDocumentToDisk()
-    object FileAlreadyExists : SaveDocumentToDisk()
-    data class Unexpected(val error: String) : SaveDocumentToDisk()
+sealed class SaveDocumentToDiskError : CoreError() {
+    object TreatedFolderAsDocument : SaveDocumentToDiskError()
+    object NoAccount : SaveDocumentToDiskError()
+    object FileDoesNotExist : SaveDocumentToDiskError()
+    object BadPath : SaveDocumentToDiskError()
+    object FileAlreadyExistsInDisk : SaveDocumentToDiskError()
+    data class Unexpected(val error: String) : SaveDocumentToDiskError()
 }
 
 sealed class ExportDrawingError : CoreError() {
@@ -125,11 +125,11 @@ sealed class ExportDrawingError : CoreError() {
 
 sealed class ExportDrawingToDiskError : CoreError() {
     object FolderTreatedAsDrawing : ExportDrawingToDiskError()
-    object FileDoesNotExist : ExportDrawingToDiskError()
+    object DrawingDoesNotExist : ExportDrawingToDiskError()
     object NoAccount : ExportDrawingToDiskError()
     object InvalidDrawing : ExportDrawingToDiskError()
     object BadPath : ExportDrawingToDiskError()
-    object FileAlreadyExists : ExportDrawingToDiskError()
+    object FileAlreadyExistsInDisk : ExportDrawingToDiskError()
     data class Unexpected(val error: String) : ExportDrawingToDiskError()
 }
 

--- a/clients/android/app/src/main/res/drawable/ic_baseline_share_24.xml
+++ b/clients/android/app/src/main/res/drawable/ic_baseline_share_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/blue">
+  <path
+      android:fillColor="@color/colorPrimary"
+      android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/clients/android/app/src/main/res/layout/activity_list_files.xml
+++ b/clients/android/app/src/main/res/layout/activity_list_files.xml
@@ -1,25 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/list_files_activity_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical"
-    tools:context=".screen.WelcomeActivity">
+    android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/list_files_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="@style/Main.Widget.Actionbar" />
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/files_fragment"
-        android:name="app.lockbook.screen.ListFilesFragment"
+    <LinearLayout
+        android:id="@+id/list_files_activity_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:layout="@layout/fragment_list_files" />
+        android:gravity="center"
+        android:orientation="vertical"
+        tools:context=".screen.WelcomeActivity">
 
-</LinearLayout>
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/list_files_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="@style/Main.Widget.Actionbar" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/files_fragment"
+            android:name="app.lockbook.screen.ListFilesFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:layout="@layout/fragment_list_files" />
+
+    </LinearLayout>
+
+    <include
+        android:id="@+id/progress_overlay"
+        layout="@layout/progress_overlay" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/clients/android/app/src/main/res/layout/progress_overlay.xml
+++ b/clients/android/app/src/main/res/layout/progress_overlay.xml
@@ -4,7 +4,6 @@
     android:id="@+id/progress_overlay"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:alpha="0.4"
     android:animateLayoutChanges="true"
     android:background="@android:color/black"
     android:clickable="true"

--- a/clients/android/app/src/main/res/layout/progress_overlay.xml
+++ b/clients/android/app/src/main/res/layout/progress_overlay.xml
@@ -8,7 +8,7 @@
     android:background="@android:color/black"
     android:clickable="true"
     android:visibility="gone"
-    tools:ignore="KeyboardInaccessibleWidget">
+    tools:ignore="KeyboardInaccessibleWidget,Overdraw">
 
     <ProgressBar
         style="?android:attr/progressBarStyleLarge"

--- a/clients/android/app/src/main/res/layout/progress_overlay.xml
+++ b/clients/android/app/src/main/res/layout/progress_overlay.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/progress_overlay"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:alpha="0.4"
+    android:animateLayoutChanges="true"
+    android:background="@android:color/black"
+    android:clickable="true"
+    android:visibility="gone"
+    tools:ignore="KeyboardInaccessibleWidget">
+
+    <ProgressBar
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true" />
+
+</FrameLayout>

--- a/clients/android/app/src/main/res/menu/menu_list_files.xml
+++ b/clients/android/app/src/main/res/menu/menu_list_files.xml
@@ -86,8 +86,16 @@
         app:showAsAction="always" />
 
     <item
-        android:icon="@drawable/ic_baseline_more_vert_24"
+        android:id="@+id/menu_list_files_share"
+        android:icon="@drawable/ic_baseline_share_24"
+        android:title="@string/menu_list_files_move"
+        android:visible="false"
         android:orderInCategory="5"
+        app:showAsAction="always" />
+
+    <item
+        android:icon="@drawable/ic_baseline_more_vert_24"
+        android:orderInCategory="6"
         app:showAsAction="always"
         android:title="@string/overflow">
         <menu

--- a/clients/android/app/src/main/res/xml/files_path.xml
+++ b/clients/android/app/src/main/res/xml/files_path.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="shared_images" path="images/"/>
+    <cache-path name="shared_docs" path="docs/"/>
+</paths>

--- a/clients/android/app/src/main/res/xml/files_path.xml
+++ b/clients/android/app/src/main/res/xml/files_path.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <cache-path name="shared_images" path="images/"/>
-    <cache-path name="shared_docs" path="docs/"/>
+    <cache-path name="share" path="share/"/>
 </paths>

--- a/clients/android/app/src/test/java/app/lockbook/ExportDrawingTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/ExportDrawingTest.kt
@@ -1,6 +1,7 @@
 package app.lockbook
 
 import app.lockbook.core.exportDrawing
+import app.lockbook.core.exportDrawingToDisk
 import app.lockbook.model.CoreModel
 import app.lockbook.util.*
 import com.beust.klaxon.Klaxon
@@ -11,6 +12,8 @@ import org.junit.Test
 
 class ExportDrawingTest {
     var config = Config(createRandomPath())
+
+    private fun generateUniqueName() = "/tmp/${System.currentTimeMillis()}"
 
     companion object {
         @BeforeClass
@@ -55,12 +58,20 @@ class ExportDrawingTest {
         assertType<List<Byte>>(
             CoreModel.exportDrawing(config, document.id, SupportedImageFormats.Jpeg).component1()
         )
+
+        assertType<Unit>(
+            CoreModel.exportDrawingToDisk(config, document.id, SupportedImageFormats.Jpeg, generateUniqueName()).component1()
+        )
     }
 
     @Test
     fun exportDrawingNoAccount() {
         assertType<ExportDrawingError.NoAccount>(
             CoreModel.exportDrawing(config, generateId(), SupportedImageFormats.Jpeg).component2()
+        )
+
+        assertType<ExportDrawingToDiskError.NoAccount>(
+            CoreModel.exportDrawingToDisk(config, generateId(), SupportedImageFormats.Jpeg, generateUniqueName()).component2()
         )
     }
 
@@ -76,6 +87,10 @@ class ExportDrawingTest {
 
         assertType<ExportDrawingError.FileDoesNotExist>(
             CoreModel.exportDrawing(config, generateId(), SupportedImageFormats.Jpeg).component2()
+        )
+
+        assertType<ExportDrawingToDiskError.FileDoesNotExist>(
+            CoreModel.exportDrawingToDisk(config, generateId(), SupportedImageFormats.Jpeg, generateUniqueName()).component2()
         )
     }
 
@@ -109,6 +124,10 @@ class ExportDrawingTest {
         assertType<ExportDrawingError.InvalidDrawing>(
             CoreModel.exportDrawing(config, document.id, SupportedImageFormats.Jpeg).component2()
         )
+
+        assertType<ExportDrawingToDiskError.InvalidDrawing>(
+            CoreModel.exportDrawingToDisk(config, document.id, SupportedImageFormats.Jpeg, generateUniqueName()).component2()
+        )
     }
 
     @Test
@@ -137,6 +156,10 @@ class ExportDrawingTest {
         assertType<ExportDrawingError.FolderTreatedAsDrawing>(
             CoreModel.exportDrawing(config, folder.id, SupportedImageFormats.Jpeg).component2()
         )
+
+        assertType<ExportDrawingToDiskError.FolderTreatedAsDrawing>(
+            CoreModel.exportDrawingToDisk(config, folder.id, SupportedImageFormats.Jpeg, generateUniqueName()).component2()
+        )
     }
 
     @Test
@@ -144,6 +167,11 @@ class ExportDrawingTest {
         assertType<ExportDrawingError.Unexpected>(
             Klaxon().converter(exportDrawingConverter)
                 .parse<Result<List<Byte>, ExportDrawingError>>(exportDrawing("", "", ""))?.component2()
+        )
+
+        assertType<ExportDrawingToDiskError.Unexpected>(
+            Klaxon().converter(exportDrawingToDiskConverter)
+                .parse<Result<Unit, ExportDrawingToDiskError>>(exportDrawingToDisk("", "", "", ""))?.component2()
         )
     }
 }

--- a/clients/android/app/src/test/java/app/lockbook/ExportDrawingTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/ExportDrawingTest.kt
@@ -1,0 +1,149 @@
+package app.lockbook
+
+import app.lockbook.core.exportDrawing
+import app.lockbook.model.CoreModel
+import app.lockbook.util.*
+import com.beust.klaxon.Klaxon
+import com.github.michaelbull.result.Result
+import org.junit.After
+import org.junit.BeforeClass
+import org.junit.Test
+
+class ExportDrawingTest {
+    var config = Config(createRandomPath())
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun loadLib() {
+            System.loadLibrary("lockbook_core")
+        }
+    }
+
+    @After
+    fun createDirectory() {
+        config = Config(createRandomPath())
+    }
+
+    @Test
+    fun exportDrawingOk() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val document = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Document)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, document).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.writeContentToDocument(config, document.id, Klaxon().toJsonString(Drawing())).component1()
+        )
+
+        assertType<List<Byte>>(
+            CoreModel.exportDrawing(config, document.id, SupportedImageFormats.Jpeg).component1()
+        )
+    }
+
+    @Test
+    fun exportDrawingNoAccount() {
+        assertType<ExportDrawingError.NoAccount>(
+            CoreModel.exportDrawing(config, generateId(), SupportedImageFormats.Jpeg).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingFileDoesNotExist() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        assertType<ExportDrawingError.FileDoesNotExist>(
+            CoreModel.exportDrawing(config, generateId(), SupportedImageFormats.Jpeg).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingInvalidDrawing() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val document = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Document)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, document).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.writeContentToDocument(config, document.id, "").component1()
+        )
+
+        assertType<ExportDrawingError.InvalidDrawing>(
+            CoreModel.exportDrawing(config, document.id, SupportedImageFormats.Jpeg).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingFolderTreatedAsDrawing() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val folder = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Folder)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, folder).component1()
+        )
+
+        assertType<ExportDrawingError.FolderTreatedAsDrawing>(
+            CoreModel.exportDrawing(config, folder.id, SupportedImageFormats.Jpeg).component2()
+        )
+    }
+
+    @Test
+    fun createFileUnexpectedError() {
+        assertType<ExportDrawingError.Unexpected>(
+            Klaxon().converter(exportDrawingConverter)
+                .parse<Result<List<Byte>, ExportDrawingError>>(exportDrawing("", "", ""))?.component2()
+        )
+    }
+}

--- a/clients/android/app/src/test/java/app/lockbook/ExportDrawingToDiskTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/ExportDrawingToDiskTest.kt
@@ -74,7 +74,7 @@ class ExportDrawingToDiskTest {
             CoreModel.getRoot(config).component1()
         )
 
-        assertType<ExportDrawingToDiskError.DrawingDoesNotExist>(
+        assertType<ExportDrawingToDiskError.FileDoesNotExist>(
             CoreModel.exportDrawingToDisk(config, generateId(), SupportedImageFormats.Jpeg, generateFakeRandomPath()).component2()
         )
     }

--- a/clients/android/app/src/test/java/app/lockbook/ExportDrawingToDiskTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/ExportDrawingToDiskTest.kt
@@ -1,0 +1,219 @@
+package app.lockbook
+
+import app.lockbook.core.exportDrawingToDisk
+import app.lockbook.model.CoreModel
+import app.lockbook.util.*
+import com.beust.klaxon.Klaxon
+import com.github.michaelbull.result.Result
+import org.junit.After
+import org.junit.BeforeClass
+import org.junit.Test
+
+class ExportDrawingToDiskTest {
+    var config = Config(createRandomPath())
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun loadLib() {
+            System.loadLibrary("lockbook_core")
+        }
+    }
+
+    @After
+    fun createDirectory() {
+        config = Config(createRandomPath())
+    }
+
+    @Test
+    fun exportDrawingToDiskOk() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val document = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Document)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, document).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.writeContentToDocument(config, document.id, Klaxon().toJsonString(Drawing())).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.exportDrawingToDisk(config, document.id, SupportedImageFormats.Jpeg, generateFakeRandomPath()).component1()
+        )
+    }
+
+    @Test
+    fun exportDrawingToDiskNoAccount() {
+        assertType<ExportDrawingToDiskError.NoAccount>(
+            CoreModel.exportDrawingToDisk(config, generateId(), SupportedImageFormats.Jpeg, generateFakeRandomPath()).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingToDiskFileDoesNotExist() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        assertType<ExportDrawingToDiskError.DrawingDoesNotExist>(
+            CoreModel.exportDrawingToDisk(config, generateId(), SupportedImageFormats.Jpeg, generateFakeRandomPath()).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingToDiskInvalidDrawing() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val document = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Document)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, document).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.writeContentToDocument(config, document.id, "").component1()
+        )
+
+        assertType<ExportDrawingToDiskError.InvalidDrawing>(
+            CoreModel.exportDrawingToDisk(config, document.id, SupportedImageFormats.Jpeg, generateFakeRandomPath()).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingToDiskFolderTreatedAsDrawing() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val folder = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Folder)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, folder).component1()
+        )
+
+        assertType<ExportDrawingToDiskError.FolderTreatedAsDrawing>(
+            CoreModel.exportDrawingToDisk(config, folder.id, SupportedImageFormats.Jpeg, generateFakeRandomPath()).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingToDiskBadPath() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val document = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Document)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, document).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.writeContentToDocument(config, document.id, Klaxon().toJsonString(Drawing())).component1()
+        )
+
+        assertType<ExportDrawingToDiskError.BadPath>(
+            CoreModel.exportDrawingToDisk(config, document.id, SupportedImageFormats.Jpeg, "").component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingToDiskFileAlreadyExistsInDisk() {
+        assertType<Unit>(
+            CoreModel.generateAccount(config, generateAlphaString()).component1()
+        )
+
+        val rootFileMetadata = assertTypeReturn<FileMetadata>(
+            CoreModel.getRoot(config).component1()
+        )
+
+        val document = assertTypeReturn<FileMetadata>(
+            CoreModel.createFile(
+                config,
+                rootFileMetadata.id,
+                generateAlphaString(),
+                Klaxon().toJsonString(FileType.Document)
+            ).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.insertFile(config, document).component1()
+        )
+
+        assertType<Unit>(
+            CoreModel.writeContentToDocument(config, document.id, Klaxon().toJsonString(Drawing())).component1()
+        )
+
+        val path = generateFakeRandomPath()
+
+        assertType<Unit>(
+            CoreModel.exportDrawingToDisk(config, document.id, SupportedImageFormats.Jpeg, path).component1()
+        )
+
+        assertType<ExportDrawingToDiskError.FileAlreadyExistsInDisk>(
+            CoreModel.exportDrawingToDisk(config, document.id, SupportedImageFormats.Jpeg, path).component2()
+        )
+    }
+
+    @Test
+    fun exportDrawingToDiskUnexpectedError() {
+        assertType<ExportDrawingToDiskError.Unexpected>(
+            Klaxon().converter(exportDrawingToDiskConverter)
+                .parse<Result<Unit, ExportDrawingToDiskError>>(exportDrawingToDisk("", "", "", ""))?.component2()
+        )
+    }
+}

--- a/clients/android/app/src/test/java/app/lockbook/ReadDocumentTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/ReadDocumentTest.kt
@@ -49,7 +49,7 @@ class ReadDocumentTest {
         )
 
         assertType<String>(
-            CoreModel.getDocumentContent(config, document.id).component1()
+            CoreModel.readDocument(config, document.id).component1()
         )
     }
 
@@ -77,7 +77,7 @@ class ReadDocumentTest {
         )
 
         assertType<ReadDocumentError.TreatedFolderAsDocument>(
-            CoreModel.getDocumentContent(config, folder.id).component2()
+            CoreModel.readDocument(config, folder.id).component2()
         )
     }
 
@@ -88,7 +88,7 @@ class ReadDocumentTest {
         )
 
         assertType<ReadDocumentError.FileDoesNotExist>(
-            CoreModel.getDocumentContent(config, generateId()).component2()
+            CoreModel.readDocument(config, generateId()).component2()
         )
     }
 

--- a/clients/android/app/src/test/java/app/lockbook/utils.kt
+++ b/clients/android/app/src/test/java/app/lockbook/utils.kt
@@ -61,6 +61,7 @@ val errorsToCheck = listOf<KClass<*>>(
     SetLastSyncedError::class,
     SyncAllError::class,
     WriteToDocumentError::class,
+    ExportDrawingError::class
 )
 
 val checkIfAllErrorsPresentConverter = object : Converter {

--- a/clients/android/app/src/test/java/app/lockbook/utils.kt
+++ b/clients/android/app/src/test/java/app/lockbook/utils.kt
@@ -16,6 +16,8 @@ fun generateAlphaString(): String =
 
 fun generateId(): String = UUID.randomUUID().toString()
 
+fun generateFakeRandomPath() = "/tmp/${System.currentTimeMillis()}"
+
 fun createRandomPath(): String {
     val path = "/tmp/${generateAlphaString()}"
     Runtime.getRuntime().exec("mkdir $path")

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -20,6 +20,7 @@ external fun createFile(config: String, id: String, fileType: String, name: Stri
 external fun deleteFile(config: String, id: String): String
 external fun readDocument(config: String, id: String): String
 external fun exportDrawing(config: String, id: String, format: String): String
+external fun exportDrawingToDisk(config: String, id: String, format: String, location: String): String
 external fun writeDocument(config: String, id: String, content: String): String
 external fun moveFile(config: String, id: String, parentId: String): String
 external fun syncAll(config: String, fragment: Any): String

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -19,6 +19,7 @@ external fun renameFile(config: String, id: String, name: String): String
 external fun createFile(config: String, id: String, fileType: String, name: String): String
 external fun deleteFile(config: String, id: String): String
 external fun readDocument(config: String, id: String): String
+external fun exportDrawing(config: String, id: String, format: String): String
 external fun writeDocument(config: String, id: String, content: String): String
 external fun moveFile(config: String, id: String, parentId: String): String
 external fun syncAll(config: String, fragment: Any): String

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -19,6 +19,7 @@ external fun renameFile(config: String, id: String, name: String): String
 external fun createFile(config: String, id: String, fileType: String, name: String): String
 external fun deleteFile(config: String, id: String): String
 external fun readDocument(config: String, id: String): String
+external fun saveDocumentToDisk(config: String, id: String, location: String): String
 external fun exportDrawing(config: String, id: String, format: String): String
 external fun exportDrawingToDisk(config: String, id: String, format: String, location: String): String
 external fun writeDocument(config: String, id: String, content: String): String

--- a/clients/windows/test/CoreServiceTest.cs
+++ b/clients/windows/test/CoreServiceTest.cs
@@ -781,12 +781,14 @@ namespace test {
                 {"GetDrawingError", typeof(Core.GetDrawing.PossibleErrors)},
                 {"SaveDrawingError", typeof(Core.SaveDrawing.PossibleErrors)},
                 {"ExportDrawingError", typeof(Core.ExportDrawing.PossibleErrors)},
+                // {"ExportDrawingToDiskError", typeof(Core.???.PossibleErrors)},
+                // {"SaveDocumentToDiskError", typeof(Core.???.PossibleErrors)},
             };
 
             var variants = CoreService.GetVariants().WaitResult();
 
             foreach(var kvp in variants) {
-                if(kvp.Key == "GetFileByIdError" || kvp.Key == "InsertFileError") {
+                if(kvp.Key == "GetFileByIdError" || kvp.Key == "InsertFileError" || kvp.Key == "ExportDrawingToDiskError" || kvp.Key == "SaveDocumentToDiskError") {
                     continue; // these endpoints, and therefore these errors, are not used by this client
                 }
                 var enumType = typeMap[kvp.Key];

--- a/core/Makefile
+++ b/core/Makefile
@@ -14,10 +14,10 @@ android:
 	@mkdir $(jniLibs)/x86
 	@mkdir $(jniLibs)/x86_64
 	
-	@cp target/aarch64-linux-android/release/$(libName) $(jniLibs)/arm64-v8a/$(libName)
-	@cp target/armv7-linux-androideabi/release/$(libName) $(jniLibs)/armeabi-v7a/$(libName)
-	@cp target/i686-linux-android/release/$(libName) $(jniLibs)/x86/$(libName)
-	@cp target/x86_64-linux-android/release/$(libName) $(jniLibs)/x86_64/$(libName)
+	@cp ../target/aarch64-linux-android/release/$(libName) $(jniLibs)/arm64-v8a/$(libName)
+	@cp ../target/armv7-linux-androideabi/release/$(libName) $(jniLibs)/armeabi-v7a/$(libName)
+	@cp ../target/i686-linux-android/release/$(libName) $(jniLibs)/x86/$(libName)
+	@cp ../target/x86_64-linux-android/release/$(libName) $(jniLibs)/x86_64/$(libName)
 
 .PHONY: macos_jni
 macos_jni:

--- a/core/Makefile
+++ b/core/Makefile
@@ -30,7 +30,7 @@ macos_jni:
 	@echo "Moving new .dylib over"
 	@mkdir -p $(jniLibs)/desktop
 
-	@cp target/release/$(macosLibName) $(jniLibs)/desktop/$(macosLibName)
+	@cp ../target/release/$(macosLibName) $(jniLibs)/desktop/$(macosLibName)
 
 .PHONY: windows_jni
 windows_jni:
@@ -43,7 +43,7 @@ windows_jni:
 	@echo "Moving new .dll over"
 	@mkdir -p $(jniLibs)/desktop
 
-	@cp target/release/$(windowsLibName) $(jniLibs)/desktop/$(windowsLibName)
+	@cp ../target/release/$(windowsLibName) $(jniLibs)/desktop/$(windowsLibName)
 
 .PHONY: linux_jni
 linux_jni:
@@ -56,7 +56,7 @@ linux_jni:
 	@echo "Moving new .so over"
 	@mkdir -p $(jniLibs)/desktop
 
-	@cp target/release/$(libName) $(jniLibs)/desktop/$(libName)
+	@cp ../target/release/$(libName) $(jniLibs)/desktop/$(libName)
 
 .PHONY: lib_c_for_swift_ios
 lib_c_for_swift_ios:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -960,7 +960,7 @@ pub fn save_drawing(
 #[derive(Debug, Serialize, EnumIter)]
 pub enum ExportDrawingError {
     FolderTreatedAsDrawing,
-    DrawingDoesNotExist,
+    FileDoesNotExist,
     NoAccount,
     InvalidDrawing,
 }
@@ -990,7 +990,7 @@ pub fn export_drawing(
                     }
                 },
                 FSReadDocumentError::CouldNotFindFile => {
-                    UiError(ExportDrawingError::DrawingDoesNotExist)
+                    UiError(ExportDrawingError::FileDoesNotExist)
                 }
                 FSReadDocumentError::DbError(_)
                 | FSReadDocumentError::DocumentReadError(_)
@@ -1015,7 +1015,7 @@ pub fn export_drawing(
 #[derive(Debug, Serialize, EnumIter)]
 pub enum ExportDrawingToDiskError {
     FolderTreatedAsDrawing,
-    DrawingDoesNotExist,
+    FileDoesNotExist,
     NoAccount,
     InvalidDrawing,
     BadPath,
@@ -1069,7 +1069,7 @@ pub fn export_drawing_to_disk(
                                 }
                             }
                             FSReadDocumentError::CouldNotFindFile => {
-                                UiError(ExportDrawingToDiskError::DrawingDoesNotExist)
+                                UiError(ExportDrawingToDiskError::FileDoesNotExist)
                             }
                             FSReadDocumentError::DbError(_)
                             | FSReadDocumentError::DocumentReadError(_)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,9 +27,14 @@ use crate::service::account_service::{
     AccountCreationError, AccountExportError as ASAccountExportError, AccountImportError,
 };
 use crate::service::db_state_service::State;
+use crate::service::drawing_service::{
+    ExportDrawingError as FSExportDrawingError,
+    ExportDrawingToDiskError as FSExportDrawingToDiskError, GetDrawingError as FSGetDrawingError,
+    SaveDrawingError as FSSaveDrawingError,
+};
 use crate::service::file_service::{
     DocumentRenameError, DocumentUpdateError, FileMoveError, NewFileError, NewFileFromPathError,
-    ReadDocumentError as FSReadDocumentError,
+    ReadDocumentError as FSReadDocumentError, SaveDocumentToDiskError as FSSaveDocumentToDiskError,
 };
 use crate::service::sync_service::{
     CalculateWorkError as SSCalculateWorkError, SyncError, SyncProgress, WorkCalculated,
@@ -58,6 +63,7 @@ use crate::service::drawing_service::SupportedImageFormats;
 use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
 use serde_json::error::Category;
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use Error::UiError;
 
 macro_rules! unexpected {
@@ -509,6 +515,58 @@ pub fn read_document(
 }
 
 #[derive(Debug, Serialize, EnumIter)]
+pub enum SaveDocumentToDiskError {
+    TreatedFolderAsDocument,
+    NoAccount,
+    FileDoesNotExist,
+    BadPath,
+    FileAlreadyExists,
+}
+
+pub fn save_document_to_disk(
+    config: &Config,
+    id: Uuid,
+    location: String,
+) -> Result<(), Error<SaveDocumentToDiskError>> {
+    file_service::save_document_to_disk(&config, id, location).map_err(|e| match e {
+        FSSaveDocumentToDiskError::CouldNotCreateDocumentError(creation_err) => {
+            match creation_err.kind() {
+                ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::InvalidInput => {
+                    UiError(SaveDocumentToDiskError::BadPath)
+                }
+                ErrorKind::AlreadyExists => UiError(SaveDocumentToDiskError::FileAlreadyExists),
+                _ => unexpected!("{:#?}", creation_err),
+            }
+        }
+        FSSaveDocumentToDiskError::CouldNotWriteToDocumentError(_) => {
+            unexpected!("{:#?}", e)
+        }
+        FSSaveDocumentToDiskError::ReadDocumentError(read_document_err) => {
+            match read_document_err {
+                FSReadDocumentError::TreatedFolderAsDocument => {
+                    UiError(SaveDocumentToDiskError::TreatedFolderAsDocument)
+                }
+
+                FSReadDocumentError::AccountRetrievalError(account_error) => match account_error {
+                    AccountRepoError::NoAccount => UiError(SaveDocumentToDiskError::NoAccount),
+                    AccountRepoError::BackendError(_) | AccountRepoError::SerdeError(_) => {
+                        unexpected!("{:#?}", account_error)
+                    }
+                },
+                FSReadDocumentError::CouldNotFindFile => {
+                    UiError(SaveDocumentToDiskError::FileDoesNotExist)
+                }
+                FSReadDocumentError::DbError(_)
+                | FSReadDocumentError::DocumentReadError(_)
+                | FSReadDocumentError::CouldNotFindParents(_)
+                | FSReadDocumentError::FileEncryptionError(_)
+                | FSReadDocumentError::FileDecompressionError(_) => unexpected!("{:#?}", read_document_err),
+            }
+        }
+    })
+}
+
+#[derive(Debug, Serialize, EnumIter)]
 pub enum ListPathsError {
     Stub, // TODO: Enums should not be empty
 }
@@ -823,14 +881,14 @@ pub enum GetDrawingError {
 }
 
 pub fn get_drawing(config: &Config, id: Uuid) -> Result<Drawing, Error<GetDrawingError>> {
-    drawing_service::get_drawing(&config, id).map_err(|drawing_err| match drawing_err {
-        drawing_service::GetDrawingError::InvalidDrawingError(err) => match err.classify() {
+    drawing_service::get_drawing(&config, id).map_err(|e| match e {
+        FSGetDrawingError::InvalidDrawingError(err) => match err.classify() {
             Category::Io => unexpected!("{:#?}", err),
             Category::Syntax | Category::Data | Category::Eof => {
                 UiError(GetDrawingError::InvalidDrawing)
             }
         },
-        drawing_service::GetDrawingError::FailedToRetrieveJson(err) => match err {
+        FSGetDrawingError::FailedToRetrieveJson(err) => match err {
             FSReadDocumentError::TreatedFolderAsDocument => {
                 UiError(GetDrawingError::FolderTreatedAsDrawing)
             }
@@ -863,46 +921,42 @@ pub fn save_drawing(
     id: Uuid,
     drawing_bytes: &[u8],
 ) -> Result<(), Error<SaveDrawingError>> {
-    drawing_service::save_drawing(&config, id, drawing_bytes).map_err(|drawing_err| {
-        match drawing_err {
-            drawing_service::SaveDrawingError::InvalidDrawingError(err) => match err.classify() {
-                Category::Io => unexpected!("{:#?}", err),
-                Category::Syntax | Category::Data | Category::Eof => {
-                    UiError(SaveDrawingError::InvalidDrawing)
+    drawing_service::save_drawing(&config, id, drawing_bytes).map_err(|e| match e {
+        FSSaveDrawingError::InvalidDrawingError(err) => match err.classify() {
+            Category::Io => unexpected!("{:#?}", err),
+            Category::Syntax | Category::Data | Category::Eof => {
+                UiError(SaveDrawingError::InvalidDrawing)
+            }
+        },
+        FSSaveDrawingError::FailedToSaveJson(err) => match err {
+            DocumentUpdateError::AccountRetrievalError(account_err) => match account_err {
+                AccountRepoError::BackendError(_) | AccountRepoError::SerdeError(_) => {
+                    unexpected!("{:#?}", account_err)
                 }
+                AccountRepoError::NoAccount => UiError(SaveDrawingError::NoAccount),
             },
-            drawing_service::SaveDrawingError::FailedToSaveJson(err) => match err {
-                DocumentUpdateError::AccountRetrievalError(account_err) => match account_err {
-                    AccountRepoError::BackendError(_) | AccountRepoError::SerdeError(_) => {
-                        unexpected!("{:#?}", account_err)
-                    }
-                    AccountRepoError::NoAccount => UiError(SaveDrawingError::NoAccount),
-                },
-                DocumentUpdateError::CouldNotFindFile => {
-                    UiError(SaveDrawingError::FileDoesNotExist)
-                }
-                DocumentUpdateError::FolderTreatedAsDocument => {
-                    UiError(SaveDrawingError::FolderTreatedAsDrawing)
-                }
-                DocumentUpdateError::CouldNotFindParents(_)
-                | DocumentUpdateError::FileEncryptionError(_)
-                | DocumentUpdateError::FileCompressionError(_)
-                | DocumentUpdateError::FileDecompressionError(_)
-                | DocumentUpdateError::DocumentWriteError(_)
-                | DocumentUpdateError::DbError(_)
-                | DocumentUpdateError::FetchOldVersionError(_)
-                | DocumentUpdateError::DecryptOldVersionError(_)
-                | DocumentUpdateError::AccessInfoCreationError(_)
-                | DocumentUpdateError::FailedToRecordChange(_) => unexpected!("{:#?}", err),
-            },
-        }
+            DocumentUpdateError::CouldNotFindFile => UiError(SaveDrawingError::FileDoesNotExist),
+            DocumentUpdateError::FolderTreatedAsDocument => {
+                UiError(SaveDrawingError::FolderTreatedAsDrawing)
+            }
+            DocumentUpdateError::CouldNotFindParents(_)
+            | DocumentUpdateError::FileEncryptionError(_)
+            | DocumentUpdateError::FileCompressionError(_)
+            | DocumentUpdateError::FileDecompressionError(_)
+            | DocumentUpdateError::DocumentWriteError(_)
+            | DocumentUpdateError::DbError(_)
+            | DocumentUpdateError::FetchOldVersionError(_)
+            | DocumentUpdateError::DecryptOldVersionError(_)
+            | DocumentUpdateError::AccessInfoCreationError(_)
+            | DocumentUpdateError::FailedToRecordChange(_) => unexpected!("{:#?}", err),
+        },
     })
 }
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum ExportDrawingError {
     FolderTreatedAsDrawing,
-    FileDoesNotExist,
+    DrawingDoesNotExist,
     NoAccount,
     InvalidDrawing,
 }
@@ -913,53 +967,124 @@ pub fn export_drawing(
     format: SupportedImageFormats,
     render_theme: Option<HashMap<ColorAlias, ColorRGB>>,
 ) -> Result<Vec<u8>, Error<ExportDrawingError>> {
-    drawing_service::export_drawing(&config, id, format, render_theme).map_err(
-        |export_drawing_err| match export_drawing_err {
-            drawing_service::ExportDrawingError::GetDrawingError(get_drawing_err) => {
-                match get_drawing_err {
-                    drawing_service::GetDrawingError::InvalidDrawingError(err) => {
-                        match err.classify() {
-                            Category::Io => unexpected!("{:#?}", err),
-                            Category::Syntax | Category::Data | Category::Eof => {
-                                UiError(ExportDrawingError::InvalidDrawing)
-                            }
-                        }
+    drawing_service::export_drawing(&config, id, format, render_theme).map_err(|e| match e {
+        FSExportDrawingError::GetDrawingError(get_drawing_err) => match get_drawing_err {
+            FSGetDrawingError::InvalidDrawingError(err) => match err.classify() {
+                Category::Io => unexpected!("{:#?}", err),
+                Category::Syntax | Category::Data | Category::Eof => {
+                    UiError(ExportDrawingError::InvalidDrawing)
+                }
+            },
+            FSGetDrawingError::FailedToRetrieveJson(err) => match err {
+                FSReadDocumentError::TreatedFolderAsDocument => {
+                    UiError(ExportDrawingError::FolderTreatedAsDrawing)
+                }
+                FSReadDocumentError::AccountRetrievalError(account_error) => match account_error {
+                    AccountRepoError::NoAccount => UiError(ExportDrawingError::NoAccount),
+                    AccountRepoError::BackendError(_) | AccountRepoError::SerdeError(_) => {
+                        unexpected!("{:#?}", account_error)
                     }
-                    drawing_service::GetDrawingError::FailedToRetrieveJson(err) => match err {
-                        FSReadDocumentError::TreatedFolderAsDocument => {
-                            UiError(ExportDrawingError::FolderTreatedAsDrawing)
-                        }
-                        FSReadDocumentError::AccountRetrievalError(account_error) => {
-                            match account_error {
-                                AccountRepoError::NoAccount => {
-                                    UiError(ExportDrawingError::NoAccount)
-                                }
-                                AccountRepoError::BackendError(_)
-                                | AccountRepoError::SerdeError(_) => {
-                                    unexpected!("{:#?}", account_error)
-                                }
-                            }
-                        }
-                        FSReadDocumentError::CouldNotFindFile => {
-                            UiError(ExportDrawingError::FileDoesNotExist)
-                        }
-                        FSReadDocumentError::DbError(_)
-                        | FSReadDocumentError::DocumentReadError(_)
-                        | FSReadDocumentError::CouldNotFindParents(_)
-                        | FSReadDocumentError::FileEncryptionError(_)
-                        | FSReadDocumentError::FileDecompressionError(_) => {
-                            unexpected!("{:#?}", err)
-                        }
-                    },
+                },
+                FSReadDocumentError::CouldNotFindFile => {
+                    UiError(ExportDrawingError::DrawingDoesNotExist)
+                }
+                FSReadDocumentError::DbError(_)
+                | FSReadDocumentError::DocumentReadError(_)
+                | FSReadDocumentError::CouldNotFindParents(_)
+                | FSReadDocumentError::FileEncryptionError(_)
+                | FSReadDocumentError::FileDecompressionError(_) => {
+                    unexpected!("{:#?}", err)
+                }
+            },
+        },
+        FSExportDrawingError::UnableToGetColorFromAlias
+        | FSExportDrawingError::UnableToGetStrokePoint
+        | FSExportDrawingError::UnableToGetStrokeGirth
+        | FSExportDrawingError::UnequalPointsAndGirthMetrics
+        | FSExportDrawingError::InvalidAlphaValue
+        | FSExportDrawingError::FailedToEncodeImage(_) => {
+            unexpected!("{:#?}", e)
+        }
+    })
+}
+
+#[derive(Debug, Serialize, EnumIter)]
+pub enum ExportDrawingToDiskError {
+    FolderTreatedAsDrawing,
+    DrawingDoesNotExist,
+    NoAccount,
+    InvalidDrawing,
+    BadPath,
+    FileAlreadyExists,
+}
+
+pub fn export_drawing_to_disk(
+    config: &Config,
+    id: Uuid,
+    format: SupportedImageFormats,
+    render_theme: Option<HashMap<ColorAlias, ColorRGB>>,
+    location: String,
+) -> Result<(), Error<ExportDrawingToDiskError>> {
+    drawing_service::export_drawing_to_disk(&config, id, format, render_theme, location).map_err(
+        |e| match e {
+            FSExportDrawingToDiskError::CouldNotCreateDocumentError(creation_err) => {
+                match creation_err.kind() {
+                    ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::InvalidInput => {
+                        UiError(ExportDrawingToDiskError::BadPath)
+                    }
+                    ErrorKind::AlreadyExists => {
+                        UiError(ExportDrawingToDiskError::FileAlreadyExists)
+                    }
+                    _ => unexpected!("{:#?}", creation_err),
                 }
             }
-            drawing_service::ExportDrawingError::UnableToGetColorFromAlias
-            | drawing_service::ExportDrawingError::UnableToGetStrokePoint
-            | drawing_service::ExportDrawingError::UnableToGetStrokeGirth
-            | drawing_service::ExportDrawingError::UnequalPointsAndGirthMetrics
-            | drawing_service::ExportDrawingError::InvalidAlphaValue
-            | drawing_service::ExportDrawingError::FailedToEncodeImage(_) => {
-                unexpected!("{:#?}", export_drawing_err)
+            FSExportDrawingToDiskError::CouldNotWriteToDocumentError(_) => unexpected!("{:#?}", e),
+            FSExportDrawingToDiskError::ExportDrawingError(export_drawing_err) => {
+                match export_drawing_err {
+                    FSExportDrawingError::GetDrawingError(get_drawing_err) => match get_drawing_err
+                    {
+                        FSGetDrawingError::InvalidDrawingError(err) => match err.classify() {
+                            Category::Io => unexpected!("{:#?}", err),
+                            Category::Syntax | Category::Data | Category::Eof => {
+                                UiError(ExportDrawingToDiskError::InvalidDrawing)
+                            }
+                        },
+                        FSGetDrawingError::FailedToRetrieveJson(err) => match err {
+                            FSReadDocumentError::TreatedFolderAsDocument => {
+                                UiError(ExportDrawingToDiskError::FolderTreatedAsDrawing)
+                            }
+                            FSReadDocumentError::AccountRetrievalError(account_error) => {
+                                match account_error {
+                                    AccountRepoError::NoAccount => {
+                                        UiError(ExportDrawingToDiskError::NoAccount)
+                                    }
+                                    AccountRepoError::BackendError(_)
+                                    | AccountRepoError::SerdeError(_) => {
+                                        unexpected!("{:#?}", account_error)
+                                    }
+                                }
+                            }
+                            FSReadDocumentError::CouldNotFindFile => {
+                                UiError(ExportDrawingToDiskError::DrawingDoesNotExist)
+                            }
+                            FSReadDocumentError::DbError(_)
+                            | FSReadDocumentError::DocumentReadError(_)
+                            | FSReadDocumentError::CouldNotFindParents(_)
+                            | FSReadDocumentError::FileEncryptionError(_)
+                            | FSReadDocumentError::FileDecompressionError(_) => {
+                                unexpected!("{:#?}", err)
+                            }
+                        },
+                    },
+                    FSExportDrawingError::UnableToGetColorFromAlias
+                    | FSExportDrawingError::UnableToGetStrokePoint
+                    | FSExportDrawingError::UnableToGetStrokeGirth
+                    | FSExportDrawingError::UnequalPointsAndGirthMetrics
+                    | FSExportDrawingError::InvalidAlphaValue
+                    | FSExportDrawingError::FailedToEncodeImage(_) => {
+                        unexpected!("{:#?}", export_drawing_err)
+                    }
+                }
             }
         },
     )
@@ -1009,6 +1134,8 @@ impl_get_variants!(
     GetDrawingError,
     SaveDrawingError,
     ExportDrawingError,
+    ExportDrawingToDiskError,
+    SaveDocumentToDiskError,
 );
 
 pub mod c_interface;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -520,7 +520,7 @@ pub enum SaveDocumentToDiskError {
     NoAccount,
     FileDoesNotExist,
     BadPath,
-    FileAlreadyExists,
+    FileAlreadyExistsInDisk,
 }
 
 pub fn save_document_to_disk(
@@ -534,7 +534,9 @@ pub fn save_document_to_disk(
                 ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::InvalidInput => {
                     UiError(SaveDocumentToDiskError::BadPath)
                 }
-                ErrorKind::AlreadyExists => UiError(SaveDocumentToDiskError::FileAlreadyExists),
+                ErrorKind::AlreadyExists => {
+                    UiError(SaveDocumentToDiskError::FileAlreadyExistsInDisk)
+                }
                 _ => unexpected!("{:#?}", creation_err),
             }
         }
@@ -560,7 +562,9 @@ pub fn save_document_to_disk(
                 | FSReadDocumentError::DocumentReadError(_)
                 | FSReadDocumentError::CouldNotFindParents(_)
                 | FSReadDocumentError::FileEncryptionError(_)
-                | FSReadDocumentError::FileDecompressionError(_) => unexpected!("{:#?}", read_document_err),
+                | FSReadDocumentError::FileDecompressionError(_) => {
+                    unexpected!("{:#?}", read_document_err)
+                }
             }
         }
     })
@@ -1015,7 +1019,7 @@ pub enum ExportDrawingToDiskError {
     NoAccount,
     InvalidDrawing,
     BadPath,
-    FileAlreadyExists,
+    FileAlreadyExistsInDisk,
 }
 
 pub fn export_drawing_to_disk(
@@ -1033,7 +1037,7 @@ pub fn export_drawing_to_disk(
                         UiError(ExportDrawingToDiskError::BadPath)
                     }
                     ErrorKind::AlreadyExists => {
-                        UiError(ExportDrawingToDiskError::FileAlreadyExists)
+                        UiError(ExportDrawingToDiskError::FileAlreadyExistsInDisk)
                     }
                     _ => unexpected!("{:#?}", creation_err),
                 }

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -17,7 +17,9 @@ use raqote::{
 use std::collections::HashMap;
 use std::io::BufWriter;
 use uuid::Uuid;
+use serde::Deserialize;
 
+#[derive(Deserialize)]
 pub enum SupportedImageFormats {
     Png,
     Jpeg,

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -16,7 +16,7 @@ use raqote::{
 };
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use uuid::Uuid;
@@ -256,7 +256,11 @@ pub fn export_drawing_to_disk(
 ) -> Result<(), ExportDrawingToDiskError> {
     let drawing_bytes = export_drawing(config, id, format, render_theme)
         .map_err(ExportDrawingToDiskError::ExportDrawingError)?;
-    let mut file = File::create(Path::new(&location))
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(Path::new(&location))
         .map_err(ExportDrawingToDiskError::CouldNotCreateDocumentError)?;
 
     file.write_all(drawing_bytes.as_slice())

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -14,10 +14,10 @@ use image::{ColorType, ImageError};
 use raqote::{
     DrawOptions, DrawTarget, LineCap, LineJoin, PathBuilder, SolidSource, Source, StrokeStyle,
 };
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::BufWriter;
 use uuid::Uuid;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub enum SupportedImageFormats {

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -32,7 +32,7 @@ use lockbook_crypto::clock_service;
 use lockbook_models::crypto::DecryptedDocument;
 use lockbook_models::file_metadata::FileType::{Document, Folder};
 use lockbook_models::file_metadata::{FileMetadata, FileType};
-use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
@@ -479,7 +479,10 @@ pub fn save_document_to_disk(
 ) -> Result<(), SaveDocumentToDiskError> {
     let document_content =
         read_document(config, id).map_err(SaveDocumentToDiskError::ReadDocumentError)?;
-    let mut file = File::create(Path::new(&location))
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(Path::new(&location))
         .map_err(SaveDocumentToDiskError::CouldNotCreateDocumentError)?;
 
     file.write_all(document_content.as_slice())

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -32,6 +32,9 @@ use lockbook_crypto::clock_service;
 use lockbook_models::crypto::DecryptedDocument;
 use lockbook_models::file_metadata::FileType::{Document, Folder};
 use lockbook_models::file_metadata::{FileMetadata, FileType};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
 
 #[derive(Debug)]
 pub enum NewFileError {
@@ -460,6 +463,27 @@ pub fn read_document(config: &Config, id: Uuid) -> Result<DecryptedDocument, Rea
         .map_err(ReadDocumentError::FileDecompressionError)?;
 
     Ok(content)
+}
+
+#[derive(Debug)]
+pub enum SaveDocumentToDiskError {
+    ReadDocumentError(ReadDocumentError),
+    CouldNotCreateDocumentError(std::io::Error),
+    CouldNotWriteToDocumentError(std::io::Error),
+}
+
+pub fn save_document_to_disk(
+    config: &Config,
+    id: Uuid,
+    location: String,
+) -> Result<(), SaveDocumentToDiskError> {
+    let document_content =
+        read_document(config, id).map_err(SaveDocumentToDiskError::ReadDocumentError)?;
+    let mut file = File::create(Path::new(&location))
+        .map_err(SaveDocumentToDiskError::CouldNotCreateDocumentError)?;
+
+    file.write_all(document_content.as_slice())
+        .map_err(SaveDocumentToDiskError::CouldNotWriteToDocumentError)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
In this PR, I added the ability to share documents (including drawings). A user simply selects the files he wants to share, clicks the share icon on the menubar, and is given the standard share screen. If a user selects a folder, it will recursively get every document within that folder.

On android, to share a file you need to provide a `Uri`. That means there is no way to simply give bytes for something like an image, so you need to save it to some place. This is troublesome since it would just be better if it wasn't saved, but I ended up saving it within the local cache. This cache is private and only accessible to the app, and is cleared everytime the user exits lockbook. The images saved there momentarily will be not be visible in the user's gallery.

The wait time to process a document (like generating an image) and saving it to disk is short since bytes and text aren't passed over ffi and then saved by the clients. Instead, they are saved with core using two new endpoints:
- `save_document_to_disk`
- `export_drawing_to_disk`

In these endpoints you provide a location on disk where you want a file to be saved with the contents of a document/image.

### Screen Recordings
<details>

Sharing different 6 drawings and regular documents:

https://user-images.githubusercontent.com/20663038/121783834-e304ea00-cb7e-11eb-8f19-c583fc3bd307.mp4
</details>


