### PR TITLE
core: check for cycles before checking for path conflicts

### DIFF
--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -115,11 +115,11 @@ pub fn apply_move(
     validate_is_folder(&parent)?;
 
     file.parent = new_parent;
-    if !get_path_conflicts(files, &[file.clone()])?.is_empty() {
-        return Err(CoreError::PathTaken);
-    }
     if !get_invalid_cycles(files, &[file.clone()])?.is_empty() {
         return Err(CoreError::FolderMovedIntoSelf);
+    }
+    if !get_path_conflicts(files, &[file.clone()])?.is_empty() {
+        return Err(CoreError::PathTaken);
     }
 
     Ok(file)

--- a/core/tests/create_account_tests.rs
+++ b/core/tests/create_account_tests.rs
@@ -18,7 +18,7 @@ mod change_document_content_tests {
     #[test]
     fn create_account_username_case() {
         // new account
-        let mut account = generate_account();
+        let account = generate_account();
         let (root, _root_key) = generate_root_metadata(&account);
         api_service::request(&account, NewAccountRequest::new(&account, &root)).unwrap();
         let old_username = account.username;

--- a/core/tests/sync_service_tests.rs
+++ b/core/tests/sync_service_tests.rs
@@ -1868,4 +1868,15 @@ mod sync_tests {
             sync!(&db2);
         }
     }
+
+    #[test]
+    fn fuzzer_stuck_test() {
+        let db1 = test_config();
+        let account = make_account!(db1);
+        let b = path_service::create_at_path(&db1, path!(account, "b")).unwrap();
+        let c = path_service::create_at_path(&db1, path!(account, "c/")).unwrap();
+        let d = path_service::create_at_path(&db1, path!(account, "c/d/")).unwrap();
+        move_file(&db1, b.id, d.id).unwrap();
+        move_file(&db1, c.id, d.id).unwrap_err();
+    }
 }


### PR DESCRIPTION
path conflict code has a precondition that there must be no cycles in the file tree, otherwise we get caught in an inf loop.

also address a clippy warning