### PR TITLE
apple: fix loss of colors

### DIFF
--- a/clients/apple/Shared/Config/Colors.swift
+++ b/clients/apple/Shared/Config/Colors.swift
@@ -12,41 +12,94 @@ extension Color {
 
 extension ColorAlias {
     static func fromUIColor(from color: UniversalColor) -> ColorAlias {
-        switch color {
-        case .fromColorAlias(from: .Black): return .Black
-        case .fromColorAlias(from: .White): return .White
-        case .fromColorAlias(from: .Cyan): return .Cyan
-        case .fromColorAlias(from: .Magenta): return .Magenta
-        case .fromColorAlias(from: .Red): return .Red
-        case .fromColorAlias(from: .Green): return .Green
-        case .fromColorAlias(from: .Blue): return .Blue
-        case .fromColorAlias(from: .Yellow): return .Yellow
-        default: return .Black
+        if UIColor.fromColorAlias(from: .Black) == color {
+            return .Black
         }
+        
+        if UIColor.fromColorAlias(from: .White) == color {
+            return .White
+        }
+        
+        if UIColor.fromColorAlias(from: .Cyan) == color {
+            return .Cyan
+        }
+        
+        if UIColor.fromColorAlias(from: .Magenta) == color {
+            return .Magenta
+        }
+        
+        if UIColor.fromColorAlias(from: .Red) == color {
+            return .Red
+        }
+        
+        if UIColor.fromColorAlias(from: .Green) == color {
+            return .Green
+        }
+        
+        if UIColor.fromColorAlias(from: .Blue) == color {
+            return .Blue
+        }
+        
+        if UIColor.fromColorAlias(from: .Yellow) == color {
+            return .Yellow
+        }
+
+        print("🚨 unknown color: \(color), we will lose this color and it will become Yellow!")
+        return .Yellow
+    }
+}
+
+public extension UIColor {
+
+    static func == (l: UIColor, r: UIColor) -> Bool {
+        var l_red = CGFloat(0); var l_green = CGFloat(0); var l_blue = CGFloat(0); var l_alpha = CGFloat(0)
+        guard l.getRed(&l_red, green: &l_green, blue: &l_blue, alpha: &l_alpha) else { return false }
+        
+        l_red = round(l_red * 100) / 100.0
+        l_green = round(l_green * 100) / 100.0
+        l_blue = round(l_blue * 100) / 100.0
+        
+        var r_red = CGFloat(0); var r_green = CGFloat(0); var r_blue = CGFloat(0); var r_alpha = CGFloat(0)
+        guard r.getRed(&r_red, green: &r_green, blue: &r_blue, alpha: &r_alpha) else { return false }
+        
+        r_red = round(r_red * 100) / 100.0
+        r_green = round(r_green * 100) / 100.0
+        r_blue = round(r_blue * 100) / 100.0
+
+        return l_red == r_red && l_green == r_green && l_blue == r_blue && l_alpha == r_alpha
     }
 }
 
 extension UniversalColor {
     static func fromColorAlias(from color: ColorAlias) -> UniversalColor {
+        #if os(iOS)
+        switch color {
+        case .Black: return UIColor(red: 0/255.0, green: 0/255.0, blue: 0/255.0, alpha: 1)
+        case .Blue: return UIColor(red: 0/255.0, green: 122/255.0, blue: 255/255.0, alpha: 1)
+        case .Cyan: return UIColor(red: 89/255.0, green: 173/255.0, blue: 196/255.0, alpha: 1)
+        case .Yellow: return UIColor(red: 255/255.0, green: 204/255.0, blue: 0/255.0, alpha: 1)
+        case .Magenta: return UIColor(red: 175/255.0, green: 82/255.0, blue: 222/255.0, alpha: 1)
+        case .Red: return UIColor(red: 255/255.0, green: 45/255.0, blue: 85/255.0, alpha: 1)
+        case .White: return UIColor(red: 255/255.0, green: 255/255.0, blue: 255/255.0, alpha: 1)
+        case .Green: return UIColor(red: 40/255.0, green: 205/255.0, blue: 65/255.0, alpha: 1)
+        }
+        #else
         let x: UniversalColor = {
             switch color {
-                case .Black: return .black
-                case .Blue: return .systemBlue
-                case .Cyan: return .systemTeal
-                case .Yellow: return .systemYellow
-                case .Magenta: return .systemPurple
-                case .Red: return .systemPink
-                case .White: return .white
-                case .Green: return .systemGreen
+            case .Black: return .black
+            case .Blue: return .systemBlue
+            case .Cyan: return .systemTeal
+            case .Yellow: return .systemYellow
+            case .Magenta: return .systemPurple
+            case .Red: return .systemPink
+            case .White: return .white
+            case .Green: return .systemGreen
             }
         } ()
-        #if os(iOS)
-        return x.resolvedColor(with: .current)
-        #else
         return x
         #endif
     }
-
+    
     #if os(iOS)
     func addColor(_ color1: UniversalColor, with color2: UniversalColor) -> UniversalColor {
         var (r1, g1, b1, a1) = (CGFloat(0), CGFloat(0), CGFloat(0), CGFloat(0))
@@ -60,7 +113,7 @@ extension UniversalColor {
         color.getRed(&r, green: &g, blue: &b, alpha: &a)
         return UniversalColor(red: r * multiplier, green: g * multiplier, blue: b * multiplier, alpha: a)
     }
-
+    
     func blendColors(_ color: UniversalColor, by multiplier: CGFloat) -> UniversalColor {
         let base = multiplyColor(self, by: 1 - multiplier)
         let other = multiplyColor(color, by: multiplier)
@@ -71,5 +124,5 @@ extension UniversalColor {
         return self.blended(withFraction: multiplier, of: color)!
     }
     #endif
-
+    
 }


### PR DESCRIPTION
Colors were lost in two ways for two different reasons.

The ways they were lost:
+ switching between light and dark mode
+ using things like lasso select + duplicate

The reasons they were lost:
+ apple uses _slightly_ different colors depending on some contexts (dark mode, accessibility settings). They only differ slightly, and for now I just picked one set and hard coded their values: https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color/
+ when you use things like lasso select + duplicate, there was a slight difference in rounding. So I implemented a custom `==`  which will compare rgb with 2 decimal places of precision (`0.00-0.99`).

fixes #746