### PR TITLE
server: usage caps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ server/server/ca-certificate.crt
 server/server/qa-ca-certificate.crt
 .idea/
 *.iml
+containers/dev-*.env
 containers/qa.env
 containers/prod.env
 containers/devtest.env

--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -1,20 +1,21 @@
-use std::fs;
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::{fs, io};
 
 use lockbook_core::{
-    get_file_by_path, read_document, Error as CoreError, GetFileByPathError, ReadDocumentError,
+    get_file_by_path, read_document, write_document, Error as CoreError, GetFileByPathError,
+    ReadDocumentError,
 };
 
 use crate::error::CliResult;
 use crate::utils::{
     edit_file_with_editor, get_account_or_exit, get_config, get_directory_location,
-    save_temp_file_contents, set_up_auto_save, stop_auto_save,
+    handle_write_err, save_temp_file_contents, set_up_auto_save, stop_auto_save,
 };
 use crate::{err, err_unexpected};
 
-pub fn edit(file_name: &str) -> CliResult<()> {
+pub fn edit(file_name: &str, stdin: bool) -> CliResult<()> {
     get_account_or_exit();
 
     let file_metadata = get_file_by_path(&get_config(), file_name).map_err(|err| match err {
@@ -33,32 +34,46 @@ pub fn edit(file_name: &str) -> CliResult<()> {
         | CoreError::Unexpected(_) => err_unexpected!("reading encrypted doc: {:#?}", err),
     })?;
 
-    let file_location = format!("{}/{}", get_directory_location()?, file_metadata.name);
-    let temp_file_path = Path::new(file_location.as_str());
-    let mut file_handle = File::create(&temp_file_path)
-        .map_err(|err| err_unexpected!("couldn't open temporary file for writing: {:#?}", err))?;
-
-    file_handle
-        .write_all(&file_content)
-        .map_err(|err| err!(OsCouldNotWriteFile(file_location.clone(), err)))?;
-
-    file_handle
-        .sync_all()
-        .map_err(|err| err!(OsCouldNotWriteFile(file_location.clone(), err)))?;
-
-    let watcher = set_up_auto_save(file_metadata.clone(), file_location.clone());
-
-    let edit_was_successful = edit_file_with_editor(&file_location);
-
-    if let Some(ok) = watcher {
-        stop_auto_save(ok, file_location.clone());
-    }
-
-    if edit_was_successful {
-        save_temp_file_contents(file_metadata, &file_location, temp_file_path, false)
+    if stdin {
+        let mut data = String::new();
+        io::stdin().read_to_string(&mut data).unwrap();
+        match write_document(&get_config(), file_metadata.id, data.as_bytes()) {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                handle_write_err(err);
+                Ok(())
+            }
+        }
     } else {
-        eprintln!("Your editor indicated a problem, aborting and cleaning up");
-    }
+        let file_location = format!("{}/{}", get_directory_location()?, file_metadata.name);
+        let temp_file_path = Path::new(file_location.as_str());
+        let mut file_handle = File::create(&temp_file_path).map_err(|err| {
+            err_unexpected!("couldn't open temporary file for writing: {:#?}", err)
+        })?;
 
-    fs::remove_file(&temp_file_path).map_err(|err| err!(OsCouldNotDeleteFile(file_location, err)))
+        file_handle
+            .write_all(&file_content)
+            .map_err(|err| err!(OsCouldNotWriteFile(file_location.clone(), err)))?;
+
+        file_handle
+            .sync_all()
+            .map_err(|err| err!(OsCouldNotWriteFile(file_location.clone(), err)))?;
+
+        let watcher = set_up_auto_save(file_metadata.clone(), file_location.clone());
+
+        let edit_was_successful = edit_file_with_editor(&file_location);
+
+        if let Some(ok) = watcher {
+            stop_auto_save(ok, file_location.clone());
+        }
+
+        if edit_was_successful {
+            save_temp_file_contents(file_metadata, &file_location, temp_file_path, false)
+        } else {
+            eprintln!("Your editor indicated a problem, aborting and cleaning up");
+        }
+
+        fs::remove_file(&temp_file_path)
+            .map_err(|err| err!(OsCouldNotDeleteFile(file_location, err)))
+    }
 }

--- a/clients/cli/src/error.rs
+++ b/clients/cli/src/error.rs
@@ -72,6 +72,7 @@ make_errkind_enum!(
     7 => ExpectedStdin,
     8 => NoCliLocation,
     9 => NoRoot,
+    10 => DataCapExceeded,
 
     // Account (20s)
     20 => NoAccount,
@@ -118,6 +119,7 @@ impl ErrorKind {
             Self::ExpectedStdin => "expected stdin".to_string(),
             Self::NoCliLocation => "Could not read env var LOCKBOOK_CLI_LOCATION HOME or HOMEPATH, don't know where to place your `.lockbook` folder".to_string(),
             Self::NoRoot => "No root folder, have you synced yet?".to_string(),
+            Self::DataCapExceeded => "Data cap exceeded! You'll need to upgrade your storage plan or reduce usage to continue syncing.".to_string(),
 
             Self::NoAccount => "No account! Run 'new-account' or 'import-private-key' to get started!".to_string(),
             Self::AccountAlreadyExists => "Account already exists. Run `lockbook erase-everything` to erase your local state.".to_string(),

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -51,6 +51,9 @@ enum Lockbook {
         /// to select an editor. In the absence of this variable, it will default to vim. Editor
         /// options are: Vim, Emacs, Nano, Sublime, Code
         path: String,
+        /// Indicate that the contents of the file should be read from Standard Input
+        #[structopt(long)]
+        stdin: bool,
     },
 
     /// Print out what each error code means
@@ -104,6 +107,9 @@ enum Lockbook {
     New {
         /// Absolute path of the file you're creating. Will create folders that do not exist.
         path: String,
+        /// Indicate that the contents of the file should be read from Standard Input
+        #[structopt(long)]
+        stdin: bool,
     },
 
     /// Create a new Lockbook account
@@ -159,7 +165,7 @@ fn main() {
             destination,
             edit,
         } => copy::copy(file, &destination, edit),
-        Lockbook::Edit { path } => edit::edit(&path.trim()),
+        Lockbook::Edit { path, stdin } => edit::edit(&path.trim(), stdin),
         Lockbook::ExportPrivateKey => export_private_key::export_private_key(),
         Lockbook::ImportPrivateKey => import_private_key::import_private_key(),
         Lockbook::NewAccount => new_account::new_account(),
@@ -168,7 +174,7 @@ fn main() {
         Lockbook::ListDocs => list::list(Some(DocumentsOnly)),
         Lockbook::ListFolders => list::list(Some(FoldersOnly)),
         Lockbook::Move { target, new_parent } => move_file::move_file(&target, &new_parent),
-        Lockbook::New { path } => new::new(&path.trim()),
+        Lockbook::New { path, stdin } => new::new(&path.trim(), stdin),
         Lockbook::Print { path } => print::print(&path.trim()),
         Lockbook::Remove { path, force } => remove::remove(&path.trim(), force),
         Lockbook::Rename { path, name } => rename::rename(&path, &name),

--- a/clients/cli/src/sync.rs
+++ b/clients/cli/src/sync.rs
@@ -21,6 +21,7 @@ pub fn sync() -> CliResult<()> {
             SyncAllError::NoAccount => err!(NoAccount),
             SyncAllError::ClientUpdateRequired => err!(UpdateRequired),
             SyncAllError::CouldNotReachServer => err!(NetworkIssue),
+            SyncAllError::DataCapExceeded => err!(DataCapExceeded),
         },
         Error::Unexpected(msg) => err_unexpected!("{}", msg),
     })?;

--- a/core/libs/models/src/api.rs
+++ b/core/libs/models/src/api.rs
@@ -50,6 +50,7 @@ pub enum ChangeDocumentContentError {
     DocumentNotFound,
     EditConflict,
     DocumentDeleted,
+    DataCapExceeded,
 }
 
 impl Request for ChangeDocumentContentRequest {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,6 +59,7 @@ pub enum CoreError {
     AccountStringCorrupted,
     ClientUpdateRequired,
     ClientWipeRequired,
+    DataCapExceeded,
     DiskPathInvalid,
     DiskPathTaken,
     DrawingInvalid,
@@ -553,6 +554,7 @@ pub enum SyncAllError {
     NoAccount,
     ClientUpdateRequired,
     CouldNotReachServer,
+    DataCapExceeded,
 }
 
 pub fn sync_all(
@@ -563,6 +565,7 @@ pub fn sync_all(
         CoreError::AccountNonexistent => UiError(SyncAllError::NoAccount),
         CoreError::ServerUnreachable => UiError(SyncAllError::CouldNotReachServer),
         CoreError::ClientUpdateRequired => UiError(SyncAllError::ClientUpdateRequired),
+        CoreError::DataCapExceeded => UiError(SyncAllError::DataCapExceeded),
         _ => unexpected!("{:#?}", e),
     })
 }

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -24,6 +24,7 @@ pub async fn change_document_content(
         request.id,
         request.new_content.value.len() as u64,
         request.old_metadata_version,
+        &context.public_key,
     )
     .await;
 
@@ -37,9 +38,17 @@ pub async fn change_document_content(
         ChangeDocumentVersionAndSizeError::Deleted => {
             Ok(ChangeDocumentContentError::DocumentDeleted)
         }
+        ChangeDocumentVersionAndSizeError::DataCapExceed => {
+            Ok(ChangeDocumentContentError::DataCapExceeded)
+        }
         ChangeDocumentVersionAndSizeError::Postgres(_)
         | ChangeDocumentVersionAndSizeError::Deserialize(_) => Err(format!(
             "Cannot change document content version in Postgres: {:?}",
+            e
+        )),
+        ChangeDocumentVersionAndSizeError::GetDataCap(_)
+        | ChangeDocumentVersionAndSizeError::GetFileUsage(_) => Err(format!(
+            "Could not get usage information, cannot perform usage pre-check: {:?}",
             e
         )),
     })?;


### PR DESCRIPTION
**From the CLI** ft. brutal logs
```zsh
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ lipsate 100000 | ../../target/debug/lockbook edit nice/test.txt --stdin
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ ../../target/debug/lockbook sync                                       
Pushing: test.txt
Sync complete.
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ lipsate 100000 | ../../target/debug/lockbook edit nice/test.txt --stdin
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ ../../target/debug/lockbook get-usage                                  
Uncompressed File Size: 100 KB
Server Utilization: 23.03 KB
Server Data Cap: 100 KB
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ ../../target/debug/lockbook sync                                       
Pushing: test.txt
Sync complete.
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ ../../target/debug/lockbook get-usage
Uncompressed File Size: 100 KB
Server Utilization: 22.46 KB
Server Data Cap: 100 KB
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ lipsate 500000 | ../../target/debug/lockbook edit nice/test.txt --stdin
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ ../../target/debug/lockbook get-usage                                  
Uncompressed File Size: 500 KB
Server Utilization: 22.46 KB
Server Data Cap: 100 KB
raayan@raayan-p15 ~/dev/lockbook/clients/cli [raayan/usage_caps] $ ../../target/debug/lockbook sync                    
Pushing: test.txt
error: Data cap exceeded! You'll need to upgrade your storage plan or reduce usage to continue syncing.
```

**From the server**
```zsh
[2021-07-11 15:40:39] [lockbook_server_lib::file_index_repo    ] [WARN ]: tried to sync fec0ae6c-eaa9-4783-bf57-ff508fd91750 old_size=22743 new_size=104722 cap=100000 current_usage=22743 projected_usage=104722
```