### PR TITLE
core,server: upgrade libsecp256k1 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,8 @@ dependencies = [
 [[package]]
 name = "libsecp256k1"
 version = "0.7.0"
-source = "git+https://github.com/steverusso/libsecp256k1#5fa13e5aec943a829a3800f1b3f0e57bc76ff155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
 dependencies = [
  "arrayref",
  "base64 0.13.0",
@@ -2195,7 +2196,8 @@ dependencies = [
 [[package]]
 name = "libsecp256k1-core"
 version = "0.3.0"
-source = "git+https://github.com/steverusso/libsecp256k1#5fa13e5aec943a829a3800f1b3f0e57bc76ff155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
@@ -2205,7 +2207,8 @@ dependencies = [
 [[package]]
 name = "libsecp256k1-gen-ecmult"
 version = "0.3.0"
-source = "git+https://github.com/steverusso/libsecp256k1#5fa13e5aec943a829a3800f1b3f0e57bc76ff155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
 dependencies = [
  "libsecp256k1-core",
 ]
@@ -2213,7 +2216,8 @@ dependencies = [
 [[package]]
 name = "libsecp256k1-gen-genmult"
 version = "0.3.0"
-source = "git+https://github.com/steverusso/libsecp256k1#5fa13e5aec943a829a3800f1b3f0e57bc76ff155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,7 @@ tempfile = { version = "3.1.0" }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 itertools = "0.10.1"
 backtrace = "0.3"
-libsecp256k1 = { git = "https://github.com/steverusso/libsecp256k1" }
+libsecp256k1 = "0.7.0"
 tracing = "0.1.5"
 tracing-subscriber = "0.3.9"
 tracing-appender = "0.2"
@@ -53,7 +53,7 @@ debug = true
 cpuprofiler = "0.0.4"
 criterion = "0.3.5"
 indicatif = "0.17.0-beta.1"
-libsecp256k1 = { git = "https://github.com/steverusso/libsecp256k1" }
+libsecp256k1 = "0.7.0"
 variant_count = "1.1.0"
 num_cpus = "1.13.0"
 test_utils = { path = "libs/test_utils" }

--- a/core/libs/crypto/Cargo.toml
+++ b/core/libs/crypto/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 aead = "0.4.2"
 aes-gcm = "0.9.3"
 bincode = "1.2.1"
-libsecp256k1 = { git = "https://github.com/steverusso/libsecp256k1" }
+libsecp256k1 = "0.7.0"
 sha2 = "0.9.0"
 hmac = "0.11.0"
 rand = "0.8.4"

--- a/core/libs/models/Cargo.toml
+++ b/core/libs/models/Cargo.toml
@@ -10,7 +10,7 @@ rand = "0.8.4"
 http = "0.2.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-libsecp256k1 = { git = "https://github.com/steverusso/libsecp256k1" }
+libsecp256k1 = "0.7.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.44"
 shadow-rs = "0.6.2"
 tokio = { version = "1.5.0", features = ["full"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
-libsecp256k1 = { git = "https://github.com/steverusso/libsecp256k1" }
+libsecp256k1 = "0.7.0"
 prometheus = "0.13.0"
 prometheus-static-metric = "0.5.1"
 lazy_static = "1.4.0"


### PR DESCRIPTION
They released `0.7.0` less than a month ago it looks like. Built for me locally, so we should probably go back to using theirs for security reasons.