### PR TITLE
infra: certbot SSL cert update script hook

### DIFF
--- a/server/instances/haproxy/update-ssl-cert.sh
+++ b/server/instances/haproxy/update-ssl-cert.sh
@@ -19,4 +19,5 @@ for SITE in $(ls "$CERTBOT_SITES_DIR" ); do
 		echo "SSL cert written to $SSL_CERT"
 	fi
 done
-echo "please restart any dependant services..."
+
+systemctl restart haproxy && echo "HAProxy restarted"

--- a/server/instances/haproxy/update-ssl-cert.sh
+++ b/server/instances/haproxy/update-ssl-cert.sh
@@ -15,7 +15,7 @@ for SITE in $(ls "$CERTBOT_SITES_DIR" ); do
 			&& exit 1
 
 		echo "combining and updating SSL cert for $SITE"
-		# cat "$CERTBOT_CERT_DIR/fullchain.pem" "$CERTBOT_CERT_DIR/privkey.pem" > "$SSL_CERT"
+		cat "$CERTBOT_CERT_DIR/fullchain.pem" "$CERTBOT_CERT_DIR/privkey.pem" > "$SSL_CERT"
 		echo "SSL cert written to $SSL_CERT"
 	fi
 done

--- a/server/instances/haproxy/update-ssl-cert.sh
+++ b/server/instances/haproxy/update-ssl-cert.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+CERTBOT_SITES_DIR="/etc/letsencrypt/live"
+for SITE in $(ls "$CERTBOT_SITES_DIR" ); do
+	if [ -d "$CERTBOT_SITES_DIR/$SITE" ]; then
+	       	echo "found site $SITE"
+		CERTBOT_CERT_DIR="/etc/letsencrypt/live/$SITE"
+		SSL_CERT="/etc/ssl/$SITE/$SITE.pem"
+
+		[ -z "$SITE" ] && echo "usage: $0 <your-site>" \
+			&& exit 1
+		[ ! -d "$CERTBOT_CERT_DIR" ] && echo "certbot cert directory $CERTBOT_CERT_DIR does not exist!" \
+			&& exit 1
+		[ ! -f "$SSL_CERT" ] && echo "current SSL certificate $SSL_CERT does not exist" \
+			&& exit 1
+
+		echo "combining and updating SSL cert for $SITE"
+		# cat "$CERTBOT_CERT_DIR/fullchain.pem" "$CERTBOT_CERT_DIR/privkey.pem" > "$SSL_CERT"
+		echo "SSL cert written to $SSL_CERT"
+	fi
+done
+echo "please restart any dependant services..."

--- a/utils/infra/setup.load-balancer.haproxy.sh
+++ b/utils/infra/setup.load-balancer.haproxy.sh
@@ -4,7 +4,7 @@
 set -a
 . "$(dirname $0)"/vars.env
 
-TARGET=$1
+TARGET="$1"
 ssh -q $TARGET exit || { echo "could not SSH into $TARGET"; exit 1; }
 
 if [ "$2" == "-f" ]; then
@@ -25,9 +25,13 @@ ssh $TARGET << EOF
 EOF
 fi
 
-scp $GIT_ROOT/server/instances/haproxy/load-balancer.haproxy.cfg $TARGET:/etc/haproxy/haproxy.cfg
+scp $GIT_ROOT/server/instances/haproxy/load-balancer.haproxy.cfg \
+    $TARGET:/etc/haproxy/haproxy.cfg
+scp $GIT_ROOT/server/instances/haproxy/update-ssl-cert.sh \
+    $TARGET:/etc/letsencrypt/renewal-hooks/post/update-ssl-cert.sh
 
 ssh $TARGET << EOF
+  chmod +x /etc/letsencrypt/renewal-hooks/post/update-ssl-cert.sh
   systemctl enable haproxy
   systemctl restart haproxy
   systemctl status haproxy


### PR DESCRIPTION
When certbot renews it's cert this will create the combined SSL pem that haproxy points to automatically.

Server will need to be restarted manually afterwards

closes #877