### PR TITLE
linux: a few onboard screen fixes

### DIFF
--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -118,7 +118,7 @@ impl super::App {
             use ui::OnboardOp::*;
             match op {
                 CreateAccount { uname, api_url } => self.create_account(uname, api_url),
-                ImportAccount(account_string) => self.import_account(account_string),
+                ImportAccount { account_string } => self.import_account(account_string),
             }
             glib::Continue(true)
         });


### PR DESCRIPTION
* The text field entry for a user's account string is now a password entry with a "peek icon" (Closes #1081).
* The labels for captions and errors on the onboard screen now wrap so that they don't trigger massive unexpected resizing of parent components and even the window (Closes #1072).
* A few miscellaneous onboard code cleanups.