### PR TITLE
core: factor tree validation

### DIFF
--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -22,7 +22,7 @@ use crate::error::{LbErrTarget, LbError, LbResult};
 use crate::{closure, progerr, uerr, uerr_dialog, uerr_status_panel};
 use lockbook_core::service::import_export_service::ImportExportFileInfo;
 use lockbook_core::service::usage_service::{bytes_to_human, UsageMetrics};
-use lockbook_models::file_metadata::{DecryptedFileMetadata, FileMetadata, FileType};
+use lockbook_models::file_metadata::{DecryptedFileMetadata, EncryptedFileMetadata, FileType};
 use lockbook_models::work_unit::ClientWorkUnit;
 
 macro_rules! match_core_err {
@@ -172,7 +172,7 @@ impl LbCore {
         Ok(list_metadatas(&self.config)?)
     }
 
-    pub fn get_children_recursively(&self, id: Uuid) -> LbResult<Vec<FileMetadata>> {
+    pub fn get_children_recursively(&self, id: Uuid) -> LbResult<Vec<EncryptedFileMetadata>> {
         get_and_get_children_recursively(&self.config, id).map_err(map_core_err!(
             GetAndGetChildrenError,
             FileDoesNotExist => uerr_dialog!("File with id '{}' does not exist.", id),

--- a/core/libs/models/src/api.rs
+++ b/core/libs/models/src/api.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::account::Account;
 use crate::account::Username;
 use crate::crypto::*;
-use crate::file_metadata::{FileMetadata, FileMetadataDiff};
+use crate::file_metadata::{EncryptedFileMetadata, FileMetadataDiff};
 
 pub trait Request {
     type Response;
@@ -37,7 +37,7 @@ pub struct FileMetadataUpsertsRequest {
 }
 
 impl FileMetadataUpsertsRequest {
-    pub fn new(metadata: &FileMetadata) -> Self {
+    pub fn new(metadata: &EncryptedFileMetadata) -> Self {
         FileMetadataUpsertsRequest {
             updates: vec![FileMetadataDiff::new(metadata)],
         }
@@ -46,7 +46,7 @@ impl FileMetadataUpsertsRequest {
     pub fn new_diff(
         old_parent: Uuid,
         old_name: &SecretFileName,
-        new_metadata: &FileMetadata,
+        new_metadata: &EncryptedFileMetadata,
     ) -> Self {
         FileMetadataUpsertsRequest {
             updates: vec![FileMetadataDiff::new_diff(
@@ -186,7 +186,7 @@ pub struct GetUpdatesRequest {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct GetUpdatesResponse {
-    pub file_metadata: Vec<FileMetadata>,
+    pub file_metadata: Vec<EncryptedFileMetadata>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -213,7 +213,7 @@ pub struct NewAccountRequest {
 }
 
 impl NewAccountRequest {
-    pub fn new(account: &Account, root_metadata: &FileMetadata) -> Self {
+    pub fn new(account: &Account, root_metadata: &EncryptedFileMetadata) -> Self {
         NewAccountRequest {
             username: account.username.clone(),
             public_key: account.public_key(),

--- a/core/libs/models/src/crypto.rs
+++ b/core/libs/models/src/crypto.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::marker::PhantomData;
 
 use libsecp256k1::PublicKey;
@@ -64,5 +65,13 @@ pub struct SecretFileName {
 impl PartialEq for SecretFileName {
     fn eq(&self, other: &Self) -> bool {
         self.hmac == other.hmac
+    }
+}
+
+impl Eq for SecretFileName{}
+
+impl Hash for SecretFileName {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.hmac.hash(state);
     }
 }

--- a/core/libs/models/src/file_metadata.rs
+++ b/core/libs/models/src/file_metadata.rs
@@ -27,7 +27,7 @@ impl FromStr for FileType {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone)]
-pub struct FileMetadata {
+pub struct EncryptedFileMetadata {
     pub id: Uuid,
     pub file_type: FileType,
     pub parent: Uuid,
@@ -40,7 +40,7 @@ pub struct FileMetadata {
     pub folder_access_keys: EncryptedFolderAccessKey,
 }
 
-impl fmt::Debug for FileMetadata {
+impl fmt::Debug for EncryptedFileMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FileMetadata")
             .field("id", &self.id)
@@ -92,7 +92,7 @@ pub struct FileMetadataDiff {
 }
 
 impl FileMetadataDiff {
-    pub fn new(metadata: &FileMetadata) -> Self {
+    pub fn new(metadata: &EncryptedFileMetadata) -> Self {
         FileMetadataDiff {
             id: metadata.id,
             file_type: metadata.file_type,
@@ -107,7 +107,7 @@ impl FileMetadataDiff {
     pub fn new_diff(
         old_parent: Uuid,
         old_name: &SecretFileName,
-        new_metadata: &FileMetadata,
+        new_metadata: &EncryptedFileMetadata,
     ) -> Self {
         FileMetadataDiff {
             id: new_metadata.id,

--- a/core/libs/models/src/lib.rs
+++ b/core/libs/models/src/lib.rs
@@ -3,4 +3,5 @@ pub mod api;
 pub mod crypto;
 pub mod drawing;
 pub mod file_metadata;
+pub mod utils;
 pub mod work_unit;

--- a/core/libs/models/src/utils.rs
+++ b/core/libs/models/src/utils.rs
@@ -1,0 +1,5 @@
+// https://stackoverflow.com/a/58175659/4638697
+pub fn slices_equal<T: PartialEq>(a: &[T], b: &[T]) -> bool {
+    let matching = a.iter().zip(b.iter()).filter(|&(a, b)| a == b).count();
+    matching == a.len() && matching == b.len()
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,7 +20,7 @@ use lockbook_crypto::clock_service;
 use lockbook_models::account::Account;
 use lockbook_models::crypto::DecryptedDocument;
 use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
-use lockbook_models::file_metadata::{DecryptedFileMetadata, FileMetadata, FileType};
+use lockbook_models::file_metadata::{DecryptedFileMetadata, EncryptedFileMetadata, FileType};
 use model::errors::Error::UiError;
 pub use model::errors::{CoreError, Error, UnexpectedError};
 use service::log_service;
@@ -235,7 +235,7 @@ pub enum GetAndGetChildrenError {
 pub fn get_and_get_children_recursively(
     config: &Config,
     id: Uuid,
-) -> Result<Vec<FileMetadata>, Error<GetAndGetChildrenError>> {
+) -> Result<Vec<EncryptedFileMetadata>, Error<GetAndGetChildrenError>> {
     file_service::get_and_get_children_recursively(config, id).map_err(|e| match e {
         CoreError::FileNonexistent => UiError(GetAndGetChildrenError::FileDoesNotExist),
         CoreError::FileNotFolder => UiError(GetAndGetChildrenError::DocumentTreatedAsFolder),

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -177,8 +177,7 @@ pub fn get_invalid_cycles<Fm: FileMetadata>(
         let mut ancestor_double = find_parent(files, ancestor_single.id())?;
         while ancestor_single.id() != ancestor_double.id() {
             ancestor_single = find_parent(files, ancestor_single.id())?;
-            ancestor_double =
-                find_parent(files, find_parent(files, ancestor_double.id())?.id())?;
+            ancestor_double = find_parent(files, find_parent(files, ancestor_double.id())?.id())?;
         }
         if ancestor_single.id() == file.id() {
             // root in files -> non-root cycles invalid
@@ -225,10 +224,10 @@ pub fn get_path_conflicts<Fm: FileMetadata>(
                     .iter()
                     .find(|(f, _)| f.id() == child.id())
                     .ok_or_else(|| {
-                    CoreError::Unexpected(String::from(
-                        "get_path_conflicts: could not find child by id",
-                    ))
-                })?;
+                        CoreError::Unexpected(String::from(
+                            "get_path_conflicts: could not find child by id",
+                        ))
+                    })?;
                 match child_source {
                     StageSource::Base => result.push(PathConflict {
                         existing: child.id(),
@@ -284,31 +283,19 @@ pub fn save_document_to_disk(document: &[u8], location: String) -> Result<(), Co
     Ok(())
 }
 
-pub fn find<Fm: FileMetadata>(
-    files: &[Fm],
-    target_id: Uuid,
-) -> Result<Fm, CoreError> {
+pub fn find<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Result<Fm, CoreError> {
     maybe_find(files, target_id).ok_or(CoreError::FileNonexistent)
 }
 
-pub fn maybe_find<Fm: FileMetadata>(
-    files: &[Fm],
-    target_id: Uuid,
-) -> Option<Fm> {
+pub fn maybe_find<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Option<Fm> {
     files.iter().find(|f| f.id() == target_id).cloned()
 }
 
-pub fn find_mut<Fm: FileMetadata>(
-    files: &mut [Fm],
-    target_id: Uuid,
-) -> Result<&mut Fm, CoreError> {
+pub fn find_mut<Fm: FileMetadata>(files: &mut [Fm], target_id: Uuid) -> Result<&mut Fm, CoreError> {
     maybe_find_mut(files, target_id).ok_or(CoreError::FileNonexistent)
 }
 
-pub fn maybe_find_mut<Fm: FileMetadata>(
-    files: &mut [Fm],
-    target_id: Uuid,
-) -> Option<&mut Fm> {
+pub fn maybe_find_mut<Fm: FileMetadata>(files: &mut [Fm], target_id: Uuid) -> Option<&mut Fm> {
     files.iter_mut().find(|f| f.id() == target_id)
 }
 
@@ -330,25 +317,16 @@ pub fn maybe_find_state<Fm: FileMetadata>(
     } == target_id).cloned()
 }
 
-pub fn find_parent<Fm: FileMetadata>(
-    files: &[Fm],
-    target_id: Uuid,
-) -> Result<Fm, CoreError> {
+pub fn find_parent<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Result<Fm, CoreError> {
     maybe_find_parent(files, target_id).ok_or(CoreError::FileParentNonexistent)
 }
 
-pub fn maybe_find_parent<Fm: FileMetadata>(
-    files: &[Fm],
-    target_id: Uuid,
-) -> Option<Fm> {
+pub fn maybe_find_parent<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Option<Fm> {
     let file = maybe_find(files, target_id)?;
     maybe_find(files, file.parent())
 }
 
-pub fn find_ancestors<Fm: FileMetadata>(
-    files: &[Fm],
-    target_id: Uuid,
-) -> Vec<Fm> {
+pub fn find_ancestors<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Vec<Fm> {
     let mut result = Vec::new();
     let mut current_target_id = target_id;
     while let Some(target) = maybe_find(files, current_target_id) {
@@ -361,10 +339,7 @@ pub fn find_ancestors<Fm: FileMetadata>(
     result
 }
 
-pub fn find_children<Fm: FileMetadata>(
-    files: &[Fm],
-    target_id: Uuid,
-) -> Vec<Fm> {
+pub fn find_children<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Vec<Fm> {
     files
         .iter()
         .filter(|f| f.parent() == target_id && f.id() != f.parent())
@@ -408,9 +383,7 @@ pub fn is_deleted<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Result<boo
 }
 
 /// Returns the files which are not deleted and have no deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
-pub fn filter_not_deleted<Fm: FileMetadata>(
-    files: &[Fm],
-) -> Result<Vec<Fm>, CoreError> {
+pub fn filter_not_deleted<Fm: FileMetadata>(files: &[Fm]) -> Result<Vec<Fm>, CoreError> {
     let deleted = filter_deleted(files)?;
     Ok(files
         .iter()
@@ -420,9 +393,7 @@ pub fn filter_not_deleted<Fm: FileMetadata>(
 }
 
 /// Returns the files which are deleted or have deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
-pub fn filter_deleted<Fm: FileMetadata>(
-    files: &[Fm],
-) -> Result<Vec<Fm>, CoreError> {
+pub fn filter_deleted<Fm: FileMetadata>(files: &[Fm]) -> Result<Vec<Fm>, CoreError> {
     let mut result = Vec::new();
     for file in files {
         let mut ancestor = file.clone();
@@ -459,10 +430,7 @@ pub enum StageSource {
     Staged,
 }
 
-pub fn stage<Fm: FileMetadata>(
-    files: &[Fm],
-    staged_changes: &[Fm],
-) -> Vec<(Fm, StageSource)> {
+pub fn stage<Fm: FileMetadata>(files: &[Fm], staged_changes: &[Fm]) -> Vec<(Fm, StageSource)> {
     let mut result = Vec::new();
     for file in files {
         if let Some(ref staged) = maybe_find(staged_changes, file.id()) {

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use uuid::Uuid;
 
 use lockbook_crypto::symkey;
-use lockbook_models::file_metadata::{DecryptedFileMetadata, EncryptedFileMetadata, FileType};
+use lockbook_models::file_metadata::{DecryptedFileMetadata, FileMetadata, FileType};
 
 use crate::model::filename::NameComponents;
 use crate::{model::repo::RepoState, CoreError};
@@ -159,76 +159,38 @@ fn validate_file_name(name: &str) -> Result<(), CoreError> {
     Ok(())
 }
 
-pub fn get_invalid_cycles_encrypted(
-    files: &[EncryptedFileMetadata],
-    staged_changes: &[EncryptedFileMetadata],
-) -> Result<Vec<Uuid>, CoreError> {
-    let maybe_root = maybe_find_root_encrypted(files);
-    let files_with_sources = stage_encrypted(files, staged_changes);
-    let files = &files_with_sources
-        .iter()
-        .map(|(f, _)| f.clone())
-        .collect::<Vec<EncryptedFileMetadata>>();
-    let mut result = Vec::new();
-    let mut found_root = maybe_root.is_some();
-
-    for file in files {
-        let mut ancestor_single = find_parent_encrypted(files, file.id)?;
-        let mut ancestor_double = find_parent_encrypted(files, ancestor_single.id)?;
-        while ancestor_single.id != ancestor_double.id {
-            ancestor_single = find_parent_encrypted(files, ancestor_single.id)?;
-            ancestor_double =
-                find_parent_encrypted(files, find_parent_encrypted(files, ancestor_double.id)?.id)?;
-        }
-        if ancestor_single.id == file.id {
-            // root in files -> non-root cycles invalid
-            // no root in files -> accept first root from staged_changes
-            if let Some(ref root) = maybe_root {
-                if file.id != root.id {
-                    result.push(file.id);
-                }
-            } else if !found_root {
-                found_root = true;
-            } else {
-                result.push(file.id);
-            }
-        }
-    }
-
-    Ok(result)
-}
-
-pub fn get_invalid_cycles(
-    files: &[DecryptedFileMetadata],
-    staged_changes: &[DecryptedFileMetadata],
+pub fn get_invalid_cycles<Fm: FileMetadata>(
+    files: &[Fm],
+    staged_changes: &[Fm],
 ) -> Result<Vec<Uuid>, CoreError> {
     let maybe_root = maybe_find_root(files);
     let files_with_sources = stage(files, staged_changes);
     let files = &files_with_sources
         .iter()
         .map(|(f, _)| f.clone())
-        .collect::<Vec<DecryptedFileMetadata>>();
+        .collect::<Vec<Fm>>();
     let mut result = Vec::new();
     let mut found_root = maybe_root.is_some();
 
     for file in files {
-        let mut ancestor_single = find_parent(files, file.id)?;
-        let mut ancestor_double = find_parent(files, ancestor_single.id)?;
-        while ancestor_single.id != ancestor_double.id {
-            ancestor_single = find_parent(files, ancestor_single.id)?;
-            ancestor_double = find_parent(files, find_parent(files, ancestor_double.id)?.id)?;
+        let mut ancestor_single = find_parent(files, file.id())?;
+        let mut ancestor_double = find_parent(files, ancestor_single.id())?;
+        while ancestor_single.id() != ancestor_double.id() {
+            ancestor_single = find_parent(files, ancestor_single.id())?;
+            ancestor_double =
+                find_parent(files, find_parent(files, ancestor_double.id())?.id())?;
         }
-        if ancestor_single.id == file.id {
+        if ancestor_single.id() == file.id() {
             // root in files -> non-root cycles invalid
             // no root in files -> accept first root from staged_changes
             if let Some(ref root) = maybe_root {
-                if file.id != root.id {
-                    result.push(file.id);
+                if file.id() != root.id() {
+                    result.push(file.id());
                 }
             } else if !found_root {
                 found_root = true;
             } else {
-                result.push(file.id);
+                result.push(file.id());
             }
         }
     }
@@ -242,26 +204,26 @@ pub struct PathConflict {
     pub staged: Uuid,
 }
 
-pub fn get_path_conflicts(
-    files: &[DecryptedFileMetadata],
-    staged_changes: &[DecryptedFileMetadata],
+pub fn get_path_conflicts<Fm: FileMetadata>(
+    files: &[Fm],
+    staged_changes: &[Fm],
 ) -> Result<Vec<PathConflict>, CoreError> {
     let files_with_sources = stage(files, staged_changes);
     let files = &files_with_sources
         .iter()
         .map(|(f, _)| f.clone())
-        .collect::<Vec<DecryptedFileMetadata>>();
+        .collect::<Vec<Fm>>();
     let files = filter_not_deleted(files)?;
     let mut result = Vec::new();
 
     for file in &files {
-        let children = find_children(&files, file.id);
-        let mut child_ids_by_name: HashMap<String, Uuid> = HashMap::new();
+        let children = find_children(&files, file.id());
+        let mut child_ids_by_name: HashMap<Fm::Name, Uuid> = HashMap::new();
         for child in children {
-            if let Some(conflicting_child_id) = child_ids_by_name.get(&child.decrypted_name) {
+            if let Some(conflicting_child_id) = child_ids_by_name.get(&child.name()) {
                 let (_, child_source) = files_with_sources
                     .iter()
-                    .find(|(f, _)| f.id == child.id)
+                    .find(|(f, _)| f.id() == child.id())
                     .ok_or_else(|| {
                     CoreError::Unexpected(String::from(
                         "get_path_conflicts: could not find child by id",
@@ -269,16 +231,16 @@ pub fn get_path_conflicts(
                 })?;
                 match child_source {
                     StageSource::Base => result.push(PathConflict {
-                        existing: child.id,
+                        existing: child.id(),
                         staged: conflicting_child_id.to_owned(),
                     }),
                     StageSource::Staged => result.push(PathConflict {
                         existing: conflicting_child_id.to_owned(),
-                        staged: child.id,
+                        staged: child.id(),
                     }),
                 }
             }
-            child_ids_by_name.insert(child.decrypted_name, child.id);
+            child_ids_by_name.insert(child.name(), child.id());
         }
     }
 
@@ -322,138 +284,107 @@ pub fn save_document_to_disk(document: &[u8], location: String) -> Result<(), Co
     Ok(())
 }
 
-pub fn find(
-    files: &[DecryptedFileMetadata],
+pub fn find<Fm: FileMetadata>(
+    files: &[Fm],
     target_id: Uuid,
-) -> Result<DecryptedFileMetadata, CoreError> {
+) -> Result<Fm, CoreError> {
     maybe_find(files, target_id).ok_or(CoreError::FileNonexistent)
 }
 
-pub fn maybe_find(
-    files: &[DecryptedFileMetadata],
+pub fn maybe_find<Fm: FileMetadata>(
+    files: &[Fm],
     target_id: Uuid,
-) -> Option<DecryptedFileMetadata> {
-    files.iter().find(|f| f.id == target_id).cloned()
+) -> Option<Fm> {
+    files.iter().find(|f| f.id() == target_id).cloned()
 }
 
-pub fn find_mut(
-    files: &mut [DecryptedFileMetadata],
+pub fn find_mut<Fm: FileMetadata>(
+    files: &mut [Fm],
     target_id: Uuid,
-) -> Result<&mut DecryptedFileMetadata, CoreError> {
+) -> Result<&mut Fm, CoreError> {
     maybe_find_mut(files, target_id).ok_or(CoreError::FileNonexistent)
 }
 
-pub fn maybe_find_mut(
-    files: &mut [DecryptedFileMetadata],
+pub fn maybe_find_mut<Fm: FileMetadata>(
+    files: &mut [Fm],
     target_id: Uuid,
-) -> Option<&mut DecryptedFileMetadata> {
-    files.iter_mut().find(|f| f.id == target_id)
+) -> Option<&mut Fm> {
+    files.iter_mut().find(|f| f.id() == target_id)
 }
 
-pub fn find_encrypted(files: &[EncryptedFileMetadata], target_id: Uuid) -> Result<EncryptedFileMetadata, CoreError> {
-    maybe_find_encrypted(files, target_id).ok_or(CoreError::FileNonexistent)
-}
-
-pub fn maybe_find_encrypted(files: &[EncryptedFileMetadata], target_id: Uuid) -> Option<EncryptedFileMetadata> {
-    files.iter().find(|f| f.id == target_id).cloned()
-}
-
-pub fn find_state(
-    files: &[RepoState<DecryptedFileMetadata>],
+pub fn find_state<Fm: FileMetadata>(
+    files: &[RepoState<Fm>],
     target_id: Uuid,
-) -> Result<RepoState<DecryptedFileMetadata>, CoreError> {
+) -> Result<RepoState<Fm>, CoreError> {
     maybe_find_state(files, target_id).ok_or(CoreError::FileNonexistent)
 }
 
-pub fn maybe_find_state(
-    files: &[RepoState<DecryptedFileMetadata>],
+pub fn maybe_find_state<Fm: FileMetadata>(
+    files: &[RepoState<Fm>],
     target_id: Uuid,
-) -> Option<RepoState<DecryptedFileMetadata>> {
+) -> Option<RepoState<Fm>> {
     files.iter().find(|f| match f {
-        RepoState::New(l) => l.id,
-        RepoState::Modified { local: l, base: _ } => l.id,
-        RepoState::Unmodified(b) => b.id,
+        RepoState::New(l) => l.id(),
+        RepoState::Modified { local: l, base: _ } => l.id(),
+        RepoState::Unmodified(b) => b.id(),
     } == target_id).cloned()
 }
 
-pub fn find_parent(
-    files: &[DecryptedFileMetadata],
+pub fn find_parent<Fm: FileMetadata>(
+    files: &[Fm],
     target_id: Uuid,
-) -> Result<DecryptedFileMetadata, CoreError> {
+) -> Result<Fm, CoreError> {
     maybe_find_parent(files, target_id).ok_or(CoreError::FileParentNonexistent)
 }
 
-pub fn maybe_find_parent(
-    files: &[DecryptedFileMetadata],
+pub fn maybe_find_parent<Fm: FileMetadata>(
+    files: &[Fm],
     target_id: Uuid,
-) -> Option<DecryptedFileMetadata> {
+) -> Option<Fm> {
     let file = maybe_find(files, target_id)?;
-    maybe_find(files, file.parent)
+    maybe_find(files, file.parent())
 }
 
-pub fn find_parent_encrypted(
-    files: &[EncryptedFileMetadata],
+pub fn find_ancestors<Fm: FileMetadata>(
+    files: &[Fm],
     target_id: Uuid,
-) -> Result<EncryptedFileMetadata, CoreError> {
-    maybe_find_parent_encrypted(files, target_id).ok_or(CoreError::FileParentNonexistent)
-}
-
-pub fn maybe_find_parent_encrypted(
-    files: &[EncryptedFileMetadata],
-    target_id: Uuid,
-) -> Option<EncryptedFileMetadata> {
-    let file = maybe_find_encrypted(files, target_id)?;
-    maybe_find_encrypted(files, file.parent)
-}
-
-pub fn find_ancestors(
-    files: &[DecryptedFileMetadata],
-    target_id: Uuid,
-) -> Vec<DecryptedFileMetadata> {
+) -> Vec<Fm> {
     let mut result = Vec::new();
     let mut current_target_id = target_id;
     while let Some(target) = maybe_find(files, current_target_id) {
         result.push(target.clone());
-        if target.id == target.parent {
+        if target.id() == target.parent() {
             break;
         }
-        current_target_id = target.parent;
+        current_target_id = target.parent();
     }
     result
 }
 
-pub fn find_children(
-    files: &[DecryptedFileMetadata],
+pub fn find_children<Fm: FileMetadata>(
+    files: &[Fm],
     target_id: Uuid,
-) -> Vec<DecryptedFileMetadata> {
+) -> Vec<Fm> {
     files
         .iter()
-        .filter(|f| f.parent == target_id && f.id != f.parent)
+        .filter(|f| f.parent() == target_id && f.id() != f.parent())
         .cloned()
         .collect()
 }
 
-pub fn find_children_encrypted(files: &[EncryptedFileMetadata], target_id: Uuid) -> Vec<EncryptedFileMetadata> {
-    files
-        .iter()
-        .filter(|f| f.parent == target_id && f.id != f.parent)
-        .cloned()
-        .collect()
-}
-
-pub fn find_with_descendants(
-    files: &[DecryptedFileMetadata],
+pub fn find_with_descendants<Fm: FileMetadata>(
+    files: &[Fm],
     target_id: Uuid,
-) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
+) -> Result<Vec<Fm>, CoreError> {
     let mut result = vec![find(files, target_id)?];
     let mut i = 0;
     while i < result.len() {
         let target = result.get(i).ok_or_else(|| {
             CoreError::Unexpected(String::from("find_with_descendants: missing target"))
         })?;
-        let children = find_children(files, target.id);
+        let children = find_children(files, target.id());
         for child in children {
-            if child.id != target_id {
+            if child.id() != target_id {
                 result.push(child);
             }
         }
@@ -462,80 +393,51 @@ pub fn find_with_descendants(
     Ok(result)
 }
 
-pub fn find_with_descendants_encrypted(
-    files: &[EncryptedFileMetadata],
-    target_id: Uuid,
-) -> Result<Vec<EncryptedFileMetadata>, CoreError> {
-    let mut result = vec![find_encrypted(files, target_id)?];
-    let mut i = 0;
-    while i < result.len() {
-        let target = result.get(i).ok_or_else(|| {
-            CoreError::Unexpected(String::from("find_with_descendants: missing target"))
-        })?;
-        let children = find_children_encrypted(files, target.id);
-        for child in children {
-            if child.id != target_id {
-                result.push(child);
-            }
-        }
-        i += 1;
-    }
-    Ok(result)
-}
-
-pub fn find_root_encrypted(files: &[EncryptedFileMetadata]) -> Result<EncryptedFileMetadata, CoreError> {
-    maybe_find_root_encrypted(files).ok_or(CoreError::RootNonexistent)
-}
-
-pub fn maybe_find_root_encrypted(files: &[EncryptedFileMetadata]) -> Option<EncryptedFileMetadata> {
-    files.iter().find(|&f| f.id == f.parent).cloned()
-}
-
-pub fn find_root(files: &[DecryptedFileMetadata]) -> Result<DecryptedFileMetadata, CoreError> {
+pub fn find_root<Fm: FileMetadata>(files: &[Fm]) -> Result<Fm, CoreError> {
     maybe_find_root(files).ok_or(CoreError::RootNonexistent)
 }
 
-pub fn maybe_find_root(files: &[DecryptedFileMetadata]) -> Option<DecryptedFileMetadata> {
-    files.iter().find(|&f| f.id == f.parent).cloned()
+pub fn maybe_find_root<Fm: FileMetadata>(files: &[Fm]) -> Option<Fm> {
+    files.iter().find(|&f| f.id() == f.parent()).cloned()
 }
 
-pub fn is_deleted(files: &[DecryptedFileMetadata], target_id: Uuid) -> Result<bool, CoreError> {
+pub fn is_deleted<Fm: FileMetadata>(files: &[Fm], target_id: Uuid) -> Result<bool, CoreError> {
     Ok(filter_deleted(files)?
         .into_iter()
-        .any(|f| f.id == target_id))
+        .any(|f| f.id() == target_id))
 }
 
 /// Returns the files which are not deleted and have no deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
-pub fn filter_not_deleted(
-    files: &[DecryptedFileMetadata],
-) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
+pub fn filter_not_deleted<Fm: FileMetadata>(
+    files: &[Fm],
+) -> Result<Vec<Fm>, CoreError> {
     let deleted = filter_deleted(files)?;
     Ok(files
         .iter()
-        .filter(|f| !deleted.iter().any(|nd| nd.id == f.id))
+        .filter(|f| !deleted.iter().any(|nd| nd.id() == f.id()))
         .cloned()
         .collect())
 }
 
 /// Returns the files which are deleted or have deleted ancestors. It is an error for the parent of a file argument not to also be included in the arguments.
-pub fn filter_deleted(
-    files: &[DecryptedFileMetadata],
-) -> Result<Vec<DecryptedFileMetadata>, CoreError> {
+pub fn filter_deleted<Fm: FileMetadata>(
+    files: &[Fm],
+) -> Result<Vec<Fm>, CoreError> {
     let mut result = Vec::new();
     for file in files {
         let mut ancestor = file.clone();
         loop {
-            if ancestor.deleted {
+            if ancestor.deleted() {
                 result.push(file.clone());
                 break;
             }
 
-            let parent = find(files, ancestor.parent)?;
-            if ancestor.id == parent.id {
+            let parent = find(files, ancestor.parent())?;
+            if ancestor.id() == parent.id() {
                 break;
             }
             ancestor = parent;
-            if ancestor.id == file.id {
+            if ancestor.id() == file.id() {
                 break; // this is a cycle but not our problem
             }
         }
@@ -544,10 +446,10 @@ pub fn filter_deleted(
 }
 
 /// Returns the files which are documents.
-pub fn filter_documents(files: &[DecryptedFileMetadata]) -> Vec<DecryptedFileMetadata> {
+pub fn filter_documents<Fm: FileMetadata>(files: &[Fm]) -> Vec<Fm> {
     files
         .iter()
-        .filter(|f| f.file_type == FileType::Document)
+        .filter(|f| f.file_type() == FileType::Document)
         .cloned()
         .collect()
 }
@@ -557,40 +459,20 @@ pub enum StageSource {
     Staged,
 }
 
-pub fn stage(
-    files: &[DecryptedFileMetadata],
-    staged_changes: &[DecryptedFileMetadata],
-) -> Vec<(DecryptedFileMetadata, StageSource)> {
+pub fn stage<Fm: FileMetadata>(
+    files: &[Fm],
+    staged_changes: &[Fm],
+) -> Vec<(Fm, StageSource)> {
     let mut result = Vec::new();
     for file in files {
-        if let Some(ref staged) = maybe_find(staged_changes, file.id) {
+        if let Some(ref staged) = maybe_find(staged_changes, file.id()) {
             result.push((staged.clone(), StageSource::Staged));
         } else {
             result.push((file.clone(), StageSource::Base));
         }
     }
     for staged in staged_changes {
-        if maybe_find(files, staged.id).is_none() {
-            result.push((staged.clone(), StageSource::Staged));
-        }
-    }
-    result
-}
-
-pub fn stage_encrypted(
-    files: &[EncryptedFileMetadata],
-    staged_changes: &[EncryptedFileMetadata],
-) -> Vec<(EncryptedFileMetadata, StageSource)> {
-    let mut result = Vec::new();
-    for file in files {
-        if let Some(ref staged) = maybe_find_encrypted(staged_changes, file.id) {
-            result.push((staged.clone(), StageSource::Staged));
-        } else {
-            result.push((file.clone(), StageSource::Base));
-        }
-    }
-    for staged in staged_changes {
-        if maybe_find_encrypted(files, staged.id).is_none() {
+        if maybe_find(files, staged.id()).is_none() {
             result.push((staged.clone(), StageSource::Staged));
         }
     }

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -11,12 +11,6 @@ use lockbook_models::file_metadata::{DecryptedFileMetadata, EncryptedFileMetadat
 use crate::model::filename::NameComponents;
 use crate::{model::repo::RepoState, CoreError};
 
-// https://stackoverflow.com/a/58175659/4638697
-pub fn slices_equal<T: PartialEq>(a: &[T], b: &[T]) -> bool {
-    let matching = a.iter().zip(b.iter()).filter(|&(a, b)| a == b).count();
-    matching == a.len() && matching == b.len()
-}
-
 pub fn single_or<T, E>(v: Vec<T>, e: E) -> Result<T, E> {
     let mut v = v;
     match &v[..] {

--- a/core/src/repo/metadata_repo.rs
+++ b/core/src/repo/metadata_repo.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-use lockbook_models::file_metadata::FileMetadata;
+use lockbook_models::file_metadata::EncryptedFileMetadata;
 
 use crate::model::errors::core_err_unexpected;
 use crate::model::repo::RepoSource;
@@ -18,7 +18,7 @@ fn namespace(source: RepoSource) -> &'static str {
     }
 }
 
-pub fn insert(config: &Config, source: RepoSource, file: &FileMetadata) -> Result<(), CoreError> {
+pub fn insert(config: &Config, source: RepoSource, file: &EncryptedFileMetadata) -> Result<(), CoreError> {
     local_storage::write(
         config,
         namespace(source),
@@ -27,7 +27,7 @@ pub fn insert(config: &Config, source: RepoSource, file: &FileMetadata) -> Resul
     )
 }
 
-pub fn get(config: &Config, source: RepoSource, id: Uuid) -> Result<FileMetadata, CoreError> {
+pub fn get(config: &Config, source: RepoSource, id: Uuid) -> Result<EncryptedFileMetadata, CoreError> {
     maybe_get(config, source, id).and_then(|f| f.ok_or(CoreError::FileNonexistent))
 }
 
@@ -35,7 +35,7 @@ pub fn maybe_get(
     config: &Config,
     source: RepoSource,
     id: Uuid,
-) -> Result<Option<FileMetadata>, CoreError> {
+) -> Result<Option<EncryptedFileMetadata>, CoreError> {
     let maybe_bytes: Option<Vec<u8>> =
         local_storage::read(config, namespace(source), id.to_string().as_str())?;
     Ok(match maybe_bytes {
@@ -44,12 +44,12 @@ pub fn maybe_get(
     })
 }
 
-pub fn get_all(config: &Config, source: RepoSource) -> Result<Vec<FileMetadata>, CoreError> {
+pub fn get_all(config: &Config, source: RepoSource) -> Result<Vec<EncryptedFileMetadata>, CoreError> {
     Ok(
         local_storage::dump::<_, Vec<u8>>(config, namespace(source))?
             .into_iter()
             .map(|s| serde_json::from_slice(s.as_ref()).map_err(core_err_unexpected))
-            .collect::<Result<Vec<FileMetadata>, CoreError>>()?
+            .collect::<Result<Vec<EncryptedFileMetadata>, CoreError>>()?
             .into_iter()
             .collect(),
     )

--- a/core/src/repo/metadata_repo.rs
+++ b/core/src/repo/metadata_repo.rs
@@ -18,7 +18,11 @@ fn namespace(source: RepoSource) -> &'static str {
     }
 }
 
-pub fn insert(config: &Config, source: RepoSource, file: &EncryptedFileMetadata) -> Result<(), CoreError> {
+pub fn insert(
+    config: &Config,
+    source: RepoSource,
+    file: &EncryptedFileMetadata,
+) -> Result<(), CoreError> {
     local_storage::write(
         config,
         namespace(source),
@@ -27,7 +31,11 @@ pub fn insert(config: &Config, source: RepoSource, file: &EncryptedFileMetadata)
     )
 }
 
-pub fn get(config: &Config, source: RepoSource, id: Uuid) -> Result<EncryptedFileMetadata, CoreError> {
+pub fn get(
+    config: &Config,
+    source: RepoSource,
+    id: Uuid,
+) -> Result<EncryptedFileMetadata, CoreError> {
     maybe_get(config, source, id).and_then(|f| f.ok_or(CoreError::FileNonexistent))
 }
 
@@ -44,7 +52,10 @@ pub fn maybe_get(
     })
 }
 
-pub fn get_all(config: &Config, source: RepoSource) -> Result<Vec<EncryptedFileMetadata>, CoreError> {
+pub fn get_all(
+    config: &Config,
+    source: RepoSource,
+) -> Result<Vec<EncryptedFileMetadata>, CoreError> {
     Ok(
         local_storage::dump::<_, Vec<u8>>(config, namespace(source))?
             .into_iter()

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -584,7 +584,14 @@ pub fn promote_documents(config: &Config) -> Result<(), CoreError> {
                 },
             ))
         })
-        .collect::<Result<Vec<(EncryptedFileMetadata, Option<EncryptedDocument>, Option<Vec<u8>>)>, CoreError>>()?;
+        .collect::<Result<
+            Vec<(
+                EncryptedFileMetadata,
+                Option<EncryptedDocument>,
+                Option<Vec<u8>>,
+            )>,
+            CoreError,
+        >>()?;
 
     document_repo::delete_all(config, RepoSource::Base)?;
     digest_repo::delete_all(config, RepoSource::Base)?;

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use lockbook_models::utils;
 use std::collections::HashSet;
 
 use sha2::Digest;
@@ -225,7 +226,7 @@ pub fn insert_metadata(
         if let Some(opposite) =
             metadata_repo::maybe_get(config, source.opposite(), encrypted_metadata.id)?
         {
-            if files::slices_equal(&opposite.name.hmac, &encrypted_metadata.name.hmac)
+            if utils::slices_equal(&opposite.name.hmac, &encrypted_metadata.name.hmac)
                 && opposite.parent == metadatum.parent
                 && opposite.deleted == metadatum.deleted
             {
@@ -427,7 +428,7 @@ pub fn insert_document(
 
     // remove local if local == base
     if let Some(opposite) = digest_repo::maybe_get(config, source.opposite(), metadata.id)? {
-        if files::slices_equal(&opposite, &digest) {
+        if utils::slices_equal(&opposite, &digest) {
             document_repo::delete(config, RepoSource::Local, metadata.id)?;
             digest_repo::delete(config, RepoSource::Local, metadata.id)?;
         }

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -41,14 +41,14 @@ pub fn test_file_tree_integrity<Fm: FileMetadata>(files: &[Fm]) -> Result<(), Te
         return Err(TestFileTreeError::CycleDetected(self_descendant));
     }
 
-    let maybe_doc_with_children = files::filter_documents(&files)
+    let maybe_doc_with_children = files::filter_documents(files)
         .into_iter()
-        .find(|doc| !files::find_children(&files, doc.id()).is_empty());
+        .find(|doc| !files::find_children(files, doc.id()).is_empty());
     if let Some(doc) = maybe_doc_with_children {
         return Err(TestFileTreeError::DocumentTreatedAsFolder(doc.id()));
     }
 
-    let maybe_path_conflict = files::get_path_conflicts(&files, &[])
+    let maybe_path_conflict = files::get_path_conflicts(files, &[])
         .map_err(TestFileTreeError::Core)?
         .into_iter()
         .next();

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use uuid::Uuid;
 
-use lockbook_models::file_metadata::{FileMetadata, FileType};
+use lockbook_models::file_metadata::{EncryptedFileMetadata, FileType};
 
 use crate::model::repo::RepoSource;
 use crate::model::state::Config;
@@ -47,7 +47,7 @@ pub fn test_repo_integrity(config: &Config) -> Result<Vec<Warning>, TestRepoErro
     )
     .into_iter()
     .map(|(f, _)| f)
-    .collect::<Vec<FileMetadata>>();
+    .collect::<Vec<EncryptedFileMetadata>>();
 
     for file_encrypted in &files_encrypted {
         if files::maybe_find_encrypted(&files_encrypted, file_encrypted.parent).is_none() {

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -41,7 +41,7 @@ pub fn test_repo_integrity(config: &Config) -> Result<Vec<Warning>, TestRepoErro
         .map_err(TestRepoError::Core)?
         .ok_or(TestRepoError::NoRootFolder)?;
 
-    let files_encrypted = files::stage_encrypted(
+    let files_encrypted = files::stage(
         &metadata_repo::get_all(config, RepoSource::Base).map_err(TestRepoError::Core)?,
         &metadata_repo::get_all(config, RepoSource::Local).map_err(TestRepoError::Core)?,
     )
@@ -50,12 +50,12 @@ pub fn test_repo_integrity(config: &Config) -> Result<Vec<Warning>, TestRepoErro
     .collect::<Vec<EncryptedFileMetadata>>();
 
     for file_encrypted in &files_encrypted {
-        if files::maybe_find_encrypted(&files_encrypted, file_encrypted.parent).is_none() {
+        if files::maybe_find(&files_encrypted, file_encrypted.parent).is_none() {
             return Err(TestRepoError::FileOrphaned(file_encrypted.id));
         }
     }
 
-    let maybe_self_descendant = files::get_invalid_cycles_encrypted(&files_encrypted, &[])
+    let maybe_self_descendant = files::get_invalid_cycles(&files_encrypted, &[])
         .map_err(TestRepoError::Core)?
         .into_iter()
         .next();

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use uuid::Uuid;
 
-use lockbook_models::file_metadata::{EncryptedFileMetadata, FileType};
+use lockbook_models::file_metadata::{EncryptedFileMetadata, FileMetadata, FileType};
 
 use crate::model::repo::RepoSource;
 use crate::model::state::Config;
@@ -15,6 +15,51 @@ use crate::CoreError;
 const UTF8_SUFFIXES: [&str; 12] = [
     "md", "txt", "text", "markdown", "sh", "zsh", "bash", "html", "css", "js", "csv", "rs",
 ];
+
+#[derive(Debug, Clone)]
+pub enum TestFileTreeError {
+    NoRootFolder,
+    DocumentTreatedAsFolder(Uuid),
+    FileOrphaned(Uuid),
+    CycleDetected(Uuid),
+    NameConflictDetected(Uuid),
+    Core(CoreError),
+}
+
+pub fn test_file_tree_integrity<Fm: FileMetadata>(files: &[Fm]) -> Result<(), TestFileTreeError> {
+    for file in files {
+        if files::maybe_find(files, file.parent()).is_none() {
+            return Err(TestFileTreeError::FileOrphaned(file.id()));
+        }
+    }
+
+    let maybe_self_descendant = files::get_invalid_cycles(files, &[])
+        .map_err(TestFileTreeError::Core)?
+        .into_iter()
+        .next();
+    if let Some(self_descendant) = maybe_self_descendant {
+        return Err(TestFileTreeError::CycleDetected(self_descendant));
+    }
+
+    let maybe_doc_with_children = files::filter_documents(&files)
+        .into_iter()
+        .find(|doc| !files::find_children(&files, doc.id()).is_empty());
+    if let Some(doc) = maybe_doc_with_children {
+        return Err(TestFileTreeError::DocumentTreatedAsFolder(doc.id()));
+    }
+
+    let maybe_path_conflict = files::get_path_conflicts(&files, &[])
+        .map_err(TestFileTreeError::Core)?
+        .into_iter()
+        .next();
+    if let Some(path_conflict) = maybe_path_conflict {
+        return Err(TestFileTreeError::NameConflictDetected(
+            path_conflict.existing,
+        ));
+    }
+
+    Ok(())
+}
 
 #[derive(Debug, Clone)]
 pub enum TestRepoError {
@@ -49,51 +94,32 @@ pub fn test_repo_integrity(config: &Config) -> Result<Vec<Warning>, TestRepoErro
     .map(|(f, _)| f)
     .collect::<Vec<EncryptedFileMetadata>>();
 
-    for file_encrypted in &files_encrypted {
-        if files::maybe_find(&files_encrypted, file_encrypted.parent).is_none() {
-            return Err(TestRepoError::FileOrphaned(file_encrypted.id));
-        }
-    }
+    test_file_tree_integrity(&files_encrypted).map_err(|err| match err {
+        TestFileTreeError::NoRootFolder => TestRepoError::NoRootFolder,
+        TestFileTreeError::DocumentTreatedAsFolder(e) => TestRepoError::DocumentTreatedAsFolder(e),
+        TestFileTreeError::FileOrphaned(e) => TestRepoError::FileOrphaned(e),
+        TestFileTreeError::CycleDetected(e) => TestRepoError::CycleDetected(e),
+        TestFileTreeError::NameConflictDetected(e) => TestRepoError::NameConflictDetected(e),
+        TestFileTreeError::Core(e) => TestRepoError::Core(e),
+    })?;
 
-    let maybe_self_descendant = files::get_invalid_cycles(&files_encrypted, &[])
-        .map_err(TestRepoError::Core)?
-        .into_iter()
-        .next();
-    if let Some(self_descendant) = maybe_self_descendant {
-        return Err(TestRepoError::CycleDetected(self_descendant));
-    }
-
-    let all_files =
+    let files =
         file_service::get_all_metadata(config, RepoSource::Local).map_err(TestRepoError::Core)?;
-    let maybe_doc_with_children = files::filter_documents(&all_files)
-        .into_iter()
-        .find(|d| !files::find_children(&all_files, d.id).is_empty());
-    if let Some(doc) = maybe_doc_with_children {
-        return Err(TestRepoError::DocumentTreatedAsFolder(doc.id));
-    }
 
-    let maybe_file_with_empty_name = all_files.iter().find(|f| f.decrypted_name.is_empty());
+    let maybe_file_with_empty_name = files.iter().find(|f| f.decrypted_name.is_empty());
     if let Some(file_with_empty_name) = maybe_file_with_empty_name {
         return Err(TestRepoError::FileNameEmpty(file_with_empty_name.id));
     }
 
-    let maybe_file_with_name_with_slash = all_files.iter().find(|f| f.decrypted_name.contains('/'));
+    let maybe_file_with_name_with_slash = files.iter().find(|f| f.decrypted_name.contains('/'));
     if let Some(file_with_name_with_slash) = maybe_file_with_name_with_slash {
         return Err(TestRepoError::FileNameContainsSlash(
             file_with_name_with_slash.id,
         ));
     }
 
-    let maybe_path_conflict = files::get_path_conflicts(&all_files, &[])
-        .map_err(TestRepoError::Core)?
-        .into_iter()
-        .next();
-    if let Some(path_conflict) = maybe_path_conflict {
-        return Err(TestRepoError::NameConflictDetected(path_conflict.existing));
-    }
-
     let mut warnings = Vec::new();
-    for file in files::filter_not_deleted(&all_files).map_err(TestRepoError::Core)? {
+    for file in files::filter_not_deleted(&files).map_err(TestRepoError::Core)? {
         if file.file_type == FileType::Document {
             let file_content = file_service::get_document(config, RepoSource::Local, &file)
                 .map_err(|err| DocumentReadError(file.id, err))?;

--- a/core/src/service/sync_service.rs
+++ b/core/src/service/sync_service.rs
@@ -8,7 +8,7 @@ use lockbook_models::api::{
     ChangeDocumentContentRequest, FileMetadataUpsertsRequest, GetDocumentRequest, GetUpdatesRequest,
 };
 use lockbook_models::crypto::DecryptedDocument;
-use lockbook_models::file_metadata::{DecryptedFileMetadata, FileMetadata, FileType};
+use lockbook_models::file_metadata::{DecryptedFileMetadata, EncryptedFileMetadata, FileType};
 use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
 
 use crate::model::filename::DocumentType;
@@ -60,7 +60,7 @@ pub fn calculate_work(config: &Config) -> Result<WorkCalculated, CoreError> {
 
 fn calculate_work_from_updates(
     config: &Config,
-    server_updates: &[FileMetadata],
+    server_updates: &[EncryptedFileMetadata],
     mut last_sync: u64,
 ) -> Result<WorkCalculated, CoreError> {
     let mut work_units: Vec<WorkUnit> = vec![];

--- a/core/src/service/test_utils.rs
+++ b/core/src/service/test_utils.rs
@@ -11,7 +11,7 @@ use lockbook_crypto::{pubkey, symkey};
 use lockbook_models::account::Account;
 use lockbook_models::crypto::*;
 use lockbook_models::file_metadata::FileType::Folder;
-use lockbook_models::file_metadata::{FileMetadata, FileType};
+use lockbook_models::file_metadata::{EncryptedFileMetadata, FileType};
 
 use crate::model::state::Config;
 use crate::repo::root_repo;
@@ -99,7 +99,7 @@ pub fn generate_account() -> Account {
     }
 }
 
-pub fn generate_root_metadata(account: &Account) -> (FileMetadata, AESKey) {
+pub fn generate_root_metadata(account: &Account) -> (EncryptedFileMetadata, AESKey) {
     let id = Uuid::new_v4();
     let key = symkey::generate_key();
     let name = symkey::encrypt_and_hmac(&key, &account.username.clone()).unwrap();
@@ -116,7 +116,7 @@ pub fn generate_root_metadata(account: &Account) -> (FileMetadata, AESKey) {
     user_access_keys.insert(account.username.clone(), use_access_key);
 
     (
-        FileMetadata {
+        EncryptedFileMetadata {
             file_type: Folder,
             id,
             name,
@@ -134,14 +134,14 @@ pub fn generate_root_metadata(account: &Account) -> (FileMetadata, AESKey) {
 
 pub fn generate_file_metadata(
     account: &Account,
-    parent: &FileMetadata,
+    parent: &EncryptedFileMetadata,
     parent_key: &AESKey,
     file_type: FileType,
-) -> (FileMetadata, AESKey) {
+) -> (EncryptedFileMetadata, AESKey) {
     let id = Uuid::new_v4();
     let file_key = symkey::generate_key();
     (
-        FileMetadata {
+        EncryptedFileMetadata {
             file_type,
             id,
             name: random_filename(),

--- a/server/server/src/file_index_repo.rs
+++ b/server/server/src/file_index_repo.rs
@@ -5,7 +5,7 @@ use lockbook_models::api::FileUsage;
 use lockbook_models::crypto::{
     EncryptedFolderAccessKey, EncryptedUserAccessKey, SecretFileName, UserAccessInfo,
 };
-use lockbook_models::file_metadata::{FileMetadata, FileMetadataDiff, FileType};
+use lockbook_models::file_metadata::{EncryptedFileMetadata, FileMetadataDiff, FileType};
 use log::debug;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::{ConnectOptions, PgPool, Postgres, Transaction};
@@ -470,7 +470,7 @@ pub enum GetFilesError {
 pub async fn get_files(
     transaction: &mut Transaction<'_, Postgres>,
     public_key: &PublicKey,
-) -> Result<Vec<FileMetadata>, GetFilesError> {
+) -> Result<Vec<EncryptedFileMetadata>, GetFilesError> {
     sqlx::query!(
         r#"
 SELECT
@@ -490,7 +490,7 @@ WHERE
     .await
     .map_err(GetFilesError::Postgres)?
     .iter()
-    .map(|row| Ok(FileMetadata {
+    .map(|row| Ok(EncryptedFileMetadata {
         id: Uuid::parse_str(&row.id).map_err(GetFilesError::UuidDeserialize)?,
         file_type: if row.is_folder { FileType::Folder } else { FileType::Document },
         parent: Uuid::parse_str(&row.parent).map_err(GetFilesError::UuidDeserialize)?,
@@ -542,7 +542,7 @@ pub async fn get_updates(
     transaction: &mut Transaction<'_, Postgres>,
     public_key: &PublicKey,
     metadata_version: u64,
-) -> Result<Vec<FileMetadata>, GetUpdatesError> {
+) -> Result<Vec<EncryptedFileMetadata>, GetUpdatesError> {
     sqlx::query!(
         r#"
 SELECT
@@ -564,7 +564,7 @@ WHERE
     .await
     .map_err(GetUpdatesError::Postgres)?
     .iter()
-    .map(|row| Ok(FileMetadata {
+    .map(|row| Ok(EncryptedFileMetadata {
         id: Uuid::parse_str(&row.id).map_err(GetUpdatesError::UuidDeserialize)?,
         file_type: if row.is_folder { FileType::Folder } else { FileType::Document },
         parent: Uuid::parse_str(&row.parent).map_err(GetUpdatesError::UuidDeserialize)?,


### PR DESCRIPTION
In this PR we rename `FileMetadata` to `EncryptedFileMetadata` and introduce a new `FileMetadata` trait which is implemented by `EncryptedFileMetadata` and `DecryptedFileMetadata`. Using the trait, we reduce code duplication in `files.rs`, which sets us up for re-using the tree validation logic in server.