### PR TITLE
server: make sure usernames are case sensitive

### DIFF
--- a/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/SwiftLockbookCoreTests.swift
+++ b/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/SwiftLockbookCoreTests.swift
@@ -64,7 +64,7 @@ extension SLCTest {
     /// Generates a random username
     /// - Returns: A random username
     func randomUsername() -> String {
-        let validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        let validChars = "abcdefghijklmnopqrstuvwxyz"
         return "swiftintegrationtest" + String((0..<10).compactMap { _ in validChars.randomElement() })
     }
     

--- a/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/SwiftLockbookCoreTests.swift
+++ b/clients/apple/SwiftLockbookCore/Tests/SwiftLockbookCoreTests/SwiftLockbookCoreTests.swift
@@ -65,7 +65,7 @@ extension SLCTest {
     /// - Returns: A random username
     func randomUsername() -> String {
         let validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        return "SwiftIntegrationTest" + String((0..<10).compactMap { _ in validChars.randomElement() })
+        return "swiftintegrationtest" + String((0..<10).compactMap { _ in validChars.randomElement() })
     }
     
     /// Generates a random filename

--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -31,7 +31,7 @@ pub fn create_account(
     let keys = pubkey::generate_key();
 
     let account = Account {
-        username: String::from(username),
+        username,
         api_url: api_url.to_string(),
         private_key: keys,
     };

--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -19,6 +19,7 @@ pub fn create_account(
     username: &str,
     api_url: &str,
 ) -> Result<Account, CoreError> {
+    let username = String::from(username).to_lowercase();
     info!(
         "creating with username {} against server {}",
         username, api_url

--- a/core/tests/account_service_tests.rs
+++ b/core/tests/account_service_tests.rs
@@ -94,6 +94,33 @@ mod account_tests {
     }
 
     #[test]
+    fn create_account_account_exists_case() {
+        let db = test_config();
+        let generated_account = generate_account();
+
+        account_service::create_account(
+            &db,
+            &generated_account.username,
+            &generated_account.api_url,
+        )
+        .unwrap();
+
+        let db = test_config();
+        assert!(
+            matches!(
+                account_service::create_account(
+                    &db,
+                    &(generated_account.username.to_uppercase()),
+                    &generated_account.api_url,
+                ),
+                Err(CoreError::UsernameTaken)
+            ),
+            "This action should have failed with AccountAlreadyExists!",
+        );
+        println!("{} {}", &generated_account.username, &(generated_account.username.to_uppercase()))
+    }
+
+    #[test]
     fn import_account_account_exists() {
         let cfg1 = test_config();
         let generated_account = generate_account();

--- a/core/tests/account_service_tests.rs
+++ b/core/tests/account_service_tests.rs
@@ -117,7 +117,11 @@ mod account_tests {
             ),
             "This action should have failed with AccountAlreadyExists!",
         );
-        println!("{} {}", &generated_account.username, &(generated_account.username.to_uppercase()))
+        println!(
+            "{} {}",
+            &generated_account.username,
+            &(generated_account.username.to_uppercase())
+        )
     }
 
     #[test]

--- a/core/tests/create_account_tests.rs
+++ b/core/tests/create_account_tests.rs
@@ -2,7 +2,10 @@ mod integration_test;
 
 #[cfg(test)]
 mod change_document_content_tests {
+    use lockbook_core::CreateAccountError;
     use lockbook_core::service::api_service;
+    use lockbook_core::service::api_service::ApiError;
+    use lockbook_core::service::api_service::ApiError::Endpoint;
     use lockbook_core::service::test_utils::{generate_account, generate_root_metadata};
     use lockbook_models::api::*;
 
@@ -12,5 +15,18 @@ mod change_document_content_tests {
         let account = generate_account();
         let (root, _root_key) = generate_root_metadata(&account);
         api_service::request(&account, NewAccountRequest::new(&account, &root)).unwrap();
+    }
+
+    #[test]
+    fn create_account_username_case() {
+        // new account
+        let mut account = generate_account();
+        let (root, _root_key) = generate_root_metadata(&account);
+        api_service::request(&account, NewAccountRequest::new(&account, &root)).unwrap();
+        account.username = account.username.to_uppercase();
+        match api_service::request(&account, NewAccountRequest::new(&account, &root)) {
+            Err(ApiError::Endpoint(NewAccountError::UsernameTaken)) => {} // Test pass
+            _ => panic!("Usernames must be case sensitive")
+        }
     }
 }

--- a/core/tests/create_account_tests.rs
+++ b/core/tests/create_account_tests.rs
@@ -2,10 +2,8 @@ mod integration_test;
 
 #[cfg(test)]
 mod change_document_content_tests {
-    use lockbook_core::CreateAccountError;
     use lockbook_core::service::api_service;
     use lockbook_core::service::api_service::ApiError;
-    use lockbook_core::service::api_service::ApiError::Endpoint;
     use lockbook_core::service::test_utils::{generate_account, generate_root_metadata};
     use lockbook_models::api::*;
 
@@ -21,9 +19,11 @@ mod change_document_content_tests {
     fn create_account_username_case() {
         // new account
         let mut account = generate_account();
-        let (root, _root_key) = generate_root_metadata(&account);
+        let (mut root, _root_key) = generate_root_metadata(&account);
         api_service::request(&account, NewAccountRequest::new(&account, &root)).unwrap();
+        let old_username = account.username.clone();
         account.username = account.username.to_uppercase();
+        root.user_access_keys.insert(account.username.to_uppercase(), root.user_access_keys.get(&old_username).unwrap().clone());
         match api_service::request(&account, NewAccountRequest::new(&account, &root)) {
             Err(ApiError::Endpoint(NewAccountError::UsernameTaken)) => {} // Test pass
             _ => panic!("Usernames must be case sensitive")

--- a/core/tests/create_account_tests.rs
+++ b/core/tests/create_account_tests.rs
@@ -19,14 +19,16 @@ mod change_document_content_tests {
     fn create_account_username_case() {
         // new account
         let mut account = generate_account();
-        let (mut root, _root_key) = generate_root_metadata(&account);
+        let (root, _root_key) = generate_root_metadata(&account);
         api_service::request(&account, NewAccountRequest::new(&account, &root)).unwrap();
-        let old_username = account.username.clone();
-        account.username = account.username.to_uppercase();
-        root.user_access_keys.insert(account.username.to_uppercase(), root.user_access_keys.get(&old_username).unwrap().clone());
-        match api_service::request(&account, NewAccountRequest::new(&account, &root)) {
+        let old_username  = account.username;
+        let mut account = generate_account();
+        account.username = old_username.to_uppercase();
+        let (root, _root_key) = generate_root_metadata(&account);
+        let operation = api_service::request(&account, NewAccountRequest::new(&account, &root));
+        match operation {
             Err(ApiError::Endpoint(NewAccountError::UsernameTaken)) => {} // Test pass
-            _ => panic!("Usernames must be case sensitive")
+            _ => panic!("Usernames must be case sensitive {:?}", operation)
         }
     }
 }

--- a/core/tests/create_account_tests.rs
+++ b/core/tests/create_account_tests.rs
@@ -21,14 +21,14 @@ mod change_document_content_tests {
         let mut account = generate_account();
         let (root, _root_key) = generate_root_metadata(&account);
         api_service::request(&account, NewAccountRequest::new(&account, &root)).unwrap();
-        let old_username  = account.username;
+        let old_username = account.username;
         let mut account = generate_account();
         account.username = old_username.to_uppercase();
         let (root, _root_key) = generate_root_metadata(&account);
         let operation = api_service::request(&account, NewAccountRequest::new(&account, &root));
         match operation {
             Err(ApiError::Endpoint(NewAccountError::UsernameTaken)) => {} // Test pass
-            _ => panic!("Usernames must be case sensitive {:?}", operation)
+            _ => panic!("Usernames must be case sensitive {:?}", operation),
         }
     }
 }

--- a/server/server/src/file_index_repo.rs
+++ b/server/server/src/file_index_repo.rs
@@ -6,7 +6,7 @@ use lockbook_models::crypto::{
     EncryptedFolderAccessKey, EncryptedUserAccessKey, SecretFileName, UserAccessInfo,
 };
 use lockbook_models::file_metadata::{FileMetadata, FileMetadataDiff, FileType};
-use log::debug;
+use log::{debug, info};
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::{ConnectOptions, PgPool, Postgres, Transaction};
 use std::array::IntoIter;
@@ -622,7 +622,7 @@ WITH i1 AS (
 )
 INSERT INTO accounts (name, public_key, account_tier) VALUES ($1, $2, (SELECT id FROM i1))
         "#,
-        &(username.to_uppercase()),
+        &(username.to_lowercase()),
         &serde_json::to_string(&public_key).map_err(NewAccountError::Serialization)?,
     )
     .execute(transaction)

--- a/server/server/src/file_index_repo.rs
+++ b/server/server/src/file_index_repo.rs
@@ -622,7 +622,7 @@ WITH i1 AS (
 )
 INSERT INTO accounts (name, public_key, account_tier) VALUES ($1, $2, (SELECT id FROM i1))
         "#,
-        &username,
+        &(username.to_uppercase()),
         &serde_json::to_string(&public_key).map_err(NewAccountError::Serialization)?,
     )
     .execute(transaction)

--- a/server/server/src/file_index_repo.rs
+++ b/server/server/src/file_index_repo.rs
@@ -6,7 +6,7 @@ use lockbook_models::crypto::{
     EncryptedFolderAccessKey, EncryptedUserAccessKey, SecretFileName, UserAccessInfo,
 };
 use lockbook_models::file_metadata::{FileMetadata, FileMetadataDiff, FileType};
-use log::{debug, info};
+use log::{debug};
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::{ConnectOptions, PgPool, Postgres, Transaction};
 use std::array::IntoIter;

--- a/server/server/src/file_index_repo.rs
+++ b/server/server/src/file_index_repo.rs
@@ -6,7 +6,7 @@ use lockbook_models::crypto::{
     EncryptedFolderAccessKey, EncryptedUserAccessKey, SecretFileName, UserAccessInfo,
 };
 use lockbook_models::file_metadata::{FileMetadata, FileMetadataDiff, FileType};
-use log::{debug};
+use log::debug;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::{ConnectOptions, PgPool, Postgres, Transaction};
 use std::array::IntoIter;


### PR DESCRIPTION
Adds some logic in core which will lowercase usernames during signup, add some logic in server which will lowercase usernames in server before db constraints are checked.

The logic in core prevents you from entering a weird state where your (encrypted and therefore not verifiable by server) root name doesn't end up with a different case than you username.

closes https://github.com/lockbook/lockbook/issues/873