### PR TITLE
core: core fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "strum_macros 0.19.4",
  "tempfile",
  "uuid",
+ "variant_count",
 ]
 
 [[package]]
@@ -4079,6 +4080,16 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
  "serde",
+]
+
+[[package]]
+name = "variant_count"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500f7e5a63596852b9bf7583fe86f9ad08e0df9b4eb58d12e9729071cb4952ca"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "inflate"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2066,7 @@ dependencies = [
  "fern",
  "flate2",
  "image",
+ "indicatif 0.17.0-beta.1",
  "jni",
  "libsecp256k1",
  "lockbook-crypto",
@@ -2134,7 +2147,7 @@ dependencies = [
  "fern",
  "futures",
  "hyper",
- "indicatif",
+ "indicatif 0.16.2",
  "libsecp256k1",
  "lockbook-core",
  "lockbook-crypto",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,6 +52,7 @@ debug = true
 criterion = "0.3.3"
 cpuprofiler = "0.0.4"
 libsecp256k1 = "0.5.0"
+variant_count = "1.1.0"
 
 [[bench]]
 name = "performator"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,6 +53,7 @@ criterion = "0.3.3"
 cpuprofiler = "0.0.4"
 libsecp256k1 = "0.5.0"
 variant_count = "1.1.0"
+indicatif = "0.17.0-beta.1"
 
 [[bench]]
 name = "performator"

--- a/core/tests/sync_fuzzer.rs
+++ b/core/tests/sync_fuzzer.rs
@@ -2,52 +2,112 @@ mod integration_test;
 
 #[cfg(test)]
 mod sync_fuzzer {
+    use crate::sync_fuzzer::Actions::{NewFolder, NewMarkdownFile, SyncAndCheck};
+    use indicatif::{ProgressBar, ProgressStyle};
+    use lockbook_core::model::client_conversion::ClientFileMetadata;
     use lockbook_core::model::state::Config;
-    use lockbook_core::service::test_utils::{test_config, random_username, url};
-    use rand::distributions::{Distribution, Standard};
+    use lockbook_core::service::account_service::{create_account, export_account, import_account};
+    use lockbook_core::service::sync_service::sync;
+    use lockbook_core::service::test_utils::{assert_dbs_eq, random_username, test_config, url};
+    use lockbook_core::{calculate_work, create_file, list_metadatas};
+    use lockbook_models::file_metadata::FileType::{Document, Folder};
+    use rand::distributions::{Alphanumeric, Distribution, Standard};
+    use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
     use variant_count::VariantCount;
-    use crate::sync_fuzzer::Actions::{NewFolder, NewMarkdownFile, SyncAndCheck};
-    use rand::rngs::StdRng;
-    use lockbook_core::service::account_service::{create_account, import_account, export_account};
-    use lockbook_core::service::sync_service::sync;
 
-    static CLIENTS: u8 = 2;
-    static ACTION_COUNT: u8 = 10;
+    static SEED: u64 = 0;
+    static CLIENTS: u8 = 5;
+    static ACTION_COUNT: u64 = 1000;
+    static SHOW_PROGRESS: bool = true;
+    static MAX_FILE_SIZE: u128 = 1024;
 
     /// If you add a variant here, make sure you add the corresponding entry for random selection
     /// See `impl Distribution<Actions> for Standard`
-    #[derive(VariantCount)]
+    #[derive(VariantCount, Debug)]
     enum Actions {
         NewFolder(u8),
-        NewMarkdownFile(u8),
+        NewMarkdownFile { client_id: u8, file_size: u128 },
         SyncAndCheck,
     }
 
     #[test]
     fn stress_test_sync() {
-        let mut rng = StdRng::seed_from_u64(0);
+        println!("seed: {}", SEED);
+        println!("clients: {}", CLIENTS);
+
+        let mut rng = StdRng::seed_from_u64(SEED);
         let clients = create_clients();
 
+        let pb = setup_progress_bar();
         for _ in 0..ACTION_COUNT {
-            let action: Actions = rng.gen();
-            action.execute(&clients);
+            let action = rng.gen::<Actions>();
+            if SHOW_PROGRESS {
+                pb.set_message(format!("{:?}", action));
+                pb.inc(1)
+            };
+            action.execute(&clients, &mut rng);
         }
     }
 
     impl Actions {
-        fn execute(&self, clients: &[Config])  {
+        fn execute(&self, clients: &[Config], rng: &mut StdRng) {
             match &self {
                 NewFolder(id) => {
-                    println!("New Folder: {}", id)
+                    let client = &clients[(*id as usize)];
+                    let parent = Self::pick_random_parent(&client, rng);
+                    let name = Self::random_filename(rng);
+                    create_file(&client, &name, parent.id, Folder).unwrap();
                 }
-                NewMarkdownFile(id) => {
-                    println!("Markdown: {}", id)
+                NewMarkdownFile {
+                    client_id,
+                    file_size,
+                } => {
+                    let client = &clients[(*client_id as usize)];
+                    let parent = Self::pick_random_parent(&client, rng);
+                    let name = Self::random_filename(rng);
+                    let file = create_file(client, &name, parent.id, Document).unwrap();
                 }
                 SyncAndCheck => {
-                    println!("Sync")
+                    for _ in 0..2 {
+                        for client in clients {
+                            sync(client, None).unwrap()
+                        }
+                    }
+
+                    for row in clients {
+                        for col in clients {
+                            assert_dbs_eq(row, col);
+                        }
+                        assert!(calculate_work(row).unwrap().local_files.is_empty());
+                        assert!(calculate_work(row).unwrap().server_files.is_empty());
+                        assert_eq!(calculate_work(row).unwrap().server_unknown_name_count, 0);
+                    }
                 }
             }
+        }
+
+        fn random_filename(rng: &mut StdRng) -> String {
+            rng.sample_iter(&Alphanumeric)
+                .take(7)
+                .map(char::from)
+                .collect()
+        }
+
+        fn random_utf8(rng: &mut StdRng, size) -> String {
+            rand::thread_rng()
+                .gen_iter::<char>()
+                .take(len)
+                .collect();
+        }
+
+        fn pick_random_parent(config: &Config, rng: &mut StdRng) -> ClientFileMetadata {
+            let mut possible_parents = list_metadatas(&config).unwrap();
+            possible_parents.sort_by(|lhs, rhs| lhs.name.cmp(&rhs.name));
+            possible_parents.retain(|meta| meta.file_type == Folder);
+
+            let parent_index = rng.gen_range(0, possible_parents.len());
+            possible_parents[parent_index].clone()
         }
     }
 
@@ -61,7 +121,7 @@ mod sync_fuzzer {
         create_account(&configs[0], &random_username(), &url()).unwrap();
         let account_string = export_account(&configs[0]).unwrap();
 
-        for client in configs[1..] {
+        for client in &configs[1..] {
             import_account(&client, &account_string).unwrap();
             sync(&client, None).unwrap();
         }
@@ -71,13 +131,25 @@ mod sync_fuzzer {
     impl Distribution<Actions> for Standard {
         fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Actions {
             let client_id = rng.gen_range(0, CLIENTS);
+            let file_size = rng.gen_range(0, MAX_FILE_SIZE);
 
             match rng.gen_range(0, Actions::VARIANT_COUNT) {
                 0 => NewFolder(client_id),
-                1 => NewMarkdownFile(client_id),
+                1 => NewMarkdownFile { client_id, file_size },
                 2 => SyncAndCheck,
                 _ => panic!("An enum was added to Actions, but does not have a corresponding random selection")
             }
         }
+    }
+
+    fn setup_progress_bar() -> ProgressBar {
+        let pb = ProgressBar::new(ACTION_COUNT);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {msg}")
+                .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
+                .progress_chars("#>-"),
+        );
+        pb
     }
 }

--- a/core/tests/sync_fuzzer.rs
+++ b/core/tests/sync_fuzzer.rs
@@ -1,0 +1,83 @@
+mod integration_test;
+
+#[cfg(test)]
+mod sync_fuzzer {
+    use lockbook_core::model::state::Config;
+    use lockbook_core::service::test_utils::{test_config, random_username, url};
+    use rand::distributions::{Distribution, Standard};
+    use rand::{Rng, SeedableRng};
+    use variant_count::VariantCount;
+    use crate::sync_fuzzer::Actions::{NewFolder, NewMarkdownFile, SyncAndCheck};
+    use rand::rngs::StdRng;
+    use lockbook_core::service::account_service::{create_account, import_account, export_account};
+    use lockbook_core::service::sync_service::sync;
+
+    static CLIENTS: u8 = 2;
+    static ACTION_COUNT: u8 = 10;
+
+    /// If you add a variant here, make sure you add the corresponding entry for random selection
+    /// See `impl Distribution<Actions> for Standard`
+    #[derive(VariantCount)]
+    enum Actions {
+        NewFolder(u8),
+        NewMarkdownFile(u8),
+        SyncAndCheck,
+    }
+
+    #[test]
+    fn stress_test_sync() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let clients = create_clients();
+
+        for _ in 0..ACTION_COUNT {
+            let action: Actions = rng.gen();
+            action.execute(&clients);
+        }
+    }
+
+    impl Actions {
+        fn execute(&self, clients: &[Config])  {
+            match &self {
+                NewFolder(id) => {
+                    println!("New Folder: {}", id)
+                }
+                NewMarkdownFile(id) => {
+                    println!("Markdown: {}", id)
+                }
+                SyncAndCheck => {
+                    println!("Sync")
+                }
+            }
+        }
+    }
+
+    fn create_clients() -> Vec<Config> {
+        let mut configs = vec![];
+
+        for _ in 0..CLIENTS {
+            configs.push(test_config());
+        }
+
+        create_account(&configs[0], &random_username(), &url()).unwrap();
+        let account_string = export_account(&configs[0]).unwrap();
+
+        for client in configs[1..] {
+            import_account(&client, &account_string).unwrap();
+            sync(&client, None).unwrap();
+        }
+        configs
+    }
+
+    impl Distribution<Actions> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Actions {
+            let client_id = rng.gen_range(0, CLIENTS);
+
+            match rng.gen_range(0, Actions::VARIANT_COUNT) {
+                0 => NewFolder(client_id),
+                1 => NewMarkdownFile(client_id),
+                2 => SyncAndCheck,
+                _ => panic!("An enum was added to Actions, but does not have a corresponding random selection")
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is gonna be a bit of an exploratory PR, where I try to write a fuzzer to compare the performance of sync v2 & sync v3. Sync v2 has known bugs (which is why we're re-writing), but sync v3 is also a significant re-write with lots of room for small mistakes.

The goal of the fuzzer is to identify where, not if something is going to break. We know we can't support a certain number of files, or files above a certain size, etc. Ideally it will help us more clearly define what those limits are (rather than what we think they are).

Some interesting design decisions made so far:
+ Use randomness everywhere we can, generate the most chaos possible, try to break it. 
+ How do we know we're in a good state?
    + [ ] Sync cleanly
    + [ ] DB equality
    + [ ] DB integrity
+ Reproducibility
    + How reproducible should we make this? We could write all the steps we take to a log, and have a program that could step through that file. We could write that file to disk and replay failures locally for pin-pointed debugging. 
    + However I intend to, if it is able to run for longer than like an hour, throw this on a server to run for days until a bug is found.
    + In this case, replay isn't really practical, it would be more practical to have logs throughout this stack communicate the current state of the current simulation. So that we can find the problem without having to reproduce it.
    + A log could, if all the entropy is contained to it, allow an error to be reproducible across different iterations of the fuzzer. However we could also just print the commit hash at the start of the log. The point is to find errors within core.
    + The log could also be a cool way to build a lockbook-script. That allows you to script steps of core. But this is just what integration tests are, and rust is going to be a better experience than lockbook lang.
    + But we def should cleanup core logs and make them super useful: #756.
    + So I think the move is going to be to 

closes #179 