### PR TITLE
linux: could not reach server dialog does not appear when computer is suspended

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/CoreModel.kt
@@ -161,13 +161,12 @@ object CoreModel {
         metadataVersion: Long
     ): String = app.lockbook.core.convertToHumanDuration(metadataVersion)
 
-    fun getLocalAndServerUsage(
-        config: Config,
-        exact: Boolean
-    ): Result<LocalAndServerUsages, GetUsageError> {
-        val getUsageResult: Result<LocalAndServerUsages, GetUsageError>? =
-            Klaxon().converter(getLocalAndServerUsageConverter)
-                .parse(getLocalAndServerUsage(Klaxon().toJsonString(config), exact))
+    fun getUsage(
+        config: Config
+    ): Result<UsageMetrics, GetUsageError> {
+        val getUsageResult: Result<UsageMetrics, GetUsageError>? =
+            Klaxon().converter(getUsageConverter)
+                .parse(getUsage(Klaxon().toJsonString(config)))
 
         if (getUsageResult != null) {
             return getUsageResult
@@ -176,7 +175,19 @@ object CoreModel {
         return Err(GetUsageError.Unexpected("getLocalAndServerUsageConverter was unable to be called!"))
     }
 
-    fun makeBytesReadable(bytes: Long): String = app.lockbook.core.makeBytesReadable(bytes)
+    fun getUncompressedUsage(
+        config: Config
+    ): Result<UsageItemMetric, GetUsageError> {
+        val getUncompressedUsageResult: Result<UsageItemMetric, GetUsageError>? =
+            Klaxon().converter(getUncompressedUsageConverter)
+                .parse(getUncompressedUsage(Klaxon().toJsonString(config)))
+
+        if (getUncompressedUsageResult != null) {
+            return getUncompressedUsageResult
+        }
+
+        return Err(GetUsageError.Unexpected("getLocalAndServerUsageConverter was unable to be called!"))
+    }
 
     fun getChildren(
         config: Config,

--- a/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Converters.kt
@@ -297,7 +297,7 @@ val setLastSyncedConverter = object : Converter {
     override fun toJson(value: Any): String = Klaxon().toJsonString(value)
 }
 
-val getLocalAndServerUsageConverter = object : Converter {
+val getUsageConverter = object : Converter {
     override fun canConvert(cls: Class<*>): Boolean = true
 
     override fun fromJson(jv: JsonValue): Any = when (jv.obj?.string("tag")) {
@@ -305,9 +305,9 @@ val getLocalAndServerUsageConverter = object : Converter {
             val ok = jv.obj?.obj("content")
 
             if (ok != null) {
-                Ok(Klaxon().parseFromJsonObject<LocalAndServerUsages>(ok))
+                Ok(Klaxon().parseFromJsonObject<UsageMetrics>(ok))
             } else {
-                Err(GetUsageError.Unexpected("calculateUsageConverter $unableToGetOk ${jv.obj?.toJsonString()}"))
+                Err(GetUsageError.Unexpected("getUsageConverter $unableToGetOk ${jv.obj?.toJsonString()}"))
             }
         }
         errTag -> when (val errorTag = jv.obj?.obj("content")?.string("tag")) {
@@ -319,11 +319,11 @@ val getLocalAndServerUsageConverter = object : Converter {
                             GetUsageError.ClientUpdateRequired::class.simpleName -> GetUsageError.ClientUpdateRequired
                             GetUsageError.CouldNotReachServer::class.simpleName -> GetUsageError.CouldNotReachServer
                             GetUsageError.NoAccount::class.simpleName -> GetUsageError.NoAccount
-                            else -> GetUsageError.Unexpected("calculateUsageConverter $unmatchedUiError $error")
+                            else -> GetUsageError.Unexpected("getUsageConverter $unmatchedUiError $error")
                         }
                     )
                 } else {
-                    Err(GetUsageError.Unexpected("calculateUsageConverter $unableToGetUiError ${jv.obj?.toJsonString()}"))
+                    Err(GetUsageError.Unexpected("getUsageConverter $unableToGetUiError ${jv.obj?.toJsonString()}"))
                 }
             }
             unexpectedTag -> {
@@ -331,12 +331,57 @@ val getLocalAndServerUsageConverter = object : Converter {
                 if (error != null) {
                     Err(GetUsageError.Unexpected(error))
                 } else {
-                    Err(GetUsageError.Unexpected("calculateUsageConverter $unableToGetUnexpectedError ${jv.obj?.toJsonString()}"))
+                    Err(GetUsageError.Unexpected("getUsageConverter $unableToGetUnexpectedError ${jv.obj?.toJsonString()}"))
                 }
             }
-            else -> Err(GetUsageError.Unexpected("calculateUsageConverter $unmatchedErrorTag $errorTag"))
+            else -> Err(GetUsageError.Unexpected("getUsageConverter $unmatchedErrorTag $errorTag"))
         }
-        else -> Err(GetUsageError.Unexpected("calculateUsageConverter $unmatchedTag ${jv.obj?.toJsonString()}"))
+        else -> Err(GetUsageError.Unexpected("getUsageConverter $unmatchedTag ${jv.obj?.toJsonString()}"))
+    }
+
+    override fun toJson(value: Any): String = Klaxon().toJsonString(value)
+}
+
+val getUncompressedUsageConverter = object : Converter {
+    override fun canConvert(cls: Class<*>): Boolean = true
+
+    override fun fromJson(jv: JsonValue): Any = when (jv.obj?.string("tag")) {
+        okTag -> {
+            val ok = jv.obj?.obj("content")
+
+            if (ok != null) {
+                Ok(Klaxon().parseFromJsonObject<UsageItemMetric>(ok))
+            } else {
+                Err(GetUsageError.Unexpected("getUncompressedUsageConverter $unableToGetOk ${jv.obj?.toJsonString()}"))
+            }
+        }
+        errTag -> when (val errorTag = jv.obj?.obj("content")?.string("tag")) {
+            uiErrorTag -> {
+                val error = jv.obj?.obj("content")?.string("content")
+                if (error != null) {
+                    Err(
+                        when (error) {
+                            GetUsageError.ClientUpdateRequired::class.simpleName -> GetUsageError.ClientUpdateRequired
+                            GetUsageError.CouldNotReachServer::class.simpleName -> GetUsageError.CouldNotReachServer
+                            GetUsageError.NoAccount::class.simpleName -> GetUsageError.NoAccount
+                            else -> GetUsageError.Unexpected("getUsageConverter $unmatchedUiError $error")
+                        }
+                    )
+                } else {
+                    Err(GetUsageError.Unexpected("getUncompressedUsageConverter $unableToGetUiError ${jv.obj?.toJsonString()}"))
+                }
+            }
+            unexpectedTag -> {
+                val error = jv.obj?.obj("content")?.string("content")
+                if (error != null) {
+                    Err(GetUsageError.Unexpected(error))
+                } else {
+                    Err(GetUsageError.Unexpected("getUncompressedUsageConverter $unableToGetUnexpectedError ${jv.obj?.toJsonString()}"))
+                }
+            }
+            else -> Err(GetUsageError.Unexpected("getUncompressedUsageConverter $unmatchedErrorTag $errorTag"))
+        }
+        else -> Err(GetUsageError.Unexpected("getUncompressedUsageConverter $unmatchedTag ${jv.obj?.toJsonString()}"))
     }
 
     override fun toJson(value: Any): String = Klaxon().toJsonString(value)

--- a/clients/android/app/src/main/java/app/lockbook/util/CoreData.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/CoreData.kt
@@ -57,19 +57,8 @@ data class UsageMetrics(
 
 data class UsageItemMetric(
     val exact: Int,
-    @Json(name = "readable_exact")
-    val readableExact: String,
     val readable: String,
-    val unit: ByteUnit,
 )
-
-enum class ByteUnit {
-    Byte,
-    Kilobyte,
-    Megabyte,
-    Gigabyte,
-    Terabyte,
-}
 
 data class FileUsage(
     @Json(name = "file_id")

--- a/clients/android/app/src/main/java/app/lockbook/util/CoreData.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/CoreData.kt
@@ -47,11 +47,33 @@ enum class State {
     StateRequiresClearing
 }
 
-data class LocalAndServerUsages(
+data class UsageMetrics(
+    val usages: List<FileUsage>,
     @Json(name = "server_usage")
-    val serverUsage: String,
-    @Json(name = "uncompressed_usage")
-    val uncompressedUsage: String,
+    val serverUsage: UsageItemMetric,
     @Json(name = "data_cap")
-    val dataCap: String,
+    val dataCap: UsageItemMetric,
+)
+
+data class UsageItemMetric(
+    val exact: Int,
+    @Json(name = "readable_exact")
+    val readableExact: String,
+    val readable: String,
+    val unit: ByteUnit,
+)
+
+enum class ByteUnit {
+    Byte,
+    Kilobyte,
+    Megabyte,
+    Gigabyte,
+    Terabyte,
+}
+
+data class FileUsage(
+    @Json(name = "file_id")
+    val fileId: String,
+    @Json(name = "size_bytes")
+    val sizeBytes: Int,
 )

--- a/clients/android/app/src/test/java/app/lockbook/GetUncompressedUsageTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/GetUncompressedUsageTest.kt
@@ -37,13 +37,6 @@ class GetUncompressedUsageTest {
     }
 
     @Test
-    fun getUncompressedUsageNoAccount() {
-        assertType<GetUsageError.NoAccount>(
-            CoreModel.getUncompressedUsage(config).component2()
-        )
-    }
-
-    @Test
     fun getUncompressedUsageUnexpectedError() {
         assertType<GetUsageError.Unexpected>(
             Klaxon().converter(getUncompressedUsageConverter).parse<Result<UsageItemMetric, GetUsageError>>(

--- a/clients/android/app/src/test/java/app/lockbook/GetUncompressedUsageTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/GetUncompressedUsageTest.kt
@@ -1,6 +1,6 @@
 package app.lockbook
 
-import app.lockbook.core.getUsage
+import app.lockbook.core.getUncompressedUsage
 import app.lockbook.model.CoreModel
 import app.lockbook.util.*
 import com.beust.klaxon.Klaxon
@@ -9,7 +9,7 @@ import org.junit.After
 import org.junit.BeforeClass
 import org.junit.Test
 
-class GetUsageTest {
+class GetUncompressedUsageTest {
     var config = Config(createRandomPath())
 
     companion object {
@@ -26,28 +26,28 @@ class GetUsageTest {
     }
 
     @Test
-    fun getUsageOk() {
+    fun getUncompressedUsageOk() {
         assertType<Unit>(
             CoreModel.generateAccount(config, generateAlphaString()).component1()
         )
 
-        assertType<UsageMetrics>(
-            CoreModel.getUsage(config).component1()
+        assertType<UsageItemMetric>(
+            CoreModel.getUncompressedUsage(config).component1()
         )
     }
 
     @Test
-    fun getUsageNoAccount() {
+    fun getUncompressedUsageNoAccount() {
         assertType<GetUsageError.NoAccount>(
-            CoreModel.getUsage(config).component2()
+            CoreModel.getUncompressedUsage(config).component2()
         )
     }
 
     @Test
-    fun getUsageUnexpectedError() {
+    fun getUncompressedUsageUnexpectedError() {
         assertType<GetUsageError.Unexpected>(
-            Klaxon().converter(getUsageConverter).parse<Result<UsageMetrics, GetUsageError>>(
-                getUsage("")
+            Klaxon().converter(getUncompressedUsageConverter).parse<Result<UsageItemMetric, GetUsageError>>(
+                getUncompressedUsage("")
             )?.component2()
         )
     }

--- a/clients/android/core/src/main/java/app/lockbook/core/core.kt
+++ b/clients/android/core/src/main/java/app/lockbook/core/core.kt
@@ -9,7 +9,8 @@ external fun exportAccount(config: String): String
 external fun getAccount(config: String): String
 external fun setLastSynced(config: String, lastSynced: Long): String
 external fun convertToHumanDuration(metadataVersion: Long): String
-external fun getLocalAndServerUsage(config: String, exact: Boolean): String
+external fun getUsage(config: String): String
+external fun getUncompressedUsage(config: String): String
 external fun makeBytesReadable(bytes: Long): String
 external fun getRoot(config: String): String
 external fun getChildren(config: String, id: String): String

--- a/clients/apple/Shared/Views/AccountView.swift
+++ b/clients/apple/Shared/Views/AccountView.swift
@@ -32,8 +32,8 @@ struct AccountView: View {
                     DisclosureGroup(
                         isExpanded: $showingUsage,
                         content: { () -> AnyView in
-                            if case .success(let usage) = core.api.getUsageHumanReadable() {
-                                return AnyView(Text(usage).foregroundColor(.accentColor))
+                            if case .success(let usage) = core.api.getUsage() {
+                                return AnyView(Text(usage.serverUsage.readable).foregroundColor(.accentColor))
                             } else {
                                 return AnyView(Text("Failed to retreive usage!"))
                             }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
@@ -26,12 +26,8 @@ public struct CoreApi: LockbookApi {
         fromPrimitiveResult(result: export_account(documentsDirectory))
     }
     
-    public func getUsage() -> FfiResult<[FileUsage], GetUsageError> {
+    public func getUsage() -> FfiResult<UsageMetrics, GetUsageError> {
         fromPrimitiveResult(result: get_usage(documentsDirectory))
-    }
-
-    public func getUsageHumanReadable() -> FfiResult<String, GetUsageError> {
-        fromPrimitiveResult(result: get_usage_human_string(documentsDirectory, false))
     }
     
     public func syncAll() -> FfiResult<Empty, SyncAllError> {

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public struct FakeApi: LockbookApi {
-    
     public init() {
     }
     
@@ -21,14 +20,10 @@ public struct FakeApi: LockbookApi {
         .failure(.init(unexpected: "LAZY"))
     }
     
-    public func getUsage() -> FfiResult<[FileUsage], GetUsageError> {
-        .success([FileUsage(fileId: .init(), byteSecs: UInt64(100), secs: UInt64(1))])
-    }
-
-    public func getUsageHumanReadable() -> FfiResult<String, GetUsageError> {
+    public func getUsage() -> FfiResult<UsageMetrics, GetUsageError> {
         .failure(.init(unexpected: "LAZY"))
     }
-    
+
     public func syncAll() -> FfiResult<Empty, SyncAllError> {
         .failure(.init(unexpected: "LAZY"))
     }
@@ -74,7 +69,7 @@ Vestibulum ante ipsum primis in vel.
     public func writeDrawing(id: UUID, content: Drawing) -> FfiResult<Empty, WriteToDocumentError> {
         .failure(.init(unexpected: "LAZY"))
     }
-
+    
     public func exportDrawing(id: UUID) -> FfiResult<Data, ExportDrawingError> {
         .failure(.init(unexpected: "LAZY"))
     }
@@ -95,7 +90,7 @@ Vestibulum ante ipsum primis in vel.
     public func renameFile(id: UUID, name: String) -> FfiResult<Empty, RenameFileError> {
         .failure(.init(unexpected: "LAZY"))
     }
-
+    
     public func moveFile(id: UUID, newParent: UUID) -> FfiResult<Empty, MoveFileError> {
         .failure(.init(unexpected: "LAZY"))
     }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
@@ -6,9 +6,8 @@ public protocol LockbookApi {
     func createAccount(username: String, apiLocation: String) -> FfiResult<Empty, CreateAccountError>
     func importAccount(accountString: String) -> FfiResult<Empty, ImportError>
     func exportAccount() -> FfiResult<String, AccountExportError>
-    func getUsage() -> FfiResult<[FileUsage], GetUsageError>
-    func getUsageHumanReadable() -> FfiResult<String, GetUsageError>
-    
+    func getUsage() -> FfiResult<UsageMetrics, GetUsageError>
+
     // Work
     func syncAll() -> FfiResult<Empty, SyncAllError>
     func calculateWork() -> FfiResult<WorkMetadata, CalculateWorkError>

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FileUsage.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FileUsage.swift
@@ -1,9 +1,19 @@
 import Foundation
 
+public struct UsageMetrics: Codable {
+    public var usages: [FileUsage]
+    public var serverUsage: UsageItemMetric
+    public var dataCap: UsageItemMetric
+}
+
+public struct UsageItemMetric: Codable {
+    public var exact: UInt64
+    public var readable: String
+}
+
 public struct FileUsage: Codable {
     public var fileId: UUID
-    public var byteSecs: UInt64
-    public var secs: UInt64
+    public var sizeBytes: UInt64
 }
 
 extension FileUsage: Identifiable {

--- a/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/Scenarios/UsageTests.swift
+++ b/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/Scenarios/UsageTests.swift
@@ -10,7 +10,7 @@ class UsageTests: SLCTest {
         let resultUsage = core.api.getUsage()
         
         assertSuccess(resultUsage) { usages in
-            usages.reduce(0, { $0 + ($1.byteSecs/$1.secs) }) == 0
+            usages.serverUsage.exact == 0
         }
     }
 }

--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -17,8 +17,14 @@ pub fn calculate_usage(exact: bool) -> CliResult<()> {
             },
         )?;
 
-    println!("Uncompressed File Size: {}", usage.uncompressed_usage);
-    println!("Server Utilization: {}", usage.server_usage);
-    println!("Server Data Cap: {}", usage.data_cap);
+    println!(
+        "Uncompressed File Size: {}",
+        usage.readable_metrics.uncompressed_usage
+    );
+    println!(
+        "Server Utilization: {}",
+        usage.readable_metrics.server_usage
+    );
+    println!("Server Data Cap: {}", usage.readable_metrics.data_cap);
     Ok(())
 }

--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -6,25 +6,39 @@ use lockbook_core::{Error as CoreError, GetUsageError};
 pub fn calculate_usage(exact: bool) -> CliResult<()> {
     get_account_or_exit();
 
-    let usage =
-        lockbook_core::get_local_and_server_usage(&get_config(), exact).map_err(
-            |err| match err {
-                CoreError::UiError(GetUsageError::CouldNotReachServer) => err!(NetworkIssue),
-                CoreError::UiError(GetUsageError::ClientUpdateRequired) => err!(UpdateRequired),
-                CoreError::UiError(GetUsageError::NoAccount) | CoreError::Unexpected(_) => {
-                    err_unexpected!("{:?}", err)
-                }
-            },
-        )?;
+    let usage = lockbook_core::get_usage(&get_config()).map_err(|err| match err {
+        CoreError::UiError(GetUsageError::CouldNotReachServer) => err!(NetworkIssue),
+        CoreError::UiError(GetUsageError::ClientUpdateRequired) => err!(UpdateRequired),
+        CoreError::UiError(GetUsageError::NoAccount) | CoreError::Unexpected(_) => {
+            err_unexpected!("{:?}", err)
+        }
+    })?;
 
-    println!(
-        "Uncompressed File Size: {}",
-        usage.readable_metrics.uncompressed_usage
-    );
-    println!(
-        "Server Utilization: {}",
-        usage.readable_metrics.server_usage
-    );
-    println!("Server Data Cap: {}", usage.readable_metrics.data_cap);
+    let uncompressed_usage =
+        lockbook_core::get_uncompressed_usage(&get_config()).map_err(|err| match err {
+            CoreError::UiError(GetUsageError::CouldNotReachServer) => err!(NetworkIssue),
+            CoreError::UiError(GetUsageError::ClientUpdateRequired) => err!(UpdateRequired),
+            CoreError::UiError(GetUsageError::NoAccount) | CoreError::Unexpected(_) => {
+                err_unexpected!("{:?}", err)
+            }
+        })?;
+
+    let (uncompressed, server_usage, data_cap) = if exact {
+        (
+            uncompressed_usage.readable_exact,
+            usage.server_usage.readable_exact,
+            usage.data_cap.readable_exact,
+        )
+    } else {
+        (
+            uncompressed_usage.readable,
+            usage.server_usage.readable,
+            usage.data_cap.readable,
+        )
+    };
+
+    println!("Uncompressed File Size: {}", uncompressed);
+    println!("Server Utilization: {}", server_usage);
+    println!("Server Data Cap: {}", data_cap);
     Ok(())
 }

--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -25,9 +25,9 @@ pub fn calculate_usage(exact: bool) -> CliResult<()> {
 
     let (uncompressed, server_usage, data_cap) = if exact {
         (
-            uncompressed_usage.readable_exact,
-            usage.server_usage.readable_exact,
-            usage.data_cap.readable_exact,
+            format!("{} B", uncompressed_usage.exact),
+            format!("{} B", usage.server_usage.exact),
+            format!("{} B", usage.data_cap.exact),
         )
     } else {
         (

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -59,9 +59,9 @@ impl AccountScreen {
         }
     }
 
-    pub fn fill(&self, core: &LbCore) -> LbResult<()> {
+    pub fn fill(&self, core: &LbCore, m: &Messenger) -> LbResult<()> {
         self.sidebar.fill(&core)?;
-        self.sidebar.status.set_status(&core.sync_status()?, None);
+        m.send(Msg::RefreshSyncStatus);
         Ok(())
     }
 
@@ -264,7 +264,6 @@ impl StatusPanel {
             if evt.get_button() == RIGHT_CLICK {
                 let menu = GtkMenu::new();
                 let item_data: Vec<(&str, MsgFn)> = vec![
-                    ("Refresh Usage Status", || Msg::RefreshUsageStatus),
                     ("Refresh Sync Status", || Msg::RefreshSyncStatus),
                     ("Show Sync Details", || Msg::ShowDialogSyncDetails),
                 ];

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -318,7 +318,10 @@ impl LbApp {
         spawn!(self.core as c, self.messenger as m => move || {
             match c.sync_status() {
                 Ok(txt) => m.send(Msg::SetStatus(txt, None)),
-                Err(err) => m.send_err_status_panel(err.msg())
+                Err(err) => match err.target() {
+                    LbErrTarget::Dialog => m.send_err_dialog("getting sync status", err),
+                    LbErrTarget::StatusPanel => m.send_err_status_panel(err.msg()),
+                }
             }
         });
 
@@ -331,7 +334,10 @@ impl LbApp {
                 Ok(status) => if let (Some(txt), _) = status {
                     m.send(Msg::SetStatus(txt, status.1));
                 }
-                Err(err) => m.send_err_status_panel(err.msg())
+                Err(err) => match err.target() {
+                    LbErrTarget::Dialog => m.send_err_dialog("getting usage status", err),
+                    LbErrTarget::StatusPanel => m.send_err_status_panel(err.msg()),
+                }
             }
         });
 

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -1282,14 +1282,6 @@ fn sync_details(c: &Arc<LbCore>) -> LbResult<GtkBox> {
 fn usage_dialog(c: &Arc<LbCore>) -> LbResult<GtkBox> {
     let usage = c.get_usage()?;
 
-    println!(
-        "{} | {} | {} | {}",
-        usage.server_usage.readable,
-        usage.server_usage.exact,
-        usage.server_usage.readable_exact,
-        usage.server_usage.unit
-    );
-
     let title = GtkLabel::new(Some("Total Usage"));
     let attr_list = pango::AttrList::new();
     let attr = pango::Attribute::new_weight(pango::Weight::Bold)

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -366,14 +366,19 @@ impl LbCore {
     pub fn usage_status(&self) -> LbResult<(Option<String>, Option<String>)> {
         let usage = self.get_usage()?;
 
-        if usage.server_usage.exact as f32 / usage.data_cap.exact as f32 > USAGE_WARNING_THRESHOLD {
+        if usage.server_usage.exact >= usage.data_cap.exact {
+            return Ok((
+                Some("You're out of space!".to_string()),
+                Some("You have run out of space, go to the settings to buy more!".to_string()),
+            ));
+        } else if usage.server_usage.exact as f32 / usage.data_cap.exact as f32 > USAGE_WARNING_THRESHOLD {
             return Ok((
                 Some(format!(
                     "{} of {} remaining!",
                     bytes_to_human(usage.data_cap.exact - usage.server_usage.exact).0,
                     usage.data_cap.readable
                 )),
-                Some("You are running out of space, go to settings to buy more!".to_string()),
+                Some("You are running out of space, go to the settings to buy more!".to_string()),
             ));
         }
 

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -371,7 +371,9 @@ impl LbCore {
                 Some("You're out of space!".to_string()),
                 Some("You have run out of space, go to the settings to buy more!".to_string()),
             ));
-        } else if usage.server_usage.exact as f32 / usage.data_cap.exact as f32 > USAGE_WARNING_THRESHOLD {
+        } else if usage.server_usage.exact as f32 / usage.data_cap.exact as f32
+            > USAGE_WARNING_THRESHOLD
+        {
             return Ok((
                 Some(format!(
                     "{} of {} remaining!",

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -384,4 +384,4 @@ impl LbCore {
 const UNAME_REQS: &str = "letters and numbers only";
 const STATE_REQ_CLEAN_MSG: &str =
     "Your local state cannot be migrated, please re-sync with a fresh client.";
-const USAGE_WARNING_THRESHOLD: f32 = 0.0001;
+const USAGE_WARNING_THRESHOLD: f32 = 0.9;

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -377,7 +377,7 @@ impl LbCore {
             return Ok((
                 Some(format!(
                     "{} of {} remaining!",
-                    bytes_to_human(usage.data_cap.exact - usage.server_usage.exact).0,
+                    bytes_to_human(usage.data_cap.exact - usage.server_usage.exact),
                     usage.data_cap.readable
                 )),
                 Some("You are running out of space, go to the settings to buy more!".to_string()),

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -11,18 +11,19 @@ use lockbook_core::service::sync_service::SyncProgress;
 use lockbook_core::{
     calculate_work, create_account, create_file, delete_file, export_account, get_account,
     get_and_get_children_recursively, get_children, get_db_state, get_file_by_id, get_file_by_path,
-    get_last_synced, get_root, get_usage_human_string, import_account, list_paths, migrate_db,
-    read_document, rename_file, sync_all, write_document,
+    get_last_synced, get_local_and_server_usage, get_root, get_usage_human_string, import_account,
+    list_paths, migrate_db, read_document, rename_file, sync_all, write_document,
 };
 use lockbook_models::account::Account;
 use lockbook_models::crypto::DecryptedDocument;
 use lockbook_models::file_metadata::{FileMetadata, FileType};
 
-use crate::error::{LbError, LbResult};
-use crate::{closure, progerr, uerr};
+use crate::error::{LbErrTarget, LbError, LbResult};
+use crate::{closure, progerr, uerr, uerr_dialog, uerr_status_panel};
 use lockbook_core::model::client_conversion::{
     ClientFileMetadata, ClientWorkCalculated, ClientWorkUnit,
 };
+use lockbook_core::service::usage_service::LocalAndServerUsages;
 
 macro_rules! match_core_err {
     (
@@ -55,7 +56,7 @@ macro_rules! lock {
 
 macro_rules! account {
     ($guard:expr) => {
-        $guard.as_ref().ok_or(uerr!("No account found."))
+        $guard.as_ref().ok_or(uerr_dialog!("No account found."))
     };
 }
 
@@ -85,11 +86,11 @@ impl LbCore {
             Stub => panic!("impossible"),
         ))? {
             DbState::ReadyToUse | DbState::Empty => {}
-            DbState::StateRequiresClearing => return Err(uerr!("{}", STATE_REQ_CLEAN_MSG)),
+            DbState::StateRequiresClearing => return Err(uerr_dialog!("{}", STATE_REQ_CLEAN_MSG)),
             DbState::MigrationRequired => {
                 println!("Local state requires migration! Performing migration now...");
                 migrate_db(&config).map_err(map_core_err!(MigrationError,
-                    StateRequiresCleaning => uerr!("{}", STATE_REQ_CLEAN_MSG),
+                    StateRequiresCleaning => uerr_dialog!("{}", STATE_REQ_CLEAN_MSG),
                 ))?;
             }
         }
@@ -109,11 +110,11 @@ impl LbCore {
         let api_url = api_url();
         let new_acct = create_account(&self.config, &uname, &api_url).map_err(map_core_err!(
             CreateAccountError,
-            UsernameTaken => uerr!("The username '{}' is already taken.", uname),
-            InvalidUsername => uerr!("Invalid username '{}' ({}).", uname, UNAME_REQS),
-            AccountExistsAlready => uerr!("An account already exists."),
-            CouldNotReachServer => uerr!("Unable to connect to the server."),
-            ClientUpdateRequired => uerr!("Client upgrade required."),
+            UsernameTaken => uerr_dialog!("The username '{}' is already taken.", uname),
+            InvalidUsername => uerr_dialog!("Invalid username '{}' ({}).", uname, UNAME_REQS),
+            AccountExistsAlready => uerr_dialog!("An account already exists."),
+            CouldNotReachServer => uerr_dialog!("Unable to connect to the server."),
+            ClientUpdateRequired => uerr_dialog!("Client upgrade required."),
         ))?;
         self.set_account(new_acct)
     }
@@ -121,19 +122,19 @@ impl LbCore {
     pub fn import_account(&self, privkey: &str) -> LbResult<()> {
         let new_acct = import_account(&self.config, privkey).map_err(map_core_err!(
             ImportError,
-            AccountStringCorrupted => uerr!("Your account's private key is corrupted."),
-            AccountExistsAlready => uerr!("An account already exists."),
-            AccountDoesNotExist => uerr!("The account you tried to import does not exist."),
-            UsernamePKMismatch => uerr!("The account private key does not match username."),
-            CouldNotReachServer => uerr!("Unable to connect to the server."),
-            ClientUpdateRequired => uerr!("Client upgrade required."),
+            AccountStringCorrupted => uerr_dialog!("Your account's private key is corrupted."),
+            AccountExistsAlready => uerr_dialog!("An account already exists."),
+            AccountDoesNotExist => uerr_dialog!("The account you tried to import does not exist."),
+            UsernamePKMismatch => uerr_dialog!("The account private key does not match username."),
+            CouldNotReachServer => uerr_dialog!("Unable to connect to the server."),
+            ClientUpdateRequired => uerr_dialog!("Client upgrade required."),
         ))?;
         self.set_account(new_acct)
     }
 
     pub fn export_account(&self) -> LbResult<String> {
         export_account(&self.config).map_err(map_core_err!(AccountExportError,
-            NoAccount => uerr!("No account found."),
+            NoAccount => uerr_dialog!("No account found."),
         ))
     }
 
@@ -144,12 +145,12 @@ impl LbCore {
         file_type: FileType,
     ) -> LbResult<ClientFileMetadata> {
         create_file(&self.config, name, parent, file_type).map_err(map_core_err!(CreateFileError,
-            FileNameNotAvailable => uerr!("That file name is not available."),
-            NoAccount => uerr!("No account found."),
-            DocumentTreatedAsFolder => uerr!("A document is being treated as folder."),
-            CouldNotFindAParent => uerr!("Could not find parent."),
-            FileNameEmpty => uerr!("Cannot create file with no name."),
-            FileNameContainsSlash => uerr!("The file name cannot contain a slash."),
+            FileNameNotAvailable => uerr_dialog!("That file name is not available."),
+            NoAccount => uerr_dialog!("No account found."),
+            DocumentTreatedAsFolder => uerr_dialog!("A document is being treated as folder."),
+            CouldNotFindAParent => uerr_dialog!("Could not find parent."),
+            FileNameEmpty => uerr_dialog!("Cannot create file with no name."),
+            FileNameContainsSlash => uerr_dialog!("The file name cannot contain a slash."),
         ))
     }
 
@@ -157,15 +158,15 @@ impl LbCore {
         let bytes = content.as_bytes();
 
         write_document(&self.config, id, bytes).map_err(map_core_err!(WriteToDocumentError,
-            NoAccount => uerr!("No account found."),
-            FileDoesNotExist => uerr!("The file with id '{}' does not exist.", id),
-            FolderTreatedAsDocument => uerr!(""),
+            NoAccount => uerr_dialog!("No account found."),
+            FileDoesNotExist => uerr_dialog!("The file with id '{}' does not exist.", id),
+            FolderTreatedAsDocument => uerr_dialog!(""),
         ))
     }
 
     pub fn root(&self) -> LbResult<ClientFileMetadata> {
         get_root(&self.config).map_err(map_core_err!(GetRootError,
-            NoRoot => uerr!("No root folder found."),
+            NoRoot => uerr_dialog!("No root folder found."),
         ))
     }
 
@@ -178,14 +179,14 @@ impl LbCore {
     pub fn get_children_recursively(&self, id: Uuid) -> LbResult<Vec<FileMetadata>> {
         get_and_get_children_recursively(&self.config, id).map_err(map_core_err!(
             GetAndGetChildrenError,
-            FileDoesNotExist => uerr!("File with id '{}' does not exist.", id),
-            DocumentTreatedAsFolder => uerr!("A document is being treated as folder."),
+            FileDoesNotExist => uerr_dialog!("File with id '{}' does not exist.", id),
+            DocumentTreatedAsFolder => uerr_dialog!("A document is being treated as folder."),
         ))
     }
 
     pub fn file_by_id(&self, id: Uuid) -> LbResult<ClientFileMetadata> {
         get_file_by_id(&self.config, id).map_err(map_core_err!(GetFileByIdError,
-            NoFileWithThatId => uerr!("No file found with ID '{}'.", id),
+            NoFileWithThatId => uerr_dialog!("No file found with ID '{}'.", id),
         ))
     }
 
@@ -195,22 +196,22 @@ impl LbCore {
         let p = format!("{}/{}", acct.username, path);
 
         get_file_by_path(&self.config, &p).map_err(map_core_err!(GetFileByPathError,
-            NoFileAtThatPath => uerr!("No file at path '{}'.", p),
+            NoFileAtThatPath => uerr_dialog!("No file at path '{}'.", p),
         ))
     }
 
     pub fn delete(&self, id: &Uuid) -> LbResult<()> {
         delete_file(&self.config, *id).map_err(map_core_err!(FileDeleteError,
-            CannotDeleteRoot => uerr!("Deleting the root folder is not permitted."),
-            FileDoesNotExist => uerr!("File with id '{}' does not exist.", id),
+            CannotDeleteRoot => uerr_dialog!("Deleting the root folder is not permitted."),
+            FileDoesNotExist => uerr_dialog!("File with id '{}' does not exist.", id),
         ))
     }
 
     pub fn read(&self, id: Uuid) -> LbResult<DecryptedDocument> {
         read_document(&self.config, id).map_err(map_core_err!(ReadDocumentError,
-            TreatedFolderAsDocument => uerr!("There is a folder treated as a document."),
-            NoAccount => uerr!("No account found."),
-            FileDoesNotExist => uerr!("File with id '{}' does not exist.", id),
+            TreatedFolderAsDocument => uerr_dialog!("There is a folder treated as a document."),
+            NoAccount => uerr_dialog!("No account found."),
+            FileDoesNotExist => uerr_dialog!("File with id '{}' does not exist.", id),
         ))
     }
 
@@ -222,11 +223,11 @@ impl LbCore {
 
     pub fn rename(&self, id: &Uuid, new_name: &str) -> LbResult<()> {
         rename_file(&self.config, *id, new_name).map_err(map_core_err!(RenameFileError,
-            CannotRenameRoot => uerr!("The root folder cannot be renamed."),
-            FileDoesNotExist => uerr!("The file you are trying to rename does not exist."),
-            FileNameNotAvailable => uerr!("The new file name is not available."),
-            NewNameContainsSlash => uerr!("File names cannot contain slashes."),
-            NewNameEmpty => uerr!("File names cannot be blank."),
+            CannotRenameRoot => uerr_dialog!("The root folder cannot be renamed."),
+            FileDoesNotExist => uerr_dialog!("The file you are trying to rename does not exist."),
+            FileNameNotAvailable => uerr_dialog!("The new file name is not available."),
+            NewNameContainsSlash => uerr_dialog!("File names cannot contain slashes."),
+            NewNameEmpty => uerr_dialog!("File names cannot be blank."),
         ))
     }
 
@@ -250,22 +251,25 @@ impl LbCore {
             ch.send(Some(data)).unwrap();
         });
 
-        sync_all(&self.config, Some(Box::new(closure))).map_err(map_core_err!(SyncAllError,
-            CouldNotReachServer => uerr!("Unable to connect to the server."),
-            ClientUpdateRequired => uerr!("Client upgrade required."),
-            NoAccount => uerr!("No account found."),
-        ))?;
+        let sync =
+            sync_all(&self.config, Some(Box::new(closure))).map_err(map_core_err!(SyncAllError,
+                CouldNotReachServer => uerr_status_panel!("Unable to connect to the server."),
+                ClientUpdateRequired => uerr_dialog!("Client upgrade required."),
+                NoAccount => uerr_dialog!("No account found."),
+            ));
 
         ch.send(None).unwrap();
+
+        sync?;
 
         Ok(())
     }
 
     pub fn calculate_work(&self) -> LbResult<ClientWorkCalculated> {
         calculate_work(&self.config).map_err(map_core_err!(CalculateWorkError,
-            CouldNotReachServer => uerr!("Unable to connect to the server."),
-            ClientUpdateRequired => uerr!("Client upgrade required."),
-            NoAccount => uerr!("No account found."),
+            CouldNotReachServer => uerr_status_panel!("Unable to connect to the server."),
+            ClientUpdateRequired => uerr_dialog!("Client upgrade required."),
+            NoAccount => uerr_dialog!("No account found."),
         ))
     }
 
@@ -277,9 +281,17 @@ impl LbCore {
 
     pub fn usage_human_string(&self) -> LbResult<String> {
         get_usage_human_string(&self.config, false).map_err(map_core_err!(GetUsageError,
-            NoAccount => uerr!("No account found."),
-            CouldNotReachServer => uerr!("Unable to connect to the server."),
-            ClientUpdateRequired => uerr!("Client upgrade required."),
+            NoAccount => uerr_dialog!("No account found."),
+            CouldNotReachServer => uerr_dialog!("Unable to connect to the server."),
+            ClientUpdateRequired => uerr_dialog!("Client upgrade required."),
+        ))
+    }
+
+    pub fn local_and_server_usage(&self) -> LbResult<LocalAndServerUsages> {
+        get_local_and_server_usage(&self.config, false).map_err(map_core_err!(GetUsageError,
+            NoAccount => uerr_dialog!("No account found."),
+            CouldNotReachServer => uerr_status_panel!("Unable to connect to the server."),
+            ClientUpdateRequired => uerr_dialog!("Client upgrade required."),
         ))
     }
 
@@ -358,8 +370,27 @@ impl LbCore {
             }
         }
     }
+
+    pub fn usage_status(&self) -> LbResult<(Option<String>, Option<String>)> {
+        let usage = self.local_and_server_usage()?;
+
+        if usage.metrics.server_usage as f32 / usage.metrics.data_cap as f32
+            > USAGE_WARNING_THRESHOLD
+        {
+            return Ok((
+                Some(format!(
+                    "{} of {} remaining!",
+                    usage.readable_metrics.server_usage, usage.readable_metrics.data_cap
+                )),
+                Some("You are running out of space, go to settings to buy more!".to_string()),
+            ));
+        }
+
+        Ok((None, None))
+    }
 }
 
 const UNAME_REQS: &str = "letters and numbers only";
 const STATE_REQ_CLEAN_MSG: &str =
     "Your local state cannot be migrated, please re-sync with a fresh client.";
+const USAGE_WARNING_THRESHOLD: f32 = 0.001;

--- a/clients/linux/src/error.rs
+++ b/clients/linux/src/error.rs
@@ -1,7 +1,21 @@
 #[macro_export]
 macro_rules! uerr {
+    ($base:literal $(, $args:tt )* | $target:expr) => {
+        LbError::new_user_err(format!($base $(, $args )*), $target)
+    };
+}
+
+#[macro_export]
+macro_rules! uerr_status_panel {
     ($base:literal $(, $args:tt )*) => {
-        LbError::new_user_err(format!($base $(, $args )*))
+        uerr!($base $(, $args )* | LbErrTarget::StatusPanel)
+    };
+}
+
+#[macro_export]
+macro_rules! uerr_dialog {
+    ($base:literal $(, $args:tt )*) => {
+        uerr!($base $(, $args )* | LbErrTarget::Dialog)
     };
 }
 
@@ -19,22 +33,28 @@ pub enum LbErrKind {
     User,
 }
 
+pub enum LbErrTarget {
+    Dialog,
+    StatusPanel,
+}
+
 pub struct LbError {
     kind: LbErrKind,
     msg: String,
+    target: LbErrTarget,
 }
 
 impl LbError {
-    pub fn new(kind: LbErrKind, msg: String) -> Self {
-        Self { kind, msg }
+    pub fn new(kind: LbErrKind, msg: String, target: LbErrTarget) -> Self {
+        Self { kind, msg, target }
     }
 
     pub fn new_program_err(msg: String) -> Self {
-        Self::new(LbErrKind::Program, msg)
+        Self::new(LbErrKind::Program, msg, LbErrTarget::Dialog)
     }
 
-    pub fn new_user_err(msg: String) -> Self {
-        Self::new(LbErrKind::User, msg)
+    pub fn new_user_err(msg: String, target: LbErrTarget) -> Self {
+        Self::new(LbErrKind::User, msg, target)
     }
 
     pub fn msg(&self) -> &String {
@@ -43,6 +63,10 @@ impl LbError {
 
     pub fn kind(&self) -> &LbErrKind {
         &self.kind
+    }
+
+    pub fn target(&self) -> &LbErrTarget {
+        &self.target
     }
 
     pub fn is_prog(&self) -> bool {

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -12,6 +12,7 @@ pub enum Msg {
     ExportAccount,
     PerformSync,
     RefreshSyncStatus,
+    RefreshUsageStatus,
     Quit,
 
     NewFile(FileType),
@@ -40,7 +41,8 @@ pub enum Msg {
     ToggleAutoSave(bool),
     ToggleAutoSync(bool),
 
-    Error(String, LbError),
+    ErrorDialog(String, LbError),
+    ErrorStatusPanel(String),
 }
 
 #[derive(Clone)]
@@ -57,7 +59,11 @@ impl Messenger {
         self.s.send(m).unwrap();
     }
 
-    pub fn send_err(&self, title: &str, err: LbError) {
-        self.send(Msg::Error(title.to_string(), err));
+    pub fn send_err_dialog(&self, title: &str, err: LbError) {
+        self.send(Msg::ErrorDialog(title.to_string(), err))
+    }
+
+    pub fn send_err_status_panel(&self, msg: &str) {
+        self.send(Msg::ErrorStatusPanel(msg.to_string()))
     }
 }

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -42,7 +42,7 @@ pub enum Msg {
     ToggleAutoSync(bool),
 
     ErrorDialog(String, LbError),
-    ErrorStatusPanel(String),
+    SetStatus(String, Option<String>),
 }
 
 #[derive(Clone)]
@@ -64,6 +64,6 @@ impl Messenger {
     }
 
     pub fn send_err_status_panel(&self, msg: &str) {
-        self.send(Msg::ErrorStatusPanel(msg.to_string()))
+        self.send(Msg::SetStatus(msg.to_string(), None))
     }
 }

--- a/clients/windows/core/CoreModel.cs
+++ b/clients/windows/core/CoreModel.cs
@@ -60,18 +60,36 @@ namespace Core {
         StateRequiresClearing,
     }
 
+    public class UsageMetrics {
+        [JsonProperty("usages")]
+        public List<FileUsage> usages;
+        [JsonProperty("server_usage")]
+        public UsageItemMetric server_usage;
+        [JsonProperty("data_cap")]
+        public UsageItemMetric data_cap;
+}
+
+    public class UsageItemMetric {
+        [JsonProperty("exact")]
+        public ulong exact;
+        [JsonProperty("readable")]
+        public string readable;
+    }
+
     public class FileUsage {
         [JsonProperty("file_id")]
         public string fileId;
-        [JsonProperty("byte_secs")]
-        public ulong byteSeconds;
-        [JsonProperty("secs")]
-        public ulong seconds;
+        [JsonProperty("size_bytes")]
+        public ulong sizeBytes;
     }
 
-    public class WorkCalculated {
-        [JsonProperty("work_units")]
-        public List<dynamic> workUnits;
+    public class ClientWorkCalculated {
+        [JsonProperty("local_files")]
+        public List<ClientFileMetadata> localFiles;
+        [JsonProperty("server_files")]
+        public List<ClientFileMetadata> serverFiles;
+        [JsonProperty("server_unknown_name_count")]
+        public ulong serverUnknownNameCount;
         [JsonProperty("most_recent_update_from_server")]
         public ulong mostRecentUpdateFromServer;
     }
@@ -328,7 +346,7 @@ namespace Core {
     namespace CalculateWork {
         public interface IResult { }
         public class Success : IResult {
-            public WorkCalculated workCalculated;
+            public ClientWorkCalculated workCalculated;
         }
         public enum PossibleErrors {
             NoAccount,
@@ -376,7 +394,7 @@ namespace Core {
     namespace GetUsage {
         public interface IResult { }
         public class Success : IResult {
-            public List<FileUsage> usage;
+            public UsageMetrics usage;
         }
         public enum PossibleErrors {
             NoAccount,
@@ -386,21 +404,6 @@ namespace Core {
         public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
         public class UnexpectedError : Core.UnexpectedError, IResult { }
     }
-
-    namespace GetUsageHumanString {
-        public interface IResult { }
-        public class Success : IResult {
-            public string usage;
-        }
-        public enum PossibleErrors {
-            NoAccount,
-            CouldNotReachServer,
-            ClientUpdateRequired,
-        }
-        public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
-        public class UnexpectedError : Core.UnexpectedError, IResult { }
-    }
-
 
     namespace GetDrawing {
             public interface IResult { }

--- a/clients/windows/core/CoreService.cs
+++ b/clients/windows/core/CoreService.cs
@@ -107,9 +107,6 @@ namespace lockbook {
         private static extern IntPtr get_usage(IntPtr writeable_path);
 
         [DllImport("lockbook_core", ExactSpelling = true)]
-        private static extern IntPtr get_usage_human_string(IntPtr writeable_path, bool exact);
-
-        [DllImport("lockbook_core", ExactSpelling = true)]
         private static extern IntPtr get_variants();
 
         private static string CopyToManagedAndRelease(IntPtr ptr) {
@@ -352,7 +349,7 @@ namespace lockbook {
         public async Task<Core.CalculateWork.IResult> CalculateWork() {
             return await FFICommon<Core.CalculateWork.IResult, Core.CalculateWork.ExpectedError, Core.CalculateWork.PossibleErrors, Core.CalculateWork.UnexpectedError>(
                 () => calculate_work(path),
-                s => new Core.CalculateWork.Success { workCalculated = JsonConvert.DeserializeObject<WorkCalculated>(s) });
+                s => new Core.CalculateWork.Success { workCalculated = JsonConvert.DeserializeObject<ClientWorkCalculated>(s) });
         }
 
         public async Task<Core.SetLastSynced.IResult> SetLastSynced(ulong lastSync) {
@@ -376,13 +373,7 @@ namespace lockbook {
         public async Task<Core.GetUsage.IResult> GetUsage() {
             return await FFICommon<Core.GetUsage.IResult, Core.GetUsage.ExpectedError, Core.GetUsage.PossibleErrors, Core.GetUsage.UnexpectedError>(
                 () => get_usage(path),
-                s => new Core.GetUsage.Success { usage = JsonConvert.DeserializeObject<List<FileUsage>>(s) });
-        }
-
-        public async Task<Core.GetUsageHumanString.IResult> GetUsageHumanString() {
-            return await FFICommon<Core.GetUsageHumanString.IResult, Core.GetUsageHumanString.ExpectedError, Core.GetUsageHumanString.PossibleErrors, Core.GetUsageHumanString.UnexpectedError>(
-                () => get_usage_human_string(path, false),
-                s => new Core.GetUsageHumanString.Success { usage = s });
+                s => new Core.GetUsage.Success { usage = JsonConvert.DeserializeObject<UsageMetrics>(s) });
         }
 
         public async Task<Dictionary<string, List<string>>> GetVariants() {

--- a/clients/windows/lockbook/FileExplorer.xaml.cs
+++ b/clients/windows/lockbook/FileExplorer.xaml.cs
@@ -108,7 +108,7 @@ namespace lockbook {
             switch (await App.CoreService.CalculateWork()) {
                 case Core.CalculateWork.Success success:
                     App.IsOnline = true;
-                    itemsToSync = success.workCalculated.workUnits.Count;
+                    itemsToSync = success.workCalculated.localFiles.Count + (int)success.workCalculated.serverUnknownNameCount + success.workCalculated.serverFiles.Count;
                     break;
                 case Core.CalculateWork.UnexpectedError uhOh:
                     System.Diagnostics.Debug.WriteLine("Unexpected error during calc work loop: " + uhOh.ErrorMessage);

--- a/clients/windows/lockbook/Settings.xaml.cs
+++ b/clients/windows/lockbook/Settings.xaml.cs
@@ -56,26 +56,26 @@ namespace lockbook {
 
         private async void ReloadSpaceUsed() {
             var usageString = "";
-            switch (await App.CoreService.GetUsageHumanString()) {
-                case Core.GetUsageHumanString.Success success:
-                    usageString = success.usage;
+            switch (await App.CoreService.GetUsage()) {
+                case Core.GetUsage.Success success:
+                    usageString = success.usage.server_usage.readable;
                     break;
 
-                case Core.GetUsageHumanString.ExpectedError expectedError:
+                case Core.GetUsage.ExpectedError expectedError:
                     switch (expectedError.Error) {
-                        case Core.GetUsageHumanString.PossibleErrors.NoAccount:
+                        case Core.GetUsage.PossibleErrors.NoAccount:
                             usageString = "No Account!";
                             break;
-                        case Core.GetUsageHumanString.PossibleErrors.CouldNotReachServer:
+                        case Core.GetUsage.PossibleErrors.CouldNotReachServer:
                             usageString = "Offline!";
                             break;
-                        case Core.GetUsageHumanString.PossibleErrors.ClientUpdateRequired:
+                        case Core.GetUsage.PossibleErrors.ClientUpdateRequired:
                             usageString = "Update required to calculate usage!";
                             break;
                     }
                     break;
 
-                case Core.GetUsageHumanString.UnexpectedError ohNo:
+                case Core.GetUsage.UnexpectedError ohNo:
                     await new MessageDialog(ohNo.ErrorMessage, "Unexpected Error!").ShowAsync();
                     break;
             }

--- a/clients/windows/test/CoreServiceTest.cs
+++ b/clients/windows/test/CoreServiceTest.cs
@@ -12,7 +12,7 @@ namespace test {
     public class CoreServiceTest {
         const string lockbookDir = "C:\\Temp\\.lockbook"; // todo: find a more suitable location
         CoreService CoreService = new CoreService(lockbookDir);
-        string apiUrl = Environment.GetEnvironmentVariable("API_URL");
+        string apiUrl = "https://api.prod.lockbook.net"; // Environment.GetEnvironmentVariable("API_URL");
 
         public string RandomUsername() {
             return "testUsername" + Guid.NewGuid().ToString().Replace("-", "");
@@ -296,16 +296,6 @@ namespace test {
         }
 
         [TestMethod]
-        public void GetLastSyncedHumanString() {
-            var username = RandomUsername();
-            var createAccountResult = CoreService.CreateAccount(username, apiUrl).WaitResult();
-            CastOrDie(createAccountResult, out Core.CreateAccount.Success _);
-
-            var getLastSyncedResult = CoreService.GetLastSyncedHumanString().WaitResult();
-            CastOrDie(getLastSyncedResult, out Core.GetLastSyncedHumanString.Success _);
-        }
-
-        [TestMethod]
         public void SetLastSynced() {
             var username = RandomUsername();
             var createAccountResult = CoreService.CreateAccount(username, apiUrl).WaitResult();
@@ -323,16 +313,6 @@ namespace test {
 
             var getUsageResult = CoreService.GetUsage().WaitResult();
             CastOrDie(getUsageResult, out Core.GetUsage.Success _);
-        }
-
-        [TestMethod]
-        public void GetUsageHumanString() {
-            var username = RandomUsername();
-            var createAccountResult = CoreService.CreateAccount(username, apiUrl).WaitResult();
-            CastOrDie(createAccountResult, out Core.CreateAccount.Success _);
-
-            var getUsageResult = CoreService.GetUsageHumanString().WaitResult();
-            CastOrDie(getUsageResult, out Core.GetUsageHumanString.Success _);
         }
 
         [TestMethod]

--- a/core/src/c_interface.rs
+++ b/core/src/c_interface.rs
@@ -309,19 +309,6 @@ pub unsafe extern "C" fn get_usage(writeable_path: *const c_char) -> *const c_ch
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn get_usage_human_string(
-    writeable_path: *const c_char,
-    exact: bool,
-) -> *const c_char {
-    c_string(translate(crate::get_usage_human_string(
-        &Config {
-            writeable_path: str_from_ptr(writeable_path),
-        },
-        exact,
-    )))
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn get_local_changes(writeable_path: *const c_char) -> *const c_char {
     c_string(translate(crate::get_local_changes(&Config {
         writeable_path: str_from_ptr(writeable_path),

--- a/core/src/java_interface.rs
+++ b/core/src/java_interface.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use jni::objects::{JClass, JObject, JString, JValue};
-use jni::sys::{jboolean, jlong, jstring};
+use jni::sys::{jlong, jstring};
 use jni::JNIEnv;
 use uuid::Uuid;
 
@@ -15,9 +15,9 @@ use crate::service::usage_service::bytes_to_human;
 use crate::{
     calculate_work, create_account, create_file, delete_file, export_account, export_drawing,
     export_drawing_to_disk, get_account, get_all_error_variants, get_children, get_db_state,
-    get_file_by_id, get_local_and_server_usage, get_root, import_account, init_logger, migrate_db,
-    move_file, read_document, rename_file, save_document_to_disk, set_last_synced, sync_all,
-    write_document, Error,
+    get_file_by_id, get_root, get_usage, import_account, init_logger, migrate_db, move_file,
+    read_document, rename_file, save_document_to_disk, set_last_synced, sync_all, write_document,
+    Error,
 };
 use basic_human_duration::ChronoHumanDuration;
 use chrono::Duration;
@@ -344,33 +344,17 @@ pub extern "system" fn Java_app_lockbook_core_CoreKt_convertToHumanDuration(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_app_lockbook_core_CoreKt_getLocalAndServerUsage(
+pub extern "system" fn Java_app_lockbook_core_CoreKt_getUsage(
     env: JNIEnv,
     _: JClass,
     jconfig: JString,
-    jexact: jboolean,
 ) -> jstring {
     let config = match deserialize::<Config>(&env, jconfig, "config") {
         Ok(ok) => ok,
         Err(err) => return err,
     };
 
-    let exact_int = jexact as u64;
-    let exact = match exact_int {
-        0 => false,
-        1 => true,
-        _ => {
-            return string_to_jstring(
-                &env,
-                translate::<(), Error<()>>(Err(Error::<()>::Unexpected(format!(
-                    "Couldn't get exact boolean:{}",
-                    exact_int
-                )))),
-            );
-        }
-    };
-
-    string_to_jstring(&env, translate(get_local_and_server_usage(&config, exact)))
+    string_to_jstring(&env, translate(get_usage(&config)))
 }
 
 #[no_mangle]
@@ -379,7 +363,7 @@ pub extern "system" fn Java_app_lockbook_core_CoreKt_makeBytesReadable(
     _: JClass,
     bytes: jlong,
 ) -> jstring {
-    string_to_jstring(&env, bytes_to_human(bytes as u64))
+    string_to_jstring(&env, bytes_to_human(bytes as u64).0)
 }
 
 #[no_mangle]

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -15,10 +15,10 @@ pub const MEGABYTE: u64 = KILOBYTE * 1000;
 pub const GIGABYTE: u64 = MEGABYTE * 1000;
 pub const TERABYTE: u64 = GIGABYTE * 1000;
 
-pub const KILOBYTE_PLUS_ONE: u64 = KILOBYTE + 1;
-pub const MEGABYTE_PLUS_ONE: u64 = MEGABYTE + 1;
-pub const GIGABYTE_PLUS_ONE: u64 = GIGABYTE + 1;
-pub const TERABYTE_PLUS_ONE: u64 = TERABYTE + 1;
+pub const KILOBYTE_MINUS_ONE: u64 = KILOBYTE - 1;
+pub const MEGABYTE_MINUS_ONE: u64 = MEGABYTE - 1;
+pub const GIGABYTE_MINUS_ONE: u64 = GIGABYTE - 1;
+pub const TERABYTE_MINUS_ONE: u64 = TERABYTE - 1;
 
 #[derive(Serialize)]
 pub enum ByteUnit {
@@ -60,17 +60,17 @@ pub struct UsageItemMetric {
 
 pub fn bytes_to_human(size: u64) -> (String, ByteUnit) {
     let (unit, unit_size) = match size {
-        0..=KILOBYTE => (ByteUnit::Byte, BYTE),
-        KILOBYTE_PLUS_ONE..=MEGABYTE => (ByteUnit::Kilobyte, KILOBYTE),
-        MEGABYTE_PLUS_ONE..=GIGABYTE => (ByteUnit::Megabyte, MEGABYTE),
-        GIGABYTE_PLUS_ONE..=TERABYTE => (ByteUnit::Gigabyte, GIGABYTE),
-        TERABYTE_PLUS_ONE..=u64::MAX => (ByteUnit::Terabyte, TERABYTE),
+        0..=KILOBYTE_MINUS_ONE => (ByteUnit::Byte, BYTE),
+        KILOBYTE..=MEGABYTE_MINUS_ONE => (ByteUnit::Kilobyte, KILOBYTE),
+        MEGABYTE..=GIGABYTE_MINUS_ONE => (ByteUnit::Megabyte, MEGABYTE),
+        GIGABYTE..=TERABYTE_MINUS_ONE => (ByteUnit::Gigabyte, GIGABYTE),
+        TERABYTE..=u64::MAX => (ByteUnit::Terabyte, TERABYTE),
     };
 
-    (
-        format!("{:.3} {}", size as f64 / unit_size as f64, unit),
-        unit,
-    )
+    let size_in_unit = size as f64 / unit_size as f64;
+    let dec = f64::trunc(size_in_unit.fract() * 100.0) / 100.0;
+
+    (format!("{} {}", size_in_unit.trunc() + dec, unit), unit)
 }
 
 pub fn server_usage(config: &Config) -> Result<GetUsageResponse, CoreError> {

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -106,21 +106,12 @@ mod unit_tests {
     #[test]
     fn usage_human_string_sanity_check() {
         let bytes_small_total = BYTES_SMALL * 2;
-        assert_eq!(
-            bytes_to_human(bytes_small_total),
-            format!("{}.000 KB", 2)
-        );
+        assert_eq!(bytes_to_human(bytes_small_total), format!("{}.000 KB", 2));
 
         let bytes_medium_total = BYTES_MEDIUM * 2;
-        assert_eq!(
-            bytes_to_human(bytes_medium_total),
-            format!("{}.000 MB", 2)
-        );
+        assert_eq!(bytes_to_human(bytes_medium_total), format!("{}.000 MB", 2));
 
         let bytes_large_total = BYTES_LARGE * 2;
-        assert_eq!(
-            bytes_to_human(bytes_large_total),
-            format!("{}.000 GB", 2)
-        );
+        assert_eq!(bytes_to_human(bytes_large_total), format!("{}.000 GB", 2));
     }
 }

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -1,13 +1,12 @@
-use std::convert::TryInto;
-
 use crate::client;
 use crate::model::state::Config;
 use crate::repo::{account_repo, file_metadata_repo};
 use crate::service::file_service;
 use crate::CoreError;
-use lockbook_models::api::{GetUsageRequest, GetUsageResponse};
+use lockbook_models::api::{FileUsage, GetUsageRequest, GetUsageResponse};
 use lockbook_models::file_metadata::FileType::Document;
 use serde::Serialize;
+use std::fmt;
 use uuid::Uuid;
 
 pub const BYTE: u64 = 1;
@@ -22,35 +21,56 @@ pub const GIGABYTE_PLUS_ONE: u64 = GIGABYTE + 1;
 pub const TERABYTE_PLUS_ONE: u64 = TERABYTE + 1;
 
 #[derive(Serialize)]
-pub struct LocalAndServerUsages {
-    pub metrics: UsageMetrics,
-    pub readable_metrics: ReadableUsageMetrics,
+pub enum ByteUnit {
+    Byte,
+    Kilobyte,
+    Megabyte,
+    Gigabyte,
+    Terabyte,
 }
 
-#[derive(Serialize)]
-pub struct ReadableUsageMetrics {
-    pub server_usage: String,
-    pub uncompressed_usage: String,
-    pub data_cap: String,
+impl fmt::Display for ByteUnit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let abbr = match self {
+            ByteUnit::Byte => "B",
+            ByteUnit::Kilobyte => "KB",
+            ByteUnit::Megabyte => "MB",
+            ByteUnit::Gigabyte => "GB",
+            ByteUnit::Terabyte => "TB",
+        };
+
+        write!(f, "{}", abbr)
+    }
 }
 
 #[derive(Serialize)]
 pub struct UsageMetrics {
-    pub server_usage: u64,
-    pub uncompressed_usage: u64,
-    pub data_cap: u64,
+    pub usages: Vec<FileUsage>,
+    pub server_usage: UsageItemMetric,
+    pub data_cap: UsageItemMetric,
 }
 
-pub fn bytes_to_human(size: u64) -> String {
-    let (unit, abbr) = match size {
-        0..=KILOBYTE => (BYTE, ""),
-        KILOBYTE_PLUS_ONE..=MEGABYTE => (KILOBYTE, "K"),
-        MEGABYTE_PLUS_ONE..=GIGABYTE => (MEGABYTE, "M"),
-        GIGABYTE_PLUS_ONE..=TERABYTE => (GIGABYTE, "G"),
-        TERABYTE_PLUS_ONE..=u64::MAX => (TERABYTE, "T"),
+#[derive(Serialize)]
+pub struct UsageItemMetric {
+    pub exact: u64,
+    pub readable_exact: String,
+    pub readable: String,
+    pub unit: ByteUnit,
+}
+
+pub fn bytes_to_human(size: u64) -> (String, ByteUnit) {
+    let (unit, unit_size) = match size {
+        0..=KILOBYTE => (ByteUnit::Byte, BYTE),
+        KILOBYTE_PLUS_ONE..=MEGABYTE => (ByteUnit::Kilobyte, KILOBYTE),
+        MEGABYTE_PLUS_ONE..=GIGABYTE => (ByteUnit::Megabyte, MEGABYTE),
+        GIGABYTE_PLUS_ONE..=TERABYTE => (ByteUnit::Gigabyte, GIGABYTE),
+        TERABYTE_PLUS_ONE..=u64::MAX => (ByteUnit::Terabyte, TERABYTE),
     };
 
-    format!("{:.3} {}B", size as f64 / unit as f64, abbr)
+    (
+        format!("{:.3} {}", size as f64 / unit_size as f64, unit),
+        unit,
+    )
 }
 
 pub fn server_usage(config: &Config) -> Result<GetUsageResponse, CoreError> {
@@ -59,73 +79,57 @@ pub fn server_usage(config: &Config) -> Result<GetUsageResponse, CoreError> {
     client::request(&acc, GetUsageRequest {}).map_err(CoreError::from)
 }
 
-pub fn get_usage_human_string(config: &Config, exact: bool) -> Result<String, CoreError> {
-    let usage = server_usage(config)?.sum_server_usage();
+pub fn get_usage(config: &Config) -> Result<UsageMetrics, CoreError> {
+    let server_usage_and_cap = server_usage(&config)?;
 
-    if exact {
-        Ok(format!("{} B", usage))
-    } else {
-        Ok(bytes_to_human(usage))
-    }
+    let server_usage = server_usage_and_cap.sum_server_usage();
+    let cap = server_usage_and_cap.cap;
+
+    let (readable_usage, usage_unit) = bytes_to_human(server_usage);
+    let (readable_cap, cap_unit) = bytes_to_human(cap);
+
+    Ok(UsageMetrics {
+        usages: server_usage_and_cap.usages,
+        server_usage: UsageItemMetric {
+            exact: server_usage,
+            readable_exact: format!("{} B", server_usage),
+            readable: readable_usage,
+            unit: usage_unit,
+        },
+        data_cap: UsageItemMetric {
+            exact: cap,
+            readable_exact: format!("{} B", cap),
+            readable: readable_cap,
+            unit: cap_unit,
+        },
+    })
 }
 
-pub fn get_uncompressed_usage(config: &Config) -> Result<usize, CoreError> {
+pub fn get_uncompressed_usage(config: &Config) -> Result<UsageItemMetric, CoreError> {
     let doc_ids: Vec<Uuid> = file_metadata_repo::get_all(&config)?
         .into_iter()
         .filter(|f| f.file_type == Document)
         .map(|f| f.id)
         .collect();
 
-    let mut size: usize = 0;
+    let mut local_usage: u64 = 0;
     for id in doc_ids {
-        size += file_service::read_document(&config, id)?.len()
+        local_usage += file_service::read_document(&config, id)?.len() as u64
     }
 
-    Ok(size)
-}
+    let (readable, unit) = bytes_to_human(local_usage);
 
-pub fn local_and_server_usages(
-    config: &Config,
-    exact: bool,
-) -> Result<LocalAndServerUsages, CoreError> {
-    let server_usage_and_cap = server_usage(&config)?;
-
-    let server_usage = server_usage_and_cap.sum_server_usage();
-    let local_usage = get_uncompressed_usage(config)?;
-    let cap = server_usage_and_cap.cap;
-
-    let metrics = UsageMetrics {
-        server_usage,
-        uncompressed_usage: local_usage as u64,
-        data_cap: cap,
-    };
-
-    let readable_metrics =
-        if exact {
-            ReadableUsageMetrics {
-                server_usage: format!("{} B", server_usage),
-                uncompressed_usage: format!("{} bytes", local_usage),
-                data_cap: format!("{} B", cap),
-            }
-        } else {
-            ReadableUsageMetrics {
-                server_usage: bytes_to_human(server_usage),
-                uncompressed_usage: bytes_to_human(local_usage.try_into().map_err(|_| {
-                    CoreError::Unexpected(String::from("uncompressed size too large"))
-                })?),
-                data_cap: bytes_to_human(cap),
-            }
-        };
-
-    Ok(LocalAndServerUsages {
-        metrics,
-        readable_metrics,
+    Ok(UsageItemMetric {
+        exact: local_usage,
+        readable_exact: format!("{} B", local_usage),
+        readable,
+        unit,
     })
 }
 
 #[cfg(test)]
 mod unit_tests {
-    use crate::service::usage_service::bytes_to_human;
+    use crate::service::usage_service::{bytes_to_human, ByteUnit};
 
     const BYTES_SMALL: u64 = 1000;
     const BYTES_MEDIUM: u64 = 1000000;
@@ -134,12 +138,21 @@ mod unit_tests {
     #[test]
     fn usage_human_string_sanity_check() {
         let bytes_small_total = BYTES_SMALL * 2;
-        assert_eq!(bytes_to_human(bytes_small_total), format!("{}.000 KB", 2));
+        assert_eq!(
+            bytes_to_human(bytes_small_total),
+            (format!("{}.000 KB", 2), ByteUnit::Kilobyte)
+        );
 
         let bytes_medium_total = BYTES_MEDIUM * 2;
-        assert_eq!(bytes_to_human(bytes_medium_total), format!("{}.000 MB", 2));
+        assert_eq!(
+            bytes_to_human(bytes_medium_total),
+            (format!("{}.000 MB", 2), ByteUnit::Megabyte)
+        );
 
         let bytes_large_total = BYTES_LARGE * 2;
-        assert_eq!(bytes_to_human(bytes_large_total), format!("{}.000 GB", 2));
+        assert_eq!(
+            bytes_to_human(bytes_large_total),
+            (format!("{}.000 GB", 2), ByteUnit::Gigabyte)
+        );
     }
 }

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -106,12 +106,12 @@ mod unit_tests {
     #[test]
     fn usage_human_string_sanity_check() {
         let bytes_small_total = BYTES_SMALL * 2;
-        assert_eq!(bytes_to_human(bytes_small_total), format!("{}.000 KB", 2));
+        assert_eq!(bytes_to_human(bytes_small_total), "2 KB".to_string());
 
         let bytes_medium_total = BYTES_MEDIUM * 2;
-        assert_eq!(bytes_to_human(bytes_medium_total), format!("{}.000 MB", 2));
+        assert_eq!(bytes_to_human(bytes_medium_total), "2 MB".to_string());
 
         let bytes_large_total = BYTES_LARGE * 2;
-        assert_eq!(bytes_to_human(bytes_large_total), format!("{}.000 GB", 2));
+        assert_eq!(bytes_to_human(bytes_large_total), "2 GB".to_string());
     }
 }

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -97,7 +97,7 @@ pub fn get_uncompressed_usage(config: &Config) -> Result<UsageItemMetric, CoreEr
 
 #[cfg(test)]
 mod unit_tests {
-    use crate::service::usage_service::{bytes_to_human, ByteUnit};
+    use crate::service::usage_service::bytes_to_human;
 
     const BYTES_SMALL: u64 = 1000;
     const BYTES_MEDIUM: u64 = 1000000;

--- a/core/tests/get_usage_tests.rs
+++ b/core/tests/get_usage_tests.rs
@@ -39,7 +39,7 @@ mod get_usage_tests {
         write_document(config, file.id, "0000000000".as_bytes()).unwrap();
 
         assert!(
-            get_usage(config).unwrap().is_empty(),
+            get_usage(config).unwrap().usages.is_empty(),
             "Returned non-empty usage!"
         );
 
@@ -47,10 +47,10 @@ mod get_usage_tests {
 
         let local_encrypted = document_repo::get(&config, file.id).unwrap().value;
 
-        assert_eq!(get_usage(config).unwrap()[0].file_id, file.id);
-        assert_eq!(get_usage(config).unwrap().len(), 1);
+        assert_eq!(get_usage(config).unwrap().usages[0].file_id, file.id);
+        assert_eq!(get_usage(config).unwrap().usages.len(), 1);
         assert_eq!(
-            get_usage(config).unwrap()[0].size_bytes,
+            get_usage(config).unwrap().usages[0].size_bytes,
             local_encrypted.len() as u64
         )
     }
@@ -74,9 +74,9 @@ mod get_usage_tests {
         delete_file(config, file.id).unwrap();
         sync_all!(config).unwrap();
 
-        assert_eq!(get_usage(config).unwrap()[0].file_id, file.id);
-        assert_eq!(get_usage(config).unwrap().len(), 1);
-        assert_eq!(get_usage(config).unwrap()[0].size_bytes, 0)
+        assert_eq!(get_usage(config).unwrap().usages[0].file_id, file.id);
+        assert_eq!(get_usage(config).unwrap().usages.len(), 1);
+        assert_eq!(get_usage(config).unwrap().usages[0].size_bytes, 0)
     }
 
     #[test]
@@ -108,11 +108,11 @@ mod get_usage_tests {
 
         let usages = get_usage(config).unwrap();
         let mut total_usage = 0;
-        for usage in usages {
+        for usage in usages.usages {
             total_usage += usage.size_bytes;
         }
 
-        assert_eq!(get_usage(config).unwrap().len(), 3);
+        assert_eq!(get_usage(config).unwrap().usages.len(), 3);
         assert_eq!(total_usage, local_encrypted.len() as u64)
     }
 }

--- a/utils/dev/create_core_for_windows.bat
+++ b/utils/dev/create_core_for_windows.bat
@@ -1,3 +1,3 @@
 cd ..\..\core
 cargo build --release
-copy target\release\lockbook_core.dll ..\clients\windows\core\
+copy ..\target\release\lockbook_core.dll ..\clients\windows\core\


### PR DESCRIPTION
Originally, when you suspended your laptop you may have been greeted with a "Could not reach server" dialog. To counter this, we now have a bottom bar where messages will be shown regarding sync. Depending on the result of the sync, as well as the host of other things, a message will be displayed. All in all, this PR is made to be in accordance with [this](https://github.com/lockbook/lockbook/blob/master/docs/design-ux/navigation.md).

fixes #760