### PR TITLE
core: fix owners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-cli"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "atty",
  "chrono",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "backtrace",
  "base64 0.11.0",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "atomic-counter",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,6 +2067,7 @@ dependencies = [
 name = "lockbook-desktop"
 version = "0.1.6"
 dependencies = [
+ "base64 0.11.0",
  "fuzzy-matcher",
  "gdk",
  "gdk-pixbuf",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-cli"
-version = "0.2.24"
+version = "0.2.25"
 authors = ["parth"]
 edition = "2018"
 

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 sourceview = "0.9.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
+base64 = "0.11.0"

--- a/clients/linux/src/account.rs
+++ b/clients/linux/src/account.rs
@@ -443,9 +443,10 @@ impl Editor {
         let grid = gtk::Grid::new();
         grid.set_halign(gtk::Align::Center);
 
+        let owner = base64::encode(&f.owner.0.serialize_compressed());
         let rows = vec![
             ("ID", f.id.to_string()),
-            ("Owner", f.owner.clone()),
+            ("Owner", owner),
             ("Children", n_children.to_string()),
         ];
         for (row, (key, val)) in rows.into_iter().enumerate() {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-core"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Parth <parth@mehrotra.me>", "Raayan <raayan@raayanpillai.com>", "Travis <t.vanderstad@gmail.com>", "Smail <smailbarkouch1@gmail.com>"]
 edition = "2018"
 description = "The functional components of the iOS and Android lockbook clients."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,6 +45,7 @@ tempfile = { version = "3.1.0" }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 itertools = "0.10.1"
 backtrace = "0.3"
+libsecp256k1 = "0.7.0"
 
 [profile.release]
 debug = true

--- a/core/libs/models/src/tree.rs
+++ b/core/libs/models/src/tree.rs
@@ -1,4 +1,4 @@
-use crate::file_metadata::FileType;
+use crate::file_metadata::{FileType, Owner};
 use crate::tree::TreeError::{FileNonexistent, RootNonexistent};
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -11,7 +11,7 @@ pub trait FileMetadata: Clone {
     fn file_type(&self) -> FileType;
     fn parent(&self) -> Uuid;
     fn name(&self) -> Self::Name;
-    fn owner(&self) -> String;
+    fn owner(&self) -> Owner;
     fn metadata_version(&self) -> u64;
     fn content_version(&self) -> u64;
     fn deleted(&self) -> bool;

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -33,7 +33,7 @@ pub fn create(
         file_type,
         parent,
         decrypted_name: String::from(name),
-        owner: Owner { 0: owner.clone() },
+        owner: Owner { 0: *owner },
         metadata_version: 0,
         content_version: 0,
         deleted: false,

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -1,3 +1,4 @@
+use libsecp256k1::PublicKey;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
@@ -5,7 +6,8 @@ use std::path::Path;
 use uuid::Uuid;
 
 use lockbook_crypto::symkey;
-use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
+use lockbook_models::account::Account;
+use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType, Owner};
 use lockbook_models::tree::FileMetaExt;
 use lockbook_models::tree::FileMetadata;
 
@@ -20,13 +22,18 @@ pub fn single_or<T, E>(v: Vec<T>, e: E) -> Result<T, E> {
     }
 }
 
-pub fn create(file_type: FileType, parent: Uuid, name: &str, owner: &str) -> DecryptedFileMetadata {
+pub fn create(
+    file_type: FileType,
+    parent: Uuid,
+    name: &str,
+    owner: &PublicKey,
+) -> DecryptedFileMetadata {
     DecryptedFileMetadata {
         id: Uuid::new_v4(),
         file_type,
         parent,
         decrypted_name: String::from(name),
-        owner: String::from(owner),
+        owner: Owner { 0: owner.clone() },
         metadata_version: 0,
         content_version: 0,
         deleted: false,
@@ -34,14 +41,14 @@ pub fn create(file_type: FileType, parent: Uuid, name: &str, owner: &str) -> Dec
     }
 }
 
-pub fn create_root(username: &str) -> DecryptedFileMetadata {
+pub fn create_root(account: &Account) -> DecryptedFileMetadata {
     let id = Uuid::new_v4();
     DecryptedFileMetadata {
         id,
         file_type: FileType::Folder,
         parent: id,
-        decrypted_name: String::from(username),
-        owner: String::from(username),
+        decrypted_name: account.username.clone(),
+        owner: Owner::from(account),
         metadata_version: 0,
         content_version: 0,
         deleted: false,
@@ -56,7 +63,7 @@ pub fn apply_create(
     file_type: FileType,
     parent: Uuid,
     name: &str,
-    owner: &str,
+    owner: &PublicKey,
 ) -> Result<DecryptedFileMetadata, CoreError> {
     let file = create(file_type, parent, name, owner);
     validate_not_root(&file)?;
@@ -271,9 +278,14 @@ mod unit_tests {
     #[test]
     fn apply_rename() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let document_id = document.id;
         files::apply_rename(&[root, folder, document], document_id, "document2").unwrap();
@@ -282,9 +294,14 @@ mod unit_tests {
     #[test]
     fn apply_rename_not_found() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let result = files::apply_rename(&[root, folder], document.id, "document2");
         assert_eq!(result, Err(CoreError::FileNonexistent));
@@ -293,9 +310,14 @@ mod unit_tests {
     #[test]
     fn apply_rename_root() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let root_id = root.id;
         let result = files::apply_rename(&[root, folder, document], root_id, "root2");
@@ -305,9 +327,14 @@ mod unit_tests {
     #[test]
     fn apply_rename_invalid_name() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let document_id = document.id;
         let result = files::apply_rename(&[root, folder, document], document_id, "invalid/name");
@@ -317,10 +344,20 @@ mod unit_tests {
     #[test]
     fn apply_rename_path_conflict() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document1 = files::create(FileType::Document, root.id, "document1", &account.username);
-        let document2 = files::create(FileType::Document, root.id, "document2", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document1 = files::create(
+            FileType::Document,
+            root.id,
+            "document1",
+            &account.public_key(),
+        );
+        let document2 = files::create(
+            FileType::Document,
+            root.id,
+            "document2",
+            &account.public_key(),
+        );
 
         let document1_id = document1.id;
         let result = files::apply_rename(
@@ -334,9 +371,14 @@ mod unit_tests {
     #[test]
     fn apply_move() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let folder_id = folder.id;
         let document_id = document.id;
@@ -346,9 +388,14 @@ mod unit_tests {
     #[test]
     fn apply_move_not_found() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let folder_id = folder.id;
         let document_id = document.id;
@@ -359,9 +406,14 @@ mod unit_tests {
     #[test]
     fn apply_move_parent_not_found() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let folder_id = folder.id;
         let document_id = document.id;
@@ -372,9 +424,19 @@ mod unit_tests {
     #[test]
     fn apply_move_parent_document() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document1 = files::create(FileType::Document, root.id, "document1", &account.username);
-        let document2 = files::create(FileType::Document, root.id, "document2", &account.username);
+        let root = files::create_root(&account);
+        let document1 = files::create(
+            FileType::Document,
+            root.id,
+            "document1",
+            &account.public_key(),
+        );
+        let document2 = files::create(
+            FileType::Document,
+            root.id,
+            "document2",
+            &account.public_key(),
+        );
 
         let document1_id = document1.id;
         let document2_id = document2.id;
@@ -385,9 +447,14 @@ mod unit_tests {
     #[test]
     fn apply_move_root() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let folder_id = folder.id;
         let root_id = root.id;
@@ -398,10 +465,20 @@ mod unit_tests {
     #[test]
     fn apply_move_path_conflict() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document1 = files::create(FileType::Document, root.id, "document", &account.username);
-        let document2 = files::create(FileType::Document, folder.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document1 = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
+        let document2 = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
 
         let folder_id = folder.id;
         let document1_id = document1.id;
@@ -416,9 +493,14 @@ mod unit_tests {
     #[test]
     fn apply_move_2cycle() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder1 = files::create(FileType::Folder, root.id, "folder1", &account.username);
-        let folder2 = files::create(FileType::Folder, folder1.id, "folder2", &account.username);
+        let root = files::create_root(&account);
+        let folder1 = files::create(FileType::Folder, root.id, "folder1", &account.public_key());
+        let folder2 = files::create(
+            FileType::Folder,
+            folder1.id,
+            "folder2",
+            &account.public_key(),
+        );
 
         let folder1_id = folder1.id;
         let folder2_id = folder2.id;
@@ -429,8 +511,8 @@ mod unit_tests {
     #[test]
     fn apply_move_1cycle() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder1", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder1", &account.public_key());
 
         let folder1_id = folder.id;
         let result = files::apply_move(&[root, folder], folder1_id, folder1_id);
@@ -440,9 +522,14 @@ mod unit_tests {
     #[test]
     fn apply_delete() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let document_id = document.id;
         files::apply_delete(&[root, folder, document], document_id).unwrap();
@@ -451,9 +538,14 @@ mod unit_tests {
     #[test]
     fn apply_delete_root() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         let root_id = root.id;
         let result = files::apply_delete(&[root, folder, document], root_id);
@@ -463,8 +555,8 @@ mod unit_tests {
     #[test]
     fn get_nonconflicting_filename() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
         assert_eq!(
             files::suggest_non_conflicting_filename(folder.id, &[root, folder], &[]).unwrap(),
             "folder-1"
@@ -474,9 +566,9 @@ mod unit_tests {
     #[test]
     fn get_nonconflicting_filename2() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let folder2 = files::create(FileType::Folder, root.id, "folder-1", &account.username);
+        let root = files::create_root(&account);
+        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let folder2 = files::create(FileType::Folder, root.id, "folder-1", &account.public_key());
         assert_eq!(
             files::suggest_non_conflicting_filename(folder1.id, &[root, folder1, folder2], &[])
                 .unwrap(),
@@ -487,9 +579,9 @@ mod unit_tests {
     #[test]
     fn get_path_conflicts_no_conflicts() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let folder2 = files::create(FileType::Folder, root.id, "folder2", &account.username);
+        let root = files::create_root(&account);
+        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let folder2 = files::create(FileType::Folder, root.id, "folder2", &account.public_key());
 
         let path_conflicts = &[root, folder1.clone()]
             .get_path_conflicts(&[folder2.clone()])
@@ -501,9 +593,9 @@ mod unit_tests {
     #[test]
     fn get_path_conflicts_one_conflict() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let folder2 = files::create(FileType::Folder, root.id, "folder", &account.username);
+        let root = files::create_root(&account);
+        let folder1 = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let folder2 = files::create(FileType::Folder, root.id, "folder", &account.public_key());
 
         let path_conflicts = &[root, folder1.clone()]
             .get_path_conflicts(&[folder2.clone()])

--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -106,7 +106,6 @@ pub fn import_account(config: &Config, account_string: &str) -> Result<Account, 
         }
     };
     debug!("key was valid bincode");
-
     let server_public_key = match api_service::request(
         &account,
         GetPublicKeyRequest {

--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -36,7 +36,7 @@ pub fn create_account(
         private_key: keys,
     };
 
-    let mut root_metadata = files::create_root(&account.username);
+    let mut root_metadata = files::create_root(&account);
     let encrypted_metadata =
         file_encryption_service::encrypt_metadata(&account, &[root_metadata.clone()])?;
     let encrypted_metadatum = files::single_or(

--- a/core/src/service/db_state_service.rs
+++ b/core/src/service/db_state_service.rs
@@ -52,7 +52,7 @@ pub fn perform_migration(config: &Config) -> Result<(), CoreError> {
     }
 
     match db_version.as_str() {
-        "0.1.5" => Ok(()),
+        "0.1.6" => Ok(()),
         _ => Err(CoreError::ClientWipeRequired),
     }
 }

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -205,7 +205,12 @@ mod unit_tests {
     fn encrypt_decrypt_metadatum() {
         let account = test_utils::generate_account();
         let key = symkey::generate_key();
-        let file = files::create(FileType::Folder, Uuid::new_v4(), "folder", "owner");
+        let file = files::create(
+            FileType::Folder,
+            Uuid::new_v4(),
+            "folder",
+            &account.public_key(),
+        );
 
         let encrypted_file =
             file_encryption_service::encrypt_metadatum(&account, &key, &file).unwrap();
@@ -218,9 +223,14 @@ mod unit_tests {
     #[test]
     fn encrypt_decrypt_metadata() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Folder, folder.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Folder,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
         let files = [root.clone(), folder.clone(), document.clone()];
 
         let encrypted_files = file_encryption_service::encrypt_metadata(&account, &files).unwrap();

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -47,7 +47,13 @@ pub fn create_file(
     let account = account_repo::get(config)?;
     file_service::get_not_deleted_metadata(config, RepoSource::Local, parent)?;
     let all_metadata = file_service::get_all_metadata(config, RepoSource::Local)?;
-    let metadata = files::apply_create(&all_metadata, file_type, parent, name, &account.username)?;
+    let metadata = files::apply_create(
+        &all_metadata,
+        file_type,
+        parent,
+        name,
+        &account.public_key(),
+    )?;
     file_service::insert_metadatum(config, RepoSource::Local, &metadata)?;
     Ok(metadata)
 }
@@ -810,7 +816,7 @@ mod unit_tests {
     fn insert_metadata() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -825,7 +831,7 @@ mod unit_tests {
     fn get_metadata() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -857,7 +863,7 @@ mod unit_tests {
     fn get_metadata_local_falls_back_to_base() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -874,7 +880,7 @@ mod unit_tests {
     fn get_metadata_local_prefers_local() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let mut root = files::create_root(&account.username);
+        let mut root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -895,7 +901,7 @@ mod unit_tests {
     fn maybe_get_metadata() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -928,8 +934,13 @@ mod unit_tests {
     fn insert_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -947,8 +958,13 @@ mod unit_tests {
     fn get_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -975,9 +991,9 @@ mod unit_tests {
             RepoSource::Local,
             &files::create(
                 FileType::Document,
-                files::create_root(&account.username).id,
+                files::create_root(&account).id,
                 "asdf",
-                &account.username,
+                &account.public_key(),
             ),
         );
 
@@ -992,8 +1008,13 @@ mod unit_tests {
     fn get_document_local_falls_back_to_base() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1013,8 +1034,13 @@ mod unit_tests {
     fn get_document_local_prefers_local() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1036,8 +1062,13 @@ mod unit_tests {
     fn maybe_get_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1065,9 +1096,9 @@ mod unit_tests {
             RepoSource::Local,
             &files::create(
                 FileType::Document,
-                files::create_root(&account.username).id,
+                files::create_root(&account).id,
                 "asdf",
-                &account.username,
+                &account.public_key(),
             ),
         )
         .unwrap();
@@ -1098,7 +1129,7 @@ mod unit_tests {
     fn new() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -1118,7 +1149,7 @@ mod unit_tests {
     fn new_idempotent() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -1140,7 +1171,7 @@ mod unit_tests {
     fn matching_base_and_local() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1158,7 +1189,7 @@ mod unit_tests {
     fn matching_local_and_base() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -1176,10 +1207,14 @@ mod unit_tests {
     fn move_unmove() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let mut document =
-            files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let mut document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1224,10 +1259,14 @@ mod unit_tests {
     fn rename_unrename() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let mut document =
-            files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let mut document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1272,10 +1311,14 @@ mod unit_tests {
     fn delete() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let mut document =
-            files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let mut document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1315,10 +1358,14 @@ mod unit_tests {
     fn multiple_metadata_edits() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let mut root = files::create_root(&account.username);
-        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let mut document =
-            files::create(FileType::Document, root.id, "document", &account.username);
+        let mut root = files::create_root(&account);
+        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let mut document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1338,7 +1385,12 @@ mod unit_tests {
         root.decrypted_name = String::from("root 2");
         folder.deleted = true;
         document.parent = folder.id;
-        let document2 = files::create(FileType::Document, root.id, "document 2", &account.username);
+        let document2 = files::create(
+            FileType::Document,
+            root.id,
+            "document 2",
+            &account.public_key(),
+        );
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &folder).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &document).unwrap();
@@ -1356,8 +1408,13 @@ mod unit_tests {
     fn document_edit() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1389,8 +1446,13 @@ mod unit_tests {
     fn document_edit_idempotent() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1426,8 +1488,13 @@ mod unit_tests {
     fn document_edit_revert() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1471,8 +1538,13 @@ mod unit_tests {
     fn document_edit_manual_promote() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1516,15 +1588,19 @@ mod unit_tests {
     fn promote() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let mut root = files::create_root(&account.username);
-        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let mut document =
-            files::create(FileType::Document, folder.id, "document", &account.username);
+        let mut root = files::create_root(&account);
+        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let mut document = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
         let document2 = files::create(
             FileType::Document,
             folder.id,
             "document 2",
-            &account.username,
+            &account.public_key(),
         );
 
         account_repo::insert(config, &account).unwrap();
@@ -1547,7 +1623,12 @@ mod unit_tests {
         root.decrypted_name = String::from("root 2");
         folder.deleted = true;
         document.parent = root.id;
-        let document3 = files::create(FileType::Document, root.id, "document 3", &account.username);
+        let document3 = files::create(
+            FileType::Document,
+            root.id,
+            "document 3",
+            &account.public_key(),
+        );
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &folder).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &document).unwrap();
@@ -1587,9 +1668,13 @@ mod unit_tests {
     fn prune_deleted() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let mut document =
-            files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let mut document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1621,9 +1706,13 @@ mod unit_tests {
     fn prune_deleted_document_edit() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let mut document =
-            files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let mut document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1659,9 +1748,14 @@ mod unit_tests {
     fn prune_deleted_document_in_deleted_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, folder.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1698,10 +1792,14 @@ mod unit_tests {
     fn prune_deleted_document_moved_from_deleted_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let mut document =
-            files::create(FileType::Document, folder.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let mut document = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1741,9 +1839,13 @@ mod unit_tests {
     fn prune_deleted_base_only() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let mut document =
-            files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let mut document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1779,8 +1881,13 @@ mod unit_tests {
     fn prune_deleted_local_only() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1814,9 +1921,14 @@ mod unit_tests {
     fn prune_deleted_document_moved_from_deleted_folder_local_only() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, folder.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1855,7 +1967,7 @@ mod unit_tests {
     fn prune_deleted_new_local_deleted_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1868,7 +1980,7 @@ mod unit_tests {
         assert_document_count!(config, RepoSource::Local, 0);
 
         let mut deleted_folder =
-            files::create(FileType::Folder, root.id, "folder", &account.username);
+            files::create(FileType::Folder, root.id, "folder", &account.public_key());
         deleted_folder.deleted = true;
         file_service::insert_metadatum(config, RepoSource::Local, &deleted_folder).unwrap();
         file_service::prune_deleted(config).unwrap();
@@ -1885,8 +1997,13 @@ mod unit_tests {
     fn prune_deleted_new_local_deleted_folder_with_existing_moved_child() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1902,7 +2019,7 @@ mod unit_tests {
         assert_document_count!(config, RepoSource::Local, 1);
 
         let mut deleted_folder =
-            files::create(FileType::Folder, root.id, "folder", &account.username);
+            files::create(FileType::Folder, root.id, "folder", &account.public_key());
         deleted_folder.deleted = true;
         let mut document_moved = document.clone();
         document_moved.parent = deleted_folder.id;
@@ -1924,8 +2041,13 @@ mod unit_tests {
     fn prune_deleted_new_local_deleted_folder_with_deleted_existing_moved_child() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -1941,7 +2063,7 @@ mod unit_tests {
         assert_document_count!(config, RepoSource::Local, 1);
 
         let mut deleted_folder =
-            files::create(FileType::Folder, root.id, "folder", &account.username);
+            files::create(FileType::Folder, root.id, "folder", &account.public_key());
         deleted_folder.deleted = true;
         let mut document_moved_and_deleted = document.clone();
         document_moved_and_deleted.parent = deleted_folder.id;

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -147,9 +147,14 @@ mod unit_tests {
     #[test]
     fn test_file_tree_integrity_nonempty_ok() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, folder.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
 
         let result = [root, folder, document].verify_integrity();
 
@@ -159,9 +164,14 @@ mod unit_tests {
     #[test]
     fn test_file_tree_integrity_no_root() {
         let account = test_utils::generate_account();
-        let mut root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let document = files::create(FileType::Document, folder.id, "document", &account.username);
+        let mut root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let document = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
         root.parent = folder.id;
 
         let result = [root, folder, document].verify_integrity();
@@ -172,10 +182,14 @@ mod unit_tests {
     #[test]
     fn test_file_tree_integrity_orphan() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "folder", &account.username);
-        let mut document =
-            files::create(FileType::Document, folder.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
+        let mut document = files::create(
+            FileType::Document,
+            folder.id,
+            "document",
+            &account.public_key(),
+        );
         document.parent = Uuid::new_v4();
         let document_id = document.id;
 
@@ -187,8 +201,8 @@ mod unit_tests {
     #[test]
     fn test_file_tree_integrity_1cycle() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.username);
+        let root = files::create_root(&account);
+        let mut folder = files::create(FileType::Folder, root.id, "folder", &account.public_key());
         folder.parent = folder.id;
 
         let result = [root, folder].verify_integrity();
@@ -199,9 +213,11 @@ mod unit_tests {
     #[test]
     fn test_file_tree_integrity_2cycle() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let mut folder1 = files::create(FileType::Folder, root.id, "folder1", &account.username);
-        let mut folder2 = files::create(FileType::Folder, root.id, "folder2", &account.username);
+        let root = files::create_root(&account);
+        let mut folder1 =
+            files::create(FileType::Folder, root.id, "folder1", &account.public_key());
+        let mut folder2 =
+            files::create(FileType::Folder, root.id, "folder2", &account.public_key());
         folder1.parent = folder2.id;
         folder2.parent = folder1.id;
 
@@ -213,13 +229,18 @@ mod unit_tests {
     #[test]
     fn test_file_tree_integrity_document_treated_as_folder() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document1 = files::create(FileType::Document, root.id, "document1", &account.username);
+        let root = files::create_root(&account);
+        let document1 = files::create(
+            FileType::Document,
+            root.id,
+            "document1",
+            &account.public_key(),
+        );
         let document2 = files::create(
             FileType::Document,
             document1.id,
             "document2",
-            &account.username,
+            &account.public_key(),
         );
         let document1_id = document1.id;
 
@@ -234,9 +255,9 @@ mod unit_tests {
     #[test]
     fn test_file_tree_integrity_path_conflict() {
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let folder = files::create(FileType::Folder, root.id, "file", &account.username);
-        let document = files::create(FileType::Document, root.id, "file", &account.username);
+        let root = files::create_root(&account);
+        let folder = files::create(FileType::Folder, root.id, "file", &account.public_key());
+        let document = files::create(FileType::Document, root.id, "file", &account.public_key());
 
         let result = [root, folder, document].verify_integrity();
 

--- a/core/src/service/path_service.rs
+++ b/core/src/service/path_service.rs
@@ -67,7 +67,13 @@ pub fn create_at_path(
             Document
         };
 
-        current = files::apply_create(&files, file_type, current.id, next_name, &account.username)?;
+        current = files::apply_create(
+            &files,
+            file_type,
+            current.id,
+            next_name,
+            &account.public_key(),
+        )?;
         files.push(current.clone());
         file_service::insert_metadatum(config, RepoSource::Local, &current)?;
     }
@@ -209,7 +215,7 @@ mod unit_tests {
     fn create_at_path_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -224,7 +230,7 @@ mod unit_tests {
     fn create_at_path_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -240,7 +246,7 @@ mod unit_tests {
     fn create_at_path_in_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -260,7 +266,7 @@ mod unit_tests {
     fn create_at_path_missing_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -279,7 +285,7 @@ mod unit_tests {
     fn create_at_path_missing_folders() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -304,7 +310,7 @@ mod unit_tests {
     fn create_at_path_path_contains_empty_file_name() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -319,7 +325,7 @@ mod unit_tests {
     fn create_at_path_path_starts_with_non_root() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -336,7 +342,7 @@ mod unit_tests {
     fn create_at_path_path_taken() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -353,7 +359,7 @@ mod unit_tests {
     fn create_at_path_not_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -371,7 +377,7 @@ mod unit_tests {
     fn get_by_path_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -389,7 +395,7 @@ mod unit_tests {
     fn get_by_path_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -407,7 +413,7 @@ mod unit_tests {
     fn get_by_path_document_in_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -426,7 +432,7 @@ mod unit_tests {
     fn get_path_by_id_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -443,7 +449,7 @@ mod unit_tests {
     fn get_path_by_id_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -460,7 +466,7 @@ mod unit_tests {
     fn get_path_by_id_document_in_folder() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -480,7 +486,7 @@ mod unit_tests {
     fn get_all_paths() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -519,7 +525,7 @@ mod unit_tests {
     fn get_all_paths_documents_only() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -546,7 +552,7 @@ mod unit_tests {
     fn get_all_paths_folders_only() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();
@@ -582,7 +588,7 @@ mod unit_tests {
     fn get_all_paths_leaf_nodes_only() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
+        let root = files::create_root(&account);
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Local, &root).unwrap();

--- a/core/src/service/sync_service.rs
+++ b/core/src/service/sync_service.rs
@@ -286,7 +286,7 @@ fn merge_maybe_documents(
                             FileType::Document,
                             merged_metadata.parent,
                             &merged_metadata.decrypted_name,
-                            &merged_metadata.owner,
+                            &merged_metadata.owner.0,
                         );
 
                         ResolvedDocument::Copied {
@@ -324,13 +324,13 @@ fn merge_maybe_documents(
                             FileType::Document,
                             merged_metadata.parent,
                             &merged_metadata.decrypted_name,
-                            &merged_metadata.owner,
+                            &merged_metadata.owner.0,
                         );
 
                         ResolvedDocument::Copied {
                             remote_metadata: remote_metadata.clone(),
                             remote_document,
-                            copied_local_metadata: copied_local_metadata,
+                            copied_local_metadata,
                             copied_local_document: local_document,
                         }
                     }
@@ -815,9 +815,10 @@ mod unit_tests {
 
     use uuid::Uuid;
 
-    use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
+    use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType, Owner};
 
     use crate::service::sync_service::{self, MaybeMergeResult};
+    use crate::service::test_utils::generate_account;
 
     #[test]
     fn merge_maybe_resolved_base() {
@@ -920,6 +921,7 @@ mod unit_tests {
 
     #[test]
     fn merge_metadata_local_and_remote_moved() {
+        let account = &generate_account();
         let base = DecryptedFileMetadata {
             id: Uuid::from_str("db63957b-3e52-410c-8e5e-66db2619fb33").unwrap(),
             file_type: FileType::Document,
@@ -928,7 +930,7 @@ mod unit_tests {
             metadata_version: 1634693786444,
             content_version: 1634693786444,
             deleted: false,
-            owner: Default::default(),
+            owner: Owner::from(account),
             decrypted_access_key: Default::default(),
         };
         let local = DecryptedFileMetadata {
@@ -939,7 +941,7 @@ mod unit_tests {
             metadata_version: 1634693786444,
             content_version: 1634693786444,
             deleted: false,
-            owner: Default::default(),
+            owner: Owner::from(account),
             decrypted_access_key: Default::default(),
         };
         let remote = DecryptedFileMetadata {
@@ -950,7 +952,7 @@ mod unit_tests {
             metadata_version: 1634693786756,
             content_version: 1634693786556,
             deleted: false,
-            owner: Default::default(),
+            owner: Owner::from(account),
             decrypted_access_key: Default::default(),
         };
 
@@ -966,7 +968,7 @@ mod unit_tests {
                 metadata_version: 1634693786756,
                 content_version: 1634693786556,
                 deleted: false,
-                owner: Default::default(),
+                owner: Owner::from(account),
                 decrypted_access_key: Default::default(),
             }
         );
@@ -974,6 +976,7 @@ mod unit_tests {
 
     #[test]
     fn merge_maybe_metadata_local_and_remote_moved() {
+        let account = &generate_account();
         let base = Some(DecryptedFileMetadata {
             id: Uuid::from_str("db63957b-3e52-410c-8e5e-66db2619fb33").unwrap(),
             file_type: FileType::Document,
@@ -982,7 +985,7 @@ mod unit_tests {
             metadata_version: 1634693786444,
             content_version: 1634693786444,
             deleted: false,
-            owner: Default::default(),
+            owner: Owner::from(account),
             decrypted_access_key: Default::default(),
         });
         let local = Some(DecryptedFileMetadata {
@@ -993,7 +996,7 @@ mod unit_tests {
             metadata_version: 1634693786444,
             content_version: 1634693786444,
             deleted: false,
-            owner: Default::default(),
+            owner: Owner::from(account),
             decrypted_access_key: Default::default(),
         });
         let remote = Some(DecryptedFileMetadata {
@@ -1004,7 +1007,7 @@ mod unit_tests {
             metadata_version: 1634693786756,
             content_version: 1634693786556,
             deleted: false,
-            owner: Default::default(),
+            owner: Owner::from(account),
             decrypted_access_key: Default::default(),
         });
 
@@ -1020,7 +1023,7 @@ mod unit_tests {
                 metadata_version: 1634693786756,
                 content_version: 1634693786556,
                 deleted: false,
-                owner: Default::default(),
+                owner: Owner::from(account),
                 decrypted_access_key: Default::default(),
             }
         );

--- a/core/src/service/test_utils.rs
+++ b/core/src/service/test_utils.rs
@@ -14,7 +14,9 @@ use lockbook_crypto::{pubkey, symkey};
 use lockbook_models::account::Account;
 use lockbook_models::crypto::*;
 use lockbook_models::file_metadata::FileType::Folder;
-use lockbook_models::file_metadata::{DecryptedFileMetadata, EncryptedFileMetadata, FileType};
+use lockbook_models::file_metadata::{
+    DecryptedFileMetadata, EncryptedFileMetadata, FileType, Owner,
+};
 
 use crate::model::repo::RepoSource;
 use crate::model::state::Config;
@@ -256,7 +258,7 @@ pub fn generate_root_metadata(account: &Account) -> (EncryptedFileMetadata, AESK
             file_type: Folder,
             id,
             name,
-            owner: account.username.clone(),
+            owner: Owner::from(account),
             parent: id,
             content_version: 0,
             metadata_version: 0,
@@ -281,7 +283,7 @@ pub fn generate_file_metadata(
             file_type,
             id,
             name: random_filename(),
-            owner: account.username.clone(),
+            owner: Owner::from(account),
             parent: parent.id,
             content_version: 0,
             metadata_version: 0,

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -148,8 +148,13 @@ mod unit_tests {
     fn get_uncompressed_usage_empty_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -169,8 +174,13 @@ mod unit_tests {
     fn get_uncompressed_usage_one_document() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();
@@ -190,9 +200,19 @@ mod unit_tests {
     fn get_uncompressed_usage_multiple_documents() {
         let config = &temp_config();
         let account = test_utils::generate_account();
-        let root = files::create_root(&account.username);
-        let document = files::create(FileType::Document, root.id, "document", &account.username);
-        let document2 = files::create(FileType::Document, root.id, "document 2", &account.username);
+        let root = files::create_root(&account);
+        let document = files::create(
+            FileType::Document,
+            root.id,
+            "document",
+            &account.public_key(),
+        );
+        let document2 = files::create(
+            FileType::Document,
+            root.id,
+            "document 2",
+            &account.public_key(),
+        );
 
         account_repo::insert(config, &account).unwrap();
         file_service::insert_metadatum(config, RepoSource::Base, &root).unwrap();

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-server"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Parth <parth@mehrotra.me>"]
 edition = "2018"
 build = "build.rs"

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -201,7 +201,7 @@ pub async fn change_document_content(
             )));
         }
 
-        if meta.owner.is_empty() {
+        if false {
             return Err(Abort(ClientError(
                 ChangeDocumentContentError::NotPermissioned,
             )));

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -82,7 +82,7 @@ pub fn verify_client_version<Req: Request>(
     request: &RequestWrapper<Req>,
 ) -> Result<(), ErrorWrapper<Req::Error>> {
     match &request.client_version as &str {
-        "0.1.5" => Ok(()),
+        "0.1.6" => Ok(()),
         _ => Err(ErrorWrapper::<Req::Error>::ClientUpdateRequired),
     }
 }


### PR DESCRIPTION
use T Y P E S A F E T Y  to make owners not be a string, which could cause different people to draw different conclusions about it's intended purpose, which is what happened as core saved a username and server saved a public key. It is now exclusively a public key, which is gonna make ownership checks on the server a breeze.

This is every type of breaking change that could happen.

fixes #949 

The line count bloat is all formatting, `account.public_key()` is longer than `account.username`, so a handful of functions are now formatted in the "tall" mode, rather than the horizontal "compact" mode.