### PR TITLE
core+linux: add search in core and use it in linux client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,6 +2245,7 @@ dependencies = [
 name = "lockbook-desktop"
 version = "0.3.19"
 dependencies = [
+ "fuzzy-matcher",
  "gdk-pixbuf",
  "gio",
  "gtk4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "gdk-pixbuf"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2199,7 @@ dependencies = [
  "criterion",
  "diffy",
  "flate2",
+ "fuzzy-matcher",
  "image 0.23.14",
  "indicatif 0.17.0-rc.6",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,6 @@ dependencies = [
 name = "lockbook-desktop"
 version = "0.3.19"
 dependencies = [
- "fuzzy-matcher",
  "gdk-pixbuf",
  "gio",
  "gtk4",

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -11,6 +11,7 @@ name = "lockbook_desktop_gtk"
 lb = { package = "lb-api", path = "./lb-api" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
+fuzzy-matcher = "0.3.7"
 gtk = { package = "gtk4", version = "0.4.1", features = ["v4_6"] }
 gio = "0.15.1"
 sv5 = { package = "sourceview5", version = "0.4.1" }

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -11,7 +11,6 @@ name = "lockbook_desktop_gtk"
 lb = { package = "lb-api", path = "./lb-api" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
-fuzzy-matcher = "0.3.7"
 gtk = { package = "gtk4", version = "0.4.1", features = ["v4_6"] }
 gio = "0.15.1"
 sv5 = { package = "sourceview5", version = "0.4.1" }

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -40,6 +40,7 @@ pub use lockbook_core::model::state::Config;
 pub use lockbook_core::service::db_state_service::State as DbState;
 pub use lockbook_core::service::import_export_service::ImportExportFileInfo;
 pub use lockbook_core::service::import_export_service::ImportStatus;
+pub use lockbook_core::service::search_service::SearchResultItem;
 pub use lockbook_core::service::sync_service::SyncProgress;
 pub use lockbook_core::service::sync_service::WorkCalculated;
 pub use lockbook_core::service::usage_service::UsageItemMetric;
@@ -96,6 +97,8 @@ pub trait Api: Send + Sync {
     fn usage(&self) -> Result<UsageMetrics, Error<GetUsageError>>;
     fn sync_all(&self, f: Option<Box<dyn Fn(SyncProgress)>>) -> Result<(), Error<SyncAllError>>;
     fn is_syncing(&self) -> bool;
+
+    fn search_file_paths(&self, input: &str) -> Result<Vec<SearchResultItem>, UnexpectedError>;
 }
 
 pub enum SyncProgressReport {
@@ -266,6 +269,10 @@ impl Api for DefaultApi {
 
     fn is_syncing(&self) -> bool {
         self.sync_lock.try_lock().is_err()
+    }
+
+    fn search_file_paths(&self, input: &str) -> Result<Vec<SearchResultItem>, UnexpectedError> {
+        lockbook_core::search_file_paths(&self.cfg, input)
     }
 }
 

--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -16,11 +16,14 @@ impl super::App {
         let writeable_path =
             env::var("LOCKBOOK_PATH").unwrap_or(format!("{}/.lockbook", env::var("HOME").unwrap()));
 
+        let overlay = gtk::Overlay::new();
+
         let titlebar = ui::Titlebar::new();
+        titlebar.set_window_overlay(&overlay);
 
         let window = gtk::ApplicationWindow::new(a);
-        window.set_title(Some("Lockbook"));
         window.set_titlebar(Some(&titlebar));
+        window.set_child(Some(&overlay));
 
         if let Err(err) = api.init_logger(Path::new(&writeable_path)) {
             show_launch_error(&window, &err.0);
@@ -50,9 +53,6 @@ impl super::App {
                 return;
             }
         };
-
-        let overlay = gtk::Overlay::new();
-        window.set_child(Some(&overlay));
 
         let (bg_op_tx, bg_op_rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
         let bg_state = bg::State::new(bg_op_tx);

--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -16,11 +16,11 @@ impl super::App {
         let writeable_path =
             env::var("LOCKBOOK_PATH").unwrap_or(format!("{}/.lockbook", env::var("HOME").unwrap()));
 
-        let header_bar = ui::LbHeaderBar::new();
+        let titlebar = ui::Titlebar::new();
 
         let window = gtk::ApplicationWindow::new(a);
         window.set_title(Some("Lockbook"));
-        window.set_titlebar(Some(&header_bar));
+        window.set_titlebar(Some(&titlebar));
 
         if let Err(err) = api.init_logger(Path::new(&writeable_path)) {
             show_launch_error(&window, &err.0);
@@ -64,7 +64,7 @@ impl super::App {
             &settings.read().unwrap().hidden_tree_cols,
         );
 
-        let app = Self { api, settings, window, header_bar, onboard, account, bg_state };
+        let app = Self { api, settings, window, titlebar, onboard, account, bg_state };
 
         app.add_app_actions(a);
 
@@ -186,8 +186,8 @@ impl super::App {
             use ui::AccountOp::*;
             match op {
                 TreeReceiveDrop(val, x, y) => self.tree_receive_drop(&val, x, y),
-                TabSwitched(tab) => self.window.set_title(Some(&tab.name())),
-                AllTabsClosed => self.window.set_title(Some("Lockbook")),
+                TabSwitched(tab) => self.titlebar.set_title(&tab.name()),
+                AllTabsClosed => self.titlebar.set_title("Lockbook"),
             }
             glib::Continue(true)
         });

--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -16,10 +16,10 @@ impl super::App {
         let writeable_path =
             env::var("LOCKBOOK_PATH").unwrap_or(format!("{}/.lockbook", env::var("HOME").unwrap()));
 
-        let overlay = gtk::Overlay::new();
-
         let titlebar = ui::Titlebar::new();
-        titlebar.set_window_overlay(&overlay);
+
+        let overlay = gtk::Overlay::new();
+        overlay.add_overlay(titlebar.search_result_area());
 
         let window = gtk::ApplicationWindow::new(a);
         window.set_titlebar(Some(&titlebar));
@@ -75,6 +75,7 @@ impl super::App {
         app.clone().listen_for_onboard_ops(onboard_op_rx);
         app.clone().listen_for_account_ops(account_op_rx);
         app.clone().listen_for_bg_ops(bg_op_rx);
+        app.listen_for_search_ops();
 
         app.setup_window();
         app.window.present();
@@ -144,18 +145,6 @@ impl super::App {
             prompt_search.connect_activate(move |_, _| app.open_search());
             a.add_action(&prompt_search);
             a.set_accels_for_action("app.open-search", &["<Ctrl>space", "<Ctrl>L"]);
-        }
-        {
-            let app = self.clone();
-            let update_search = gio::SimpleAction::new("update-search", None);
-            update_search.connect_activate(move |_, _| app.update_search());
-            a.add_action(&update_search);
-        }
-        {
-            let app = self.clone();
-            let exec_search = gio::SimpleAction::new("exec-search", None);
-            exec_search.connect_activate(move |_, _| app.exec_search());
-            a.add_action(&exec_search);
         }
         {
             let app = self.clone();

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -50,8 +50,7 @@ impl super::App {
                 .downcast_ref::<ui::SearchRow>()
                 .unwrap()
                 .id();
-            self.titlebar.toggle_search_off();
-            self.titlebar.clear_search_box();
+            self.titlebar.clear_search();
             self.repopulate_search_results(&[]);
             self.open_file(id);
         } else {

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -1,25 +1,37 @@
+use gtk::glib;
+
 impl super::App {
     pub fn open_search(&self) {
-        self.header_bar.click_search_button();
+        self.titlebar.toggle_search_on();
     }
 
     pub fn update_search(&self) {
-        // Get current input.
-        let input = self.header_bar.search_input();
+        let input = self.titlebar.search_input();
+        let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
-        // Get the search results.
-        let search_results = match self.api.search_file_paths(&input) {
-            Ok(results) => results,
-            Err(err) => {
-                self.show_err_dialog(&format!("{:?}", err));
-                return;
+        // Do the work of getting the search results in a separate thread.
+        let api = self.api.clone();
+        std::thread::spawn(move || {
+            let result = api.search_file_paths(&input);
+            tx.send(result).unwrap();
+        });
+
+        // Act on the search results.
+        let app = self.clone();
+        rx.attach(None, move |result| {
+            match result {
+                Ok(data) => app.process_search_result_data(&data),
+                Err(err) => app.show_err_dialog(&format!("{:?}", err)),
             }
-        };
+            glib::Continue(false)
+        });
+    }
 
+    fn process_search_result_data(&self, data: &[lb::SearchResultItem]) {
         // Re-populate completion list.
-        let model = self.header_bar.search_completion_model();
+        let model = self.titlebar.search_completion_model();
         model.clear();
-        for res in search_results {
+        for res in data {
             model.set(&model.append(), &[(0, &res.path), (1, &res.id.to_string())]);
         }
     }

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -1,0 +1,26 @@
+impl super::App {
+    pub fn open_search(&self) {
+        self.header_bar.click_search_button();
+    }
+
+    pub fn update_search(&self) {
+        // Get current input.
+        let input = self.header_bar.search_input();
+
+        // Get the search results.
+        let search_results = match self.api.search_file_paths(&input) {
+            Ok(results) => results,
+            Err(err) => {
+                self.show_err_dialog(&format!("{:?}", err));
+                return;
+            }
+        };
+
+        // Re-populate completion list.
+        let model = self.header_bar.search_completion_model();
+        model.clear();
+        for res in search_results {
+            model.set(&model.append(), &[(0, &res.path), (1, &res.id.to_string())]);
+        }
+    }
+}

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -4,11 +4,22 @@ use gtk::prelude::*;
 use crate::ui;
 
 impl super::App {
+    pub fn listen_for_search_ops(&self) {
+        let app = self.clone();
+        self.titlebar.receive_search_ops(move |op| {
+            match op {
+                ui::SearchOp::Update => app.update_search(),
+                ui::SearchOp::Exec => app.exec_search(),
+            }
+            glib::Continue(true)
+        });
+    }
+
     pub fn open_search(&self) {
         self.titlebar.toggle_search_on();
     }
 
-    pub fn update_search(&self) {
+    fn update_search(&self) {
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
         // Do the work of getting the search results in a separate thread.
@@ -23,14 +34,14 @@ impl super::App {
         let app = self.clone();
         rx.attach(None, move |result| {
             match result {
-                Ok(data) => app.fill_search_results(&data),
+                Ok(data) => app.repopulate_search_results(&data),
                 Err(err) => app.show_err_dialog(&format!("{:?}", err)),
             }
             glib::Continue(false)
         });
     }
 
-    pub fn exec_search(&self) {
+    fn exec_search(&self) {
         let list = self.titlebar.search_result_list();
         if let Some(row_choice) = list.selected_row().or_else(|| list.row_at_index(0)) {
             let id = row_choice
@@ -40,14 +51,14 @@ impl super::App {
                 .unwrap()
                 .id();
             self.titlebar.toggle_search_off();
-            self.fill_search_results(&[]);
+            self.repopulate_search_results(&[]);
             self.open_file(id);
         } else {
             self.show_err_dialog("no file path matches your search!");
         }
     }
 
-    fn fill_search_results(&self, data: &[lb::SearchResultItem]) {
+    fn repopulate_search_results(&self, data: &[lb::SearchResultItem]) {
         let list = self.titlebar.search_result_list();
 
         while let Some(row) = list.row_at_index(0) {

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -51,6 +51,7 @@ impl super::App {
                 .unwrap()
                 .id();
             self.titlebar.toggle_search_off();
+            self.titlebar.clear_search_box();
             self.repopulate_search_results(&[]);
             self.open_file(id);
         } else {

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -5,7 +5,6 @@ use crate::ui;
 
 impl super::App {
     pub fn open_search(&self) {
-        self.overlay.add_overlay(self.titlebar.search_result_area());
         self.titlebar.toggle_search_on();
     }
 
@@ -41,8 +40,6 @@ impl super::App {
                 .unwrap()
                 .id();
             self.titlebar.toggle_search_off();
-            self.overlay
-                .remove_overlay(self.titlebar.search_result_area());
             self.fill_search_results(&[]);
             self.open_file(id);
         } else {

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -1,12 +1,44 @@
 use gtk::glib;
+use gtk::prelude::*;
+
+/*struct Possibility {
+    path: String,
+    id: lb::Uuid,
+    score: u32,
+}*/
 
 impl super::App {
     pub fn open_search(&self) {
+        let username = self.api.root().unwrap().decrypted_name;
+
+        let files = self.api.list_metadatas().unwrap();
+
+        let sort_model = self.titlebar.search_completion_model();
+        let list_model = sort_model.model().downcast::<gtk::ListStore>().unwrap();
+
+        //let mut possibs = Vec::new();
+        for f in files {
+            let path = self.api.path_by_id(f.id).unwrap();
+            let path = path.strip_prefix(&username).unwrap_or(&path).to_string();
+            list_model.set(&list_model.append(), &[(0, &path), (1, &f.id.to_string()), (2, &0)]);
+            /*possibs.push(Possibility {
+                path: path.strip_prefix(&username).unwrap_or(&path).to_string(),
+                id: f.id,
+                score: 0,
+            });*/
+        }
+
         self.titlebar.toggle_search_on();
     }
 
     pub fn update_search(&self) {
         let input = self.titlebar.search_input();
+        if input.is_empty() {
+            //self.titlebar.search_completion_model().clear();
+            return;
+        }
+
+        println!("updating search for input {}", input);
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
         // Do the work of getting the search results in a separate thread.
@@ -29,10 +61,12 @@ impl super::App {
 
     fn process_search_result_data(&self, data: &[lb::SearchResultItem]) {
         // Re-populate completion list.
-        let model = self.titlebar.search_completion_model();
+        /*let model = self.titlebar.search_completion_model();
         model.clear();
         for res in data {
             model.set(&model.append(), &[(0, &res.path), (1, &res.id.to_string())]);
-        }
+        }*/
     }
+
+    //fn exec_search_field(&self, use_best_match: bool) {}
 }

--- a/clients/linux/src/app/mod.rs
+++ b/clients/linux/src/app/mod.rs
@@ -11,6 +11,7 @@ pub struct App {
     pub settings: Arc<RwLock<Settings>>,
     pub titlebar: ui::Titlebar,
     pub window: gtk::ApplicationWindow,
+    pub overlay: gtk::Overlay,
     pub onboard: ui::OnboardScreen,
     pub account: ui::AccountScreen,
     pub bg_state: bg::State,

--- a/clients/linux/src/app/mod.rs
+++ b/clients/linux/src/app/mod.rs
@@ -9,6 +9,7 @@ use crate::ui;
 pub struct App {
     pub api: Arc<dyn lb::Api>,
     pub settings: Arc<RwLock<Settings>>,
+    pub header_bar: ui::LbHeaderBar,
     pub window: gtk::ApplicationWindow,
     pub onboard: ui::OnboardScreen,
     pub account: ui::AccountScreen,
@@ -27,6 +28,7 @@ mod imp_new_file;
 mod imp_open_file;
 mod imp_rename_file;
 mod imp_save_file;
+mod imp_search;
 mod imp_settings_dialog;
 mod imp_sview_ctrl_click;
 mod imp_sview_insert_files;

--- a/clients/linux/src/app/mod.rs
+++ b/clients/linux/src/app/mod.rs
@@ -9,7 +9,7 @@ use crate::ui;
 pub struct App {
     pub api: Arc<dyn lb::Api>,
     pub settings: Arc<RwLock<Settings>>,
-    pub header_bar: ui::LbHeaderBar,
+    pub titlebar: ui::Titlebar,
     pub window: gtk::ApplicationWindow,
     pub onboard: ui::OnboardScreen,
     pub account: ui::AccountScreen,

--- a/clients/linux/src/ui/header_bar.rs
+++ b/clients/linux/src/ui/header_bar.rs
@@ -1,57 +1,204 @@
+use gtk::glib;
 use gtk::prelude::*;
+use gtk::subclass::prelude::*;
 
-use crate::ui;
-use crate::ui::icons;
+glib::wrapper! {
+    pub struct LbHeaderBar(ObjectSubclass<imp::LbHeaderBar>)
+        @extends gtk::Widget, gtk::HeaderBar,
+        @implements gtk::Accessible;
+}
 
-pub fn new() -> gtk::HeaderBar {
-    let p = gtk::Popover::new();
+impl LbHeaderBar {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("failed to create LbHeaderBar")
+    }
 
-    /*let btn_search = ui::MenuItemBuilder::new()
-    .action("app.prompt-search")
-    .icon(icons::SEARCH)
-    .label("Search")
-    .accel("Ctrl - L")
-    .popsdown(&p)
-    .build();*/
+    pub fn set_title(&self, title: &str) {
+        self.imp().title.set_markup(&format!("<b>{}</b>", title));
+    }
 
-    let btn_sync = ui::MenuItemBuilder::new()
-        .action("app.sync")
-        .icon(icons::SYNC)
-        .label("Sync")
-        .accel("Alt - S")
-        .popsdown(&p)
-        .build();
+    pub fn click_search_button(&self) {
+        self.imp().search_btn.emit_clicked();
+    }
 
-    let btn_prefs = ui::MenuItemBuilder::new()
-        .action("app.settings")
-        .icon(icons::SETTINGS)
-        .label("Settings")
-        .accel("Ctrl - ,")
-        .popsdown(&p)
-        .build();
+    pub fn search_input(&self) -> String {
+        self.imp().search_box.text().to_string()
+    }
 
-    let btn_about = ui::MenuItemBuilder::new()
-        .action("app.about")
-        .icon(icons::ABOUT)
-        .label("About")
-        .popsdown(&p)
-        .build();
+    pub fn search_completion_model(&self) -> gtk::ListStore {
+        self.imp()
+            .search_cmpl
+            .model()
+            .unwrap()
+            .downcast::<gtk::ListStore>()
+            .unwrap()
+    }
+}
 
-    let app_menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    //app_menu.append(&btn_search);
-    app_menu.append(&btn_sync);
-    app_menu.append(&btn_prefs);
-    app_menu.append(&btn_about);
+mod imp {
+    use gtk::glib;
+    use gtk::prelude::*;
+    use gtk::subclass::prelude::*;
 
-    p.set_halign(gtk::Align::Start);
-    p.set_child(Some(&app_menu));
+    use crate::ui;
+    use crate::ui::icons;
 
-    let app_menu_btn = gtk::MenuButton::builder()
-        .icon_name("open-menu-symbolic")
-        .popover(&p)
-        .build();
+    #[derive(Debug, Default)]
+    pub struct LbHeaderBar {
+        pub app_menu_btn: gtk::MenuButton,
+        pub search_btn: gtk::ToggleButton,
 
-    let hb = gtk::HeaderBar::new();
-    hb.pack_end(&app_menu_btn);
-    hb
+        pub title: gtk::Label,
+        pub search_box: gtk::Entry,
+        pub search_cmpl: gtk::EntryCompletion,
+        pub center: gtk::Stack,
+
+        pub base: gtk::HeaderBar,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for LbHeaderBar {
+        const NAME: &'static str = "LbHeaderBar";
+        type Type = super::LbHeaderBar;
+        type ParentType = gtk::Widget;
+
+        fn class_init(c: &mut Self::Class) {
+            // The layout manager determines how child widgets are laid out.
+            c.set_layout_manager_type::<gtk::BinLayout>();
+        }
+    }
+
+    impl ObjectImpl for LbHeaderBar {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            self.app_menu_btn.set_icon_name("open-menu-symbolic");
+            self.app_menu_btn.set_popover(Some(&app_menu_popover()));
+
+            self.title.set_markup("<b>Lockbook</b>");
+
+            self.search_btn.set_icon_name(icons::SEARCH);
+            self.search_btn.set_active(false);
+            self.search_btn.connect_clicked({
+                let center = self.center.clone();
+                let search_box = self.search_box.clone();
+
+                move |search_btn| {
+                    let is_search = search_btn.is_active();
+                    if is_search {
+                        center.set_transition_type(gtk::StackTransitionType::SlideUp);
+                        center.set_visible_child_name("search");
+                        search_box.grab_focus();
+                    } else {
+                        center.set_transition_type(gtk::StackTransitionType::SlideDown);
+                        center.set_visible_child_name("title");
+                    }
+                    search_btn.set_active(is_search);
+                }
+            });
+
+            let model = gtk::ListStore::new(&[String::static_type(), String::static_type()]);
+            self.search_cmpl.set_model(Some(&model));
+            self.search_cmpl.set_popup_completion(true);
+            self.search_cmpl.set_inline_selection(true);
+            self.search_cmpl.set_text_column(0);
+            self.search_cmpl.set_match_func(|_, _, _| true);
+
+            self.search_box.set_width_request(400);
+            self.search_box.set_primary_icon_name(Some(icons::SEARCH));
+            self.search_box.set_completion(Some(&self.search_cmpl));
+
+            self.search_box.connect_changed(|search_box| {
+                search_box
+                    .activate_action("app.update-search", None)
+                    .unwrap();
+            });
+
+            let search_key_press = gtk::EventControllerKey::new();
+            search_key_press.connect_key_pressed({
+                let search_box = self.search_box.clone();
+                let search_btn = self.search_btn.clone();
+
+                move |_, key, _, _| {
+                    if key == gtk::gdk::Key::Escape {
+                        search_box.set_text("");
+                        search_btn.emit_clicked();
+                    }
+                    gtk::Inhibit(false)
+                }
+            });
+            self.search_box.add_controller(&search_key_press);
+
+            self.center.set_transition_duration(350);
+            self.center.add_named(&self.title, Some("title"));
+            self.center.add_named(&self.search_box, Some("search"));
+
+            self.base.set_title_widget(Some(&self.center));
+            self.base.pack_end(&self.app_menu_btn);
+            self.base.pack_end(&self.search_btn);
+            self.base.set_parent(obj);
+        }
+
+        fn properties() -> &'static [glib::ParamSpec] {
+            use once_cell::sync::Lazy;
+            static PROPS: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| vec![]);
+            PROPS.as_ref()
+        }
+
+        fn set_property(
+            &self, _obj: &Self::Type, _id: usize, _value: &glib::Value, pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, _obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.base.unparent();
+        }
+    }
+
+    impl WidgetImpl for LbHeaderBar {}
+
+    fn app_menu_popover() -> gtk::Popover {
+        let p = gtk::Popover::new();
+
+        let btn_sync = ui::MenuItemBuilder::new()
+            .action("app.sync")
+            .icon(icons::SYNC)
+            .label("Sync")
+            .accel("Alt - S")
+            .popsdown(&p)
+            .build();
+
+        let btn_prefs = ui::MenuItemBuilder::new()
+            .action("app.settings")
+            .icon(icons::SETTINGS)
+            .label("Settings")
+            .accel("Ctrl - ,")
+            .popsdown(&p)
+            .build();
+
+        let btn_about = ui::MenuItemBuilder::new()
+            .action("app.about")
+            .icon(icons::ABOUT)
+            .label("About")
+            .popsdown(&p)
+            .build();
+
+        let app_menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        app_menu.append(&btn_sync);
+        app_menu.append(&btn_prefs);
+        app_menu.append(&btn_about);
+
+        p.set_halign(gtk::Align::Center);
+        p.set_child(Some(&app_menu));
+        p
+    }
 }

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -3,6 +3,7 @@ mod onboard_screen;
 
 mod filetree;
 mod menu_item;
+mod search_row;
 mod sync_panel;
 mod text_editor;
 mod titlebar;
@@ -16,6 +17,7 @@ pub use filetree::FileTree;
 pub use filetree::FileTreeCol;
 pub use menu_item::menu_separator;
 pub use menu_item::MenuItemBuilder;
+pub use search_row::SearchRow;
 pub use sync_panel::SyncPanel;
 pub use text_editor::TextEditor;
 pub use titlebar::Titlebar;
@@ -24,16 +26,6 @@ pub mod about_dialog;
 
 use gtk::glib;
 use gtk::prelude::*;
-
-pub fn id_from_tree_iter(
-    model: &impl IsA<gtk::TreeModel>, iter: &gtk::TreeIter, col: i32,
-) -> lb::Uuid {
-    let iter_id = model
-        .get_value(&iter, col)
-        .get::<String>()
-        .unwrap_or_else(|_| panic!("getting treeview string for uuid: column id {}", col));
-    lb::Uuid::parse_str(&iter_id).unwrap()
-}
 
 pub fn id_from_tpath(model: &impl IsA<gtk::TreeModel>, tpath: &gtk::TreePath) -> lb::Uuid {
     let col = filetree::FileTreeCol::Id.as_tree_store_index();

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -25,6 +25,16 @@ pub mod about_dialog;
 use gtk::glib;
 use gtk::prelude::*;
 
+pub fn id_from_tree_iter(
+    model: &impl IsA<gtk::TreeModel>, iter: &gtk::TreeIter, col: i32,
+) -> lb::Uuid {
+    let iter_id = model
+        .get_value(&iter, col)
+        .get::<String>()
+        .unwrap_or_else(|_| panic!("getting treeview string for uuid: column id {}", col));
+    lb::Uuid::parse_str(&iter_id).unwrap()
+}
+
 pub fn id_from_tpath(model: &impl IsA<gtk::TreeModel>, tpath: &gtk::TreePath) -> lb::Uuid {
     let col = filetree::FileTreeCol::Id.as_tree_store_index();
     let iter = model.iter(tpath).unwrap();

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -5,6 +5,7 @@ mod filetree;
 mod menu_item;
 mod sync_panel;
 mod text_editor;
+mod titlebar;
 
 pub use account_screen::AccountOp;
 pub use account_screen::AccountScreen;
@@ -17,11 +18,9 @@ pub use menu_item::menu_separator;
 pub use menu_item::MenuItemBuilder;
 pub use sync_panel::SyncPanel;
 pub use text_editor::TextEditor;
+pub use titlebar::Titlebar;
 
 pub mod about_dialog;
-pub mod header_bar;
-
-pub use header_bar::LbHeaderBar;
 
 use gtk::glib;
 use gtk::prelude::*;

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -21,6 +21,8 @@ pub use text_editor::TextEditor;
 pub mod about_dialog;
 pub mod header_bar;
 
+pub use header_bar::LbHeaderBar;
+
 use gtk::glib;
 use gtk::prelude::*;
 
@@ -89,7 +91,7 @@ pub mod icons {
     pub const NEW_DOC: &str = "document-new-symbolic";
     pub const NEW_FOLDER: &str = "folder-new-symbolic";
     pub const RENAME: &str = "go-jump-symbolic";
-    //pub const SEARCH: &str = "system-search-symbolic";
+    pub const SEARCH: &str = "system-search-symbolic";
     pub const SETTINGS: &str = "preferences-system-symbolic";
     pub const SYNC: &str = "emblem-synchronizing-symbolic";
     pub const USAGE: &str = "utilities-system-monitor-symbolic";

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -20,6 +20,7 @@ pub use menu_item::MenuItemBuilder;
 pub use search_row::SearchRow;
 pub use sync_panel::SyncPanel;
 pub use text_editor::TextEditor;
+pub use titlebar::SearchOp;
 pub use titlebar::Titlebar;
 
 pub mod about_dialog;

--- a/clients/linux/src/ui/search_row.rs
+++ b/clients/linux/src/ui/search_row.rs
@@ -1,0 +1,73 @@
+use gtk::glib;
+use gtk::subclass::prelude::*;
+
+glib::wrapper! {
+    pub struct SearchRow(ObjectSubclass<imp::SearchRow>)
+        @extends gtk::Widget, gtk::HeaderBar,
+        @implements gtk::Accessible;
+}
+
+impl SearchRow {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("failed to create custom SearchRow")
+    }
+
+    pub fn set_data(&self, id: lb::Uuid, path: &str) {
+        self.imp().id.set(id);
+        self.imp().path.set_text(path);
+    }
+
+    pub fn id(&self) -> lb::Uuid {
+        self.imp().id.get()
+    }
+
+    pub fn path(&self) -> String {
+        self.imp().path.text().to_string()
+    }
+}
+
+impl Default for SearchRow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+mod imp {
+    use std::cell::Cell;
+
+    use gtk::glib;
+    use gtk::prelude::*;
+    use gtk::subclass::prelude::*;
+
+    #[derive(Debug, Default)]
+    pub struct SearchRow {
+        pub id: Cell<lb::Uuid>,
+        pub path: gtk::Label,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SearchRow {
+        const NAME: &'static str = "SearchRow";
+        type Type = super::SearchRow;
+        type ParentType = gtk::Widget;
+
+        fn class_init(c: &mut Self::Class) {
+            // The layout manager determines how child widgets are laid out.
+            c.set_layout_manager_type::<gtk::BinLayout>();
+        }
+    }
+
+    impl ObjectImpl for SearchRow {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+            self.path.set_halign(gtk::Align::Start);
+            self.path.set_parent(obj);
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.path.unparent();
+        }
+    }
+
+    impl WidgetImpl for SearchRow {}
+}

--- a/clients/linux/src/ui/titlebar.rs
+++ b/clients/linux/src/ui/titlebar.rs
@@ -36,7 +36,11 @@ impl Titlebar {
         if btn.is_active() {
             btn.emit_clicked();
         }
+    }
+
+    pub fn clear_search_box(&self) {
         self.imp().search_box.set_text("");
+        *self.imp().real_input.borrow_mut() = "".to_string();
     }
 
     pub fn receive_search_ops<F: FnMut(SearchOp) -> glib::Continue + 'static>(&self, f: F) {

--- a/clients/linux/src/ui/titlebar.rs
+++ b/clients/linux/src/ui/titlebar.rs
@@ -31,14 +31,11 @@ impl Titlebar {
         }
     }
 
-    pub fn toggle_search_off(&self) {
+    pub fn clear_search(&self) {
         let btn = &self.imp().search_btn;
         if btn.is_active() {
             btn.emit_clicked();
         }
-    }
-
-    pub fn clear_search_box(&self) {
         self.imp().search_box.set_text("");
         *self.imp().real_input.borrow_mut() = "".to_string();
     }
@@ -125,7 +122,6 @@ mod imp {
             self.title.set_markup("<b>Lockbook</b>");
 
             self.search_btn.set_icon_name(icons::SEARCH);
-            self.search_btn.set_active(false);
             self.search_btn.connect_clicked({
                 let center = self.center.clone();
                 let search_box = self.search_box.clone();

--- a/clients/linux/src/ui/titlebar.rs
+++ b/clients/linux/src/ui/titlebar.rs
@@ -21,13 +21,32 @@ impl Titlebar {
         let btn = &self.imp().search_btn;
         if !btn.is_active() {
             btn.emit_clicked();
+        } else {
+            self.imp().search_box.grab_focus();
         }
-        self.imp().search_box.grab_focus();
     }
 
     pub fn toggle_search_off(&self) {
+        let btn = &self.imp().search_btn;
+        if btn.is_active() {
+            btn.emit_clicked();
+        }
         self.imp().search_box.set_text("");
-        self.imp().search_btn.emit_clicked();
+    }
+
+    pub fn set_window_overlay(&self, overlay: &gtk::Overlay) {
+        let focus = gtk::EventControllerFocus::new();
+        focus.connect_enter({
+            let overlay = overlay.clone();
+            let result_area_wrap_2 = self.imp().result_area_wrap_2.clone();
+            move |_| overlay.add_overlay(&result_area_wrap_2)
+        });
+        focus.connect_leave({
+            let overlay = overlay.clone();
+            let result_area_wrap_2 = self.imp().result_area_wrap_2.clone();
+            move |_| overlay.remove_overlay(&result_area_wrap_2)
+        });
+        self.imp().search_box.add_controller(&focus);
     }
 
     pub fn search_result_list(&self) -> gtk::ListBox {

--- a/clients/linux/src/ui/titlebar.rs
+++ b/clients/linux/src/ui/titlebar.rs
@@ -29,17 +29,20 @@ impl Titlebar {
         self.imp().search_box.text().to_string()
     }
 
-    pub fn search_completion_model(&self) -> gtk::ListStore {
+    pub fn search_completion_model(&self) -> gtk::TreeModelSort {
         self.imp()
             .search_cmpl
             .model()
             .unwrap()
-            .downcast::<gtk::ListStore>()
+            .downcast::<gtk::TreeModelSort>()
+            //.downcast::<gtk::ListStore>()
             .unwrap()
     }
 }
 
 mod imp {
+    use fuzzy_matcher::skim::SkimMatcherV2;
+    use fuzzy_matcher::FuzzyMatcher;
     use gtk::gdk;
     use gtk::glib;
     use gtk::prelude::*;
@@ -102,14 +105,32 @@ mod imp {
                 }
             });
 
-            let model = gtk::ListStore::new(&[String::static_type(), String::static_type()]);
-            self.search_cmpl.set_model(Some(&model));
-            self.search_cmpl.set_match_func(|_, _, _| true);
+            let list_model = gtk::ListStore::new(&[
+                String::static_type(),
+                String::static_type(),
+                i64::static_type(),
+            ]);
+            let sort_model = gtk::TreeModelSort::with_model(&list_model);
+            self.search_cmpl.set_model(Some(&sort_model));
             self.search_cmpl.set_popup_completion(true);
             self.search_cmpl.set_inline_selection(true);
             self.search_cmpl.set_text_column(0);
+            self.search_cmpl.set_match_func({
+                let matcher = SkimMatcherV2::default();
+
+                move |_, input, iter| {
+                    let path = sort_model
+                        .get_value(iter, 0)
+                        .get::<String>()
+                        .expect("getting `path` column String value of search result list model");
+
+                    matcher.fuzzy_match(&path, input).is_some()
+                }
+            });
             self.search_cmpl.connect_match_selected({
-                move |_, _model, _iter| {
+                move |_, model, iter| {
+                    let id = ui::id_from_tree_iter(model, &iter, 1);
+                    println!("{}", id);
                     gtk::Inhibit(false)
                 }
             });
@@ -124,21 +145,21 @@ mod imp {
                 let search_box = self.search_box.clone();
                 let search_btn = self.search_btn.clone();
 
-                move |_, key, code, _| {
-                    const ARROW_UP: u32 = 111;
-                    const ARROW_DOWN: u32 = 116;
-
+                move |_, key, _, _| {
                     if key == gdk::Key::Escape {
                         search_box.set_text("");
                         search_btn.emit_clicked();
-                    } else if code == ARROW_UP || code == ARROW_DOWN {
-                    } else {
-                        search_box
-                            .activate_action("app.update-search", None)
-                            .unwrap();
                     }
-
                     gtk::Inhibit(false)
+                }
+            });
+            search_key_press.connect_key_released({
+                let search_cmpl = self.search_cmpl.clone();
+
+                move |_, _, code, _| {
+                    if code != ARROW_UP || code != ARROW_DOWN {
+                        //search_cmpl.complete();
+                    }
                 }
             });
             self.search_box.add_controller(&search_key_press);
@@ -215,4 +236,7 @@ mod imp {
         p.set_child(Some(&app_menu));
         p
     }
+
+    const ARROW_UP: u32 = 111;
+    const ARROW_DOWN: u32 = 116;
 }

--- a/clients/linux/src/ui/titlebar.rs
+++ b/clients/linux/src/ui/titlebar.rs
@@ -25,24 +25,34 @@ impl Titlebar {
         self.imp().search_box.grab_focus();
     }
 
+    pub fn toggle_search_off(&self) {
+        self.imp().search_box.set_text("");
+        self.imp().search_btn.emit_clicked();
+    }
+
+    pub fn search_result_list(&self) -> gtk::ListBox {
+        self.imp().result_list.clone()
+    }
+
+    pub fn search_result_area(&self) -> &gtk::Box {
+        &self.imp().result_area_wrap_2
+    }
+
     pub fn search_input(&self) -> String {
         self.imp().search_box.text().to_string()
     }
+}
 
-    pub fn search_completion_model(&self) -> gtk::TreeModelSort {
-        self.imp()
-            .search_cmpl
-            .model()
-            .unwrap()
-            .downcast::<gtk::TreeModelSort>()
-            //.downcast::<gtk::ListStore>()
-            .unwrap()
+impl Default for Titlebar {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 mod imp {
-    use fuzzy_matcher::skim::SkimMatcherV2;
-    use fuzzy_matcher::FuzzyMatcher;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
     use gtk::gdk;
     use gtk::glib;
     use gtk::prelude::*;
@@ -57,10 +67,13 @@ mod imp {
         pub search_btn: gtk::ToggleButton,
 
         pub title: gtk::Label,
-        pub search_box: gtk::Entry,
-        pub search_cmpl: gtk::EntryCompletion,
-        pub center: gtk::Stack,
 
+        pub real_input: Rc<RefCell<String>>,
+        pub search_box: gtk::Entry,
+        pub result_area_wrap_2: gtk::Box,
+        pub result_list: gtk::ListBox,
+
+        pub center: gtk::Stack,
         pub base: gtk::HeaderBar,
     }
 
@@ -105,61 +118,96 @@ mod imp {
                 }
             });
 
-            let list_model = gtk::ListStore::new(&[
-                String::static_type(),
-                String::static_type(),
-                i64::static_type(),
-            ]);
-            let sort_model = gtk::TreeModelSort::with_model(&list_model);
-            self.search_cmpl.set_model(Some(&sort_model));
-            self.search_cmpl.set_popup_completion(true);
-            self.search_cmpl.set_inline_selection(true);
-            self.search_cmpl.set_text_column(0);
-            self.search_cmpl.set_match_func({
-                let matcher = SkimMatcherV2::default();
+            self.result_list.set_hexpand(true);
+            self.result_list
+                .connect_row_activated(move |result_list, _| {
+                    result_list
+                        .activate_action("app.exec-search", None)
+                        .unwrap();
+                });
+            self.result_list.connect_row_selected({
+                let search_box = self.search_box.clone();
+                let real_input = self.real_input.clone();
 
-                move |_, input, iter| {
-                    let path = sort_model
-                        .get_value(iter, 0)
-                        .get::<String>()
-                        .expect("getting `path` column String value of search result list model");
-
-                    matcher.fuzzy_match(&path, input).is_some()
+                move |_, maybe_row| {
+                    if let Some(row) = maybe_row {
+                        let path = row
+                            .child()
+                            .unwrap()
+                            .downcast_ref::<ui::SearchRow>()
+                            .unwrap()
+                            .path();
+                        search_box.set_text(&path);
+                        search_box.select_region(0, -1);
+                    } else {
+                        // fill in user entered text
+                        search_box.set_text(&real_input.borrow());
+                        search_box.set_position(-1);
+                    }
                 }
             });
-            self.search_cmpl.connect_match_selected({
-                move |_, model, iter| {
-                    let id = ui::id_from_tree_iter(model, &iter, 1);
-                    println!("{}", id);
-                    gtk::Inhibit(false)
-                }
-            });
+
+            let result_area_wrap_1 = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+            result_area_wrap_1.set_width_request(400);
+            result_area_wrap_1.add_css_class("contents");
+            result_area_wrap_1.append(&self.result_list);
+
+            self.result_area_wrap_2
+                .set_orientation(gtk::Orientation::Vertical);
+            self.result_area_wrap_2.add_css_class("view");
+            self.result_area_wrap_2.set_width_request(400);
+            self.result_area_wrap_2.set_halign(gtk::Align::Center);
+            self.result_area_wrap_2.set_valign(gtk::Align::Start);
+            self.result_area_wrap_2.append(&result_area_wrap_1);
 
             self.search_box.set_width_request(400);
             self.search_box.set_primary_icon_name(Some(icons::SEARCH));
-            self.search_box.set_completion(Some(&self.search_cmpl));
 
             let search_key_press = gtk::EventControllerKey::new();
             search_key_press.set_propagation_phase(gtk::PropagationPhase::Capture);
             search_key_press.connect_key_pressed({
                 let search_box = self.search_box.clone();
                 let search_btn = self.search_btn.clone();
+                let result_list = self.result_list.clone();
+                let real_input = self.real_input.clone();
 
-                move |_, key, _, _| {
+                move |_, key, code, _| {
                     if key == gdk::Key::Escape {
                         search_box.set_text("");
                         search_btn.emit_clicked();
+                    } else if code == ARROW_DOWN {
+                        let next_index = result_list
+                            .selected_row()
+                            .map(|row| row.index() + 1)
+                            .unwrap_or_default();
+                        if next_index == 0 {
+                            *real_input.borrow_mut() = search_box.text().to_string();
+                        }
+                        result_list.select_row(result_list.row_at_index(next_index).as_ref());
+                    } else if code == ARROW_UP {
+                        let mut prev_index = result_list
+                            .selected_row()
+                            .map(|row| row.index() - 1)
+                            .unwrap_or(-2);
+                        if prev_index == -2 {
+                            prev_index = n_listbox_rows(&result_list) as i32;
+                            *real_input.borrow_mut() = search_box.text().to_string();
+                        }
+                        result_list.select_row(result_list.row_at_index(prev_index).as_ref());
+                    } else if code == ENTER {
+                        search_box.activate_action("app.exec-search", None).unwrap();
                     }
                     gtk::Inhibit(false)
                 }
             });
             search_key_press.connect_key_released({
-                let search_cmpl = self.search_cmpl.clone();
+                let search_box = self.search_box.clone();
 
-                move |_, _, code, _| {
-                    if code != ARROW_UP || code != ARROW_DOWN {
-                        //search_cmpl.complete();
-                    }
+                move |_, _, code, _| match code {
+                    ALT_L | ALT_R | CTRL_L | CTRL_R | ARROW_DOWN | ARROW_UP | ENTER => {}
+                    _ => search_box
+                        .activate_action("app.update-search", None)
+                        .unwrap(),
                 }
             });
             self.search_box.add_controller(&search_key_press);
@@ -172,26 +220,6 @@ mod imp {
             self.base.pack_end(&self.app_menu_btn);
             self.base.pack_end(&self.search_btn);
             self.base.set_parent(obj);
-        }
-
-        fn properties() -> &'static [glib::ParamSpec] {
-            use once_cell::sync::Lazy;
-            static PROPS: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| vec![]);
-            PROPS.as_ref()
-        }
-
-        fn set_property(
-            &self, _obj: &Self::Type, _id: usize, _value: &glib::Value, pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                _ => unimplemented!(),
-            }
-        }
-
-        fn property(&self, _obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
-            match pspec.name() {
-                _ => unimplemented!(),
-            }
         }
 
         fn dispose(&self, _obj: &Self::Type) {
@@ -237,6 +265,22 @@ mod imp {
         p
     }
 
+    fn n_listbox_rows(list: &gtk::ListBox) -> u32 {
+        let mut n = 0;
+        loop {
+            if list.row_at_index(n + 1).is_none() {
+                break;
+            }
+            n += 1;
+        }
+        n as u32
+    }
+
+    const ENTER: u32 = 36;
+    const CTRL_L: u32 = 37;
+    const CTRL_R: u32 = 105;
+    const ALT_L: u32 = 64;
+    const ALT_R: u32 = 108;
     const ARROW_UP: u32 = 111;
     const ARROW_DOWN: u32 = 116;
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,7 @@ bincode = "1.3.3"
 chrono = "0.4.15"
 diffy = "0.2.0"
 flate2 = "1.0"
+fuzzy-matcher = "0.3.7"
 image = "0.23.13" 
 jni = { version = "0.13.1", default-features = false }
 rand = "0.8.4"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,11 +33,12 @@ use crate::pure_functions::drawing::SupportedImageFormats;
 use crate::repo::{account_repo, last_updated_repo};
 use crate::service::db_state_service::State;
 use crate::service::import_export_service::{self, ImportExportFileInfo, ImportStatus};
+use crate::service::search_service::SearchResultItem;
 use crate::service::sync_service::SyncProgress;
 use crate::service::usage_service::{UsageItemMetric, UsageMetrics};
 use crate::service::{
     account_service, billing_service, db_state_service, drawing_service, file_service,
-    path_service, sync_service, usage_service,
+    path_service, search_service, sync_service, usage_service,
 };
 use crate::sync_service::WorkCalculated;
 
@@ -689,6 +690,13 @@ pub fn get_credit_card(config: &Config) -> Result<CreditCardLast4Digits, Error<G
         CoreError::ClientUpdateRequired => UiError(GetCreditCard::ClientUpdateRequired),
         _ => unexpected!("{:#?}", e),
     })
+}
+
+#[instrument(skip(config), err(Debug))]
+pub fn search_file_paths(
+    config: &Config, input: &str,
+) -> Result<Vec<SearchResultItem>, UnexpectedError> {
+    search_service::search_file_paths(config, input).map_err(|e| unexpected_only!("{:#?}", e))
 }
 
 // This basically generates a function called `get_all_error_variants`,

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -10,6 +10,7 @@ pub mod import_export_service;
 pub mod integrity_service;
 pub mod log_service;
 pub mod path_service;
+pub mod search_service;
 pub mod sync_service;
 pub mod test_utils;
 pub mod usage_service;

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -1,0 +1,38 @@
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use uuid::Uuid;
+
+use crate::file_service;
+use crate::model::repo::RepoSource;
+use crate::model::state::Config;
+use crate::path_service;
+use crate::CoreError;
+
+#[derive(Debug)]
+pub struct SearchResultItem {
+    pub id: Uuid,
+    pub path: String,
+    pub score: i64,
+}
+
+pub fn search_file_paths(config: &Config, input: &str) -> Result<Vec<SearchResultItem>, CoreError> {
+    let mut possibs = Vec::new();
+    for f in file_service::get_all_not_deleted_metadata(config, RepoSource::Local)? {
+        possibs.push((f.id, path_service::get_path_by_id(config, f.id)?));
+    }
+
+    let matcher = SkimMatcherV2::default();
+
+    let mut results = possibs
+        .into_iter()
+        .filter_map(|(id, path)| {
+            matcher
+                .fuzzy_match(&path, &input)
+                .and_then(|score| Some(SearchResultItem { id, path, score }))
+        })
+        .collect::<Vec<SearchResultItem>>();
+
+    results.sort_by(|a, b| a.score.cmp(&b.score));
+
+    Ok(results)
+}

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -22,22 +22,7 @@ impl Ord for SearchResultItem {
         match self.score.cmp(&other.score) {
             Ordering::Greater => Ordering::Less,
             Ordering::Less => Ordering::Greater,
-            Ordering::Equal => {
-                let chars1: Vec<char> = self.path.chars().collect();
-                let chars2: Vec<char> = other.path.chars().collect();
-
-                let n_chars1 = chars1.len();
-                let n_chars2 = chars2.len();
-
-                for i in 0..std::cmp::min(n_chars1, n_chars2) {
-                    let ord = chars1[i].cmp(&chars2[i]);
-                    if ord != Ordering::Equal {
-                        return ord;
-                    }
-                }
-
-                n_chars1.cmp(&n_chars2)
-            }
+            Ordering::Equal => self.path.cmp(&other.path),
         }
     }
 }

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use uuid::Uuid;
@@ -16,23 +18,49 @@ pub struct SearchResultItem {
 }
 
 pub fn search_file_paths(config: &Config, input: &str) -> Result<Vec<SearchResultItem>, CoreError> {
+    if input.is_empty() {
+        return Ok(Vec::new());
+    }
+
     let mut possibs = Vec::new();
     for f in file_service::get_all_not_deleted_metadata(config, RepoSource::Local)? {
         possibs.push((f.id, path_service::get_path_by_id(config, f.id)?));
     }
 
+    let root_name = file_service::get_root(config)?.decrypted_name;
     let matcher = SkimMatcherV2::default();
 
     let mut results = possibs
         .into_iter()
         .filter_map(|(id, path)| {
+            let path = path.strip_prefix(&root_name).unwrap_or(&path).to_string();
+
             matcher
-                .fuzzy_match(&path, &input)
-                .and_then(|score| Some(SearchResultItem { id, path, score }))
+                .fuzzy_match(&path, input)
+                .map(|score| SearchResultItem { id, path, score })
         })
         .collect::<Vec<SearchResultItem>>();
 
-    results.sort_by(|a, b| a.score.cmp(&b.score));
+    results.sort_by(|a, b| match a.score.cmp(&b.score) {
+        Ordering::Greater => Ordering::Less,
+        Ordering::Less => Ordering::Greater,
+        Ordering::Equal => {
+            let chars1: Vec<char> = a.path.chars().collect();
+            let chars2: Vec<char> = b.path.chars().collect();
+
+            let n_chars1 = chars1.len();
+            let n_chars2 = chars2.len();
+
+            for i in 0..std::cmp::min(n_chars1, n_chars2) {
+                let ord = chars1[i].cmp(&chars2[i]);
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+
+            n_chars1.cmp(&n_chars2)
+        }
+    });
 
     Ok(results)
 }

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -10,11 +10,42 @@ use crate::model::state::Config;
 use crate::path_service;
 use crate::CoreError;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SearchResultItem {
     pub id: Uuid,
     pub path: String,
     pub score: i64,
+}
+
+impl Ord for SearchResultItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.score.cmp(&other.score) {
+            Ordering::Greater => Ordering::Less,
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => {
+                let chars1: Vec<char> = self.path.chars().collect();
+                let chars2: Vec<char> = other.path.chars().collect();
+
+                let n_chars1 = chars1.len();
+                let n_chars2 = chars2.len();
+
+                for i in 0..std::cmp::min(n_chars1, n_chars2) {
+                    let ord = chars1[i].cmp(&chars2[i]);
+                    if ord != Ordering::Equal {
+                        return ord;
+                    }
+                }
+
+                n_chars1.cmp(&n_chars2)
+            }
+        }
+    }
+}
+
+impl PartialOrd for SearchResultItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 pub fn search_file_paths(config: &Config, input: &str) -> Result<Vec<SearchResultItem>, CoreError> {
@@ -22,45 +53,19 @@ pub fn search_file_paths(config: &Config, input: &str) -> Result<Vec<SearchResul
         return Ok(Vec::new());
     }
 
-    let mut possibs = Vec::new();
-    for f in file_service::get_all_not_deleted_metadata(config, RepoSource::Local)? {
-        possibs.push((f.id, path_service::get_path_by_id(config, f.id)?));
-    }
-
     let root_name = file_service::get_root(config)?.decrypted_name;
     let matcher = SkimMatcherV2::default();
 
-    let mut results = possibs
-        .into_iter()
-        .filter_map(|(id, path)| {
-            let path = path.strip_prefix(&root_name).unwrap_or(&path).to_string();
+    let mut results = Vec::new();
+    for f in file_service::get_all_not_deleted_metadata(config, RepoSource::Local)? {
+        let path = path_service::get_path_by_id(config, f.id)?;
+        let path_without_root = path.strip_prefix(&root_name).unwrap_or(&path).to_string();
 
-            matcher
-                .fuzzy_match(&path, input)
-                .map(|score| SearchResultItem { id, path, score })
-        })
-        .collect::<Vec<SearchResultItem>>();
-
-    results.sort_by(|a, b| match a.score.cmp(&b.score) {
-        Ordering::Greater => Ordering::Less,
-        Ordering::Less => Ordering::Greater,
-        Ordering::Equal => {
-            let chars1: Vec<char> = a.path.chars().collect();
-            let chars2: Vec<char> = b.path.chars().collect();
-
-            let n_chars1 = chars1.len();
-            let n_chars2 = chars2.len();
-
-            for i in 0..std::cmp::min(n_chars1, n_chars2) {
-                let ord = chars1[i].cmp(&chars2[i]);
-                if ord != Ordering::Equal {
-                    return ord;
-                }
-            }
-
-            n_chars1.cmp(&n_chars2)
+        if let Some(score) = matcher.fuzzy_match(&path_without_root, input) {
+            results.push(SearchResultItem { id: f.id, path: path_without_root, score });
         }
-    });
+    }
+    results.sort();
 
     Ok(results)
 }

--- a/core/tests/search_service_tests.rs
+++ b/core/tests/search_service_tests.rs
@@ -1,0 +1,45 @@
+#[cfg(test)]
+mod search_tests {
+    use lockbook_core::create_account;
+    use lockbook_core::create_file_at_path;
+    use lockbook_core::search_file_paths;
+    use lockbook_core::service::search_service::SearchResultItem;
+    use lockbook_core::service::test_utils;
+
+    #[test]
+    fn test_matches() {
+        let config = test_utils::test_config();
+        let generated_account = test_utils::generate_account();
+        let username = generated_account.username;
+        create_account(&config, &username, &generated_account.api_url).unwrap();
+
+        vec!["abc.md", "abcd.md", "abcde.md", "dir/doc1", "dir/doc2", "dir/doc3"]
+            .into_iter()
+            .for_each(|path| {
+                let path = format!("{}/{}", username, path);
+                create_file_at_path(&config, &path).unwrap();
+            });
+
+        let search_results = search_file_paths(&config, "").unwrap();
+        assert!(search_results.is_empty());
+
+        let search_results = search_file_paths(&config, "abcde.md").unwrap();
+        assert_result_paths(&search_results, &["/abcde.md"]);
+
+        let search_results = search_file_paths(&config, "d/o").unwrap();
+        assert_result_paths(&search_results, &["/dir/doc1", "/dir/doc2", "/dir/doc3"]);
+
+        let search_results = search_file_paths(&config, "d/3").unwrap();
+        assert_result_paths(&search_results, &["/dir/doc3"]);
+
+        let search_results = search_file_paths(&config, "ad").unwrap();
+        assert_result_paths(&search_results, &["/abcd.md", "/abcde.md", "/abc.md"]);
+    }
+
+    fn assert_result_paths(results: &[SearchResultItem], paths: &[&str]) {
+        assert_eq!(results.len(), paths.len());
+        for i in 0..results.len() {
+            assert_eq!(results.get(i).unwrap().path, *paths.get(i).unwrap());
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a `search_service` in core and then implements the use of it within the linux client.

The `search_service` has a single function that fuzzy searches all file paths and returns the (sorted) ID, path, and score of any matches.

The search interface in linux is created from scratch (so to speak) using an overlay and a list box instead of using a gtk entry completion setup (as was the case in the old client). `Ctrl-space` and `Ctrl-L` are used to display a search input field in place of the app's title in the window's titlebar.

Closes #828.