### PR TITLE
core: ignore path conflicts where one file is deleted

### DIFF
--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -259,7 +259,7 @@ pub fn get_path_conflicts(
     let mut result = Vec::new();
 
     for file in files {
-        let children = find_children(files, file.id);
+        let children = filter_not_deleted(&find_children(files, file.id));
         let mut child_ids_by_name: HashMap<String, Uuid> = HashMap::new();
         for child in children {
             if let Some(conflicting_child_id) = child_ids_by_name.get(&child.decrypted_name) {

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -242,6 +242,7 @@ pub fn get_invalid_cycles(
     Ok(result)
 }
 
+#[derive(Debug, PartialEq)]
 pub struct PathConflict {
     pub existing: Uuid,
     pub staged: Uuid,
@@ -256,10 +257,11 @@ pub fn get_path_conflicts(
         .iter()
         .map(|(f, _)| f.clone())
         .collect::<Vec<DecryptedFileMetadata>>();
+    let files = filter_not_deleted(files)?;
     let mut result = Vec::new();
 
-    for file in files {
-        let children = filter_not_deleted(&find_children(files, file.id));
+    for file in &files {
+        let children = find_children(&files, file.id);
         let mut child_ids_by_name: HashMap<String, Uuid> = HashMap::new();
         for child in children {
             if let Some(conflicting_child_id) = child_ids_by_name.get(&child.decrypted_name) {
@@ -503,22 +505,22 @@ pub fn maybe_find_root(files: &[DecryptedFileMetadata]) -> Option<DecryptedFileM
     files.iter().find(|&f| f.id == f.parent).cloned()
 }
 
-pub fn is_deleted(files: &[DecryptedFileMetadata], target_id: Uuid) -> bool {
-    filter_deleted(files).into_iter().any(|f| f.id == target_id)
+pub fn is_deleted(files: &[DecryptedFileMetadata], target_id: Uuid) -> Result<bool, CoreError> {
+    Ok(filter_deleted(files)?.into_iter().any(|f| f.id == target_id))
 }
 
-/// Returns the files which are not deleted and have no deleted ancestors. Files with parents not present in the argument are considered deleted.
-pub fn filter_not_deleted(files: &[DecryptedFileMetadata]) -> Vec<DecryptedFileMetadata> {
-    let deleted = filter_deleted(files);
-    files
+/// Returns the files which are not deleted and have no deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
+pub fn filter_not_deleted(files: &[DecryptedFileMetadata]) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
+    let deleted = filter_deleted(files)?;
+    Ok(files
         .iter()
         .filter(|f| !deleted.iter().any(|nd| nd.id == f.id))
         .cloned()
-        .collect()
+        .collect())
 }
 
-/// Returns the files which are deleted or have deleted ancestors. Files with parents not present in the argument are considered deleted.
-pub fn filter_deleted(files: &[DecryptedFileMetadata]) -> Vec<DecryptedFileMetadata> {
+/// Returns the files which are deleted or have deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
+pub fn filter_deleted(files: &[DecryptedFileMetadata]) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
     let mut result = Vec::new();
     for file in files {
         let mut ancestor = file.clone();
@@ -527,21 +529,18 @@ pub fn filter_deleted(files: &[DecryptedFileMetadata]) -> Vec<DecryptedFileMetad
                 result.push(file.clone());
                 break;
             }
-            match maybe_find(files, ancestor.parent) {
-                Some(parent) => {
-                    if ancestor.id == parent.id {
-                        break;
-                    }
-                    ancestor = parent;
-                }
-                None => {
-                    result.push(file.clone());
-                    break;
-                }
+
+            let parent = find(files, ancestor.parent)?;
+            if ancestor.id == parent.id {
+                break;
+            }
+            ancestor = parent;
+            if ancestor.id == file.id {
+                break; // this is a cycle but not our problem
             }
         }
     }
-    result
+    Ok(result)
 }
 
 /// Returns the files which are documents.
@@ -602,7 +601,7 @@ pub fn stage_encrypted(
 mod unit_tests {
     use lockbook_models::file_metadata::FileType;
 
-    use crate::pure_functions::files;
+    use crate::pure_functions::files::{self, PathConflict};
     use crate::{service::test_utils, CoreError};
 
     #[test]
@@ -819,5 +818,30 @@ mod unit_tests {
                 .unwrap(),
             "folder-2"
         );
+    }
+
+    #[test]
+    fn get_path_conflicts_no_conflicts() {
+        let account = test_utils::generate_account();
+        let root = files::create_root(&account.username);
+        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.username);
+        let folder2 = files::create(FileType::Folder, root.id, "folder2", &account.username);
+
+        let path_conflicts = files::get_path_conflicts(&[root, folder1.clone()], &[folder2.clone()]).unwrap();
+
+        assert_eq!(path_conflicts.len(), 0);
+    }
+
+    #[test]
+    fn get_path_conflicts_one_conflict() {
+        let account = test_utils::generate_account();
+        let root = files::create_root(&account.username);
+        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.username);
+        let folder2 = files::create(FileType::Folder, root.id, "folder", &account.username);
+
+        let path_conflicts = files::get_path_conflicts(&[root, folder1.clone()], &[folder2.clone()]).unwrap();
+
+        assert_eq!(path_conflicts.len(), 1);
+        assert_eq!(path_conflicts[0], PathConflict{ existing: folder1.id, staged: folder2.id });
     }
 }

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -506,11 +506,15 @@ pub fn maybe_find_root(files: &[DecryptedFileMetadata]) -> Option<DecryptedFileM
 }
 
 pub fn is_deleted(files: &[DecryptedFileMetadata], target_id: Uuid) -> Result<bool, CoreError> {
-    Ok(filter_deleted(files)?.into_iter().any(|f| f.id == target_id))
+    Ok(filter_deleted(files)?
+        .into_iter()
+        .any(|f| f.id == target_id))
 }
 
 /// Returns the files which are not deleted and have no deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
-pub fn filter_not_deleted(files: &[DecryptedFileMetadata]) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
+pub fn filter_not_deleted(
+    files: &[DecryptedFileMetadata],
+) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
     let deleted = filter_deleted(files)?;
     Ok(files
         .iter()
@@ -520,7 +524,9 @@ pub fn filter_not_deleted(files: &[DecryptedFileMetadata]) -> Result<Vec<Decrypt
 }
 
 /// Returns the files which are deleted or have deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
-pub fn filter_deleted(files: &[DecryptedFileMetadata]) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
+pub fn filter_deleted(
+    files: &[DecryptedFileMetadata],
+) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
     let mut result = Vec::new();
     for file in files {
         let mut ancestor = file.clone();
@@ -827,7 +833,8 @@ mod unit_tests {
         let folder1 = files::create(FileType::Folder, root.id, "folder", &account.username);
         let folder2 = files::create(FileType::Folder, root.id, "folder2", &account.username);
 
-        let path_conflicts = files::get_path_conflicts(&[root, folder1.clone()], &[folder2.clone()]).unwrap();
+        let path_conflicts =
+            files::get_path_conflicts(&[root, folder1.clone()], &[folder2.clone()]).unwrap();
 
         assert_eq!(path_conflicts.len(), 0);
     }
@@ -839,9 +846,16 @@ mod unit_tests {
         let folder1 = files::create(FileType::Folder, root.id, "folder", &account.username);
         let folder2 = files::create(FileType::Folder, root.id, "folder", &account.username);
 
-        let path_conflicts = files::get_path_conflicts(&[root, folder1.clone()], &[folder2.clone()]).unwrap();
+        let path_conflicts =
+            files::get_path_conflicts(&[root, folder1.clone()], &[folder2.clone()]).unwrap();
 
         assert_eq!(path_conflicts.len(), 1);
-        assert_eq!(path_conflicts[0], PathConflict{ existing: folder1.id, staged: folder2.id });
+        assert_eq!(
+            path_conflicts[0],
+            PathConflict {
+                existing: folder1.id,
+                staged: folder2.id
+            }
+        );
     }
 }

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -278,9 +278,7 @@ pub fn get_all_not_deleted_metadata(
     config: &Config,
     source: RepoSource,
 ) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
-    Ok(files::filter_not_deleted(&get_all_metadata(
-        config, source,
-    )?)?)
+    files::filter_not_deleted(&get_all_metadata(config, source)?)
 }
 
 pub fn get_all_metadata(

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -93,7 +93,7 @@ pub fn test_repo_integrity(config: &Config) -> Result<Vec<Warning>, TestRepoErro
     }
 
     let mut warnings = Vec::new();
-    for file in files::filter_not_deleted(&all_files) {
+    for file in files::filter_not_deleted(&all_files).map_err(TestRepoError::Core)? {
         if file.file_type == FileType::Document {
             let file_content = file_service::get_document(config, RepoSource::Local, &file)
                 .map_err(|err| DocumentReadError(file.id, err))?;


### PR DESCRIPTION
also fix validate so it doesn't try to read deleted documents (which can be present locally when a sync doesn't finish gracefully)