### PR TITLE
android: added billing permission

### DIFF
--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:$logger_version"
     implementation "androidx.work:work-runtime-ktx:$work_version"
     implementation "com.github.tingyik90:snackprogressbar:$snackprogressbar_version"
+    implementation "com.android.billingclient:billing:$billing_version"
 
     implementation project(':core')
 }

--- a/clients/android/build.gradle
+++ b/clients/android/build.gradle
@@ -32,8 +32,9 @@ buildscript {
         snackprogressbar_version = '6.4.2'
         fragment_version = '1.4.1'
         sliding_pane_layout_version = '1.2.0'
-        recyclical_version = "1.1.0"
-        safe_args_gradle_plugin = "2.3.5"
+        recyclical_version = '1.1.0'
+        safe_args_gradle_plugin = '2.3.5'
+        billing_version = '4.1.0'
     }
 
     repositories {


### PR DESCRIPTION
Added the billing permission to android. This is needed to enable billing features on the google play console. 

I previously had billing permissions because I uploaded an `apk` (from my branch) with the permission, but with the last new official release, the new permissions were revoked.