### PR TITLE
linux: use a custom tooltip for usage compression stats

### DIFF
--- a/clients/linux/src/ui/usage_settings.rs
+++ b/clients/linux/src/ui/usage_settings.rs
@@ -27,18 +27,14 @@ impl UsageSettings {
         compr_stats.attach(&grid_key("Compression ratio: "), 0, 1, 1, 1);
         compr_stats.attach(&lbl_compr_ratio, 1, 1, 1, 1);
 
-        let info_popover = gtk::Popover::new();
-        info_popover.set_child(Some(&compr_stats));
-
-        let info_btn = gtk::MenuButton::builder()
-            .direction(gtk::ArrowType::Right)
-            .popover(&info_popover)
-            .child(&gtk::Image::from_icon_name("dialog-information-symbolic"))
-            .build();
-
         let current_title = gtk::Box::new(gtk::Orientation::Horizontal, 8);
         current_title.append(&heading("Current"));
-        current_title.append(&info_btn);
+        current_title.append(&gtk::Image::from_icon_name("dialog-information-symbolic"));
+        current_title.set_has_tooltip(true);
+        current_title.connect_query_tooltip(move |_, _, _, _, tt| {
+            tt.set_custom(Some(&compr_stats));
+            true
+        });
 
         let current_usage = ui::UsageTier::new();
         current_usage.set_title(&current_title);


### PR DESCRIPTION
I learned how to make a custom tooltip with gtk, and this is much better (imo) than using a popover with a menu button.

Before:
![image](https://user-images.githubusercontent.com/6127189/173252651-6f9028b5-d459-4560-987f-37c443d19b8b.png)

After:
![image](https://user-images.githubusercontent.com/6127189/173252626-9fdb87a2-0188-431f-aafc-10101d847165.png)