### PR TITLE
apple: apple silicon build infra

### DIFF
--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 		EA5C7D632516605F00F7F358 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1240;
 				TargetAttributes = {
 					EA5C7D6E2516606000F7F358 = {
@@ -637,7 +637,7 @@
 		EA5C7D872516606100F7F358 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
@@ -666,7 +666,7 @@
 		EA5C7D882516606100F7F358 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
@@ -780,7 +780,7 @@
 		EADA116025336B97005F69DB /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;

--- a/containers/Dockerfile.swift_interface_tests
+++ b/containers/Dockerfile.swift_interface_tests
@@ -13,7 +13,7 @@ COPY . .
 WORKDIR core
 # This will cause problems for you during tests
 ENV API_URL=http://lockbook_server:8000
-RUN make lib_c_for_swift
+RUN make lib_c_for_swift_native
 
 # Build Swift Package
 COPY clients/apple ../clients/apple

--- a/core/Makefile
+++ b/core/Makefile
@@ -72,8 +72,9 @@ lib_c_for_swift_ios:
 	@mkdir -p ${swift_lib_ios}
 	cp ../target/universal/release/liblockbook_core.a ${swift_lib_ios}
 
-.PHONY: lib_c_for_swift
-lib_c_for_swift:
+# for non lipo builds (linux)
+.PHONY: lib_c_for_swift_native
+lib_c_for_swift_native:
 	@{ command -v cargo || { echo "Y'ain't got cargo"; exit 1; } }
 	@echo "Creating header"
 	@rm ${swift_inc}lockbook_core.h || echo "no prior .h"
@@ -86,8 +87,26 @@ lib_c_for_swift:
 	@mkdir -p ${swift_lib}
 	cp ../target/release/liblockbook_core.a ${swift_lib}
 
+.PHONY: lib_c_for_swift_universal
+lib_c_for_swift_universal:
+	@{ command -v cargo || { echo "Y'ain't got cargo"; exit 1; } }
+	@echo "Creating header"
+	@rm ${swift_inc}lockbook_core.h || echo "no prior .h"
+	cbindgen src/c_interface.rs -l c > lockbook_core.h
+	@mkdir -p ${swift_inc}
+	cp lockbook_core.h ${swift_inc}
+	@echo "Building fat library"
+	@rm ${swift_lib}liblockbook_core.a || echo "no prior .a"
+	cargo build --release --target=x86_64-apple-darwin
+	cargo build --release --target=aarch64-apple-darwin
+	rm -rf ../target/xcode-lipo-universal
+	mkdir ../target/xcode-lipo-universal
+	lipo -create -output ../target/xcode-lipo-universal/liblockbook_core.a ../target/x86_64-apple-darwin/release/liblockbook_core.a ../target/aarch64-apple-darwin/release/liblockbook_core.a
+	@mkdir -p ${swift_lib}
+	cp ../target/xcode-lipo-universal/liblockbook_core.a ${swift_lib}
+
 .PHONY: swift_libs
-swift_libs: lib_c_for_swift lib_c_for_swift_ios
+swift_libs: lib_c_for_swift_universal lib_c_for_swift_ios
 
 .PHONY: lib_c_for_windows
 lib_c_for_windows:

--- a/docs/guides/building.md
+++ b/docs/guides/building.md
@@ -95,8 +95,10 @@ rustup target add aarch64-apple-ios x86_64-apple-ios
 + The build targets:
 
 ```shell script
-rustup target add aarch64-apple-ios armv7-apple-ios armv7s-apple-ios x86_64-apple-ios i386-apple-ios
+rustup target add aarch64-apple-ios armv7-apple-ios armv7s-apple-ios x86_64-apple-ios i386-apple-ios aarch64-apple-darwin x86_64-apple-darwin
 ```
+
+`make lib_c_for_swift_universal` in the `core` folder.
 
 ## Reference Instructions
 


### PR DESCRIPTION
+ modifies our xcode mac target build description to say we support any macOS
+ modifies our makefile to build for both intel & apple silicon and then uses lipo (not cargo lipo) to create a universal binary
+ updates our docs to include both targets for building for macos, either platform can create this universal application.


+ we can and probably should do this for our macOS binary as well

closes #847 