### PR TITLE
linux: refactor how the data directory is determined

### DIFF
--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -47,6 +47,7 @@ pub use lockbook_core::service::usage_service::bytes_to_human;
 pub use lockbook_core::service::usage_service::UsageItemMetric;
 pub use lockbook_core::service::usage_service::UsageMetrics;
 
+use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -139,10 +140,7 @@ pub struct DefaultApi {
 
 impl DefaultApi {
     pub fn new() -> Result<Self, String> {
-        let lockbook_dir = std::env::var("LOCKBOOK_PATH")
-            .unwrap_or_else(|_| format!("{}/.lockbook", std::env::var("HOME").unwrap()));
-
-        let writeable_path = format!("{}/linux", lockbook_dir);
+        let writeable_path = format!("{}/linux", data_dir());
 
         let core = Core::init(&Config { logs: true, writeable_path }).map_err(|e| e.0)?;
 
@@ -300,6 +298,15 @@ impl Api for DefaultApi {
     ) -> Result<(), Error<SwitchAccountTierError>> {
         self.core.switch_account_tier(new_tier)
     }
+}
+
+pub fn data_dir() -> String {
+    const ERR_MSG: &str = "Unable to determine a Lockbook data directory.\
+ Please consider setting the LOCKBOOK_PATH environment variable.";
+
+    env::var("LOCKBOOK_PATH").unwrap_or_else(|_| {
+        format!("{}/.lockbook", env::var("HOME").unwrap_or_else(|_| env::var("HOMEPATH").expect(ERR_MSG)))
+    })
 }
 
 pub fn parent_info(api: &Arc<dyn Api>, maybe_id: Option<Uuid>) -> Result<(Uuid, String), String> {

--- a/clients/linux/src/app/imp_activate.rs
+++ b/clients/linux/src/app/imp_activate.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -13,8 +12,7 @@ use crate::ui;
 
 impl super::App {
     pub fn activate(api: Arc<dyn lb::Api>, a: &gtk::Application) {
-        let writeable_path =
-            env::var("LOCKBOOK_PATH").unwrap_or(format!("{}/.lockbook", env::var("HOME").unwrap()));
+        let data_dir = lb::data_dir();
 
         let titlebar = ui::Titlebar::new();
 
@@ -24,7 +22,7 @@ impl super::App {
         let window = gtk::ApplicationWindow::new(a);
         window.set_child(Some(&overlay));
 
-        let settings = match Settings::from_data_dir(&writeable_path) {
+        let settings = match Settings::from_data_dir(&data_dir) {
             Ok(s) => Arc::new(RwLock::new(s)),
             Err(err) => {
                 let msg = format!("unable to read settings file: {}", err);
@@ -33,7 +31,7 @@ impl super::App {
             }
         };
 
-        let lang_mngr = match new_language_manager(&writeable_path) {
+        let lang_mngr = match new_language_manager(&data_dir) {
             Ok(lm) => lm,
             Err(err) => {
                 let msg = format!("unable to write custom language file: {}", err);


### PR DESCRIPTION
Notably, include `HOMEPATH` as a last resort so that the gtk app can behave normally on windows.