### PR TITLE
apple: prevent double syncs on sign ups

### DIFF
--- a/clients/apple/Shared/Stateful Logic/OnboardingState.swift
+++ b/clients/apple/Shared/Stateful Logic/OnboardingState.swift
@@ -23,40 +23,42 @@ class OnboardingService: ObservableObject {
     }
     
     func attemptCreate() {
-        self.working = true
-        self.createAccountError = ""
-        self.importAccountError = ""
-        DispatchQueue.global(qos: .userInitiated).async {
-            let operation = self.core.createAccount(username: self.username, apiLocation: ConfigHelper.get(.apiLocation))
-            DispatchQueue.main.async {
-                self.working = false
-                
-                switch operation {
-                case .success:
-                    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { self.anAccountWasCreatedThisSession = true }
-                    self.getAccountAndFinalize()
-                    break
-                case .failure(let err):
-                    switch err.kind {
-                    case .UiError(let uiError):
-                        switch uiError {
-                        case .AccountExistsAlready:
-                            self.createAccountError = "You already have an account! Please file a bug report!"
-                        case .ClientUpdateRequired:
-                            self.createAccountError = "Please download the most recent version of Lockbook to create an account!"
-                        case .CouldNotReachServer:
-                            self.createAccountError = "Could not reach \(ConfigHelper.get(.apiLocation))!"
-                        case .InvalidUsername:
-                            self.createAccountError = "That username is not valid!"
-                        case .UsernameTaken:
-                            self.createAccountError = "That username is not available!"
+        if !self.working {
+            self.working = true
+            self.createAccountError = ""
+            self.importAccountError = ""
+            DispatchQueue.global(qos: .userInitiated).async {
+                let operation = self.core.createAccount(username: self.username, apiLocation: ConfigHelper.get(.apiLocation))
+                DispatchQueue.main.async {
+                    self.working = false
+                    
+                    switch operation {
+                    case .success:
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { self.anAccountWasCreatedThisSession = true }
+                        self.getAccountAndFinalize()
+                        break
+                    case .failure(let err):
+                        switch err.kind {
+                        case .UiError(let uiError):
+                            switch uiError {
+                            case .AccountExistsAlready:
+                                self.createAccountError = "You already have an account! Please file a bug report!"
+                            case .ClientUpdateRequired:
+                                self.createAccountError = "Please download the most recent version of Lockbook to create an account!"
+                            case .CouldNotReachServer:
+                                self.createAccountError = "Could not reach \(ConfigHelper.get(.apiLocation))!"
+                            case .InvalidUsername:
+                                self.createAccountError = "That username is not valid!"
+                            case .UsernameTaken:
+                                self.createAccountError = "That username is not available!"
+                            }
+                            break;
+                        case .Unexpected:
+                            self.createAccountError = "Unexpected Error!"
+                            DI.errors.handleError(err)
                         }
-                        break;
-                    case .Unexpected:
-                        self.createAccountError = "Unexpected Error!"
-                        DI.errors.handleError(err)
+                        break
                     }
-                    break
                 }
             }
             
@@ -64,43 +66,45 @@ class OnboardingService: ObservableObject {
     }
     
     func handleImport() {
-        self.working = true
-        self.createAccountError = ""
-        self.importAccountError = ""
-        DispatchQueue.global(qos: .userInitiated).async {
-            let res = self.core.importAccount(accountString: self.accountString)
-            DispatchQueue.main.async {
-                self.working = false
-                switch res {
-                case .success:
-                    self.initialSyncing = true
-                    DispatchQueue.global(qos: .userInteractive).async {
-                        switch self.core.syncAll() {
-                        case .success:
-                            DispatchQueue.main.async { self.getAccountAndFinalize() }
-                        case .failure(let err):
-                            DI.errors.handleError(err)
+        if !self.working {
+            self.working = true
+            self.createAccountError = ""
+            self.importAccountError = ""
+            DispatchQueue.global(qos: .userInitiated).async {
+                let res = self.core.importAccount(accountString: self.accountString)
+                DispatchQueue.main.async {
+                    self.working = false
+                    switch res {
+                    case .success:
+                        self.initialSyncing = true
+                        DispatchQueue.global(qos: .userInteractive).async {
+                            switch self.core.syncAll() {
+                            case .success:
+                                DispatchQueue.main.async { self.getAccountAndFinalize() }
+                            case .failure(let err):
+                                DI.errors.handleError(err)
+                            }
                         }
-                    }
-                case .failure(let error):
-                    switch error.kind {
-                    case .UiError(let importError):
-                        switch importError {
-                        case .AccountDoesNotExist:
-                            self.importAccountError = "The account specified in the key does not exist on the server specified on the key!"
-                        case .AccountExistsAlready:
-                            self.importAccountError = "An account exists already! Please file a bug report!"
-                        case .AccountStringCorrupted:
-                            self.importAccountError = "This account string is corrupted!"
-                        case .ClientUpdateRequired:
-                            self.importAccountError = "Lockbook must be updated before you can continue!"
-                        case .CouldNotReachServer:
-                            self.importAccountError = "Could not reach \(ConfigHelper.get(.apiLocation))!"
-                        case .UsernamePKMismatch:
-                            self.importAccountError = "That username does not match the public key stored on this server!"
+                    case .failure(let error):
+                        switch error.kind {
+                        case .UiError(let importError):
+                            switch importError {
+                            case .AccountDoesNotExist:
+                                self.importAccountError = "The account specified in the key does not exist on the server specified on the key!"
+                            case .AccountExistsAlready:
+                                self.importAccountError = "An account exists already! Please file a bug report!"
+                            case .AccountStringCorrupted:
+                                self.importAccountError = "This account string is corrupted!"
+                            case .ClientUpdateRequired:
+                                self.importAccountError = "Lockbook must be updated before you can continue!"
+                            case .CouldNotReachServer:
+                                self.importAccountError = "Could not reach \(ConfigHelper.get(.apiLocation))!"
+                            case .UsernamePKMismatch:
+                                self.importAccountError = "That username does not match the public key stored on this server!"
+                            }
+                        case .Unexpected:
+                            DI.errors.handleError(error)
                         }
-                    case .Unexpected:
-                        DI.errors.handleError(error)
                     }
                 }
             }

--- a/clients/apple/Shared/Views/AppView.swift
+++ b/clients/apple/Shared/Views/AppView.swift
@@ -67,7 +67,7 @@ struct AppView: View {
             case let error as ErrorWithTitle:
                 return Alert(
                     title: Text(error.title),
-                    message: Text(error.message),
+                    message: Text(error.message),   
                     dismissButton: .default(Text("Dismiss"))
                 )
             default:

--- a/clients/apple/Shared/Views/OnboardingView.swift
+++ b/clients/apple/Shared/Views/OnboardingView.swift
@@ -38,6 +38,7 @@ struct OnboardingView: View {
                     TextField("Choose a username: a-z, 0-9", text: self.$onboardingState.username, onCommit: self.onboardingState.attemptCreate)
                         .disableAutocorrection(true)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .disabled(self.onboardingState.working)
                     Text(onboardingState.createAccountError)
                         .foregroundColor(.red)
                         .bold()


### PR DESCRIPTION
Apple detects that a user has pressed enter on a field by paying attention to `onCommit`. There's a strange behavior: if a button has a `.disabled` property (for example when the long computation begins), the commit is called twice. In the case of an import account this led to sync being called twice, which causes one of the operations to fail for one reason or another.

Perhaps related to #869 