### PR TITLE
infra: add a simple script to run the lockbook server setup

### DIFF
--- a/server/server/run-server
+++ b/server/server/run-server
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -ea
+
+dir="$1"
+if [ -z "$dir" ]; then
+	dir="/tmp/lbdev"
+fi
+
+printf "Starting redis server... "
+redis-server > redis-server.log 2>&1 &
+printf "Done. PID: $! \n"
+
+printf "Starting minio server... "
+minio server $dir > minio-server.log 2>&1 &
+
+. ../../containers/local.env
+
+while ! nc -z $FILES_DB_HOST $FILES_DB_PORT
+do
+	sleep 0.2
+done
+printf "Done. PID: $! \n"
+
+echo "Configuring minio..."
+mc config host add filesdb $FILES_DB_SCHEME://$FILES_DB_HOST:$FILES_DB_PORT $FILES_DB_ACCESS_KEY $FILES_DB_SECRET_KEY
+mc mb -p --region=$FILES_DB_REGION filesdb/$FILES_DB_BUCKET
+mc policy set public filesdb/$FILES_DB_BUCKET
+
+echo "Compiling and running lockbook server..."
+cargo run

--- a/utils/dev/run-server.sh
+++ b/utils/dev/run-server.sh
@@ -2,6 +2,9 @@
 
 set -ea
 
+projRoot=`git rev-parse --show-toplevel`
+cd $projRoot/server/server
+
 dir="$1"
 if [ -z "$dir" ]; then
 	dir="/tmp/lbdev"


### PR DESCRIPTION
This is a script to run the server setup. It does the following:
* Starts redis, directing any output to `./redis-server.log`.
* Starts minio, directing any output to `./minio-server.log`.
* Configures minio once it is running (note: the `-p` flag is added to the make bucket command so the script won't fail if the bucket already exists).
* Compiles and runs the lockbook server (blocking here).

The script takes one optional argument: the data directory for the minio server. If none is provided, `/tmp/lbdev` is used.