### PR TITLE
linux: populating file tree is quicker

### DIFF
--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
@@ -8,13 +9,7 @@ use uuid::Uuid;
 use lockbook_core::model::state::Config;
 use lockbook_core::service::db_state_service::State as DbState;
 use lockbook_core::service::sync_service::{SyncProgress, WorkCalculated};
-use lockbook_core::{
-    calculate_work, create_account, create_file, delete_file, export_account, export_file,
-    get_account, get_and_get_children_recursively, get_children, get_db_state, get_file_by_id,
-    get_file_by_path, get_last_synced, get_path_by_id, get_root, get_usage, import_account,
-    import_file, list_paths, migrate_db, move_file, read_document, rename_file, sync_all,
-    write_document,
-};
+use lockbook_core::{calculate_work, create_account, create_file, delete_file, export_account, export_file, get_account, get_and_get_children_recursively, get_children, get_db_state, get_file_by_id, get_file_by_path, get_last_synced, get_path_by_id, get_root, get_usage, import_account, import_file, list_metadatas, list_paths, migrate_db, move_file, read_document, rename_file, sync_all, write_document};
 use lockbook_models::account::Account;
 use lockbook_models::crypto::DecryptedDocument;
 
@@ -166,6 +161,10 @@ impl LbCore {
 
     pub fn children(&self, parent: &DecryptedFileMetadata) -> LbResult<Vec<DecryptedFileMetadata>> {
         Ok(get_children(&self.config, parent.id)?)
+    }
+
+    pub fn get_all_files(&self) -> LbResult<Vec<DecryptedFileMetadata>> {
+        Ok(list_metadatas(&self.config)?)
     }
 
     pub fn get_children_recursively(&self, id: Uuid) -> LbResult<Vec<FileMetadata>> {

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
@@ -9,7 +8,13 @@ use uuid::Uuid;
 use lockbook_core::model::state::Config;
 use lockbook_core::service::db_state_service::State as DbState;
 use lockbook_core::service::sync_service::{SyncProgress, WorkCalculated};
-use lockbook_core::{calculate_work, create_account, create_file, delete_file, export_account, export_file, get_account, get_and_get_children_recursively, get_children, get_db_state, get_file_by_id, get_file_by_path, get_last_synced, get_path_by_id, get_root, get_usage, import_account, import_file, list_metadatas, list_paths, migrate_db, move_file, read_document, rename_file, sync_all, write_document};
+use lockbook_core::{
+    calculate_work, create_account, create_file, delete_file, export_account, export_file,
+    get_account, get_and_get_children_recursively, get_children, get_db_state, get_file_by_id,
+    get_file_by_path, get_last_synced, get_path_by_id, get_root, get_usage, import_account,
+    import_file, list_metadatas, list_paths, migrate_db, move_file, read_document, rename_file,
+    sync_all, write_document,
+};
 use lockbook_models::account::Account;
 use lockbook_models::crypto::DecryptedDocument;
 

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -381,12 +381,8 @@ impl FileTree {
         let name = &metadata.decrypted_name;
         let id = &metadata.id.to_string();
         let ftype = &format!("{:?}", metadata.file_type);
-        self.model.insert_with_values(
-            iter,
-            None,
-            &[0, 1, 2, 3],
-            &[&icon_name, name, id, ftype],
-        )
+        self.model
+            .insert_with_values(iter, None, &[0, 1, 2, 3], &[&icon_name, name, id, ftype])
     }
 
     pub fn fill(&self, c: &LbCore) -> LbResult<()> {

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -347,12 +347,12 @@ impl FileTree {
         self.tree.get_selection().get_selected_rows()
     }
 
-    pub fn vec_into_tree(
+    pub fn populate_tree(
         &self,
         metadatas: &[DecryptedFileMetadata],
         parent_metadata: &DecryptedFileMetadata,
         parent_iter: &TreeIter,
-    ) -> LbResult<()> {
+    ) {
         let children: Vec<&DecryptedFileMetadata> = metadatas
             .iter()
             .filter(|metadata| {
@@ -364,11 +364,9 @@ impl FileTree {
             let item_iter = self.shallow_append(Some(parent_iter), child);
 
             if child.file_type == FileType::Folder {
-                self.vec_into_tree(metadatas, child, &item_iter)?;
+                self.populate_tree(metadatas, child, &item_iter);
             }
         }
-
-        Ok(())
     }
 
     fn shallow_append(
@@ -391,7 +389,7 @@ impl FileTree {
         let root = &c.root()?;
         let root_iter = self.shallow_append(None, root);
 
-        self.vec_into_tree(metadatas.as_slice(), root, &root_iter)?;
+        self.populate_tree(metadatas.as_slice(), root, &root_iter);
         Ok(())
     }
 


### PR DESCRIPTION
Originally in the linux client, the filetree was populated using a chain of `get_children` calls, starting from the root. This was an inefficient process as it would require `core` to keep retrieving all the files using io operations, and matching to get the desired parent. 

In this PR, I call the exposed `lib.rs` function, `list_metadatas`, to get all the metadata. I match on these metadata to construct the file tree myself, so I don't make any more `core` calls.

On my local machine, with my lockbook containing `307` files and `14.54 mb` of compressed usage, these were the time differences between the new algorithm and the old one (the time it takes to load the file tree)

Debug Build:
`58524ms` old algorithm
`6ms` new algorithm

Release Build:
`4707ms` old algorithm
`1ms` new algorithm



