### PR TITLE
server: upgrade pagerduty dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,8 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "pagerduty-rs"
-version = "0.1.4"
-source = "git+https://github.com/steverusso/pagerduty-rs#6fcc4722a143cfa6b3d7a6bc9c82ead1285ac758"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861ba8e8af4b263249594d5c627a5dcdc680e71157bbd4172b2b47b8d5f9ef22"
 dependencies = [
  "reqwest",
  "serde",

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.13"
 lockbook-crypto = { path = "../../core/libs/crypto" }
 lockbook-models = { path = "../../core/libs/models" }
 log = "0.4.8"
-pagerduty-rs = { git = "https://github.com/steverusso/pagerduty-rs", default-features = false, features = ["async", "rustls"] }
+pagerduty-rs = { version = "0.1.5", default-features = false, features = ["async", "rustls"] }
 rust-s3 = { version = "0.27.0-rc3", default-features = false, features = ["tokio-rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"


### PR DESCRIPTION
The latest pagerduty includes the dependency feature flagging we need to eliminate native-tls use: https://github.com/polyverse/pagerduty-rs/pull/5