### PR TITLE
core: refactor importing files

### DIFF
--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -1,48 +1,48 @@
+use std::cell::Cell;
+use std::io::Write;
 use std::path::PathBuf;
 
+use lockbook_core::service::import_export_service::ImportStatus;
 use lockbook_core::{
-    create_file_at_path, get_file_by_path, import_file, CreateFileAtPathError, Error as CoreError,
-    Error, GetFileByPathError, ImportFileError,
+    create_file_at_path, get_file_by_path, import_files, CoreError, CreateFileAtPathError,
+    GetFileByPathError, ImportFileError,
 };
+use lockbook_models::file_metadata::DecryptedFileMetadata;
 
 use crate::error::CliResult;
 use crate::utils::{account, config};
 use crate::{err, err_unexpected};
-use lockbook_core::service::import_export_service::ImportExportFileInfo;
-use lockbook_models::file_metadata::DecryptedFileMetadata;
 
 pub fn copy(disk_paths: &[PathBuf], lb_path: &str) -> CliResult<()> {
     account()?;
 
-    let file_metadata = get_or_create_file(lb_path)?;
-
-    let import_progress = |info: ImportExportFileInfo| {
-        println!("importing: {} to {}", info.disk_path.display(), info.lockbook_path);
+    let total = Cell::new(0);
+    let nth_file = Cell::new(0);
+    let update_status = move |status: ImportStatus| match status {
+        ImportStatus::CalculatedTotal(n_files) => total.set(n_files),
+        ImportStatus::Error(disk_path, err) => match err {
+            CoreError::DiskPathInvalid => eprintln!("invalid disk path '{}'", disk_path.display()),
+            _ => eprintln!("unexpected error: {:#?}", err),
+        },
+        ImportStatus::StartingItem(disk_path) => {
+            nth_file.set(nth_file.get() + 1);
+            print!("({}/{}) Importing: {}... ", nth_file.get(), total.get(), disk_path);
+            std::io::stdout().flush().unwrap();
+        }
+        ImportStatus::FinishedItem(_meta) => println!("Done."),
     };
 
-    for path in disk_paths {
-        import_file(
-            &config()?,
-            path.to_path_buf(),
-            file_metadata.id,
-            Some(Box::new(import_progress)),
-        )
-        .map_err(|err| match err {
-            CoreError::UiError(err) => match err {
-                ImportFileError::NoAccount => err!(NoAccount),
-                ImportFileError::ParentDoesNotExist => {
-                    err!(FileNotFound(file_metadata.decrypted_name.clone()))
-                }
-                ImportFileError::DocumentTreatedAsFolder => {
-                    err!(DocTreatedAsFolder(file_metadata.decrypted_name.clone()))
-                }
-                ImportFileError::DiskPathInvalid => err!(OsInvalidPath(lb_path.to_string())),
-            },
-            CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
-        })?;
-    }
+    let dest = get_or_create_file(lb_path)?;
+    let dest_name = dest.decrypted_name;
 
-    Ok(())
+    import_files(&config()?, disk_paths, dest.id, &update_status).map_err(|err| match err {
+        lockbook_core::Error::UiError(err) => match err {
+            ImportFileError::NoAccount => err!(NoAccount),
+            ImportFileError::ParentDoesNotExist => err!(FileNotFound(dest_name)),
+            ImportFileError::DocumentTreatedAsFolder => err!(DocTreatedAsFolder(dest_name)),
+        },
+        lockbook_core::Error::Unexpected(msg) => err_unexpected!("{}", msg),
+    })
 }
 
 fn get_or_create_file(lb_path: &str) -> CliResult<DecryptedFileMetadata> {
@@ -50,15 +50,15 @@ fn get_or_create_file(lb_path: &str) -> CliResult<DecryptedFileMetadata> {
     match get_file_by_path(&config()?, lb_path) {
         Ok(file) => return Ok(file),
         Err(err) => match err {
-            Error::UiError(GetFileByPathError::NoFileAtThatPath) => {} // Continue
-            Error::Unexpected(msg) => return Err(err_unexpected!("{}", msg)),
+            lockbook_core::Error::UiError(GetFileByPathError::NoFileAtThatPath) => {} // Continue
+            lockbook_core::Error::Unexpected(msg) => return Err(err_unexpected!("{}", msg)),
         },
     };
 
     // It does not exist, create it
     if lb_path.ends_with('/') {
         create_file_at_path(&config()?, lb_path).map_err(|err| match err {
-            CoreError::UiError(err) => match err {
+            lockbook_core::Error::UiError(err) => match err {
                 CreateFileAtPathError::FileAlreadyExists => {
                     err!(FileAlreadyExists(lb_path.to_string()))
                 }
@@ -74,7 +74,7 @@ fn get_or_create_file(lb_path: &str) -> CliResult<DecryptedFileMetadata> {
                     err!(DocTreatedAsFolder(lb_path.to_string()))
                 }
             },
-            CoreError::Unexpected(msg) => err_unexpected!("{}", msg),
+            lockbook_core::Error::Unexpected(msg) => err_unexpected!("{}", msg),
         })
     } else {
         eprintln!("Copy destination must be a folder!");

--- a/clients/linux/src/app.rs
+++ b/clients/linux/src/app.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -19,7 +20,8 @@ use gtk::{
 };
 use uuid::Uuid;
 
-use lockbook_core::service::import_export_service::ImportExportFileInfo;
+use lockbook_core::service::import_export_service::{ImportExportFileInfo, ImportStatus};
+use lockbook_core::CoreError;
 use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 
 use crate::account::{AccountScreen, TextAreaDropPasteInfo};
@@ -694,22 +696,39 @@ impl LbApp {
     fn show_dialog_import_file(
         &self, parent: Uuid, uris: Vec<String>, finish_ch: Option<glib::Sender<Vec<String>>>,
     ) -> LbResult<()> {
-        let (d, disk_lbl, lb_lbl, prog_lbl, pbar) = self.gui.new_import_export_dialog(true);
+        let d = self.gui.new_dialog("Import Files");
+        util::gui::set_marginy(&d, 36);
+        util::gui::set_marginx(&d, 100);
+
+        let disk_lbl = GtkLabel::new(None);
+        util::gui::set_marginx(&disk_lbl, 16);
+        disk_lbl.set_margin_top(5);
+
+        let pbar = GtkProgressBar::new();
+        util::gui::set_marginx(&pbar, 16);
+        util::gui::set_marginy(&pbar, 16);
+        pbar.set_size_request(300, -1);
+
+        let prog_lbl = GtkLabel::new(None);
+        util::gui::set_marginy(&prog_lbl, 4);
+
+        d.get_content_area().add(&disk_lbl);
+        d.get_content_area().add(&pbar);
+        d.get_content_area().add(&prog_lbl);
 
         const FILE_SCHEME: &str = "file://";
 
-        let mut total = 0;
+        let total = Cell::new(0);
         let progress = Rc::new(RefCell::new(-1));
 
         let mut paths = Vec::new();
 
         for uri in &uris {
             if let Some(path) = uri.strip_prefix(FILE_SCHEME) {
-                let escaped_uri = glib::uri_unescape_string(path, None)
+                let unescaped_uri = glib::uri_unescape_string(path, None)
                     .ok_or_else(|| uerr_dialog!("Unable to escape uri!"))?
                     .to_string();
-                total += util::io::get_children_count(PathBuf::from(&escaped_uri))?;
-                paths.push(escaped_uri);
+                paths.push(PathBuf::from(&format!("{}/bad", unescaped_uri)));
             } else {
                 return Err(uerr_dialog!("Unsupported uri!"));
             }
@@ -717,25 +736,47 @@ impl LbApp {
 
         d.show_all();
 
+        let mut errors: Vec<String> = Vec::new();
+
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
         rx.attach(
             None,
             glib::clone!(
                 @strong self.messenger as m,
                 @strong progress
-                => move |maybe_info: Option<ImportExportFileInfo>| {
+                => move |maybe_info: Option<ImportStatus>| {
                     *progress.borrow_mut() += 1;
-                    pbar.set_fraction(*progress.borrow() as f64 / total as f64);
+                    pbar.set_fraction(*progress.borrow() as f64 / total.get() as f64);
 
                     match maybe_info {
                         None => {
-                            d.close();
                             m.send(Msg::RefreshTree);
+                            if !errors.is_empty() {
+                                let area = d.get_content_area();
+                                area.foreach(|w| area.remove(w));
+                                for err_msg in &errors {
+                                    let lbl = gtk::Label::new(Some(err_msg));
+                                    lbl.set_halign(gtk::Align::Start);
+                                    util::gui::set_margin(&lbl, 8);
+                                    area.add(&lbl);
+                                }
+                                d.set_title("Import Errors");
+                                d.show_all();
+                            } else {
+                                d.close();
+                            }
                         }
-                        Some(info) => {
-                            lb_lbl.set_text(&info.lockbook_path);
-                            disk_lbl.set_text(&format!("{}", info.disk_path.display()));
-                            prog_lbl.set_text(&format!("{}/{}", *progress.borrow(), total));
+                        Some(status) => match status {
+                            ImportStatus::CalculatedTotal(n_files) => total.set(n_files),
+                            ImportStatus::Error(disk_path, err) => errors.push(match err {
+                                CoreError::DiskPathInvalid => format!("invalid disk path '{}'", disk_path.display()),
+                                _ => format!("unexpected error: {:#?}", err),
+                            }),
+                            ImportStatus::StartingItem(disk_path) => {
+                                disk_lbl.set_text(&format!("Importing: {}", disk_path));
+                                prog_lbl.set_text(&format!("{}/{}", *progress.borrow(), total.get()));
+                            }
+                            ImportStatus::FinishedItem(_metadata) => {}
                         }
                     }
                     glib::Continue(true)
@@ -743,20 +784,17 @@ impl LbApp {
             ),
         );
 
-        let import_progress = glib::clone!(@strong tx => move |progress: ImportExportFileInfo| {
-            tx.send(Some(progress)).unwrap();
+        let import_progress = glib::clone!(@strong tx => move |status: ImportStatus| {
+            tx.send(Some(status)).unwrap();
         });
 
         thread::spawn(glib::clone!(
             @strong self.core as c,
             @strong self.messenger as m
             => move || {
-                for path in &paths {
-                    if let Err(err) = c.import_file(parent, path, Some(Box::new(import_progress.clone()))) {
-                        m.send_err_dialog("Import files", err);
-                        break;
-                    };
-                }
+                if let Err(err) = c.import_files(parent, &paths, &import_progress) {
+                    m.send_err_dialog("Import files", err);
+                };
 
                 tx.send(None).unwrap();
 
@@ -771,7 +809,7 @@ impl LbApp {
                     };
 
                     for path in paths {
-                        let name = match PathBuf::from(path).file_name() {
+                        let name = match path.file_name() {
                             None => {
                                 m.send_err_dialog("getting disk file name", uerr_dialog!("Unable to get disk file's name"));
                                 return;

--- a/clients/linux/src/util.rs
+++ b/clients/linux/src/util.rs
@@ -79,27 +79,6 @@ pub mod gui {
     pub const RIGHT_CLICK: u32 = 3;
 }
 
-pub mod io {
-    use crate::error::{LbError, LbResult};
-    use std::fs;
-    use std::path::PathBuf;
-
-    pub fn get_children_count(path: PathBuf) -> LbResult<u64> {
-        let mut count = 1;
-
-        if !path.is_file() {
-            let children = fs::read_dir(path).map_err(LbError::fmt_program_err)?;
-            for maybe_child in children {
-                let child_path = maybe_child.map_err(LbError::fmt_program_err)?.path();
-
-                count += get_children_count(child_path)?;
-            }
-        }
-
-        Ok(count)
-    }
-}
-
 pub const LOCKBOOK_FILES_TARGET_INFO: u32 = 0;
 pub const TEXT_TARGET_INFO: u32 = 1;
 pub const URI_TARGET_INFO: u32 = 2;


### PR DESCRIPTION
This PR improves the file importing functionality (touches `core` as well as the `cli` and `linux` clients).

### Why

I've found the current implementation to be limited in the following ways:
1. I want to know when the work of importing a single item has started _and finished_. Right now, there is only the option to be alerted when an item has started.
2. When the process of importing an item is done, a graphical client with a tree might want to add an entry at that point. In the case of `linux` for example, this would require the `FileMetadata` of the newly imported file.

### Changes to Code

To start, `import_file` in lib.rs is now `import_files` and takes _at least one_ `PathBuf` to import. (Same change made for the `import_file` function in `import_export_service`.)

Within `import_export_service::import_file_recursively`, the notable change is that `file_service::create_file` is used instead of `path_service::create_file_at_path`. This removes the need to reason about strings and how a string ends in order to determine things such as file type.

In order to determine the stage of the import process as it relates to each individual item, the closure was modified to take a new enum, `ImportStatus`, as a single argument. This is used to communicate to the caller things like when an item is started, when it is done (with the newly created `FileMetadata`), and if there was an error.

The closure that is passed to receive progress updates is no longer optional. Errors while importing files and communicated via the closure and do not halt the entire import process.

### Changes to UI/UX

During import, I think that the destination of each item is both redundant (because they can deduce where things are going as they're the one who kicked off the import) and unimportant (imo the progress is far more important).

<details><summary>cli::before</summary>

![image](https://user-images.githubusercontent.com/6127189/157281541-7b25f515-3411-4724-81d2-331d1c0ade6d.png)
</details>

<details><summary>cli::after</summary>

![image](https://user-images.githubusercontent.com/6127189/157356307-dfadc5ba-2ea2-4486-bc0f-4b76bcb5d27a.png)
</details>

<details><summary>linux::before</summary>

![image](https://user-images.githubusercontent.com/6127189/157280941-9ae90225-f612-4f70-a06b-3418074093fc.png)
</details>

<details><summary>linux::after</summary>

![image](https://user-images.githubusercontent.com/6127189/157282331-0b310ebf-ceac-4d1a-9b25-42d264897515.png)

and if there are errors:

![image](https://user-images.githubusercontent.com/6127189/157370777-9408870a-8d79-4912-b25b-dcbd73dc8988.png)
</details>

If there is consensus that the destination path actually is important information, it can easily be added back in, likely with a `path_service` call.

Name conflicts are automatically resolved by incrementing the conflicting name.

<details><summary>Here's an example of repeatedly importing the same file in cli.</summary>

![image](https://user-images.githubusercontent.com/6127189/157511227-502fe630-dfd8-41ca-a6ab-c42e22949583.png)
</details>