### PR TITLE
linux: fix / cleanup rename file

### DIFF
--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -756,8 +756,7 @@ impl LbApp {
             match lb.core.rename(&id, &name) {
                 Ok(_) => {
                     d.close();
-                    let acctscr = &lb.gui.account;
-                    acctscr.sidebar.tree.set_name(&id, &name);
+                    lb.gui.account.sidebar.tree.set_name(&id, &name);
                     lb.gui.win.set_title(&name);
 
                     match lb.core.file_by_id(id) {

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -762,15 +762,7 @@ impl LbApp {
                             lb.gui.win.set_title(&name);
                         }
                     }
-
-                    match lb.core.file_by_id(id) {
-                        Ok(f) => {
-                            if lb.core.full_path_for(&f.id).is_ok() {
-                                lb.messenger.send(Msg::RefreshSyncStatus);
-                            }
-                        }
-                        Err(err) => lb.messenger.send_err_dialog("getting renamed file", err)
-                    }
+                    lb.messenger.send(Msg::RefreshSyncStatus);
                 }
                 Err(err) => match err.kind() {
                     UserErr => {

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -757,7 +757,11 @@ impl LbApp {
                 Ok(_) => {
                     d.close();
                     lb.gui.account.sidebar.tree.set_name(&id, &name);
-                    lb.gui.win.set_title(&name);
+                    if let Some(meta) = &lb.state.borrow().opened_file {
+                        if meta.id == id {
+                            lb.gui.win.set_title(&name);
+                        }
+                    }
 
                     match lb.core.file_by_id(id) {
                         Ok(f) => {

--- a/clients/linux/src/filetree.rs
+++ b/clients/linux/src/filetree.rs
@@ -504,7 +504,7 @@ impl FileTree {
 
     pub fn set_name(&self, id: &Uuid, name: &str) {
         if let Some(iter) = self.search(&self.iter(), id) {
-            self.model.set(&iter, &[0], &[&name.to_string()]);
+            self.model.set(&iter, &[1], &[&name.to_string()]);
         }
     }
 


### PR DESCRIPTION
This PR fixes #885 so that renaming a file no longer breaks its icon, as well as makes it so that the window title is only changed to the renamed file's name if it is the file that is open.