### PR TITLE
linux: redesign search ui/ux

### DIFF
--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -118,12 +118,8 @@ impl AccountScreen {
         buf.get_text(&start, &end, true).unwrap().to_string()
     }
 
-    pub fn set_saving(&self, is_saving: bool) {
-        if is_saving {
-            //self.header.show_spinner();
-        } else {
-            //self.header.hide_spinner();
-        }
+    pub fn set_saving(&self, _is_saving: bool) {
+        // todo: how to indicate saving now since there is no more header bar
     }
 
     pub fn status(&self) -> &Rc<StatusPanel> {

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -63,19 +63,11 @@ impl AccountScreen {
 
     pub fn show(&self, mode: &EditMode) {
         match mode {
-            EditMode::PlainText {
-                path: _,
-                meta,
-                content,
-            } => {
+            EditMode::PlainText { meta, content } => {
                 self.sidebar.tree.select(&meta.id);
                 self.editor.set_file(&meta.name, content);
             }
-            EditMode::Folder {
-                path: _,
-                meta,
-                n_children,
-            } => {
+            EditMode::Folder { meta, n_children } => {
                 self.sidebar.tree.focus();
                 self.sidebar.tree.select(&meta.id);
                 self.editor.show_folder_info(meta, *n_children);

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -28,7 +28,7 @@ use crate::{closure, get_language_specs_dir, progerr, uerr, uerr_dialog};
 pub struct AccountScreen {
     pub sidebar: Sidebar,
     editor: Editor,
-    pub cntr: GtkBox,
+    pub cntr: gtk::Paned,
 }
 
 impl AccountScreen {
@@ -36,13 +36,10 @@ impl AccountScreen {
         let sidebar = Sidebar::new(m, c, s);
         let editor = Editor::new(m);
 
-        let paned = gtk::Paned::new(Horizontal);
-        paned.set_position(350);
-        paned.add1(&sidebar.cntr);
-        paned.add2(&editor.cntr);
-
-        let cntr = GtkBox::new(Vertical, 0);
-        cntr.pack_start(&paned, true, true, 0);
+        let cntr = gtk::Paned::new(Horizontal);
+        cntr.set_position(350);
+        cntr.add1(&sidebar.cntr);
+        cntr.add2(&editor.cntr);
 
         Self {
             sidebar,

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -28,8 +28,8 @@ use crate::filetree::FileTree;
 use crate::messages::{Messenger, Msg, MsgFn};
 use crate::settings::Settings;
 use crate::util::{
-    gui as gui_util, gui::LEFT_CLICK, gui::RIGHT_CLICK, IMAGE_TARGET_INFO, TEXT_TARGET_INFO,
-    URI_TARGET_INFO,
+    gui as gui_util, gui::KEY_ARROW_DOWN, gui::KEY_ARROW_UP, gui::LEFT_CLICK, gui::RIGHT_CLICK,
+    IMAGE_TARGET_INFO, TEXT_TARGET_INFO, URI_TARGET_INFO,
 };
 use crate::{closure, get_language_specs_dir, progerr, uerr, uerr_dialog};
 
@@ -231,7 +231,7 @@ impl Header {
 
         search.connect_key_release_event(closure!(m => move |_, key| {
             let k = key.get_hardware_keycode();
-            if k != ARROW_UP && k != ARROW_DOWN {
+            if k != KEY_ARROW_UP && k != KEY_ARROW_DOWN {
                 m.send(Msg::SearchFieldUpdate);
             }
             gtk::Inhibit(false)
@@ -622,5 +622,3 @@ fn entry_set_primary_icon_tooltip(entry: &GtkEntry, tooltip: Option<&str>) {
 const LOGO: &[u8] = include_bytes!("../res/lockbook-pixdata");
 
 const ESC: u16 = 9;
-const ARROW_UP: u16 = 111;
-const ARROW_DOWN: u16 = 116;

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -766,7 +766,7 @@ impl LbApp {
 
                     match lb.core.file_by_id(id) {
                         Ok(f) => {
-                            if let Ok(_) = lb.core.full_path_for(&f.id) {
+                            if lb.core.full_path_for(&f.id).is_ok() {
                                 lb.messenger.send(Msg::RefreshSyncStatus);
                             }
                         }
@@ -846,7 +846,7 @@ impl LbApp {
             } else {
                 "edit-find-symbolic"
             };
-            util::gui::set_entry_icon(&entry, icon_name);
+            util::gui::set_entry_icon(entry, icon_name);
         });
 
         let d = self.gui.new_dialog("Search");
@@ -867,7 +867,7 @@ impl LbApp {
     }
 
     fn search_field_exec(&self, maybe_input: Option<String>) -> LbResult<()> {
-        if let Some(path) = maybe_input.or(self.state.borrow().get_first_search_match()) {
+        if let Some(path) = maybe_input.or_else(|| self.state.borrow().get_first_search_match()) {
             match self.core.file_by_path(&path) {
                 Ok(meta) => self.messenger.send(Msg::OpenFile(Some(meta.id))),
                 Err(err) => self

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -560,17 +560,12 @@ impl LbApp {
         // Check for file dirtiness here
         let (meta, content) = self.core.open(id)?;
         self.state.borrow_mut().open_file_dirty = false;
-        self.edit(&EditMode::PlainText {
-            path: self.core.full_path_for(&meta.id)?,
-            meta,
-            content,
-        })
+        self.edit(&EditMode::PlainText { meta, content })
     }
 
     fn open_folder(&self, f: &ClientFileMetadata) -> LbResult<()> {
         let children = self.core.children(f)?;
         self.edit(&EditMode::Folder {
-            path: self.core.full_path_for(&f.id)?,
             meta: f.clone(),
             n_children: children.len(),
         })

--- a/clients/linux/src/editmode.rs
+++ b/clients/linux/src/editmode.rs
@@ -2,13 +2,11 @@ use lockbook_core::model::client_conversion::ClientFileMetadata;
 
 pub enum EditMode {
     Folder {
-        path: String,
         meta: ClientFileMetadata,
         n_children: usize,
     },
 
     PlainText {
-        path: String,
         meta: ClientFileMetadata,
         content: String,
     },

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -43,7 +43,7 @@ macro_rules! tree_iter_value {
             .expect(&format!(
                 "getting treeview value: column id {}: mandatory value not found",
                 $id
-            ));
+            ))
     };
 }
 
@@ -377,10 +377,11 @@ impl FileTree {
     pub fn add(&self, b: &LbCore, f: &ClientFileMetadata) -> LbResult<()> {
         let mut file = f.clone();
         let mut parent_iter: Option<GtkTreeIter>;
-        while {
+        loop {
             parent_iter = self.search(&self.iter(), &file.parent);
-            parent_iter == None
-        } {
+            if parent_iter.is_some() {
+                break;
+            }
             file = b.file_by_id(file.parent)?;
         }
 

--- a/clients/linux/src/lbsearch.rs
+++ b/clients/linux/src/lbsearch.rs
@@ -1,0 +1,82 @@
+use std::cmp;
+
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use gtk::prelude::*;
+
+use crate::tree_iter_value;
+
+pub struct LbSearch {
+    possibs: Vec<String>,
+    list_store: gtk::ListStore,
+    pub sort_model: gtk::TreeModelSort,
+    matcher: SkimMatcherV2,
+}
+
+impl LbSearch {
+    pub fn new(possibs: Vec<String>) -> Self {
+        let list_store = gtk::ListStore::new(&[i64::static_type(), String::static_type()]);
+        let sort_model = gtk::TreeModelSort::new(&list_store);
+        sort_model.set_sort_column_id(gtk::SortColumn::Index(0), gtk::SortType::Descending);
+        sort_model.set_sort_func(gtk::SortColumn::Index(0), Self::cmp_possibs);
+
+        Self {
+            possibs,
+            list_store,
+            sort_model,
+            matcher: SkimMatcherV2::default(),
+        }
+    }
+
+    fn cmp_possibs(
+        model: &gtk::TreeModel,
+        it1: &gtk::TreeIter,
+        it2: &gtk::TreeIter,
+    ) -> cmp::Ordering {
+        let score1 = tree_iter_value!(model, it1, 0, i64);
+        let score2 = tree_iter_value!(model, it2, 0, i64);
+
+        match score1.cmp(&score2) {
+            cmp::Ordering::Greater => cmp::Ordering::Greater,
+            cmp::Ordering::Less => cmp::Ordering::Less,
+            cmp::Ordering::Equal => {
+                let text1 = tree_iter_value!(model, it1, 1, String);
+                let text2 = model
+                    .get_value(&it2, 1)
+                    .get::<String>()
+                    .unwrap_or_default()
+                    .unwrap_or_default();
+                if text2.is_empty() {
+                    return cmp::Ordering::Less;
+                }
+
+                let chars1: Vec<char> = text1.chars().collect();
+                let chars2: Vec<char> = text2.chars().collect();
+
+                let n_chars1 = chars1.len();
+                let n_chars2 = chars2.len();
+
+                for i in 0..cmp::min(n_chars1, n_chars2) {
+                    let ord = chars1[i].cmp(&chars2[i]);
+                    if ord != cmp::Ordering::Equal {
+                        return ord.reverse();
+                    }
+                }
+
+                n_chars1.cmp(&n_chars2)
+            }
+        }
+    }
+
+    pub fn update_for(&self, pattern: &str) {
+        let list = &self.list_store;
+        list.clear();
+
+        for p in &self.possibs {
+            if let Some(score) = self.matcher.fuzzy_match(&p, &pattern) {
+                let values: [&dyn ToValue; 2] = [&score, &p];
+                list.set(&list.append(), &[0, 1], &values);
+                //list.set(&list.append(), &[(0, &score), (1, &p)]);
+            }
+        }
+    }
+}

--- a/clients/linux/src/lbsearch.rs
+++ b/clients/linux/src/lbsearch.rs
@@ -41,7 +41,7 @@ impl LbSearch {
             cmp::Ordering::Equal => {
                 let text1 = tree_iter_value!(model, it1, 1, String);
                 let text2 = model
-                    .get_value(&it2, 1)
+                    .get_value(it2, 1)
                     .get::<String>()
                     .unwrap_or_default()
                     .unwrap_or_default();
@@ -72,7 +72,7 @@ impl LbSearch {
         list.clear();
 
         for p in &self.possibs {
-            if let Some(score) = self.matcher.fuzzy_match(&p, &pattern) {
+            if let Some(score) = self.matcher.fuzzy_match(p, pattern) {
                 let values: [&dyn ToValue; 2] = [&score, &p];
                 list.set(&list.append(), &[0, 1], &values);
                 //list.set(&list.append(), &[(0, &score), (1, &p)]);

--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -15,6 +15,7 @@ mod editmode;
 mod error;
 mod filetree;
 mod intro;
+mod lbsearch;
 mod menubar;
 mod messages;
 mod settings;

--- a/clients/linux/src/menubar.rs
+++ b/clients/linux/src/menubar.rs
@@ -176,7 +176,7 @@ impl Item {
     #[rustfmt::skip]
     fn data() -> Vec<(Self, ItemData)> {
         vec![
-            (Self::FileOpen, ("Open", "", || Msg::SearchFieldFocus)),
+            (Self::FileOpen, ("Open", "<Primary>L", || Msg::PromptSearch)),
             (Self::FileSave, ("Save", "<Primary>S", || Msg::SaveFile)),
             (Self::FileClose, ("Close File", "<Primary>W", || Msg::CloseFile)),
             (Self::FileQuit, ("Quit", "", || Msg::Quit)),

--- a/clients/linux/src/menubar.rs
+++ b/clients/linux/src/menubar.rs
@@ -83,7 +83,6 @@ impl Menubar {
     pub fn set(&self, mode: &EditMode) {
         match mode {
             EditMode::Folder {
-                path: _,
                 meta: _,
                 n_children: _,
             } => {
@@ -92,7 +91,6 @@ impl Menubar {
                 );
             }
             EditMode::PlainText {
-                path: _,
                 meta: _,
                 content: _,
             } => {

--- a/clients/linux/src/menubar.rs
+++ b/clients/linux/src/menubar.rs
@@ -176,7 +176,7 @@ impl Item {
     #[rustfmt::skip]
     fn data() -> Vec<(Self, ItemData)> {
         vec![
-            (Self::FileOpen, ("Open", "<Primary>L", || Msg::SearchFieldFocus)),
+            (Self::FileOpen, ("Open", "", || Msg::SearchFieldFocus)),
             (Self::FileSave, ("Save", "<Primary>S", || Msg::SaveFile)),
             (Self::FileClose, ("Close File", "<Primary>W", || Msg::CloseFile)),
             (Self::FileQuit, ("Quit", "", || Msg::Quit)),

--- a/clients/linux/src/messages.rs
+++ b/clients/linux/src/messages.rs
@@ -26,10 +26,7 @@ pub enum Msg {
 
     MarkdownLinkExec(String, String),
 
-    SearchFieldFocus,
-    SearchFieldBlur(bool),
-    SearchFieldUpdate,
-    SearchFieldUpdateIcon,
+    PromptSearch,
     SearchFieldExec(Option<String>),
 
     ToggleTreeCol(FileTreeCol),

--- a/clients/linux/src/util.rs
+++ b/clients/linux/src/util.rs
@@ -19,8 +19,9 @@ macro_rules! closure {
 pub mod gui {
     use gtk::prelude::ButtonExt;
     use gtk::prelude::ContainerExt;
+    use gtk::prelude::EntryExt;
     use gtk::prelude::IsA;
-    use gtk::prelude::WidgetExt as GtkWidgetExt;
+    use gtk::prelude::WidgetExt;
     use gtk::Adjustment as GtkAdjustment;
     use gtk::Align as GtkAlign;
     use gtk::Button as GtkButton;
@@ -59,7 +60,7 @@ pub mod gui {
     }
 
     pub fn set_widget_name<W: IsA<GtkWidget>>(w: &W, name: &str) {
-        GtkWidgetExt::set_widget_name(w, name);
+        gtk::WidgetExt::set_widget_name(w, name);
     }
 
     pub fn set_margin<W: IsA<GtkWidget>>(w: &W, v: i32) {
@@ -91,8 +92,14 @@ pub mod gui {
         l
     }
 
-    pub const RIGHT_CLICK: u32 = 3;
+    pub fn set_entry_icon(entry: &gtk::Entry, name: &str) {
+        entry.set_icon_from_icon_name(gtk::EntryIconPosition::Primary, Some(name));
+    }
+
+    pub const KEY_ARROW_UP: u16 = 111;
+    pub const KEY_ARROW_DOWN: u16 = 116;
     pub const LEFT_CLICK: u32 = 1;
+    pub const RIGHT_CLICK: u32 = 3;
 }
 
 pub mod io {


### PR DESCRIPTION
This PR removes the top search bar on the linux client in favor of a search dialog shown on `Ctrl-L` or `Ctrl-Space`. Additionally, the search functionality is placed into its own file. (There are a few minor cleanups sprinkled in as well.)

The spinner in the header bar was used for indicating to the user that a file was in the process of being saved. If we still want to notify the user when this happens, we need to come up with a different way. Otherwise, that last bit of code can go as well.

<details><summary>Before:</summary>

![image](https://user-images.githubusercontent.com/6127189/140621137-2ba0d2fe-0624-4bf9-a48f-96ebe4d049f7.png)

</details>

<details><summary>After:</summary>

![image](https://user-images.githubusercontent.com/6127189/140621207-bcfc040e-2b96-448a-b056-f1bf6c0a2ab5.png)

</details>