### PR TITLE
linux: reorder file types in new file dialog, add txt extension

### DIFF
--- a/clients/linux/src/app/imp_new_file.rs
+++ b/clients/linux/src/app/imp_new_file.rs
@@ -33,9 +33,9 @@ impl super::App {
         name_and_ext.append(&ext_lbl);
 
         let ftype_choices = ui::ToggleGroup::with_buttons(&[
-            ("Folder", NewFileType::Folder),
-            ("Plain Text", NewFileType::PlainText),
             ("Markdown", NewFileType::Markdown),
+            ("Plain Text", NewFileType::PlainText),
+            ("Folder", NewFileType::Folder),
         ]);
         ftype_choices.connect_changed(move |value: NewFileType| {
             if let Some(ext) = value.ext() {
@@ -169,14 +169,14 @@ fn action_btn(text: &str) -> gtk::Button {
 
 #[derive(Clone, Copy, PartialEq)]
 enum NewFileType {
-    Folder,
-    PlainText,
     Markdown,
+    PlainText,
+    Folder,
 }
 
 impl Default for NewFileType {
     fn default() -> Self {
-        Self::Folder
+        Self::Markdown
     }
 }
 
@@ -190,8 +190,9 @@ impl NewFileType {
 
     fn ext(&self) -> Option<&str> {
         match self {
-            Self::PlainText | Self::Folder => None,
             Self::Markdown => Some(".md"),
+            Self::PlainText => Some(".txt"),
+            Self::Folder => None,
         }
     }
 }

--- a/clients/linux/src/ui/toggle_group.rs
+++ b/clients/linux/src/ui/toggle_group.rs
@@ -62,6 +62,7 @@ where
     }
 
     pub fn connect_changed(&self, f: F) {
+        f(self.value());
         *self.on_changed.borrow_mut() = Some(f);
     }
 }


### PR DESCRIPTION
Reorder the file types in the new file dialog to: Markdown, Plain Text, Folder. Also, add a `.txt` extension for plain text files.

![image](https://user-images.githubusercontent.com/6127189/173157861-2ba28dfc-63c4-4e91-a2cd-9b01179b2964.png)

![image](https://user-images.githubusercontent.com/6127189/173157878-f274e3b5-7602-4caf-944f-fe6971e1fd22.png)
