### PR TITLE
linux: miscellaneous refactors and cleanups

### DIFF
--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -84,31 +84,6 @@ impl super::App {
     fn add_app_actions(&self, a: &gtk::Application) {
         {
             let app = self.clone();
-            let new_doc = gio::SimpleAction::new("new-document", None);
-            new_doc.connect_activate(move |_, _| app.new_file(lb::FileType::Document));
-            a.add_action(&new_doc);
-        }
-        {
-            let app = self.clone();
-            let new_folder = gio::SimpleAction::new("new-folder", None);
-            new_folder.connect_activate(move |_, _| app.new_file(lb::FileType::Folder));
-            a.add_action(&new_folder);
-        }
-        {
-            let app = self.clone();
-            let open_file = gio::SimpleAction::new("open-file", Some(glib::VariantTy::STRING));
-            open_file.connect_activate(move |_, param| {
-                let param = param
-                    .expect("there must be a uuid string for 'app.open-file'")
-                    .get::<String>()
-                    .expect("the 'app.open-file' parameter must be type String");
-                let id = lb::Uuid::parse_str(&param).unwrap();
-                app.open_file(id);
-            });
-            a.add_action(&open_file);
-        }
-        {
-            let app = self.clone();
             let save_file = gio::SimpleAction::new("save-file", None);
             save_file.connect_activate(move |_, _| app.save_file(None));
             a.add_action(&save_file);
@@ -120,24 +95,6 @@ impl super::App {
             close_file.connect_activate(move |_, _| app.close_file());
             a.add_action(&close_file);
             a.set_accels_for_action("app.close-file", &["<Ctrl>W"]);
-        }
-        {
-            let app = self.clone();
-            let rename_file = gio::SimpleAction::new("rename-file", None);
-            rename_file.connect_activate(move |_, _| app.rename_file());
-            a.add_action(&rename_file);
-        }
-        {
-            let app = self.clone();
-            let del_files = gio::SimpleAction::new("delete-files", None);
-            del_files.connect_activate(move |_, _| app.delete_files());
-            a.add_action(&del_files);
-        }
-        {
-            let app = self.clone();
-            let exp_files = gio::SimpleAction::new("export-files", None);
-            exp_files.connect_activate(move |_, _| app.export_files());
-            a.add_action(&exp_files);
         }
         {
             let app = self.clone();
@@ -183,8 +140,14 @@ impl super::App {
         account_op_rx.attach(None, move |op| {
             use ui::AccountOp::*;
             match op {
-                CutSelectedFile => self.cut_selected_file(),
-                PasteIntoSelectedFile => self.paste_into_selected_file(),
+                NewDocument => self.new_file(lb::FileType::Document),
+                NewFolder => self.new_file(lb::FileType::Folder),
+                OpenFile(id) => self.open_file(id),
+                RenameFile => self.rename_file(),
+                DeleteFiles => self.delete_files(),
+                ExportFiles => self.export_files(),
+                CutFile => self.cut_selected_file(),
+                PasteFile => self.paste_into_selected_file(),
                 TreeReceiveDrop(val, x, y) => self.tree_receive_drop(&val, x, y),
                 TabSwitched(tab) => self.titlebar.set_title(&tab.name()),
                 AllTabsClosed => self.titlebar.set_title("Lockbook"),

--- a/clients/linux/src/app/imp_delete_files.rs
+++ b/clients/linux/src/app/imp_delete_files.rs
@@ -59,7 +59,7 @@ impl super::App {
                 }
 
                 // Remove the file from the file tree.
-                if let Some(iter) = app.account.tree.search(&info.id) {
+                if let Some(iter) = app.account.tree.search(info.id) {
                     app.account.tree.model.remove(&iter);
                 }
 

--- a/clients/linux/src/app/imp_errors.rs
+++ b/clients/linux/src/app/imp_errors.rs
@@ -1,5 +1,7 @@
 use gtk::prelude::*;
 
+use crate::ui::icons;
+
 impl super::App {
     pub fn show_err_dialog(&self, txt: &str) {
         let err_lbl = gtk::Label::builder()
@@ -7,13 +9,28 @@ impl super::App {
             .name("err")
             .halign(gtk::Align::Start)
             .margin_top(16)
-            .margin_bottom(8)
+            .margin_bottom(16)
+            .margin_start(16)
+            .margin_end(16)
             .build();
+
+        let err_icon = gtk::Image::from_icon_name(icons::ERROR_RED);
+        err_icon.set_pixel_size(24);
+
+        let title = gtk::Label::new(None);
+        title.set_markup("<b>Error</b>");
+
+        let titlebar = gtk::HeaderBar::new();
+        titlebar.set_title_widget(Some(&title));
+        titlebar.pack_start(&err_icon);
+
         let d = gtk::Dialog::builder()
             .transient_for(&self.window)
             .default_width(300)
+            .titlebar(&titlebar)
             .modal(true)
             .build();
+
         d.content_area().append(&err_lbl);
         d.show();
     }

--- a/clients/linux/src/app/imp_export_files.rs
+++ b/clients/linux/src/app/imp_export_files.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use gtk::glib;
 use gtk::prelude::*;
 
+use crate::ui;
 use crate::ui::icons;
 
 impl super::App {
@@ -69,9 +70,9 @@ impl super::App {
             .window
             .titlebar()
             .expect("app window should have a titlebar")
-            .downcast::<gtk::HeaderBar>()
-            .expect("app window titlebar should be a header bar");
-        titlebar.pack_start(&menu_btn);
+            .downcast::<ui::Titlebar>()
+            .expect("app window titlebar should be a `ui::Titlebar`");
+        titlebar.base().pack_start(&menu_btn);
 
         let total = match self.api.file_and_all_children(lb_file) {
             Ok(children) => children.len(),
@@ -117,7 +118,7 @@ impl super::App {
                         p.connect_closed({
                             let titlebar = titlebar.clone();
                             let menu_btn = menu_btn.clone();
-                            move |_| titlebar.remove(&menu_btn)
+                            move |_| titlebar.base().remove(&menu_btn)
                         });
                     }
                     Err(err) => {

--- a/clients/linux/src/app/imp_file_copy_paste.rs
+++ b/clients/linux/src/app/imp_file_copy_paste.rs
@@ -37,12 +37,12 @@ impl super::App {
 
         match self.api.move_file(id, dest_id) {
             Ok(_) => {
-                let iter = t.search(&id).unwrap();
+                let iter = t.search(id).unwrap();
                 t.model.remove(&iter);
 
                 let children = self.api.file_and_all_children(id).unwrap();
-                let parent_iter = t.search(&dest_id).unwrap();
-                t.append_any_children(&dest_id, &parent_iter, &children);
+                let parent_iter = t.search(dest_id).unwrap();
+                t.append_any_children(dest_id, &parent_iter, &children);
             }
             Err(err) => self.show_err_dialog(&format!("{:?}", err)),
         }

--- a/clients/linux/src/app/imp_import_files.rs
+++ b/clients/linux/src/app/imp_import_files.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use gtk::glib;
 use gtk::prelude::*;
 
+use crate::ui;
 use crate::ui::icons;
 
 impl super::App {
@@ -29,9 +30,9 @@ impl super::App {
             .window
             .titlebar()
             .expect("app window should have a titlebar")
-            .downcast::<gtk::HeaderBar>()
-            .expect("app window titlebar should be a header bar");
-        titlebar.pack_start(&menu_btn);
+            .downcast::<ui::Titlebar>()
+            .expect("app window titlebar should be a `ui::Titlebar`");
+        titlebar.base().pack_start(&menu_btn);
 
         let (file_paths, unsupported_uris) = process_uris(uris);
         if !unsupported_uris.is_empty() {
@@ -76,7 +77,7 @@ impl super::App {
                     }
                     lb::ImportStatus::FinishedItem(meta) => {
                         count += 1;
-                        if let Some(iter) = app.account.tree.search(&meta.parent) {
+                        if let Some(iter) = app.account.tree.search(meta.parent) {
                             app.account.tree.append(Some(&iter), &meta);
                         }
                     }
@@ -89,7 +90,7 @@ impl super::App {
                         let menu_btn = menu_btn.clone();
                         move |_| {
                             p.popdown();
-                            titlebar.remove(&menu_btn);
+                            titlebar.base().remove(&menu_btn);
                         }
                     });
 
@@ -107,7 +108,7 @@ impl super::App {
                                 p.connect_closed({
                                     let titlebar = titlebar.clone();
                                     let menu_btn = menu_btn.clone();
-                                    move |_| titlebar.remove(&menu_btn)
+                                    move |_| titlebar.base().remove(&menu_btn)
                                 });
                             } else {
                                 menu_btn.set_icon_name(icons::ERROR_RED);

--- a/clients/linux/src/app/imp_rename_file.rs
+++ b/clients/linux/src/app/imp_rename_file.rs
@@ -63,8 +63,8 @@ impl super::App {
             // Update the name (and icon if necessary) in the filetree.
             let tree = &app.account.tree;
             let iter = tree
-                .search(&id)
-                .unwrap_or_else(|| panic!("renaming file tree entry: none found for id '{}'", &id));
+                .search(id)
+                .unwrap_or_else(|| panic!("renaming file tree entry: none found for id '{}'", id));
             if meta.file_type == lb::FileType::Document {
                 tree.model
                     .set_value(&iter, 0, &ui::document_icon_from_name(&new_name).to_value());

--- a/clients/linux/src/app/imp_save_file.rs
+++ b/clients/linux/src/app/imp_save_file.rs
@@ -11,7 +11,7 @@ impl super::App {
             let id = tab.id();
             let b = tab.editor().buffer();
             let data = b.text(&b.start_iter(), &b.end_iter(), true);
-            match self.save_file_content(&id, &data) {
+            match self.save_file_content(id, &data) {
                 Ok(()) => self.update_sync_status(),
                 Err(err) => self.show_err_dialog(&format!("error saving: {}", err)),
             }
@@ -19,10 +19,10 @@ impl super::App {
         }
     }
 
-    fn save_file_content(&self, id: &lb::Uuid, data: &str) -> Result<(), String> {
+    fn save_file_content(&self, id: lb::Uuid, data: &str) -> Result<(), String> {
         use lb::WriteDocumentError::*;
         self.api
-            .write_document(*id, data.as_bytes())
+            .write_document(id, data.as_bytes())
             .map_err(|err| match err {
                 lb::Error::UiError(err) => match err {
                     NoAccount => "no account",

--- a/clients/linux/src/ui/titlebar.rs
+++ b/clients/linux/src/ui/titlebar.rs
@@ -55,6 +55,10 @@ impl Titlebar {
     pub fn search_input(&self) -> String {
         self.imp().search_box.text().to_string()
     }
+
+    pub fn base(&self) -> &gtk::HeaderBar {
+        &self.imp().base
+    }
 }
 
 impl Default for Titlebar {
@@ -207,6 +211,10 @@ mod imp {
                     if key == gdk::Key::Escape {
                         search_btn.grab_focus();
                         search_btn.emit_clicked();
+                        search_box.set_text("");
+                        while let Some(row) = result_list.row_at_index(0) {
+                            result_list.remove(&row);
+                        }
                     } else if code == ARROW_DOWN {
                         let next_index = result_list
                             .selected_row()


### PR DESCRIPTION
code:
* adopt a clearer pattern in more places of scoping cloned closure variables
* stop borrowing `Uuid`s
* use the account op channel for more things instead of gtk actions and their string names

ui:
* error dialog is nicer (proper title and icon, label margin balanced)
* search box is cleared on `Escape` instead of holding onto the input and results