### PR TITLE
server: do s3 things async where possible

### DIFF
--- a/server/admin/src/main.rs
+++ b/server/admin/src/main.rs
@@ -6,10 +6,11 @@ use deadpool_redis::Pool;
 
 use deadpool_redis::Runtime;
 use lockbook_server_lib::config::Config;
-use lockbook_server_lib::{file_content_client, ServerState};
+use lockbook_server_lib::{ ServerState};
 
 use s3::bucket::Bucket;
 use structopt::StructOpt;
+use lockbook_server_lib::content::file_content_client;
 
 #[derive(Debug, PartialEq, StructOpt)]
 #[structopt(about = "A utility for a lockbook server administrator.")]

--- a/server/admin/src/main.rs
+++ b/server/admin/src/main.rs
@@ -6,11 +6,11 @@ use deadpool_redis::Pool;
 
 use deadpool_redis::Runtime;
 use lockbook_server_lib::config::Config;
-use lockbook_server_lib::{ ServerState};
+use lockbook_server_lib::ServerState;
 
+use lockbook_server_lib::content::file_content_client;
 use s3::bucket::Bucket;
 use structopt::StructOpt;
-use lockbook_server_lib::content::file_content_client;
 
 #[derive(Debug, PartialEq, StructOpt)]
 #[structopt(about = "A utility for a lockbook server administrator.")]

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -8,7 +8,7 @@ use redis_utils::converters::{JsonGet, JsonSet};
 use redis_utils::tx;
 use uuid::Uuid;
 
-use crate::content::file_content_client;
+use crate::content::document_service;
 use crate::keys::{data_cap, file, meta, owned_files, public_key, size, username};
 use crate::ServerError::ClientError;
 use lockbook_models::api::GetUsageError::UserNotFound;
@@ -166,13 +166,7 @@ pub async fn delete_account(
         .filter_documents();
 
     for file in non_deleted_document {
-        file_content_client::delete(
-            &context.server_state.files_db_client,
-            file.id,
-            file.content_version,
-        )
-        .await
-        .map_err(|err| internal!("Cannot delete file in S3: {:?}", err))?;
+        document_service::delete(context.server_state, file.id, file.content_version).await?;
     }
 
     Ok(())

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -1,5 +1,5 @@
 use crate::utils::username_is_valid;
-use crate::{file_content_client, keys, RequestContext, ServerError, ServerState, FREE_TIER};
+use crate::{keys, RequestContext, ServerError, ServerState, FREE_TIER};
 use deadpool_redis::redis::AsyncCommands;
 use lockbook_crypto::clock_service::get_time;
 use log::error;
@@ -8,6 +8,7 @@ use redis_utils::converters::{JsonGet, JsonSet};
 use redis_utils::tx;
 use uuid::Uuid;
 
+use crate::content::file_content_client;
 use crate::keys::{data_cap, file, meta, owned_files, public_key, size, username};
 use crate::ServerError::ClientError;
 use lockbook_models::api::GetUsageError::UserNotFound;

--- a/server/server/src/content/content_cache.rs
+++ b/server/server/src/content/content_cache.rs
@@ -1,0 +1,40 @@
+use crate::{keys, ServerError, ServerState};
+use redis::AsyncCommands;
+use std::fmt::Debug;
+use uuid::Uuid;
+
+const YEAR: usize = 31536000;
+
+pub async fn create<T: Debug>(
+    state: &ServerState,
+    id: Uuid,
+    content_version: u64,
+    content: &[u8],
+) -> Result<(), ServerError<T>> {
+    let key = &keys::doc(id, content_version);
+    let mut con = state.index_db_pool.get().await?;
+    con.set_ex(key, content, YEAR).await?;
+    Ok(())
+}
+
+pub async fn delete<T: Debug>(
+    state: &ServerState,
+    id: Uuid,
+    content_version: u64,
+) -> Result<(), ServerError<T>> {
+    let key = &keys::doc(id, content_version);
+    let mut con = state.index_db_pool.get().await?;
+    con.del(key).await?;
+    Ok(())
+}
+
+pub async fn get<T: Debug>(
+    state: &ServerState,
+    id: Uuid,
+    content_version: u64,
+) -> Result<Option<Vec<u8>>, ServerError<T>> {
+    let key = &keys::doc(id, content_version);
+    let mut con = state.index_db_pool.get().await?;
+    let data: Option<Vec<u8>> = con.get(&key).await?;
+    Ok(data)
+}

--- a/server/server/src/content/document_service.rs
+++ b/server/server/src/content/document_service.rs
@@ -1,0 +1,94 @@
+use crate::content::{content_cache, file_content_client};
+use crate::file_content_client::Error::{
+    InvalidAccessKeyId, NoSuchKey, ResponseNotUtf8, SignatureDoesNotMatch, Unknown,
+};
+use crate::ServerError::InternalError;
+use crate::{keys, ServerError, ServerState};
+use futures::future::join;
+use lockbook_models::api::GetDocumentError;
+use lockbook_models::api::GetDocumentError::DocumentNotFound;
+use lockbook_models::crypto::EncryptedDocument;
+use log::error;
+use std::fmt::Debug;
+use uuid::Uuid;
+
+pub enum Error {
+    S3Error(file_content_client::Error),
+    RedisError,
+}
+
+pub async fn create<T: Debug>(
+    state: &ServerState,
+    id: Uuid,
+    content_version: u64,
+    file_contents: &EncryptedDocument,
+) -> Result<(), ServerError<T>> {
+    let content = bincode::serialize(file_contents)
+        .map_err(|err| internal!("Failed to serialize a document: {}", err))?;
+    let redis_save = content_cache::create::<T>(state, id, content_version, &content);
+    let s3_save = file_content_client::create(state, id, content_version, &content);
+
+    let result = join(redis_save, s3_save).await;
+    match result {
+        (Ok(_), Ok(_)) => Ok(()),
+        (Ok(_), Err(s3)) => {
+            let message = format!("Failed to insert doc into s3, succeeded in redis, failing the request, cleaning up redis. Err: {:?}", s3);
+            error!("{}", message);
+            content_cache::delete(state, id, content_version).await?;
+            Err(InternalError(message))
+        }
+        (Err(redis), Ok(_)) => {
+            error!("Failed to insert document into redis: {:?}. Successfully inserted in s3, continuing with request", redis);
+            Ok(())
+        }
+        (Err(err), Err(err2)) => Err(internal!(
+            "Fails to both doc locations failed. redis err: {:?}, s3 err: {:?}, id: {}, ver: {}",
+            err,
+            err2,
+            id,
+            content_version
+        )),
+    }
+}
+
+pub async fn get(
+    state: &ServerState,
+    id: Uuid,
+    content_version: u64,
+) -> Result<Option<EncryptedDocument>, ServerError<GetDocumentError>> {
+    let maybe_bytes = match content_cache::get(state, id, content_version).await? {
+        Some(document_bytes) => Some(document_bytes),
+        None => {
+            let maybe_bytes = file_content_client::get(state, id, content_version)
+                .await
+                .map_err(|err| match err {
+                    NoSuchKey(_) => ServerError::ClientError(DocumentNotFound),
+                    InvalidAccessKeyId(_)
+                    | ResponseNotUtf8(_)
+                    | SignatureDoesNotMatch(_)
+                    | Unknown(_) => internal!("Cannot get file from s3: {:?}", err),
+                })?;
+            if let Some(bytes) = &maybe_bytes {
+                content_cache::create(state, id, content_version, bytes).await?;
+            }
+            maybe_bytes
+        }
+    };
+
+    match maybe_bytes {
+        Some(document_bytes) => Ok(Some(bincode::deserialize(&document_bytes)?)),
+        None => Ok(None),
+    }
+}
+
+pub async fn background_delete<T: Debug>(
+    state: &ServerState,
+    id: Uuid,
+    content_version: u64,
+) -> Result<(), ServerError<T>> {
+    content_cache::delete(state, id, content_version).await?;
+
+    file_content_client::background_delete(state, id, content_version);
+
+    Ok(())
+}

--- a/server/server/src/content/document_service.rs
+++ b/server/server/src/content/document_service.rs
@@ -3,7 +3,7 @@ use crate::file_content_client::Error::{
     InvalidAccessKeyId, NoSuchKey, ResponseNotUtf8, SignatureDoesNotMatch, Unknown,
 };
 use crate::ServerError::InternalError;
-use crate::{keys, ServerError, ServerState};
+use crate::{ServerError, ServerState};
 use futures::future::join;
 use lockbook_models::api::GetDocumentError;
 use lockbook_models::api::GetDocumentError::DocumentNotFound;

--- a/server/server/src/content/document_service.rs
+++ b/server/server/src/content/document_service.rs
@@ -81,6 +81,20 @@ pub async fn get(
     }
 }
 
+pub async fn delete<T: Debug>(
+    state: &ServerState,
+    id: Uuid,
+    content_version: u64,
+) -> Result<(), ServerError<T>> {
+    content_cache::delete(state, id, content_version).await?;
+
+    file_content_client::delete(state, id, content_version)
+        .await
+        .map_err(|err| internal!("could not delete file from s3: {:?}", err))?;
+
+    Ok(())
+}
+
 pub async fn background_delete<T: Debug>(
     state: &ServerState,
     id: Uuid,

--- a/server/server/src/content/file_content_client.rs
+++ b/server/server/src/content/file_content_client.rs
@@ -1,6 +1,6 @@
 use crate::config::FilesDbConfig;
 use crate::ServerState;
-use lockbook_models::crypto::EncryptedDocument;
+
 use log::{debug, error};
 use s3::bucket::Bucket as S3Client;
 use s3::creds::Credentials;

--- a/server/server/src/content/mod.rs
+++ b/server/server/src/content/mod.rs
@@ -1,0 +1,3 @@
+pub mod content_cache;
+pub mod document_service;
+pub mod file_content_client;

--- a/server/server/src/file_content_client.rs
+++ b/server/server/src/file_content_client.rs
@@ -89,25 +89,6 @@ pub async fn create(
     }
 }
 
-pub async fn create_empty(
-    client: &S3Client,
-    file_id: Uuid,
-    content_version: u64,
-) -> Result<(), Error> {
-    match client
-        .put_object_with_content_type(
-            &format!("/{}-{}", file_id, content_version),
-            &[],
-            "binary/octet-stream",
-        )
-        .await
-        .map_err(|err| err.to_string())?
-    {
-        (_, 200) => Ok(()),
-        (body, _) => Err(Error::from(body)),
-    }
-}
-
 pub async fn delete(client: &S3Client, file_id: Uuid, content_version: u64) -> Result<(), Error> {
     match client
         .delete_object(&format!("/{}-{}", file_id, content_version))

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -1,10 +1,10 @@
 use crate::internal;
 use crate::keys::{file, owned_files, size};
 use crate::ServerError;
-use crate::ServerError::{ClientError};
+use crate::ServerError::ClientError;
 use crate::{keys, RequestContext};
 
-use crate::content::{document_service};
+use crate::content::document_service;
 use lockbook_crypto::clock_service::get_time;
 use lockbook_models::api::FileMetadataUpsertsError::{GetUpdatesRequired, RootImmutable};
 use lockbook_models::api::*;

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -1,10 +1,10 @@
 use crate::internal;
 use crate::keys::{file, owned_files, size};
 use crate::ServerError;
-use crate::ServerError::{ClientError, InternalError};
+use crate::ServerError::{ClientError};
 use crate::{keys, RequestContext};
 
-use crate::content::{document_service, file_content_client};
+use crate::content::{document_service};
 use lockbook_crypto::clock_service::get_time;
 use lockbook_models::api::FileMetadataUpsertsError::{GetUpdatesRequired, RootImmutable};
 use lockbook_models::api::*;

--- a/server/server/src/keys.rs
+++ b/server/server/src/keys.rs
@@ -30,6 +30,10 @@ pub fn meta<File: FileMetadata>(meta: &File) -> String {
     file(meta.id())
 }
 
+pub fn doc(id: Uuid, content_version: u64) -> String {
+    format!("id-version:{}-{}:encrypted_document", id, content_version)
+}
+
 fn stringify_public_key(pk: &PublicKey) -> String {
     base64::encode(pk.serialize_compressed())
 }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 static CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[derive(Clone)]
 pub struct ServerState {
     pub config: config::Config,
     pub index_db_pool: deadpool_redis::Pool,

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -9,7 +9,7 @@ use lockbook_server_lib::*;
 use deadpool_redis::Runtime;
 use lockbook_server_lib::content::file_content_client;
 use log::info;
-use redis::AsyncCommands;
+
 use std::sync::Arc;
 use warp::Filter;
 

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -7,7 +7,9 @@ use lockbook_server_lib::config::Config;
 use lockbook_server_lib::*;
 
 use deadpool_redis::Runtime;
+use lockbook_server_lib::content::file_content_client;
 use log::info;
+use redis::AsyncCommands;
 use std::sync::Arc;
 use warp::Filter;
 


### PR DESCRIPTION
Uses redis as an lru cache for documents.

creates document_service as the interface for server, which negotiates files that could be in redis or in s3.

closes: #954 