### PR TITLE
fuzzer: garbage collection

### DIFF
--- a/containers/local.env
+++ b/containers/local.env
@@ -1,4 +1,4 @@
-INDEX_DB_REDIS_URL=redis://127.0.0.1
+INDEX_DB_REDIS_URL=redis://localhost
 
 FILES_DB_SCHEME=http
 FILES_DB_HOST=localhost

--- a/core/src/repo/local_storage.rs
+++ b/core/src/repo/local_storage.rs
@@ -54,7 +54,7 @@ where
 {
     let path_str = key_path(db, namespace, key);
     let path = Path::new(&path_str);
-    trace!("delete\t{}", &path_str);
+    debug!("delete\t{}", &path_str);
     if path.exists() {
         remove_file(path).map_err(CoreError::from)
     } else {

--- a/core/src/repo/local_storage.rs
+++ b/core/src/repo/local_storage.rs
@@ -67,6 +67,7 @@ where
     N: AsRef<[u8]>,
 {
     let path_str = namespace_path(db, namespace);
+    debug!("deleting all\t{}", path_str);
     // note: this fails if a file is deleted between call to read_dir and subsequent calls to remove_file
     if let Ok(rd) = fs::read_dir(path_str) {
         for entry in rd {

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -72,7 +72,7 @@ impl Experiment {
     pub fn kick_off(self) {
         let state = Arc::new(Mutex::new(self));
 
-        for thread in 0..num_cpus::get() * 2 {
+        for thread in 0..num_cpus::get() {
             let thread_state = state.clone();
             thread::spawn(move || loop {
                 match Self::grab_ready_trial_for_thread(thread, thread_state.clone()) {

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -93,6 +93,7 @@ impl Experiment {
             print_count += 1;
             thread::sleep(time::Duration::from_millis(10000));
             let experiments = state.lock().unwrap().clone();
+            let current_time = get_time().0;
             let mut failures = experiments.concluded.clone();
             failures.retain(|trial| trial.status.failed());
             if experiments.pending.is_empty() && experiments.running.is_empty() {
@@ -103,11 +104,10 @@ impl Experiment {
                 .running
                 .clone()
                 .into_iter()
-                .filter(|(_, (time, _))| time.0 != 0 && get_time().0 - time.0 > 10000)
+                .filter(|(_, (time, _))| time.0 != 0 && current_time - time.0 > 10000)
                 .collect();
 
             println!(
-                // show count of trails that have been running over 10 seconds
                 "{} pending, {} running, {} stuck, {} run, {} failures.",
                 &experiments.pending.len(),
                 &experiments.running.len(),

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -71,7 +71,7 @@ impl Experiment {
     pub fn kick_off(self) {
         let state = Arc::new(Mutex::new(self));
 
-        for thread in 0..num_cpus::get() {
+        for thread in 0..(num_cpus::get() / 4) {
             let thread_state = state.clone();
             thread::spawn(move || loop {
                 match Self::grab_ready_trial_for_thread(thread, thread_state.clone()) {

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -71,7 +71,7 @@ impl Experiment {
     pub fn kick_off(self) {
         let state = Arc::new(Mutex::new(self));
 
-        for thread in 0..(num_cpus::get() / 4) {
+        for thread in 0..num_cpus::get() {
             let thread_state = state.clone();
             thread::spawn(move || loop {
                 match Self::grab_ready_trial_for_thread(thread, thread_state.clone()) {

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -386,9 +386,9 @@ impl Trial {
             }
         }
 
+        self.end_time = get_time().0;
         self.cleanup();
 
-        self.end_time = get_time().0;
         all_mutations
     }
 

--- a/core/tests/exhaustive_sync_check.rs
+++ b/core/tests/exhaustive_sync_check.rs
@@ -6,7 +6,7 @@ pub mod sync_fuzzer2 {
 
     #[test]
     #[ignore]
-    /// Run with: cargo test --release exhaustive_test_sync -- --nocapture --ignored
+    /// Run with: (export "API_URL=http://localhost:8000" && cargo test --release exhaustive_test_sync -- --nocapture --ignored)
     fn exhaustive_test_sync() {
         Experiment::default().kick_off();
     }

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -41,7 +41,7 @@ macro_rules! core_req {
             .and(warp::body::bytes())
             .then(|state: Arc<ServerState>, request: Bytes| async move {
                 let state = state.as_ref();
-
+                log::info!("pool status: {:?}", state.index_db_pool.status());
                 let timer = router_service::HTTP_REQUEST_DURATION_HISTOGRAM
                     .with_label_values(&[<$Req>::ROUTE])
                     .start_timer();

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -41,7 +41,6 @@ macro_rules! core_req {
             .and(warp::body::bytes())
             .then(|state: Arc<ServerState>, request: Bytes| async move {
                 let state = state.as_ref();
-                log::info!("pool status: {:?}", state.index_db_pool.status());
                 let timer = router_service::HTTP_REQUEST_DURATION_HISTOGRAM
                     .with_label_values(&[<$Req>::ROUTE])
                     .start_timer();


### PR DESCRIPTION
+ fuzzer now deletes accounts once trials are concluded
+ small performance optimization, we now pause execution for much less time while calculating metrics every 10s. We take a snapshot of the experiments and release the mutex immediately.
+ adds a handful of debugging info to core