### PR TITLE
linux: add a setting to open newly created documents

### DIFF
--- a/clients/linux/src/app/imp_new_file.rs
+++ b/clients/linux/src/app/imp_new_file.rs
@@ -95,16 +95,18 @@ impl super::App {
             }
 
             match app.api.create_file(&fname, parent_id, ftype.lb_type()) {
-                Ok(new_file) => {
-                    match app.account.tree.add_file(&new_file) {
-                        Ok(_) => {
-                            app.update_sync_status();
-                            d.close();
-                            //open the file if doc?
+                Ok(new_file) => match app.account.tree.add_file(&new_file) {
+                    Ok(_) => {
+                        app.update_sync_status();
+                        d.close();
+                        if new_file.file_type == lb::FileType::Document
+                            && app.settings.read().unwrap().open_new_files
+                        {
+                            app.open_file(new_file.id)
                         }
-                        Err(err) => display_error(&err),
                     }
-                }
+                    Err(err) => display_error(&err),
+                },
                 Err(err) => display_error(&{
                     use lb::CreateFileError::*;
                     match err {

--- a/clients/linux/src/app/imp_settings_dialog.rs
+++ b/clients/linux/src/app/imp_settings_dialog.rs
@@ -247,6 +247,13 @@ impl super::App {
         });
 
         let s = self.settings.clone();
+        let open_new_files = gtk::CheckButton::with_label("Open newly created files");
+        open_new_files.set_active(s.read().unwrap().open_new_files);
+        open_new_files.connect_toggled(move |open_new_files| {
+            s.write().unwrap().open_new_files = open_new_files.is_active();
+        });
+
+        let s = self.settings.clone();
         let auto_save = gtk::CheckButton::with_label("Auto-save");
         auto_save.set_active(s.read().unwrap().auto_save);
         auto_save.connect_toggled(move |auto_save| {
@@ -262,6 +269,7 @@ impl super::App {
 
         let general = section();
         general.append(&maximize);
+        general.append(&open_new_files);
         general.append(&auto_save);
         general.append(&auto_sync);
         general

--- a/clients/linux/src/settings.rs
+++ b/clients/linux/src/settings.rs
@@ -6,6 +6,7 @@ use std::io;
 pub struct Settings {
     pub hidden_tree_cols: Vec<String>,
     pub window_maximize: bool,
+    pub open_new_files: bool,
     pub auto_save: bool,
     pub auto_sync: bool,
     #[serde(skip_serializing, skip_deserializing)]
@@ -37,6 +38,7 @@ impl Default for Settings {
         Self {
             hidden_tree_cols: vec!["Id".to_string(), "Type".to_string()],
             window_maximize: false,
+            open_new_files: true,
             auto_save: true,
             auto_sync: true,
             path: "".to_string(),


### PR DESCRIPTION
On by default, this allows the user to choose whether or not newly created documents are opened automatically.

Closes #1133.