### PR TITLE
linux: read document content in separate thread when opening file

### DIFF
--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -140,6 +140,15 @@ impl super::App {
                 TreeReceiveDrop(val, x, y) => self.tree_receive_drop(&val, x, y),
                 TabSwitched(tab) => self.titlebar.set_title(&tab.name()),
                 AllTabsClosed => self.titlebar.set_title("Lockbook"),
+                SviewCtrlClick { click, x, y, sview } => {
+                    self.handle_sview_ctrl_click(&click, x, y, &sview)
+                }
+                SviewInsertFileList { id, buf, flist } => {
+                    self.sview_insert_file_list(id, &buf, flist)
+                }
+                SviewInsertTexture { id, buf, texture } => {
+                    self.sview_insert_texture(id, &buf, texture)
+                }
             }
             glib::Continue(true)
         });

--- a/clients/linux/src/ui/filetree.rs
+++ b/clients/linux/src/ui/filetree.rs
@@ -27,8 +27,8 @@ pub enum FileTreeCol {
 }
 
 impl FileTree {
-    pub fn new(account_op_tx: glib::Sender<ui::AccountOp>, hidden_cols: &[String]) -> Self {
-        let menu = FileTreeMenu::new(&account_op_tx);
+    pub fn new(account_op_tx: &glib::Sender<ui::AccountOp>, hidden_cols: &[String]) -> Self {
+        let menu = FileTreeMenu::new(account_op_tx);
 
         let cut_files = Rc::new(RefCell::new(None));
 
@@ -113,6 +113,7 @@ impl FileTree {
         // Controller for receiving drops.
         let drop = gtk::DropTarget::new(glib::types::Type::STRING, gdk::DragAction::COPY);
         drop.connect_motion(|_, _x, _y| gdk::DragAction::COPY);
+        let account_op_tx = account_op_tx.clone();
         drop.connect_drop(move |_, val, x, y| {
             account_op_tx
                 .send(ui::AccountOp::TreeReceiveDrop(val.clone(), x, y))

--- a/clients/linux/src/ui/text_editor.rs
+++ b/clients/linux/src/ui/text_editor.rs
@@ -3,7 +3,7 @@ use gtk::subclass::prelude::*;
 
 glib::wrapper! {
     pub struct TextEditor(ObjectSubclass<imp::TextEditor>)
-        @extends gtk::Widget, gtk::Box,
+        @extends gtk::Widget,
         @implements gtk::Accessible;
 }
 
@@ -42,7 +42,6 @@ mod imp {
         type ParentType = gtk::Widget;
 
         fn class_init(c: &mut Self::Class) {
-            // The layout manager determines how child widgets are laid out.
             c.set_layout_manager_type::<gtk::BinLayout>();
         }
     }


### PR DESCRIPTION
Along with some clean up, this PR improves the UI/UX around opening a document in the linux client. Instead of the UI locking while reading the document content, it opens the tab with a loading icon (a spinner) as the content and reads the content in a separate thread.

Closes #1082.