### PR TITLE
linux: remove certain macros

### DIFF
--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -21,7 +21,7 @@ use crate::util::{
     gui as gui_util, gui::LEFT_CLICK, gui::RIGHT_CLICK, IMAGE_TARGET_INFO, TEXT_TARGET_INFO,
     URI_TARGET_INFO,
 };
-use crate::{closure, get_language_specs_dir, progerr, uerr, uerr_dialog};
+use crate::{get_language_specs_dir, progerr, uerr, uerr_dialog};
 
 use lockbook_models::file_metadata::DecryptedFileMetadata;
 use lockbook_models::work_unit::ClientWorkUnit;
@@ -159,7 +159,7 @@ impl StatusPanel {
 
         let status_evbox = gtk::EventBox::new();
         status_evbox.add(&status);
-        status_evbox.connect_button_press_event(closure!(m => move |_, evt| {
+        status_evbox.connect_button_press_event(glib::clone!(@strong m => move |_, evt| {
             if evt.get_button() == RIGHT_CLICK {
                 let menu = gtk::Menu::new();
                 let item_data: Vec<(&str, MsgFn)> = vec![
@@ -168,7 +168,7 @@ impl StatusPanel {
                 ];
                 for (name, msg) in item_data {
                     let mi = gtk::MenuItem::with_label(name);
-                    mi.connect_activate(closure!(m => move |_| m.send(msg())));
+                    mi.connect_activate(glib::clone!(@strong m => move |_| m.send(msg())));
                     menu.append(&mi);
                 }
                 menu.show_all();
@@ -178,7 +178,7 @@ impl StatusPanel {
         }));
 
         let sync_button = gtk::Button::with_label("Sync");
-        sync_button.connect_clicked(closure!(m => move |_| m.send(Msg::PerformSync)));
+        sync_button.connect_clicked(glib::clone!(@strong m => move |_| m.send(Msg::PerformSync)));
 
         let progress = gtk::ProgressBar::new();
         progress.set_margin_top(3);
@@ -309,7 +309,7 @@ impl Editor {
     fn on_drag_data_received(
         m: &Messenger,
     ) -> impl Fn(&GtkSourceView, &gdk::DragContext, i32, i32, &gtk::SelectionData, u32, u32) {
-        closure!(m => move |_, _, _, _, s, info, _| {
+        glib::clone!(@strong m => move |_, _, _, _, s, info, _| {
             let target = match info {
                 URI_TARGET_INFO => {
                     TextAreaDropPasteInfo::Uris(s.get_uris().iter().map(|uri| uri.to_string()).collect())
@@ -339,7 +339,7 @@ impl Editor {
     }
 
     fn on_paste_clipboard(m: &Messenger) -> impl Fn(&GtkSourceView) {
-        closure!(m => move |w| {
+        glib::clone!(@strong m => move |w| {
             let clipboard = gtk::Clipboard::get(&gdk::SELECTION_CLIPBOARD);
 
             if let Some(pixbuf) = clipboard.wait_for_image() {
@@ -364,7 +364,7 @@ impl Editor {
     }
 
     fn on_button_press(m: &Messenger) -> impl Fn(&GtkSourceView, &gdk::EventButton) -> Inhibit {
-        closure!(m => move |w, evt| {
+        glib::clone!(@strong m => move |w, evt| {
             if evt.get_button() == LEFT_CLICK && evt.get_state() == gdk::ModifierType::CONTROL_MASK {
                 let (absol_x, absol_y) = evt.get_position();
                 let (x, y) = w.window_to_buffer_coords(gtk::TextWindowType::Text, absol_x as i32, absol_y as i32);
@@ -431,7 +431,7 @@ impl Editor {
         svb.end_not_undoable_action();
 
         self.change_sig_id.replace(Some(svb.connect_changed(
-            closure!(self.messenger as m => move |_| m.send(Msg::FileEdited)),
+            glib::clone!(@strong self.messenger as m => move |_| m.send(Msg::FileEdited)),
         )));
 
         self.show("scroll");

--- a/clients/linux/src/backend.rs
+++ b/clients/linux/src/backend.rs
@@ -19,7 +19,7 @@ use lockbook_models::account::Account;
 use lockbook_models::crypto::DecryptedDocument;
 
 use crate::error::{LbErrTarget, LbError, LbResult};
-use crate::{closure, progerr, uerr, uerr_dialog, uerr_status_panel};
+use crate::{progerr, uerr, uerr_dialog, uerr_status_panel};
 use lockbook_core::service::import_export_service::ImportExportFileInfo;
 use lockbook_core::service::usage_service::{bytes_to_human, UsageMetrics};
 use lockbook_models::file_metadata::{DecryptedFileMetadata, EncryptedFileMetadata, FileType};
@@ -269,7 +269,7 @@ impl LbCore {
     }
 
     pub fn sync(&self, ch: glib::Sender<Option<LbSyncMsg>>) -> LbResult<()> {
-        let closure = closure!(ch => move |sync_progress: SyncProgress| {
+        let closure = glib::clone!(@strong ch => move |sync_progress: SyncProgress| {
             let name = match sync_progress.current_work_unit {
                 ClientWorkUnit::PullMetadata => String::from("file tree updates"),
                 ClientWorkUnit::PushMetadata => String::from("file tree updates"),

--- a/clients/linux/src/main.rs
+++ b/clients/linux/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
     }
 
     let gtk_app = GtkApp::new(None, Default::default()).unwrap();
-    gtk_app.connect_activate(closure!(core, settings => move |app| {
+    gtk_app.connect_activate(glib::clone!(@strong core, @strong settings => move |app| {
         if let Err(err) = gtk_add_css_provider() {
             launch_err("adding css provider", &err);
         }
@@ -69,7 +69,7 @@ fn main() {
             launch_err("displaying app", err.msg());
         }
     }));
-    gtk_app.connect_shutdown(closure!(settings => move |_| {
+    gtk_app.connect_shutdown(glib::clone!(@strong settings => move |_| {
         if let Err(err) = settings.borrow_mut().to_file() {
             println!("error: {:?}", err);
         }

--- a/clients/linux/src/util.rs
+++ b/clients/linux/src/util.rs
@@ -1,21 +1,3 @@
-#[macro_export]
-macro_rules! cloned_var_name {
-    ($v:ident) => {
-        $v
-    };
-    ($v:ident $( $_:ident )+) => {
-        $v
-    };
-}
-
-#[macro_export]
-macro_rules! closure {
-    ($( $( $vars:ident ).+ $( as $aliases:ident )? ),+ => $fn:expr) => {{
-        $( let $crate::cloned_var_name!($( $aliases )? $( $vars )+)  = $( $vars ).+.clone(); )+
-        $fn
-    }};
-}
-
 pub mod gui {
     use gtk::prelude::ButtonExt;
     use gtk::prelude::ContainerExt;


### PR DESCRIPTION
This removes the `make_glib_chan` and `spawn` macros from `app.rs`, the `menu_set` one in `menubar.rs`, and the `closure` macro everywhere in favor of `glib::clone`.