### PR TITLE
linux: improve onboard uiux

### DIFF
--- a/clients/linux/src/app/imp_account_create.rs
+++ b/clients/linux/src/app/imp_account_create.rs
@@ -1,29 +1,89 @@
 use gtk::glib;
+use gtk::prelude::*;
 
 impl super::App {
     pub fn create_account(&self, uname: String, url: String) {
         self.onboard.start("Creating account...");
 
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
-        {
+        std::thread::spawn({
             let api = self.api.clone();
             let uname = uname.clone();
-            std::thread::spawn(move || {
+
+            move || {
                 let result = api.create_account(&uname, &url);
                 tx.send(result).unwrap();
-            });
-        }
+            }
+        });
 
         let app = self.clone();
         rx.attach(None, move |create_acct_result| {
             app.onboard.stop("create");
 
             match create_acct_result {
-                Ok(_acct) => app.init_account_screen(),
+                Ok(_acct) => app.prompt_backup(),
                 Err(err) => app.onboard.handle_create_error(err, &uname),
             }
 
             glib::Continue(true)
         });
     }
+
+    fn prompt_backup(&self) {
+        self.init_account_screen();
+
+        let info = gtk::Dialog::builder()
+            .title("Welcome to Lockbook!")
+            .transient_for(&self.window)
+            .modal(true)
+            .build();
+        info.set_default_size(350, -1);
+
+        let message = gtk::Label::new(Some(MESSAGE));
+        message.set_wrap(true);
+        message.set_margin_bottom(16);
+
+        let goto_settings = gtk::Button::with_label("Backup Now");
+        goto_settings.connect_clicked({
+            let info = info.clone();
+            let app = self.clone();
+
+            move |_| {
+                info.close();
+                app.open_settings_dialog();
+            }
+        });
+
+        let goto_account_screen = gtk::Button::with_label("Skip and Backup Later");
+        goto_account_screen.connect_clicked({
+            let info = info.clone();
+            move |_| info.close()
+        });
+
+        let btns = gtk::Grid::builder()
+            .column_spacing(4)
+            .column_homogeneous(true)
+            .margin_top(16)
+            .build();
+        btns.attach(&goto_settings, 0, 0, 1, 1);
+        btns.attach(&goto_account_screen, 1, 0, 1, 1);
+
+        let cntr = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .halign(gtk::Align::Center)
+            .valign(gtk::Align::Center)
+            .margin_top(16)
+            .margin_bottom(16)
+            .margin_start(16)
+            .margin_end(16)
+            .build();
+        cntr.append(&message);
+        cntr.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+        cntr.append(&btns);
+
+        info.content_area().append(&cntr);
+        info.present();
+    }
 }
+
+static MESSAGE: &str = "Lockbook encrypts your notes with a key that stays on your Lockbook devices. This makes your notes unreadable to everyone except you. However, if you lose this key, your notes are not recoverable. Therefore, we recommend you make a backup in case something happens to this device.";

--- a/clients/linux/src/app/imp_account_create.rs
+++ b/clients/linux/src/app/imp_account_create.rs
@@ -1,9 +1,11 @@
 use gtk::glib;
 use gtk::prelude::*;
 
+use crate::ui;
+
 impl super::App {
     pub fn create_account(&self, uname: String, url: String) {
-        self.onboard.start("Creating account...");
+        self.onboard.start(ui::OnboardRoute::Create);
 
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
         std::thread::spawn({
@@ -18,7 +20,7 @@ impl super::App {
 
         let app = self.clone();
         rx.attach(None, move |create_acct_result| {
-            app.onboard.stop("create");
+            app.onboard.stop(ui::OnboardRoute::Create);
 
             match create_acct_result {
                 Ok(_acct) => app.prompt_backup(),

--- a/clients/linux/src/app/imp_account_create.rs
+++ b/clients/linux/src/app/imp_account_create.rs
@@ -41,9 +41,19 @@ impl super::App {
 
         let message = gtk::Label::new(Some(MESSAGE));
         message.set_wrap(true);
-        message.set_margin_bottom(16);
 
-        let goto_settings = gtk::Button::with_label("Backup Now");
+        let learn_more_e2e_btn = gtk::LinkButton::builder()
+            .uri("https://en.wikipedia.org/wiki/End-to-end_encryption")
+            .label("Learn more")
+            .build();
+        learn_more_e2e_btn.add_css_class("onboard-link");
+        let learn_more_e2e = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .build();
+        learn_more_e2e.append(&learn_more_e2e_btn);
+        learn_more_e2e.append(&gtk::Label::new(Some(" about end-to-end encryption.")));
+
+        let goto_settings = icon_button("security-high", "Backup Now");
         goto_settings.connect_clicked({
             let info = info.clone();
             let app = self.clone();
@@ -54,7 +64,7 @@ impl super::App {
             }
         });
 
-        let goto_account_screen = gtk::Button::with_label("Skip and Backup Later");
+        let goto_account_screen = icon_button("security-low", "Backup Later");
         goto_account_screen.connect_clicked({
             let info = info.clone();
             move |_| info.close()
@@ -63,27 +73,53 @@ impl super::App {
         let btns = gtk::Grid::builder()
             .column_spacing(4)
             .column_homogeneous(true)
-            .margin_top(16)
             .build();
         btns.attach(&goto_settings, 0, 0, 1, 1);
         btns.attach(&goto_account_screen, 1, 0, 1, 1);
 
         let cntr = gtk::Box::builder()
             .orientation(gtk::Orientation::Vertical)
+            .spacing(20)
             .halign(gtk::Align::Center)
             .valign(gtk::Align::Center)
-            .margin_top(16)
-            .margin_bottom(16)
-            .margin_start(16)
-            .margin_end(16)
+            .margin_top(20)
+            .margin_bottom(20)
+            .margin_start(20)
+            .margin_end(20)
             .build();
         cntr.append(&message);
+        cntr.append(&learn_more_e2e);
         cntr.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
         cntr.append(&btns);
 
+        let info_icon = gtk::Image::from_icon_name("emblem-important");
+        info_icon.set_pixel_size(32);
+
+        let info_hbar = gtk::HeaderBar::new();
+        info_hbar.pack_start(&info_icon);
+
+        info.set_titlebar(Some(&info_hbar));
         info.content_area().append(&cntr);
         info.present();
+        goto_settings.grab_focus();
     }
+}
+
+fn icon_button(icon_name: &str, label: &str) -> gtk::Button {
+    let icon = gtk::Image::from_icon_name(icon_name);
+    icon.set_pixel_size(24);
+
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .halign(gtk::Align::Center)
+        .margin_top(4)
+        .margin_bottom(4)
+        .spacing(8)
+        .build();
+    content.append(&icon);
+    content.append(&gtk::Label::new(Some(label)));
+
+    gtk::Button::builder().child(&content).build()
 }
 
 static MESSAGE: &str = "Lockbook encrypts your notes with a key that stays on your Lockbook devices. This makes your notes unreadable to everyone except you. However, if you lose this key, your notes are not recoverable. Therefore, we recommend you make a backup in case something happens to this device.";

--- a/clients/linux/src/app/imp_account_import.rs
+++ b/clients/linux/src/app/imp_account_import.rs
@@ -4,7 +4,7 @@ use crate::ui;
 
 impl super::App {
     pub fn import_account(&self, acct_str: String) {
-        self.onboard.start("Importing account...");
+        self.onboard.start(ui::OnboardRoute::Import);
 
         // Create a channel to receive and process the result of importing the account.
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
@@ -50,7 +50,7 @@ impl super::App {
             match pr {
                 lb::SyncProgressReport::Update(msg) => set_import_sync_progress(&app.onboard, &msg),
                 lb::SyncProgressReport::Done(result) => {
-                    app.onboard.stop("import");
+                    app.onboard.stop(ui::OnboardRoute::Import);
                     match result {
                         Ok(_) => app.init_account_screen(),
                         Err(err) => import_sync_done_with_err(&app, err),

--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -129,7 +129,7 @@ impl super::App {
         onboard_op_rx.attach(None, move |op| {
             use ui::OnboardOp::*;
             match op {
-                CreateAccount(uname, url) => self.create_account(uname, url),
+                CreateAccount { uname, api_url } => self.create_account(uname, api_url),
                 ImportAccount(account_string) => self.import_account(account_string),
             }
             glib::Continue(true)

--- a/clients/linux/src/ui/account_screen.rs
+++ b/clients/linux/src/ui/account_screen.rs
@@ -81,7 +81,7 @@ impl AccountScreen {
         sidebar.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
         sidebar.append(&sync.cntr);
 
-        stack.add_named(&logo(), Some("logo"));
+        stack.add_named(&super::logo(400), Some("logo"));
         stack.add_named(&tabs, Some("tabs"));
 
         let cntr = gtk::Paned::new(gtk::Orientation::Horizontal);
@@ -123,19 +123,4 @@ impl AccountScreen {
         }
         false
     }
-}
-
-fn logo() -> impl IsA<gtk::Widget> {
-    static LOGO: &[u8] = include_bytes!("../../lockbook-backdrop.png");
-
-    let logo_pic = gtk::Picture::for_pixbuf(&gdk_pixbuf::Pixbuf::from_read(LOGO).unwrap());
-    let wrap_1 = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-    wrap_1.set_size_request(400, 400);
-    wrap_1.append(&logo_pic);
-    let wrap_2 = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    wrap_2.set_size_request(400, 400);
-    wrap_2.set_halign(gtk::Align::Center);
-    wrap_2.set_valign(gtk::Align::Center);
-    wrap_2.append(&wrap_1);
-    wrap_2
 }

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -82,6 +82,21 @@ pub fn document_icon_from_name(fname: &str) -> String {
     }
 }
 
+pub fn logo(size: i32) -> impl IsA<gtk::Widget> {
+    static LOGO: &[u8] = include_bytes!("../../lockbook-backdrop.png");
+
+    let logo_pic = gtk::Picture::for_pixbuf(&gdk_pixbuf::Pixbuf::from_read(LOGO).unwrap());
+    let wrap_1 = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    wrap_1.set_size_request(size, size);
+    wrap_1.append(&logo_pic);
+    let wrap_2 = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    wrap_2.set_size_request(size, size);
+    wrap_2.set_halign(gtk::Align::Center);
+    wrap_2.set_valign(gtk::Align::Center);
+    wrap_2.append(&wrap_1);
+    wrap_2
+}
+
 pub mod icons {
     pub const ABOUT: &str = "help-about-symbolic";
     pub const ACCOUNT: &str = "avatar-default-symbolic";

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -11,6 +11,7 @@ mod titlebar;
 pub use account_screen::AccountOp;
 pub use account_screen::AccountScreen;
 pub use onboard_screen::OnboardOp;
+pub use onboard_screen::OnboardRoute;
 pub use onboard_screen::OnboardScreen;
 
 pub use filetree::FileTree;

--- a/clients/linux/src/ui/onboard_screen.rs
+++ b/clients/linux/src/ui/onboard_screen.rs
@@ -33,8 +33,6 @@ impl OnboardScreen {
     pub fn new(op_chan: &glib::Sender<OnboardOp>) -> Self {
         let heading = gtk::Label::builder()
             .css_classes(vec!["onboard-heading".to_string()])
-            .margin_top(16)
-            .margin_bottom(16)
             .label("Lockbook")
             .build();
 
@@ -83,15 +81,14 @@ impl OnboardScreen {
         let status = Status::new();
         stack.add_named(&status.cntr, Some("status"));
 
-        let switcher = gtk::StackSwitcher::builder()
-            .stack(&stack)
-            .margin_top(20)
-            .margin_bottom(20)
-            .build();
+        let switcher = gtk::StackSwitcher::builder().stack(&stack).build();
 
-        let cntr = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        cntr.set_halign(gtk::Align::Center);
-        cntr.set_valign(gtk::Align::Center);
+        let cntr = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .halign(gtk::Align::Center)
+            .margin_top(30)
+            .spacing(20)
+            .build();
         cntr.append(&super::logo(256));
         cntr.append(&heading);
         cntr.append(&gtk::Separator::new(gtk::Orientation::Horizontal));

--- a/clients/linux/src/ui/onboard_screen.rs
+++ b/clients/linux/src/ui/onboard_screen.rs
@@ -6,6 +6,11 @@ pub enum OnboardOp {
     ImportAccount(String),
 }
 
+pub enum OnboardRoute {
+    Create,
+    Import,
+}
+
 #[derive(Clone)]
 pub struct OnboardScreen {
     error_create: gtk::Label,
@@ -96,18 +101,24 @@ impl OnboardScreen {
         Self { status, error_create, error_import, stack, switcher, cntr }
     }
 
-    pub fn start(&self, title: &str) {
-        self.status.title.set_text(title);
+    pub fn start(&self, which: OnboardRoute) {
+        self.status.title.set_text(match which {
+            OnboardRoute::Create => "Creating account...",
+            OnboardRoute::Import => "Importing account...",
+        });
         self.switcher.set_sensitive(false);
         self.stack.set_visible_child_name("status");
         self.status.spinner.start();
         self.status.spinner.show();
     }
 
-    pub fn stop(&self, back_to: &str) {
+    pub fn stop(&self, which: OnboardRoute) {
         self.status.spinner.stop();
         self.status.title.set_text("");
-        self.stack.set_visible_child_name(back_to);
+        self.stack.set_visible_child_name(match which {
+            OnboardRoute::Create => "create",
+            OnboardRoute::Import => "import",
+        });
         self.switcher.set_sensitive(true);
     }
 

--- a/clients/linux/style.css
+++ b/clients/linux/style.css
@@ -1,3 +1,7 @@
+.onboard-heading {
+	font-size: 28px;
+	font-weight: bold;
+}
 .settings-heading {
 	font-size: 20px;
 }

--- a/clients/linux/style.css
+++ b/clients/linux/style.css
@@ -2,6 +2,10 @@
 	font-size: 28px;
 	font-weight: bold;
 }
+.onboard-link {
+	padding: 0px;
+	margin: 0px;
+}
 .settings-heading {
 	font-size: 20px;
 }


### PR DESCRIPTION
The overall linux onboarding ux is a bit lacking from after the upgrade. This PR does the following:
* makes the initial screen nicer by adding the logo and a title.
* prompts the user to backup their private key immediately after they create an account.
* some miscellaneous onboard code cleanups.

Closes #1045.