### PR TITLE
cli: fix bug, and support globs for inputs 

### DIFF
--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -1,25 +1,20 @@
 use std::path::PathBuf;
 
 use lockbook_core::{
-    get_file_by_path, import_file, Error as CoreError, GetFileByPathError, ImportFileError,
+    create_file_at_path, get_file_by_path, import_file, CreateFileAtPathError, Error as CoreError,
+    Error, GetFileByPathError, ImportFileError,
 };
 
 use crate::error::CliResult;
 use crate::utils::{get_account_or_exit, get_config};
 use crate::{err, err_unexpected};
+use lockbook_core::model::client_conversion::ClientFileMetadata;
 use lockbook_core::service::import_export_service::ImportExportFileInfo;
 
-pub fn copy(disk_path: PathBuf, lb_path: &str, edit: bool) -> CliResult<()> {
+pub fn copy(disk_path: &[PathBuf], lb_path: &str) -> CliResult<()> {
     get_account_or_exit();
 
-    let config = get_config();
-
-    let file_metadata = get_file_by_path(&config, lb_path).map_err(|err| match err {
-        CoreError::UiError(GetFileByPathError::NoFileAtThatPath) => {
-            err!(FileNotFound(lb_path.to_string()))
-        }
-        CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
-    })?;
+    let file_metadata = get_or_create_file(lb_path)?;
 
     let import_progress = |info: ImportExportFileInfo| {
         println!(
@@ -29,23 +24,64 @@ pub fn copy(disk_path: PathBuf, lb_path: &str, edit: bool) -> CliResult<()> {
         );
     };
 
-    import_file(
-        &config,
-        file_metadata.id,
-        disk_path,
-        edit,
-        Some(Box::new(import_progress)),
-    )
-    .map_err(|err| match err {
-        CoreError::UiError(err) => match err {
-            ImportFileError::NoAccount => err!(NoAccount),
-            ImportFileError::ParentDoesNotExist => err!(FileNotFound(file_metadata.name.clone())),
-            ImportFileError::FileAlreadyExists(path) => err!(FileCollision(path)),
-            ImportFileError::DocumentTreatedAsFolder => {
-                err!(DocTreatedAsFolder(file_metadata.name.clone()))
-            }
-            ImportFileError::DiskPathInvalid => err!(OsInvalidPath(lb_path.to_string())),
+    for path in disk_path {
+        import_file(
+            &get_config(),
+            path.to_path_buf(),
+            file_metadata.id,
+            Some(Box::new(import_progress)),
+        )
+        .map_err(|err| match err {
+            CoreError::UiError(err) => match err {
+                ImportFileError::NoAccount => err!(NoAccount),
+                ImportFileError::ParentDoesNotExist => {
+                    err!(FileNotFound(file_metadata.name.clone()))
+                }
+                ImportFileError::DocumentTreatedAsFolder => {
+                    err!(DocTreatedAsFolder(file_metadata.name.clone()))
+                }
+                ImportFileError::DiskPathInvalid => err!(OsInvalidPath(lb_path.to_string())),
+            },
+            CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
+        })?;
+    }
+
+    Ok(())
+}
+
+fn get_or_create_file(lb_path: &str) -> CliResult<ClientFileMetadata> {
+    // Try to get a file
+    match get_file_by_path(&get_config(), lb_path) {
+        Ok(file) => return Ok(file),
+        Err(err) => match err {
+            Error::UiError(GetFileByPathError::NoFileAtThatPath) => {} // Continue
+            Error::Unexpected(msg) => return Err(err_unexpected!("{}", msg)),
         },
-        CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
-    })
+    };
+
+    // It does not exist, create it
+    if lb_path.ends_with("/") {
+        create_file_at_path(&get_config(), &lb_path).map_err(|err| match err {
+            CoreError::UiError(err) => match err {
+                CreateFileAtPathError::FileAlreadyExists => {
+                    err!(FileAlreadyExists(lb_path.to_string()))
+                }
+                CreateFileAtPathError::NoAccount => err!(NoAccount),
+                CreateFileAtPathError::NoRoot => err!(NoRoot),
+                CreateFileAtPathError::PathContainsEmptyFile => {
+                    err!(PathContainsEmptyFile(lb_path.to_string()))
+                }
+                CreateFileAtPathError::PathDoesntStartWithRoot => {
+                    err!(PathNoRoot(lb_path.to_string()))
+                }
+                CreateFileAtPathError::DocumentTreatedAsFolder => {
+                    err!(DocTreatedAsFolder(lb_path.to_string()))
+                }
+            },
+            CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
+        })
+    } else {
+        eprintln!("Copy destination must be a folder!");
+        Err(err!(DocTreatedAsFolder(lb_path.to_string())))
+    }
 }

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -11,7 +11,7 @@ use crate::{err, err_unexpected};
 use lockbook_core::model::client_conversion::ClientFileMetadata;
 use lockbook_core::service::import_export_service::ImportExportFileInfo;
 
-pub fn copy(disk_path: &[PathBuf], lb_path: &str) -> CliResult<()> {
+pub fn copy(disk_paths: &[PathBuf], lb_path: &str) -> CliResult<()> {
     get_account_or_exit();
 
     let file_metadata = get_or_create_file(lb_path)?;
@@ -24,7 +24,7 @@ pub fn copy(disk_path: &[PathBuf], lb_path: &str) -> CliResult<()> {
         );
     };
 
-    for path in disk_path {
+    for path in disk_paths {
         import_file(
             &get_config(),
             path.to_path_buf(),

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -18,7 +18,7 @@ pub fn copy(disk_paths: &[PathBuf], lb_path: &str) -> CliResult<()> {
 
     let import_progress = |info: ImportExportFileInfo| {
         println!(
-            "{} imported to {}",
+            "importing: {} to {}",
             info.disk_path.display(),
             info.lockbook_path
         );

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -60,8 +60,8 @@ fn get_or_create_file(lb_path: &str) -> CliResult<ClientFileMetadata> {
     };
 
     // It does not exist, create it
-    if lb_path.ends_with("/") {
-        create_file_at_path(&get_config(), &lb_path).map_err(|err| match err {
+    if lb_path.ends_with('/') {
+        create_file_at_path(&get_config(), lb_path).map_err(|err| match err {
             CoreError::UiError(err) => match err {
                 CreateFileAtPathError::FileAlreadyExists => {
                     err!(FileAlreadyExists(lb_path.to_string()))

--- a/clients/cli/src/error.rs
+++ b/clients/cli/src/error.rs
@@ -104,7 +104,6 @@ make_errkind_enum!(
     49 => NoRootOps(&'static str),
     50 => InvalidDrawing(String),
     51 => FolderTreatedAsDoc(String),
-    52 => FileCollision(String),
 
     // Validation errors (53 - 55)
     53 => FileOrphaned(String),
@@ -152,7 +151,6 @@ impl ErrorKind {
             Self::NoRootOps(op) => format!("cannot {} your root directory!", op),
             Self::InvalidDrawing(name) => format!("'{}' is an invalid drawing", name),
             Self::FolderTreatedAsDoc(path) => format!("a file in path '{}' is a folder being treated as a document", path),
-            Self::FileCollision(path) => format!("a file collision was detected at '{}'", path),
 
             Self::FileOrphaned(path) => format!("file '{}' has no path to root", path),
             Self::CycleDetected => "A cycle was detected in the file hierarchy".to_string(),

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -34,12 +34,11 @@ enum Lockbook {
 
     /// Copy a file from your file system into your Lockbook
     Copy {
-        /// Filesystem location, a folder or individual file
+        /// At-least one filesystem location
         #[structopt(required = true)]
-        files: Vec<PathBuf>,
+        disk_files: Vec<PathBuf>,
 
-        /// Lockbook location, for files this can be the parent, or the intended file name within
-        /// the parent. For folders, this specifies the parent.
+        /// A folder within your Lockbook, will be created if it does not exist
         destination: String,
     },
 
@@ -155,7 +154,7 @@ fn main() {
     }
 
     if let Err(err) = match args {
-        Lockbook::Copy { files, destination } => copy::copy(&files, &destination),
+        Lockbook::Copy { disk_files: files, destination } => copy::copy(&files, &destination),
         Lockbook::Edit { path } => edit::edit(path.trim()),
         Lockbook::ExportPrivateKey => export_private_key::export_private_key(),
         Lockbook::ImportPrivateKey => import_private_key::import_private_key(),

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -34,12 +34,9 @@ enum Lockbook {
 
     /// Copy a file from your file system into your Lockbook
     Copy {
-        /// Overwrite the file if it exists already
-        #[structopt(long)]
-        edit: bool,
-
         /// Filesystem location, a folder or individual file
-        file: PathBuf,
+        #[structopt(required = true)]
+        files: Vec<PathBuf>,
 
         /// Lockbook location, for files this can be the parent, or the intended file name within
         /// the parent. For folders, this specifies the parent.
@@ -158,11 +155,7 @@ fn main() {
     }
 
     if let Err(err) = match args {
-        Lockbook::Copy {
-            file,
-            destination,
-            edit,
-        } => copy::copy(file, &destination, edit),
+        Lockbook::Copy { files, destination } => copy::copy(&files, &destination),
         Lockbook::Edit { path } => edit::edit(path.trim()),
         Lockbook::ExportPrivateKey => export_private_key::export_private_key(),
         Lockbook::ImportPrivateKey => import_private_key::import_private_key(),

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -154,7 +154,10 @@ fn main() {
     }
 
     if let Err(err) = match args {
-        Lockbook::Copy { disk_files: files, destination } => copy::copy(&files, &destination),
+        Lockbook::Copy {
+            disk_files: files,
+            destination,
+        } => copy::copy(&files, &destination),
         Lockbook::Edit { path } => edit::edit(path.trim()),
         Lockbook::ExportPrivateKey => export_private_key::export_private_key(),
         Lockbook::ImportPrivateKey => import_private_key::import_private_key(),

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -243,8 +243,7 @@ impl LbCore {
         source: &str,
         import_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
     ) -> LbResult<()> {
-        import_file(&self.config, parent, PathBuf::from(source), false, import_progress).map_err(map_core_err!(ImportFileError,
-            FileAlreadyExists(path) => uerr_dialog!("File already exists at {}.", path),
+        import_file(&self.config, PathBuf::from(source), parent, import_progress).map_err(map_core_err!(ImportFileError,
             DocumentTreatedAsFolder => uerr_dialog!("Invalid import destination, document treated as folder."),
             ParentDoesNotExist => uerr_dialog!("Invalid import destination, parent not found."),
             NoAccount => uerr_dialog!("No account."),

--- a/core/libs/models/src/file_metadata.rs
+++ b/core/libs/models/src/file_metadata.rs
@@ -36,3 +36,13 @@ pub struct FileMetadata {
     pub user_access_keys: HashMap<Username, UserAccessInfo>,
     pub folder_access_keys: EncryptedFolderAccessKey,
 }
+
+impl FileMetadata {
+    pub fn is_folder(&self) -> bool {
+        self.file_type == FileType::Folder
+    }
+
+    pub fn is_document(&self) -> bool {
+        self.file_type == FileType::Document
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -766,25 +766,22 @@ pub fn export_drawing_to_disk(
 pub enum ImportFileError {
     NoAccount,
     ParentDoesNotExist,
-    FileAlreadyExists(String),
     DocumentTreatedAsFolder,
     DiskPathInvalid,
 }
 
 pub fn import_file(
     config: &Config,
+    disk_path: PathBuf,
     parent: Uuid,
-    source: PathBuf,
-    edit: bool,
     import_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
 ) -> Result<(), Error<ImportFileError>> {
-    import_export_service::import_file(config, parent, source, edit, import_progress).map_err(|e| {
+    import_export_service::import_file(config, disk_path, parent, import_progress).map_err(|e| {
         match e {
             CoreError::AccountNonexistent => UiError(ImportFileError::NoAccount),
             CoreError::FileNonexistent => UiError(ImportFileError::ParentDoesNotExist),
             CoreError::FileNotFolder => UiError(ImportFileError::DocumentTreatedAsFolder),
             CoreError::DiskPathInvalid => UiError(ImportFileError::DiskPathInvalid),
-            CoreError::ImportCollision(path) => UiError(ImportFileError::FileAlreadyExists(path)),
             _ => unexpected!("{:#?}", e),
         }
     })

--- a/core/src/service/import_export_service.rs
+++ b/core/src/service/import_export_service.rs
@@ -22,7 +22,7 @@ pub fn import_file(
     parent: Uuid,
     import_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
 ) -> Result<(), CoreError> {
-    if file_metadata_repo::get(&config, parent)?.is_document() {
+    if file_metadata_repo::get(config, parent)?.is_document() {
         return Err(CoreError::FileNotFolder);
     }
 

--- a/core/src/service/import_export_service.rs
+++ b/core/src/service/import_export_service.rs
@@ -18,16 +18,18 @@ pub struct ImportExportFileInfo {
 
 pub fn import_file(
     config: &Config,
+    disk_path: PathBuf,
     parent: Uuid,
-    source: PathBuf,
-    edit: bool,
     import_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
 ) -> Result<(), CoreError> {
+    if file_metadata_repo::get(&config, parent)?.is_document() {
+        return Err(CoreError::FileNotFolder);
+    }
+
     import_file_recursively(
         config,
-        &source,
+        &disk_path,
         &path_service::get_path_by_id(config, parent)?,
-        edit,
         &import_progress,
     )
 }
@@ -36,10 +38,13 @@ fn import_file_recursively(
     config: &Config,
     disk_path: &Path,
     lockbook_path: &str,
-    edit: bool,
     import_progress: &Option<Box<dyn Fn(ImportExportFileInfo)>>,
 ) -> Result<(), CoreError> {
-    let is_file = disk_path.is_file();
+    if !disk_path.exists() {
+        return Err(CoreError::DiskPathInvalid);
+    }
+
+    let is_document = disk_path.is_file();
     let lockbook_path_with_new = format!(
         "{}{}{}",
         lockbook_path,
@@ -47,7 +52,7 @@ fn import_file_recursively(
             .file_name()
             .and_then(|name| name.to_str())
             .ok_or(CoreError::DiskPathInvalid)?,
-        if is_file { "" } else { "/" }
+        if is_document { "" } else { "/" }
     );
 
     if let Some(ref func) = import_progress {
@@ -57,21 +62,14 @@ fn import_file_recursively(
         })
     }
 
-    if disk_path.is_file() {
+    if is_document {
         let content = fs::read(&disk_path).map_err(CoreError::from)?;
         let file_metadata = match path_service::create_at_path(config, &lockbook_path_with_new) {
             Ok(file_metadata) => file_metadata,
-            Err(err) => {
-                if CoreError::PathTaken == err {
-                    if edit {
-                        path_service::get_by_path(config, &lockbook_path_with_new)?
-                    } else {
-                        return Err(CoreError::ImportCollision(lockbook_path_with_new));
-                    }
-                } else {
-                    return Err(err);
-                }
+            Err(CoreError::PathTaken) => {
+                path_service::get_by_path(config, &lockbook_path_with_new)?
             }
+            Err(err) => return Err(err),
         };
 
         file_service::write_document(config, file_metadata.id, content.as_slice())?;
@@ -80,12 +78,10 @@ fn import_file_recursively(
             fs::read_dir(disk_path).map_err(CoreError::from)?.collect();
 
         if children.is_empty() {
-            path_service::create_at_path(config, &lockbook_path_with_new).map_err(
-                |err| match err {
-                    CoreError::PathTaken => CoreError::ImportCollision(lockbook_path_with_new),
-                    _ => err,
-                },
-            )?;
+            match path_service::create_at_path(config, &lockbook_path_with_new) {
+                Ok(_) | Err(CoreError::PathTaken) => {}
+                Err(err) => return Err(err),
+            }
         } else {
             for maybe_child in children {
                 let child_path = maybe_child.map_err(CoreError::from)?.path();
@@ -94,7 +90,6 @@ fn import_file_recursively(
                     config,
                     &child_path,
                     &lockbook_path_with_new,
-                    edit,
                     import_progress,
                 )?;
             }

--- a/core/tests/import_export_file_tests.rs
+++ b/core/tests/import_export_file_tests.rs
@@ -40,7 +40,7 @@ mod import_export_file_tests {
             assert!(info.disk_path.exists());
         };
 
-        import_file(&config, root.id, doc_path, false, Some(Box::new(f.clone()))).unwrap();
+        import_file(&config, doc_path, root.id, Some(Box::new(f.clone()))).unwrap();
 
         get_file_by_path(&config, &format!("/{}/{}", root.name, name)).unwrap();
 
@@ -55,14 +55,7 @@ mod import_export_file_tests {
 
         std::fs::write(&child_path, rand::thread_rng().gen::<[u8; 32]>()).unwrap();
 
-        import_file(
-            &config,
-            root.id,
-            parent_path,
-            false,
-            Some(Box::new(f.clone())),
-        )
-        .unwrap();
+        import_file(&config, parent_path, root.id, Some(Box::new(f.clone()))).unwrap();
 
         get_file_by_path(
             &config,


### PR DESCRIPTION
# Touch up `lockbook copy`

Fix a bug where files that didn't exist weren't created, and documents names were treated as folders.

Additionally added support for posix shell `*`. This enables the most straightforward recovery from a backup:

```bash 
lockbook copy parth/* parth
```

bash will expand this to include all the top level folders in your root directory, and they will be copied in one folder at a time.

the universal restore command (from a backup dir): `lockbook copy $(lockbook whoami)/* $(lockbook whoami)`

I also simplified the contract for copy, the terminal argument (the destination) must always be a folder. We also no longer check before overwriting files in core (neither does the actual `cp` command).

closes #862 