### PR TITLE
linux: implement move via right click cut & paste

### DIFF
--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -30,6 +30,7 @@ pub use lockbook_core::GetUsageError;
 pub use lockbook_core::ImportError as ImportAccountError;
 pub use lockbook_core::ImportFileError;
 pub use lockbook_core::MigrationError;
+pub use lockbook_core::MoveFileError;
 pub use lockbook_core::ReadDocumentError;
 pub use lockbook_core::RenameFileError;
 pub use lockbook_core::SyncAllError;
@@ -78,6 +79,7 @@ pub trait Api: Send + Sync {
         &self, name: &str, parent: Uuid, ftype: FileType,
     ) -> Result<FileMetadata, Error<CreateFileError>>;
     fn rename_file(&self, id: Uuid, new_name: &str) -> Result<(), Error<RenameFileError>>;
+    fn move_file(&self, id: Uuid, dest: Uuid) -> Result<(), Error<MoveFileError>>;
     fn delete_file(&self, id: Uuid) -> Result<(), Error<FileDeleteError>>;
 
     fn read_document(&self, id: Uuid) -> Result<DecryptedDocument, Error<ReadDocumentError>>;
@@ -219,6 +221,10 @@ impl Api for DefaultApi {
 
     fn rename_file(&self, id: Uuid, new_name: &str) -> Result<(), Error<RenameFileError>> {
         lockbook_core::rename_file(&self.cfg, id, new_name)
+    }
+
+    fn move_file(&self, id: Uuid, dest: Uuid) -> Result<(), Error<MoveFileError>> {
+        lockbook_core::move_file(&self.cfg, id, dest)
     }
 
     fn delete_file(&self, id: Uuid) -> Result<(), Error<FileDeleteError>> {

--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -183,6 +183,8 @@ impl super::App {
         account_op_rx.attach(None, move |op| {
             use ui::AccountOp::*;
             match op {
+                CutSelectedFile => self.cut_selected_file(),
+                PasteIntoSelectedFile => self.paste_into_selected_file(),
                 TreeReceiveDrop(val, x, y) => self.tree_receive_drop(&val, x, y),
                 TabSwitched(tab) => self.titlebar.set_title(&tab.name()),
                 AllTabsClosed => self.titlebar.set_title("Lockbook"),

--- a/clients/linux/src/app/imp_file_copy_paste.rs
+++ b/clients/linux/src/app/imp_file_copy_paste.rs
@@ -1,0 +1,50 @@
+impl super::App {
+    pub fn cut_selected_file(&self) {
+        let t = &self.account.tree;
+        match t.get_selected_uuid() {
+            Some(id) => *t.clipboard.borrow_mut() = Some(id),
+            None => self.show_err_dialog("a single file must be selected to copy or cut!"),
+        }
+    }
+
+    pub fn paste_into_selected_file(&self) {
+        let t = &self.account.tree;
+
+        let dest_id = match t.get_selected_uuid() {
+            Some(id) => match self.api.file_by_id(id) {
+                Ok(meta) => match meta.file_type {
+                    lb::FileType::Document => meta.parent,
+                    lb::FileType::Folder => meta.id,
+                },
+                Err(err) => {
+                    self.show_err_dialog(&format!("{:?}", err));
+                    return;
+                }
+            },
+            None => {
+                self.show_err_dialog("a single file must be selected to paste file!");
+                return;
+            }
+        };
+
+        let id = match t.clipboard.borrow_mut().take() {
+            Some(id) => id,
+            None => {
+                self.show_err_dialog("the clipboard is empty, there's nothing to paste!");
+                return;
+            }
+        };
+
+        match self.api.move_file(id, dest_id) {
+            Ok(_) => {
+                let iter = t.search(&id).unwrap();
+                t.model.remove(&iter);
+
+                let children = self.api.file_and_all_children(id).unwrap();
+                let parent_iter = t.search(&dest_id).unwrap();
+                t.append_any_children(&dest_id, &parent_iter, &children);
+            }
+            Err(err) => self.show_err_dialog(&format!("{:?}", err)),
+        }
+    }
+}

--- a/clients/linux/src/app/mod.rs
+++ b/clients/linux/src/app/mod.rs
@@ -24,6 +24,7 @@ mod imp_close_file;
 mod imp_delete_files;
 mod imp_errors;
 mod imp_export_files;
+mod imp_file_copy_paste;
 mod imp_import_files;
 mod imp_new_file;
 mod imp_open_file;

--- a/clients/linux/src/ui/account_screen.rs
+++ b/clients/linux/src/ui/account_screen.rs
@@ -7,6 +7,8 @@ use gtk::prelude::*;
 use crate::ui;
 
 pub enum AccountOp {
+    CutSelectedFile,
+    PasteIntoSelectedFile,
     TreeReceiveDrop(glib::Value, f64, f64),
     TabSwitched(ui::TextEditor),
     AllTabsClosed,

--- a/clients/linux/src/ui/menu_item.rs
+++ b/clients/linux/src/ui/menu_item.rs
@@ -44,7 +44,7 @@ impl MenuItemBuilder {
         if let Some(icon_name) = self.icon {
             let icon = gtk::Image::builder()
                 .icon_name(&icon_name)
-                .pixel_size(18)
+                .pixel_size(16)
                 .build();
             content.append(&icon);
         }
@@ -81,7 +81,7 @@ impl MenuItemBuilder {
 pub fn menu_separator() -> gtk::Separator {
     gtk::Separator::builder()
         .orientation(gtk::Orientation::Horizontal)
-        .margin_bottom(4)
-        .margin_top(4)
+        .margin_bottom(2)
+        .margin_top(2)
         .build()
 }

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -87,11 +87,13 @@ pub mod icons {
     pub const ACCOUNT: &str = "avatar-default-symbolic";
     pub const APP: &str = "video-display-symbolic";
     pub const CHECK_MARK: &str = "emblem-ok-symbolic";
+    pub const CUT: &str = "edit-cut-symbolic";
     pub const DELETE: &str = "edit-delete-symbolic";
     pub const ERROR_RED: &str = "dialog-error-symbolic";
     pub const EXPORT: &str = "document-save-symbolic";
     pub const NEW_DOC: &str = "document-new-symbolic";
     pub const NEW_FOLDER: &str = "folder-new-symbolic";
+    pub const PASTE: &str = "edit-paste-symbolic";
     pub const RENAME: &str = "go-jump-symbolic";
     pub const SEARCH: &str = "system-search-symbolic";
     pub const SETTINGS: &str = "preferences-system-symbolic";

--- a/clients/linux/style.css
+++ b/clients/linux/style.css
@@ -3,6 +3,7 @@
 }
 .menu-item {
 	margin: 0;
+	padding: 0;
 }
 #err {
 	color: red;


### PR DESCRIPTION
This PR adds two options to the file tree's right click menu: `Cut` and `Paste`. Only a single file (excluding root) can currently be cut and pasted (aka: moved). Pasting will clear the file clipboard, and it will only be enabled in the menu if the file clipboard has content.

The size of file menu item buttons are decreased as well (specifically by reducing padding), which brings them more inline with other applications.