### PR TITLE
server: add API endpoint for reporting server build info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,9 @@ name = "cc"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cesu8"
@@ -1327,6 +1330,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.13.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +1950,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.21+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2007,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76acb433e21d10f5f9892b1962c2856c58c7f39a9e4bd68ac82b9436a0ffd5b9"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2105,6 +2154,7 @@ dependencies = [
  "rust-s3",
  "serde",
  "serde_json",
+ "shadow-rs",
  "sqlx",
  "tokio",
  "tokio-test",
@@ -3321,6 +3371,16 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "shadow-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8330d4ddbcc8552ba57c3058346c3fc1cafd4fea7e9fe201f32e84d4afa6a"
+dependencies = [
+ "chrono",
+ "git2",
 ]
 
 [[package]]

--- a/containers/Dockerfile.admin_cli
+++ b/containers/Dockerfile.admin_cli
@@ -9,6 +9,7 @@ WORKDIR admin-cli
 
 # Admin CLI depends on server and core via a relative import
 COPY server/server/Cargo.toml /server/Cargo.toml
+COPY server/server/build.rs /server/build.rs
 COPY core/Cargo.toml /core/Cargo.toml
 COPY core/libs/models/Cargo.toml /core/libs/models/Cargo.toml
 COPY core/libs/crypto/Cargo.toml /core/libs/crypto/Cargo.toml

--- a/containers/Dockerfile.server
+++ b/containers/Dockerfile.server
@@ -21,6 +21,7 @@ COPY containers/dummy.rs /core/libs/crypto/src/lib.rs
 COPY containers/dummy.rs src/main.rs
 COPY containers/dummy.rs src/lib.rs
 COPY server/server/Cargo.toml .
+COPY server/server/build.rs .
 
 # Dependency on core which has compile-time env var
 ENV API_URL=unused

--- a/core/libs/models/src/api.rs
+++ b/core/libs/models/src/api.rs
@@ -29,7 +29,6 @@ pub enum ErrorWrapper<E> {
     InternalError,
     BadRequest,
 }
-
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ChangeDocumentContentRequest {
     pub id: Uuid,
@@ -523,4 +522,23 @@ impl Request for NewAccountRequest {
     type Error = NewAccountError;
     const METHOD: Method = Method::POST;
     const ROUTE: &'static str = "/new-account";
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct GetBuildInfoRequest {}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum GetBuildInfoError {}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct GetBuildInfoResponse {
+    pub build_version: &'static str,
+    pub git_commit_hash: &'static str,
+}
+
+impl Request for GetBuildInfoRequest {
+    type Response = GetBuildInfoResponse;
+    type Error = GetBuildInfoError;
+    const METHOD: Method = Method::GET;
+    const ROUTE: &'static str = "/get-build-info";
 }

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -3,6 +3,7 @@ name = "lockbook-server"
 version = "0.1.1"
 authors = ["Parth <parth@mehrotra.me>"]
 edition = "2018"
+build = "build.rs"
 
 [lib]
 name = "lockbook_server_lib"
@@ -24,10 +25,14 @@ pagerduty-rs = { version = "0.1.1", features = ["sync"] }
 rust-s3 = "0.27.0-rc3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
+shadow-rs = "0.6.2"
 tokio = { version = "1.5.0", features = ["full"] }
 sqlx = { version = "0.5.2", features = ["macros", "postgres", "uuid", "tls", "runtime-tokio-native-tls", "offline"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 libsecp256k1 = "0.5.0"
+
+[build-dependencies]
+shadow-rs = "0.6.2"
 
 [dev-dependencies]
 lockbook-core = { path = "../../core" }

--- a/server/server/build.rs
+++ b/server/server/build.rs
@@ -1,0 +1,3 @@
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}


### PR DESCRIPTION
* Adding a new API endpoint that returns package/build # and the corresponding git commit hash. These values are determined at build time.
  * Pulling in [`shadow-rs`](https://github.com/baoyachi/shadow-rs) as a dependency for server to compute git hash.

* I'm not sure what the testing story is here, so lmk how/if I can test this out without integrating into clients.

closes #820 