### PR TITLE
infra: improve dev server script

### DIFF
--- a/utils/dev/run-server.sh
+++ b/utils/dev/run-server.sh
@@ -2,6 +2,10 @@
 
 set -ea
 
+command -V redis-server
+command -V minio
+command -V mc
+
 projRoot=`git rev-parse --show-toplevel`
 
 dir="$1"


### PR DESCRIPTION
* create the provided (or default) directory and `cd` into it when starting `redis` and `minio`
* use `command` to print out which programs are being used, or alternatively, to fail if one of them isn't found
* use `lsof` rather than `nc` for a slightly more robust way of listening for `minio`