### PR TITLE
core: pre-sharing, pre-search, core data structure finalization

### DIFF
--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -305,7 +305,10 @@ pub fn data_dir() -> String {
  Please consider setting the LOCKBOOK_PATH environment variable.";
 
     env::var("LOCKBOOK_PATH").unwrap_or_else(|_| {
-        format!("{}/.lockbook", env::var("HOME").unwrap_or_else(|_| env::var("HOMEPATH").expect(ERR_MSG)))
+        format!(
+            "{}/.lockbook",
+            env::var("HOME").unwrap_or_else(|_| env::var("HOMEPATH").expect(ERR_MSG))
+        )
     })
 }
 

--- a/core/libs/models/src/tree.rs
+++ b/core/libs/models/src/tree.rs
@@ -26,6 +26,10 @@ pub trait FileMetadata: Clone + Display {
     fn is_document(&self) -> bool {
         self.file_type() == Document
     }
+
+    fn is_root(&self) -> bool {
+        self.id() == self.parent()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -147,7 +151,7 @@ where
     }
 
     fn maybe_find_root(&self) -> Option<Fm> {
-        self.values().find(|f| f.id() == f.parent()).cloned()
+        self.values().find(|f| f.is_root()).cloned()
     }
 
     fn maybe_find(&self, id: Uuid) -> Option<Fm> {
@@ -257,7 +261,7 @@ where
 
         for (id, (f, source)) in files_with_sources.iter() {
             let parent_id = f.parent();
-            if id == &parent_id {
+            if f.is_root() {
                 continue;
             };
             let name = f.name();

--- a/core/libs/models/src/tree.rs
+++ b/core/libs/models/src/tree.rs
@@ -229,17 +229,21 @@ where
     fn get_invalid_cycles(
         &self, staged_changes: &HashMap<Uuid, Fm>,
     ) -> Result<Vec<Uuid>, TreeError> {
-        let root = match self.maybe_find_root() {
-            Some(root) => Ok(root),
-            None => staged_changes.find_root(),
-        }?;
+        let mut root_found = false;
         let mut prev_checked = HashMap::new();
         let staged_changes = self.stage(staged_changes);
         let mut result = Vec::new();
         for (_, (f, _)) in staged_changes.clone().into_iter() {
             let mut checking = HashMap::new();
             let mut cur = &f;
-            while cur.id() != root.id() && prev_checked.get(&cur.id()).is_none() {
+
+            if !root_found && cur.is_root() {
+                root_found = true;
+            } else if root_found && cur.is_root() {
+                result.push(cur.id());
+            }
+
+            while !cur.is_root() && prev_checked.get(&cur.id()).is_none() {
                 if checking.contains_key(&cur.id()) {
                     result.extend(checking.keys());
                     break;

--- a/core/libs/models/src/tree.rs
+++ b/core/libs/models/src/tree.rs
@@ -77,22 +77,30 @@ where
     }
 }
 
+pub struct DeletedStatus {
+    pub deleted: HashSet<Uuid>,
+    pub not_deleted: HashSet<Uuid>,
+}
+
 pub trait FileMetaMapExt<Fm: FileMetadata> {
     fn with(fm: Fm) -> HashMap<Uuid, Fm>;
     fn ids(&self) -> Vec<Uuid>;
     fn push(&mut self, fm: Fm);
-    fn stage(&self, staged: &HashMap<Uuid, Fm>) -> HashMap<Uuid, (Fm, StageSource)>;
+    fn stage(self, staged: HashMap<Uuid, Fm>) -> HashMap<Uuid, Fm>;
+    fn stage_with_source(&self, staged: &HashMap<Uuid, Fm>) -> HashMap<Uuid, (Fm, StageSource)>;
     fn find(&self, id: Uuid) -> Result<Fm, TreeError>;
+    fn find_ref(&self, id: Uuid) -> Result<&Fm, TreeError>;
     fn find_mut(&mut self, id: Uuid) -> Result<&mut Fm, TreeError>;
     fn find_root(&self) -> Result<Fm, TreeError>;
     fn maybe_find_root(&self) -> Option<Fm>;
     fn maybe_find(&self, id: Uuid) -> Option<Fm>;
     fn maybe_find_mut(&mut self, id: Uuid) -> Option<&mut Fm>;
-    fn find_parent(&self, id: Uuid) -> Result<Fm, TreeError>;
-    fn maybe_find_parent(&self, id: Uuid) -> Option<Fm>;
+    fn find_parent(&self, id: Uuid) -> Result<&Fm, TreeError>;
+    fn maybe_find_parent(&self, id: Uuid) -> Option<&Fm>;
     fn find_children(&self, id: Uuid) -> HashMap<Uuid, Fm>;
-    fn filter_deleted(&self) -> Result<HashMap<Uuid, Fm>, TreeError>;
-    fn filter_not_deleted(&self) -> Result<HashMap<Uuid, Fm>, TreeError>;
+    fn filter_deleted(self) -> Result<HashMap<Uuid, Fm>, TreeError>;
+    fn deleted(&self) -> Result<DeletedStatus, TreeError>;
+    fn filter_not_deleted(self) -> Result<HashMap<Uuid, Fm>, TreeError>;
     fn documents(&self) -> HashSet<Uuid>;
     fn parents(&self) -> HashSet<Uuid>;
     fn get_invalid_cycles(
@@ -123,7 +131,13 @@ where
         self.insert(fm.id(), fm);
     }
 
-    fn stage(&self, staged: &HashMap<Uuid, Fm>) -> HashMap<Uuid, (Fm, StageSource)> {
+    fn stage(self, staged: HashMap<Uuid, Fm>) -> HashMap<Uuid, Fm> {
+        let mut base = self;
+        base.extend(staged);
+        base
+    }
+
+    fn stage_with_source(&self, staged: &HashMap<Uuid, Fm>) -> HashMap<Uuid, (Fm, StageSource)> {
         let mut result = HashMap::new();
         result.extend(
             self.clone()
@@ -141,6 +155,10 @@ where
 
     fn find(&self, id: Uuid) -> Result<Fm, TreeError> {
         self.get(&id).cloned().ok_or(FileNonexistent)
+    }
+
+    fn find_ref(&self, id: Uuid) -> Result<&Fm, TreeError> {
+        self.get(&id).ok_or(FileNonexistent)
     }
 
     fn find_mut(&mut self, id: Uuid) -> Result<&mut Fm, TreeError> {
@@ -163,13 +181,13 @@ where
         self.get_mut(&id)
     }
 
-    fn find_parent(&self, id: Uuid) -> Result<Fm, TreeError> {
+    fn find_parent(&self, id: Uuid) -> Result<&Fm, TreeError> {
         self.maybe_find_parent(id)
             .ok_or(TreeError::FileParentNonexistent)
     }
 
-    fn maybe_find_parent(&self, id: Uuid) -> Option<Fm> {
-        self.get(&self.get(&id)?.parent()).cloned()
+    fn maybe_find_parent(&self, id: Uuid) -> Option<&Fm> {
+        self.get(&self.get(&id)?.parent())
     }
 
     fn find_children(&self, folder_id: Uuid) -> HashMap<Uuid, Fm> {
@@ -184,40 +202,76 @@ where
             .collect()
     }
 
-    fn filter_deleted(&self) -> Result<HashMap<Uuid, Fm>, TreeError> {
-        let mut result = HashMap::new();
-        let mut not_deleted = HashMap::new();
-        for (id, file) in self {
-            let mut ancestors = HashMap::with(file.clone());
-            let mut ancestor = file.clone();
-            loop {
-                if not_deleted.get(&ancestor.id()).is_none() // check it isn't confirmed as not deleted
-                    && (ancestor.deleted() || result.get(&ancestor.id()).is_some())
-                {
-                    result.extend(ancestors);
-                    break;
-                }
-
-                let parent = self.find(ancestor.parent())?;
-                // first case is root, second case is a cycle (not our problem)
-                if parent.id() == ancestor.id() || &parent.id() == id {
-                    not_deleted.extend(ancestors);
-                    break; // root
-                }
-                ancestors.push(parent.clone());
-                ancestor = parent;
-            }
+    fn filter_deleted(self) -> Result<HashMap<Uuid, Fm>, TreeError> {
+        let mut tree = self;
+        for id in tree.deleted()?.not_deleted {
+            tree.remove(&id);
         }
-        Ok(result)
+
+        Ok(tree)
     }
 
-    fn filter_not_deleted(&self) -> Result<HashMap<Uuid, Fm>, TreeError> {
-        let deleted = self.filter_deleted()?;
-        Ok(self
-            .clone()
-            .into_iter()
-            .filter(|(id, _)| deleted.get(id).is_none())
-            .collect())
+    fn deleted(&self) -> Result<DeletedStatus, TreeError> {
+        let mut confirmed_not_delted = HashSet::new();
+        let mut confirmed_deleted = HashSet::new();
+        for meta in self.values() {
+            // Itself is explicitly deleted
+            if meta.deleted() {
+                confirmed_deleted.insert(meta.id());
+                continue;
+            }
+
+            // Parent is confirmed to be not deleted, and is not explicitly deleted
+            if confirmed_not_delted.contains(&meta.parent()) && !meta.deleted() {
+                confirmed_not_delted.insert(meta.id());
+                continue;
+            }
+
+            // Check all ancestors
+            let mut cur = self.find_ref(meta.parent())?;
+            let mut checked_path = vec![meta.id(), cur.id()];
+            let mut ancestor_deleted = false;
+            'ansestor_check: while !cur.is_root() {
+                if cur.deleted() {
+                    confirmed_deleted.extend(&checked_path);
+                    ancestor_deleted = true;
+                    break 'ansestor_check;
+                }
+
+                // Select the next node to explore
+                let parent = self.find_ref(cur.parent())?;
+                if confirmed_deleted.contains(&parent.id()) {
+                    confirmed_deleted.extend(&checked_path);
+                    ancestor_deleted = true;
+                    break 'ansestor_check;
+                } else if confirmed_not_delted.contains(&parent.id()) {
+                    confirmed_not_delted.extend(&checked_path);
+                    break 'ansestor_check;
+                } else {
+                    if checked_path.contains(&parent.id()) {
+                        // We've already checked this, it's likely a cycle or root, this is not the
+                        // place to detect this though, cycles are not deleted files, so we continue
+                        break 'ansestor_check;
+                    }
+                    checked_path.push(parent.id());
+                    cur = parent;
+                }
+            }
+            if !ancestor_deleted {
+                confirmed_not_delted.extend(&checked_path);
+            }
+        }
+
+        Ok(DeletedStatus { deleted: confirmed_deleted, not_deleted: confirmed_not_delted })
+    }
+
+    fn filter_not_deleted(self) -> Result<HashMap<Uuid, Fm>, TreeError> {
+        let mut tree = self;
+        for id in tree.deleted()?.deleted {
+            tree.remove(&id);
+        }
+
+        Ok(tree)
     }
 
     fn documents(&self) -> HashSet<Uuid> {
@@ -245,7 +299,7 @@ where
     ) -> Result<Vec<Uuid>, TreeError> {
         let mut root_found = false;
         let mut prev_checked = HashMap::new();
-        let staged_changes = self.stage(staged_changes);
+        let staged_changes = self.stage_with_source(staged_changes);
         let mut result = Vec::new();
         for (_, (f, _)) in staged_changes.clone().into_iter() {
             let mut checking = HashMap::new();
@@ -273,7 +327,7 @@ where
     fn get_path_conflicts(
         &self, staged_changes: &HashMap<Uuid, Fm>,
     ) -> Result<Vec<PathConflict>, TreeError> {
-        let files_with_sources = self.stage(staged_changes);
+        let files_with_sources = self.stage_with_source(staged_changes);
         let mut name_tree: HashMap<Uuid, HashMap<Fm::Name, Uuid>> = HashMap::new();
         let mut result = Vec::new();
 
@@ -329,10 +383,7 @@ where
         }
 
         let docs = self.documents();
-        let maybe_doc_with_children = self
-            .parents()
-            .into_iter()
-            .find(|id| docs.contains(id));
+        let maybe_doc_with_children = self.parents().into_iter().find(|id| docs.contains(id));
         if let Some(id) = maybe_doc_with_children {
             // Could find all of them if we wanted to
             return Err(TestFileTreeError::DocumentTreatedAsFolder(id));

--- a/core/libs/test_utils/src/lib.rs
+++ b/core/libs/test_utils/src/lib.rs
@@ -264,7 +264,7 @@ pub fn assert_server_work_paths(
                 .filter(|(id, _)| all_local_files.maybe_find(*id).is_none())
                 .collect::<DecryptedFiles>();
             all_local_files
-                .stage(&new_server_files)
+                .stage_with_source(&new_server_files)
                 .into_iter()
                 .map(|(_, (meta, _))| (meta.id, meta))
                 .collect::<DecryptedFiles>()

--- a/core/libs/test_utils/src/lib.rs
+++ b/core/libs/test_utils/src/lib.rs
@@ -2,10 +2,9 @@ use chrono::Datelike;
 use hmdb::transaction::Transaction;
 use itertools::Itertools;
 use lockbook_core::model::repo::RepoSource;
-use lockbook_core::repo::schema::Tx;
 use lockbook_core::service::api_service::ApiError;
 use lockbook_core::service::path_service::Filter::DocumentsOnly;
-use lockbook_core::{Config, Core};
+use lockbook_core::{Config, Core, RequestContext};
 use lockbook_models::api::{AccountTier, FileMetadataUpsertsError, PaymentMethod};
 use lockbook_models::file_metadata::{DecryptedFileMetadata, DecryptedFiles};
 use lockbook_models::tree::{FileMetaMapExt, FileMetadata};
@@ -225,14 +224,14 @@ pub fn assert_local_work_paths(
 ) {
     let all_local_files = db
         .db
-        .transaction(|tx| tx.get_all_metadata(RepoSource::Local))
+        .transaction(|tx| db.context(tx).unwrap().get_all_metadata(RepoSource::Local))
         .unwrap()
         .unwrap();
 
     let mut expected_paths = expected_paths.to_vec();
     let mut actual_paths: Vec<String> = get_dirty_ids(db, false)
         .iter()
-        .map(|&id| Tx::path_by_id_helper(&all_local_files, id).unwrap())
+        .map(|&id| RequestContext::path_by_id_helper(&all_local_files, id).unwrap())
         .map(|path| String::from(&path[root.decrypted_name.len() + 1..]))
         .collect();
     actual_paths.sort_unstable();
@@ -251,6 +250,7 @@ pub fn assert_server_work_paths(
     let staged = db
         .db
         .transaction(|tx| {
+            let mut tx = db.context(tx).unwrap();
             let all_local_files = tx.get_all_metadata(RepoSource::Local).unwrap();
             let new_server_files = tx
                 .calculate_work(&db.config)
@@ -274,7 +274,7 @@ pub fn assert_server_work_paths(
     let mut expected_paths = expected_paths.to_vec();
     let mut actual_paths: Vec<String> = get_dirty_ids(db, true)
         .iter()
-        .map(|&id| Tx::path_by_id_helper(&staged, id).unwrap())
+        .map(|&id| RequestContext::path_by_id_helper(&staged, id).unwrap())
         .map(|path| String::from(&path[root.decrypted_name.len() + 1..]))
         .collect();
     actual_paths.sort_unstable();
@@ -320,6 +320,7 @@ pub fn assert_all_document_contents(
 }
 pub fn assert_deleted_files_pruned(core: &Core) {
     core.db.transaction(|tx| {
+        let mut tx = core.context(tx).unwrap();
         for source in [RepoSource::Local, RepoSource::Base] {
             let all_metadata = tx.get_all_metadata(source).unwrap();
             let not_deleted_metadata = tx.get_all_not_deleted_metadata(source).unwrap();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -44,16 +44,10 @@ pub struct Config {
     pub writeable_path: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct DataCache {
     pub key_cache: HashMap<Uuid, AESKey>,
     pub public_key: Option<PublicKey>,
-}
-
-impl Default for DataCache {
-    fn default() -> Self {
-        Self { key_cache: Default::default(), public_key: None }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -163,7 +163,7 @@ impl Core {
     pub fn read_document(&self, id: Uuid) -> Result<DecryptedDocument, Error<ReadDocumentError>> {
         let val = self
             .db
-            .transaction(|tx| tx.read_document(&self.config, id))?;
+            .transaction(|tx| tx.read_document(&self.config, RepoSource::Local, id))?;
         Ok(val?)
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,7 @@ use crate::model::errors::*;
 use crate::model::repo::RepoSource;
 use crate::path_service::Filter;
 use crate::pure_functions::drawing::SupportedImageFormats;
-use crate::repo::schema::{CoreV1, OneKey, Tx};
+use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};
 use crate::service::import_export_service::{ImportExportFileInfo, ImportStatus};
 use crate::service::search_service::SearchResultItem;
 use crate::service::sync_service::SyncProgress;
@@ -20,10 +20,11 @@ use basic_human_duration::ChronoHumanDuration;
 use chrono::Duration;
 use hmdb::log::Reader;
 use hmdb::transaction::Transaction;
+use libsecp256k1::PublicKey;
 use lockbook_crypto::clock_service;
 use lockbook_models::account::Account;
 use lockbook_models::api::AccountTier;
-use lockbook_models::crypto::DecryptedDocument;
+use lockbook_models::crypto::{AESKey, DecryptedDocument};
 use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
 use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 use model::errors::Error::UiError;
@@ -33,6 +34,7 @@ use serde_json::{json, value::Value};
 use service::log_service;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
 use strum::IntoEnumIterator;
 use uuid::Uuid;
 
@@ -43,9 +45,41 @@ pub struct Config {
 }
 
 #[derive(Clone, Debug)]
+pub struct DataCache {
+    pub key_cache: HashMap<Uuid, AESKey>,
+    pub public_key: Option<PublicKey>,
+}
+
+impl Default for DataCache {
+    fn default() -> Self {
+        Self { key_cache: Default::default(), public_key: None }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct Core {
+    // TODO not pub?
     pub config: Config,
+    pub data_cache: Arc<Mutex<DataCache>>, // Or Rc<RefCell>>
     pub db: CoreV1,
+}
+
+impl Core {
+    pub fn context<'a, 'b>(
+        &'a self, tx: &'a mut Tx<'b>,
+    ) -> Result<RequestContext<'a, 'b>, CoreError> {
+        let config = &self.config;
+        let data_cache = self.data_cache.lock().map_err(|err| {
+            CoreError::Unexpected(format!("Could not get key_cache mutex: {:?}", err))
+        })?;
+        Ok(RequestContext { config, data_cache, tx })
+    }
+}
+
+pub struct RequestContext<'a, 'b> {
+    pub config: &'a Config,
+    pub data_cache: MutexGuard<'a, DataCache>,
+    pub tx: &'a mut transaction::CoreV1<'b>,
 }
 
 impl Core {
@@ -56,9 +90,10 @@ impl Core {
         }
         let db =
             CoreV1::init(&config.writeable_path).map_err(|err| unexpected_only!("{:#?}", err))?;
+        let data_cache = Arc::new(Mutex::new(DataCache::default()));
         let config = config.clone();
 
-        Ok(Self { config, db })
+        Ok(Self { config, data_cache, db })
     }
 
     #[instrument(level = "info", skip_all, err(Debug))]
@@ -67,7 +102,7 @@ impl Core {
     ) -> Result<Account, Error<CreateAccountError>> {
         let val = self
             .db
-            .transaction(|tx| tx.create_account(username, api_url))?;
+            .transaction(|tx| self.context(tx)?.create_account(username, api_url))?;
         Ok(val?)
     }
 
@@ -75,19 +110,23 @@ impl Core {
     pub fn import_account(&self, account_string: &str) -> Result<Account, Error<ImportError>> {
         let val = self
             .db
-            .transaction(|tx| tx.import_account(account_string))?;
+            .transaction(|tx| self.context(tx)?.import_account(account_string))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip_all, err(Debug))]
     pub fn export_account(&self) -> Result<String, Error<AccountExportError>> {
-        let val = self.db.transaction(|tx| tx.export_account())?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.export_account())?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip_all, err(Debug))]
     pub fn get_account(&self) -> Result<Account, Error<GetAccountError>> {
-        let account = self.db.transaction(|tx| tx.get_account())??;
+        let account = self
+            .db
+            .transaction(|tx| self.context(tx)?.get_account())??;
         Ok(account)
     }
 
@@ -95,9 +134,10 @@ impl Core {
     pub fn create_file(
         &self, name: &str, parent: Uuid, file_type: FileType,
     ) -> Result<DecryptedFileMetadata, Error<CreateFileError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.create_file(&self.config, name, parent, file_type))?;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .create_file(&self.config, name, parent, file_type)
+        })?;
         Ok(val?)
     }
 
@@ -106,8 +146,15 @@ impl Core {
         &self, id: Uuid, content: &[u8],
     ) -> Result<(), Error<WriteToDocumentError>> {
         let val: Result<_, CoreError> = self.db.transaction(|tx| {
-            let metadata = tx.get_not_deleted_metadata(RepoSource::Local, id)?;
-            tx.insert_document(&self.config, RepoSource::Local, &metadata, content)?;
+            let metadata = self
+                .context(tx)?
+                .get_not_deleted_metadata(RepoSource::Local, id)?;
+            self.context(tx)?.insert_document(
+                &self.config,
+                RepoSource::Local,
+                &metadata,
+                content,
+            )?;
             Ok(())
         })?;
         Ok(val?)
@@ -115,7 +162,7 @@ impl Core {
 
     #[instrument(level = "debug", skip_all, err(Debug))]
     pub fn get_root(&self) -> Result<DecryptedFileMetadata, Error<GetRootError>> {
-        let val = self.db.transaction(|tx| tx.root())?;
+        let val = self.db.transaction(|tx| self.context(tx)?.root())?;
         Ok(val?)
     }
 
@@ -123,7 +170,7 @@ impl Core {
     pub fn get_children(&self, id: Uuid) -> Result<Vec<DecryptedFileMetadata>, UnexpectedError> {
         let val = self
             .db
-            .transaction(|tx| tx.get_children(id))??
+            .transaction(|tx| self.context(tx)?.get_children(id))??
             .into_values()
             .collect();
         Ok(val)
@@ -135,7 +182,7 @@ impl Core {
     ) -> Result<Vec<DecryptedFileMetadata>, Error<GetAndGetChildrenError>> {
         let val = self
             .db
-            .transaction(|tx| tx.get_and_get_children_recursively(id))??
+            .transaction(|tx| self.context(tx)?.get_and_get_children_recursively(id))??
             .into_values()
             .collect();
 
@@ -146,24 +193,28 @@ impl Core {
     pub fn get_file_by_id(
         &self, id: Uuid,
     ) -> Result<DecryptedFileMetadata, Error<GetFileByIdError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.get_not_deleted_metadata(RepoSource::Local, id))?;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .get_not_deleted_metadata(RepoSource::Local, id)
+        })?;
 
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn delete_file(&self, id: Uuid) -> Result<(), Error<FileDeleteError>> {
-        let val = self.db.transaction(|tx| tx.delete_file(&self.config, id))?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.delete_file(&self.config, id))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn read_document(&self, id: Uuid) -> Result<DecryptedDocument, Error<ReadDocumentError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.read_document(&self.config, RepoSource::Local, id))?;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .read_document(&self.config, RepoSource::Local, id)
+        })?;
         Ok(val?)
     }
 
@@ -171,9 +222,10 @@ impl Core {
     pub fn save_document_to_disk(
         &self, id: Uuid, location: &str,
     ) -> Result<(), Error<SaveDocumentToDiskError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.save_document_to_disk(&self.config, id, location))?;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .save_document_to_disk(&self.config, id, location)
+        })?;
 
         Ok(val?)
     }
@@ -182,7 +234,10 @@ impl Core {
     pub fn list_metadatas(&self) -> Result<Vec<DecryptedFileMetadata>, UnexpectedError> {
         let val = self
             .db
-            .transaction(|tx| tx.get_all_not_deleted_metadata(RepoSource::Local))??
+            .transaction(|tx| {
+                self.context(tx)?
+                    .get_all_not_deleted_metadata(RepoSource::Local)
+            })??
             .into_values()
             .collect();
         Ok(val)
@@ -192,7 +247,7 @@ impl Core {
     pub fn rename_file(&self, id: Uuid, new_name: &str) -> Result<(), Error<RenameFileError>> {
         let val = self
             .db
-            .transaction(|tx| tx.rename_file(&self.config, id, new_name))?;
+            .transaction(|tx| self.context(tx)?.rename_file(&self.config, id, new_name))?;
 
         Ok(val?)
     }
@@ -201,7 +256,7 @@ impl Core {
     pub fn move_file(&self, id: Uuid, new_parent: Uuid) -> Result<(), Error<MoveFileError>> {
         let val = self
             .db
-            .transaction(|tx| tx.move_file(&self.config, id, new_parent))?;
+            .transaction(|tx| self.context(tx)?.move_file(&self.config, id, new_parent))?;
         Ok(val?)
     }
 
@@ -209,9 +264,10 @@ impl Core {
     pub fn create_at_path(
         &self, path_and_name: &str,
     ) -> Result<DecryptedFileMetadata, Error<CreateFileAtPathError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.create_at_path(&self.config, path_and_name))??;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .create_at_path(&self.config, path_and_name)
+        })??;
 
         Ok(val)
     }
@@ -220,20 +276,26 @@ impl Core {
     pub fn get_by_path(
         &self, path: &str,
     ) -> Result<DecryptedFileMetadata, Error<GetFileByPathError>> {
-        let val = self.db.transaction(|tx| tx.get_by_path(path))??;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.get_by_path(path))??;
 
         Ok(val)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn get_path_by_id(&self, id: Uuid) -> Result<String, UnexpectedError> {
-        let val: Result<_, CoreError> = self.db.transaction(|tx| tx.get_path_by_id(id))?;
+        let val: Result<_, CoreError> = self
+            .db
+            .transaction(|tx| self.context(tx)?.get_path_by_id(id))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn list_paths(&self, filter: Option<Filter>) -> Result<Vec<String>, UnexpectedError> {
-        let val: Result<_, CoreError> = self.db.transaction(|tx| tx.list_paths(filter))?;
+        let val: Result<_, CoreError> = self
+            .db
+            .transaction(|tx| self.context(tx)?.list_paths(filter))?;
 
         Ok(val?)
     }
@@ -242,19 +304,23 @@ impl Core {
     pub fn get_local_changes(&self) -> Result<Vec<Uuid>, UnexpectedError> {
         let val = self
             .db
-            .transaction(|tx| tx.get_local_changes(&self.config))?;
+            .transaction(|tx| self.context(tx)?.get_local_changes(&self.config))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn calculate_work(&self) -> Result<WorkCalculated, Error<CalculateWorkError>> {
-        let val = self.db.transaction(|tx| tx.calculate_work(&self.config))?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.calculate_work(&self.config))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip_all, err(Debug))]
     pub fn sync(&self, f: Option<Box<dyn Fn(SyncProgress)>>) -> Result<(), Error<SyncAllError>> {
-        let val = self.db.transaction(|tx| tx.sync(&self.config, f))?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.sync(&self.config, f))?;
         Ok(val?)
     }
 
@@ -278,7 +344,7 @@ impl Core {
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn get_usage(&self) -> Result<UsageMetrics, Error<GetUsageError>> {
-        let val = self.db.transaction(|tx| tx.get_usage())?;
+        let val = self.db.transaction(|tx| self.context(tx)?.get_usage())?;
         Ok(val?)
     }
 
@@ -286,13 +352,15 @@ impl Core {
     pub fn get_uncompressed_usage(&self) -> Result<UsageItemMetric, Error<GetUsageError>> {
         let val = self
             .db
-            .transaction(|tx| tx.get_uncompressed_usage(&self.config))?;
+            .transaction(|tx| self.context(tx)?.get_uncompressed_usage(&self.config))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn get_drawing(&self, id: Uuid) -> Result<Drawing, Error<GetDrawingError>> {
-        let val = self.db.transaction(|tx| tx.get_drawing(&self.config, id))?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.get_drawing(&self.config, id))?;
         Ok(val?)
     }
 
@@ -300,9 +368,10 @@ impl Core {
     pub fn save_drawing(
         &self, id: Uuid, drawing_bytes: &[u8],
     ) -> Result<(), Error<SaveDrawingError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.save_drawing(&self.config, id, drawing_bytes))?;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .save_drawing(&self.config, id, drawing_bytes)
+        })?;
         Ok(val?)
     }
 
@@ -311,9 +380,10 @@ impl Core {
         &self, id: Uuid, format: SupportedImageFormats,
         render_theme: Option<HashMap<ColorAlias, ColorRGB>>,
     ) -> Result<Vec<u8>, Error<ExportDrawingError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.export_drawing(&self.config, id, format, render_theme))?;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .export_drawing(&self.config, id, format, render_theme)
+        })?;
         Ok(val?)
     }
 
@@ -323,7 +393,13 @@ impl Core {
         render_theme: Option<HashMap<ColorAlias, ColorRGB>>, location: &str,
     ) -> Result<(), Error<ExportDrawingToDiskError>> {
         let val = self.db.transaction(|tx| {
-            tx.export_drawing_to_disk(&self.config, id, format, render_theme, location)
+            self.context(tx)?.export_drawing_to_disk(
+                &self.config,
+                id,
+                format,
+                render_theme,
+                location,
+            )
         })?;
         Ok(val?)
     }
@@ -332,9 +408,10 @@ impl Core {
     pub fn import_files<F: Fn(ImportStatus)>(
         &self, sources: &[PathBuf], dest: Uuid, update_status: &F,
     ) -> Result<(), Error<ImportFileError>> {
-        let val = self
-            .db
-            .transaction(|tx| tx.import_files(&self.config, sources, dest, update_status))?;
+        let val = self.db.transaction(|tx| {
+            self.context(tx)?
+                .import_files(&self.config, sources, dest, update_status)
+        })?;
         Ok(val?)
     }
 
@@ -344,7 +421,8 @@ impl Core {
         export_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
     ) -> Result<(), Error<ExportFileError>> {
         let val = self.db.transaction(|tx| {
-            tx.export_file(&self.config, id, destination, edit, export_progress)
+            self.context(tx)?
+                .export_file(&self.config, id, destination, edit, export_progress)
         })?;
         Ok(val?)
     }
@@ -355,26 +433,30 @@ impl Core {
     ) -> Result<(), Error<SwitchAccountTierError>> {
         let val = self
             .db
-            .transaction(|tx| tx.switch_account_tier(new_account_tier))?;
+            .transaction(|tx| self.context(tx)?.switch_account_tier(new_account_tier))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn get_credit_card(&self) -> Result<CreditCardLast4Digits, Error<GetCreditCard>> {
-        let val = self.db.transaction(|tx| tx.get_credit_card())?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.get_credit_card())?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self, input), err(Debug))]
     pub fn search_file_paths(&self, input: &str) -> Result<Vec<SearchResultItem>, UnexpectedError> {
-        let val = self.db.transaction(|tx| tx.search_file_paths(input))?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.search_file_paths(input))?;
         Ok(val?)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn validate(&self) -> Result<Vec<Warning>, TestRepoError> {
         self.db
-            .transaction(|tx| tx.test_repo_integrity(&self.config))
+            .transaction(|tx| self.context(tx)?.test_repo_integrity(&self.config))
             .map_err(CoreError::from)
             .map_err(TestRepoError::Core)?
     }

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -216,7 +216,7 @@ pub fn find_ancestors<Fm: FileMetadata>(
     let mut current_target_id = target_id;
     while let Some(target) = files.maybe_find(current_target_id) {
         result.push(target.clone());
-        if target.id() == target.parent() {
+        if target.is_root() {
             break;
         }
         current_target_id = target.parent();

--- a/core/src/pure_functions/files.rs
+++ b/core/src/pure_functions/files.rs
@@ -160,7 +160,7 @@ pub fn suggest_non_conflicting_filename(
     id: Uuid, files: &DecryptedFiles, staged_changes: &DecryptedFiles,
 ) -> Result<String, CoreError> {
     let files: DecryptedFiles = files
-        .stage(staged_changes)
+        .stage_with_source(staged_changes)
         .into_iter()
         .map(|(id, (f, _))| (id, f))
         .collect::<DecryptedFiles>();

--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -23,7 +23,7 @@ impl RequestContext<'_, '_> {
 
         let account = Account { username, api_url: api_url.to_string(), private_key: keys };
         let public_key = account.public_key();
-        self.data_cache.public_key = Some(public_key.clone());
+        self.data_cache.public_key = Some(public_key);
 
         let mut root_metadata = files::create_root(&account);
         let encrypted_metadata = file_encryption_service::encrypt_metadata(

--- a/core/src/service/billing_service.rs
+++ b/core/src/service/billing_service.rs
@@ -1,7 +1,7 @@
 use crate::model::errors::core_err_unexpected;
 use crate::service::api_service;
 use crate::service::api_service::ApiError;
-use crate::{CoreError, Tx};
+use crate::{CoreError, RequestContext};
 use lockbook_models::api::{
     AccountTier, GetCreditCardError, GetCreditCardRequest, SwitchAccountTierError,
     SwitchAccountTierRequest,
@@ -9,7 +9,7 @@ use lockbook_models::api::{
 
 pub type CreditCardLast4Digits = String;
 
-impl Tx<'_> {
+impl RequestContext<'_, '_> {
     pub fn switch_account_tier(&self, new_account_tier: AccountTier) -> Result<(), CoreError> {
         let account = self.get_account()?;
 

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -10,10 +10,10 @@ use crate::pure_functions::{drawing, files};
 
 use crate::pure_functions::drawing::SupportedImageFormats;
 use crate::service::file_service;
-use crate::{Config, Tx};
+use crate::{Config, RequestContext};
 
-impl Tx<'_> {
-    pub fn get_drawing(&self, config: &Config, id: Uuid) -> Result<Drawing, CoreError> {
+impl RequestContext<'_, '_> {
+    pub fn get_drawing(&mut self, config: &Config, id: Uuid) -> Result<Drawing, CoreError> {
         let all_metadata = self.get_all_metadata(RepoSource::Local)?;
         let drawing_bytes =
             file_service::get_not_deleted_document(config, RepoSource::Local, &all_metadata, id)?;
@@ -29,7 +29,7 @@ impl Tx<'_> {
     }
 
     pub fn export_drawing(
-        &self, config: &Config, id: Uuid, format: SupportedImageFormats,
+        &mut self, config: &Config, id: Uuid, format: SupportedImageFormats,
         render_theme: Option<HashMap<ColorAlias, ColorRGB>>,
     ) -> Result<Vec<u8>, CoreError> {
         let all_metadata = self.get_all_metadata(RepoSource::Local)?;
@@ -39,7 +39,7 @@ impl Tx<'_> {
     }
 
     pub fn export_drawing_to_disk(
-        &self, config: &Config, id: Uuid, format: SupportedImageFormats,
+        &mut self, config: &Config, id: Uuid, format: SupportedImageFormats,
         render_theme: Option<HashMap<ColorAlias, ColorRGB>>, location: &str,
     ) -> Result<(), CoreError> {
         let all_metadata = self.get_all_metadata(RepoSource::Local)?;

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -1,3 +1,4 @@
+use libsecp256k1::PublicKey;
 use std::collections::HashMap;
 
 use uuid::Uuid;
@@ -15,10 +16,10 @@ use crate::model::errors::{core_err_unexpected, CoreError};
 /// Converts a DecryptedFileMetadata to a FileMetadata using its decrypted parent key. Sharing is
 /// not supported; user access keys are encrypted for the provided account. This is a pure function.
 pub fn encrypt_metadatum(
-    account: &Account, parent_key: &AESKey, target: &DecryptedFileMetadata,
+    account: &Account, public_key: &PublicKey, parent_key: &AESKey, target: &DecryptedFileMetadata,
 ) -> Result<EncryptedFileMetadata, CoreError> {
     let user_access_keys = if target.is_root() {
-        encrypt_user_access_keys(account, &target.decrypted_access_key)?
+        encrypt_user_access_keys(account, public_key, &target.decrypted_access_key)?
     } else {
         Default::default()
     };
@@ -41,7 +42,7 @@ pub fn encrypt_metadatum(
 /// account. This is a pure function.
 /// This is O(n) now with hashmaps
 pub fn encrypt_metadata(
-    account: &Account, files: &DecryptedFiles,
+    account: &Account, public_key: &PublicKey, files: &DecryptedFiles,
 ) -> Result<EncryptedFiles, CoreError> {
     let mut result = HashMap::new();
     for target in files.values() {
@@ -51,7 +52,7 @@ pub fn encrypt_metadata(
                 ))
             })?
             .decrypted_access_key;
-        result.push(encrypt_metadatum(account, &parent_key, target)?);
+        result.push(encrypt_metadatum(account, &public_key, &parent_key, target)?);
     }
     Ok(result)
 }
@@ -63,10 +64,10 @@ fn encrypt_file_name(
 }
 
 fn encrypt_user_access_keys(
-    account: &Account, decrypted_file_key: &AESKey,
+    account: &Account, public_key: &PublicKey, decrypted_file_key: &AESKey,
 ) -> Result<HashMap<String, UserAccessInfo>, CoreError> {
-    let user_key = pubkey::get_aes_key(&account.private_key, &account.public_key())
-        .map_err(core_err_unexpected)?;
+    let user_key =
+        pubkey::get_aes_key(&account.private_key, public_key).map_err(core_err_unexpected)?;
     let encrypted_file_key =
         symkey::encrypt(&user_key, decrypted_file_key).map_err(core_err_unexpected)?;
     let mut result = HashMap::new();
@@ -74,7 +75,7 @@ fn encrypt_user_access_keys(
         account.username.clone(),
         UserAccessInfo {
             username: account.username.clone(),
-            encrypted_by: account.public_key(),
+            encrypted_by: public_key.clone(),
             access_key: encrypted_file_key,
         },
     );
@@ -109,13 +110,12 @@ pub fn decrypt_metadatum(
 /// included in files. Sharing is not supported; user access keys not for the provided account are
 /// ignored. This is a pure function.
 pub fn decrypt_metadata(
-    account: &Account, files: &EncryptedFiles,
+    account: &Account, files: &EncryptedFiles, key_cache: &mut HashMap<Uuid, AESKey>,
 ) -> Result<DecryptedFiles, CoreError> {
     let mut result = HashMap::new();
-    let mut key_cache = HashMap::new();
 
     for target in files.values() {
-        let parent_key = decrypt_file_key(account, target.parent, files, &mut key_cache)?;
+        let parent_key = decrypt_file_key(account, target.parent, files, key_cache)?;
         let decrypted_metadatum = decrypt_metadatum(&parent_key, target)?;
         result.push(decrypted_metadatum);
     }

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -52,7 +52,7 @@ pub fn encrypt_metadata(
                 ))
             })?
             .decrypted_access_key;
-        result.push(encrypt_metadatum(account, &public_key, &parent_key, target)?);
+        result.push(encrypt_metadatum(account, public_key, &parent_key, target)?);
     }
     Ok(result)
 }
@@ -75,7 +75,7 @@ fn encrypt_user_access_keys(
         account.username.clone(),
         UserAccessInfo {
             username: account.username.clone(),
-            encrypted_by: public_key.clone(),
+            encrypted_by: *public_key,
             access_key: encrypted_file_key,
         },
     );

--- a/core/src/service/file_encryption_service.rs
+++ b/core/src/service/file_encryption_service.rs
@@ -8,7 +8,7 @@ use lockbook_models::crypto::*;
 use lockbook_models::file_metadata::{
     DecryptedFileMetadata, DecryptedFiles, EncryptedFileMetadata, EncryptedFiles,
 };
-use lockbook_models::tree::FileMetaMapExt;
+use lockbook_models::tree::{FileMetaMapExt, FileMetadata};
 
 use crate::model::errors::{core_err_unexpected, CoreError};
 
@@ -17,7 +17,7 @@ use crate::model::errors::{core_err_unexpected, CoreError};
 pub fn encrypt_metadatum(
     account: &Account, parent_key: &AESKey, target: &DecryptedFileMetadata,
 ) -> Result<EncryptedFileMetadata, CoreError> {
-    let user_access_keys = if target.id == target.parent {
+    let user_access_keys = if target.is_root() {
         encrypt_user_access_keys(account, &target.decrypted_access_key)?
     } else {
         Default::default()

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -35,7 +35,7 @@ impl Tx<'_> {
     }
 
     pub fn root_id(&self) -> Result<Uuid, CoreError> {
-        Ok(self.root.get(&OneKey).unwrap())
+        self.root.get(&OneKey).ok_or(RootNonexistent)
     }
 
     pub fn root(&self) -> Result<DecryptedFileMetadata, CoreError> {

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -281,9 +281,9 @@ impl RequestContext<'_, '_> {
 
         // find files deleted on base and local; new deleted local files are also eligible
         let all_base_metadata = self.get_all_metadata(RepoSource::Base)?;
-        let deleted_base_metadata = all_base_metadata.deleted()?.deleted;
+        let deleted_base_metadata = all_base_metadata.deleted_status()?.deleted;
         let all_local_metadata = self.get_all_metadata(RepoSource::Local)?;
-        let deleted_local_metadata = all_local_metadata.deleted()?.deleted;
+        let deleted_local_metadata = all_local_metadata.deleted_status()?.deleted;
         let deleted_both_metadata = deleted_base_metadata
             .into_iter()
             .filter(|id| deleted_local_metadata.contains(id));
@@ -658,7 +658,7 @@ pub fn maybe_get_not_deleted_document(
     config: &Config, source: RepoSource, metadata: &DecryptedFiles, id: Uuid,
 ) -> Result<Option<DecryptedDocument>, CoreError> {
     let maybe_doc_metadata = metadata
-        .deleted()?
+        .deleted_status()?
         .not_deleted
         .get(&id)
         .and_then(|id| metadata.get(id));

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -635,7 +635,7 @@ pub fn maybe_get_not_deleted_document(
         .and_then(|id| metadata.get(id));
 
     if let Some(metadata) = maybe_doc_metadata {
-        maybe_get_document(config, source, &metadata)
+        maybe_get_document(config, source, metadata)
     } else {
         Ok(None)
     }

--- a/core/src/service/import_export_service.rs
+++ b/core/src/service/import_export_service.rs
@@ -163,13 +163,8 @@ impl Tx<'_> {
                 .map_err(CoreError::from)?;
 
                 file.write_all(
-                    self.get_not_deleted_document(
-                        config,
-                        RepoSource::Local,
-                        all,
-                        parent_file_metadata.id,
-                    )?
-                    .as_slice(),
+                    self.read_document(config, RepoSource::Local, parent_file_metadata.id)?
+                        .as_slice(),
                 )
                 .map_err(CoreError::from)?;
             }

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -3,7 +3,7 @@ use crate::model::repo::RepoSource;
 use crate::pure_functions::drawing;
 use crate::service::file_service;
 use crate::service::integrity_service::TestRepoError::DocumentReadError;
-use crate::{Config, OneKey, Tx};
+use crate::{Config, OneKey, RequestContext};
 use lockbook_models::tree::{FileMetaMapExt, FileMetadata, TestFileTreeError};
 
 use std::path::Path;
@@ -11,18 +11,20 @@ use std::path::Path;
 const UTF8_SUFFIXES: [&str; 12] =
     ["md", "txt", "text", "markdown", "sh", "zsh", "bash", "html", "css", "js", "csv", "rs"];
 
-impl Tx<'_> {
-    pub fn test_repo_integrity(&self, config: &Config) -> Result<Vec<Warning>, TestRepoError> {
-        if self.account.get(&OneKey {}).is_none() {
+impl RequestContext<'_, '_> {
+    pub fn test_repo_integrity(&mut self, config: &Config) -> Result<Vec<Warning>, TestRepoError> {
+        if self.tx.account.get(&OneKey {}).is_none() {
             return Err(TestRepoError::NoAccount);
         }
 
-        let local_meta = self.local_metadata.get_all();
+        let local_meta = self.tx.local_metadata.get_all();
 
-        let mut files_encrypted = self.base_metadata.get_all();
+        let mut files_encrypted = self.tx.base_metadata.get_all();
         files_encrypted.extend(local_meta);
 
-        if self.last_synced.get(&OneKey {}).unwrap_or(0) != 0 && self.root.get(&OneKey).is_none() {
+        if self.tx.last_synced.get(&OneKey {}).unwrap_or(0) != 0
+            && self.tx.root.get(&OneKey).is_none()
+        {
             return Err(TestRepoError::NoRootFolder);
         }
 

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -22,9 +22,7 @@ impl Tx<'_> {
         let mut files_encrypted = self.base_metadata.get_all();
         files_encrypted.extend(local_meta);
 
-        if self.last_synced.get(&OneKey {}).unwrap_or(0) != 0
-            && files_encrypted.maybe_find_root().is_none()
-        {
+        if self.last_synced.get(&OneKey {}).unwrap_or(0) != 0 && self.root.get(&OneKey).is_none() {
             return Err(TestRepoError::NoRootFolder);
         }
 

--- a/core/src/service/path_service.rs
+++ b/core/src/service/path_service.rs
@@ -110,14 +110,14 @@ impl RequestContext<'_, '_> {
     }
 
     pub fn path_by_id_helper(files: &DecryptedFiles, id: Uuid) -> Result<String, CoreError> {
-        let mut current_metadata = files.find(id)?;
+        let mut current_metadata = files.find_ref(id)?;
         let mut path = String::from("");
 
         let is_folder = current_metadata.is_folder();
 
-        while current_metadata.parent != current_metadata.id {
+        while !current_metadata.is_root() {
             path = format!("{}/{}", current_metadata.decrypted_name, path);
-            current_metadata = files.find(current_metadata.parent)?;
+            current_metadata = files.find_ref(current_metadata.parent)?;
         }
 
         {

--- a/core/src/service/path_service.rs
+++ b/core/src/service/path_service.rs
@@ -20,7 +20,7 @@ impl Tx<'_> {
 
         let mut files = self.get_all_not_deleted_metadata(RepoSource::Local)?;
 
-        let mut current = files.find_root()?;
+        let mut current = files.find(self.root_id()?)?;
         let root_id = current.id;
         let account = self.get_account()?;
 
@@ -75,7 +75,7 @@ impl Tx<'_> {
         let files = self.get_all_not_deleted_metadata(RepoSource::Local)?;
         let paths = split_path(path);
 
-        let mut current = files.find_root()?;
+        let mut current = files.find(self.root_id()?)?;
 
         for (i, &value) in paths.iter().enumerate() {
             if value != current.decrypted_name {

--- a/core/src/service/path_service.rs
+++ b/core/src/service/path_service.rs
@@ -1,12 +1,12 @@
 use crate::model::repo::RepoSource;
 use crate::pure_functions::files;
-use crate::{Config, CoreError, Tx};
+use crate::{Config, CoreError, RequestContext};
 use lockbook_models::file_metadata::FileType::{Document, Folder};
 use lockbook_models::file_metadata::{DecryptedFileMetadata, DecryptedFiles};
 use lockbook_models::tree::{FileMetaMapExt, FileMetadata};
 use uuid::Uuid;
 
-impl Tx<'_> {
+impl RequestContext<'_, '_> {
     pub fn create_at_path(
         &mut self, config: &Config, path_and_name: &str,
     ) -> Result<DecryptedFileMetadata, CoreError> {
@@ -71,7 +71,7 @@ impl Tx<'_> {
         Ok(current)
     }
 
-    pub fn get_by_path(&self, path: &str) -> Result<DecryptedFileMetadata, CoreError> {
+    pub fn get_by_path(&mut self, path: &str) -> Result<DecryptedFileMetadata, CoreError> {
         let files = self.get_all_not_deleted_metadata(RepoSource::Local)?;
         let paths = split_path(path);
 
@@ -104,7 +104,7 @@ impl Tx<'_> {
         Ok(current)
     }
 
-    pub fn get_path_by_id(&self, id: Uuid) -> Result<String, CoreError> {
+    pub fn get_path_by_id(&mut self, id: Uuid) -> Result<String, CoreError> {
         let files = self.get_all_not_deleted_metadata(RepoSource::Local)?;
         Self::path_by_id_helper(&files, id)
     }
@@ -130,7 +130,7 @@ impl Tx<'_> {
         Ok(path)
     }
 
-    pub fn list_paths(&self, filter: Option<Filter>) -> Result<Vec<String>, CoreError> {
+    pub fn list_paths(&mut self, filter: Option<Filter>) -> Result<Vec<String>, CoreError> {
         let files = self.get_all_not_deleted_metadata(RepoSource::Local)?;
 
         let mut filtered_files = files.clone();

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -1,6 +1,5 @@
 use crate::model::repo::RepoSource;
-use crate::CoreError;
-use crate::Tx;
+use crate::{CoreError, RequestContext};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use std::cmp::Ordering;
@@ -29,8 +28,8 @@ impl PartialOrd for SearchResultItem {
     }
 }
 
-impl Tx<'_> {
-    pub fn search_file_paths(&self, input: &str) -> Result<Vec<SearchResultItem>, CoreError> {
+impl RequestContext<'_, '_> {
+    pub fn search_file_paths(&mut self, input: &str) -> Result<Vec<SearchResultItem>, CoreError> {
         if input.is_empty() {
             return Ok(Vec::new());
         }

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -38,8 +38,9 @@ impl RequestContext<'_, '_> {
         let matcher = SkimMatcherV2::default();
 
         let mut results = Vec::new();
-        for (id, _) in self.get_all_not_deleted_metadata(RepoSource::Local)? {
-            let path = self.get_path_by_id(id)?;
+        let files = self.get_all_not_deleted_metadata(RepoSource::Local)?;
+        for &id in files.keys() {
+            let path = Self::path_by_id_helper(&files, id)?;
             let path_without_root = path.strip_prefix(&root_name).unwrap_or(&path).to_string();
 
             if let Some(score) = matcher.fuzzy_match(&path_without_root, input) {

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -56,10 +56,11 @@ impl Tx<'_> {
 
     pub fn get_uncompressed_usage(&self, config: &Config) -> Result<UsageItemMetric, CoreError> {
         let files = self.get_all_metadata(RepoSource::Local)?;
-        let docs = files.filter_documents();
+        let docs = files.documents();
 
         let mut local_usage: u64 = 0;
-        for (_, doc) in docs {
+        for id in docs {
+            let doc = files.find(id)?;
             local_usage += file_service::get_document(config, RepoSource::Local, &doc)?.len() as u64
         }
 

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -5,7 +5,7 @@ use lockbook_models::tree::FileMetaMapExt;
 
 use crate::model::repo::RepoSource;
 use crate::service::{api_service, file_service};
-use crate::{Config, CoreError, Tx};
+use crate::{Config, CoreError, RequestContext};
 
 pub const BYTE: u64 = 1;
 pub const KILOBYTE: u64 = BYTE * 1000;
@@ -31,7 +31,7 @@ pub struct UsageItemMetric {
     pub readable: String,
 }
 
-impl Tx<'_> {
+impl RequestContext<'_, '_> {
     fn server_usage(&self) -> Result<GetUsageResponse, CoreError> {
         let acc = &self.get_account()?;
 
@@ -54,7 +54,9 @@ impl Tx<'_> {
         })
     }
 
-    pub fn get_uncompressed_usage(&self, config: &Config) -> Result<UsageItemMetric, CoreError> {
+    pub fn get_uncompressed_usage(
+        &mut self, config: &Config,
+    ) -> Result<UsageItemMetric, CoreError> {
         let files = self.get_all_metadata(RepoSource::Local)?;
         let docs = files.documents();
 

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -234,11 +234,8 @@ impl Trial {
             }
 
             for folder in folders.clone() {
-                let parent_name = if folder.id == folder.parent {
-                    "root".to_string()
-                } else {
-                    folder.decrypted_name
-                };
+                let parent_name =
+                    if folder.is_root() { "root".to_string() } else { folder.decrypted_name };
 
                 mutants.push(self.create_mutation(NewDocument {
                     parent: parent_name.clone(),
@@ -268,7 +265,7 @@ impl Trial {
 
                 for folder2 in folders.clone() {
                     if folder.id != folder.parent {
-                        let folder2_name = if folder2.id == folder2.parent {
+                        let folder2_name = if folder2.is_root() {
                             "root".to_string()
                         } else {
                             folder2.decrypted_name

--- a/core/tests/file_encryption_tests.rs
+++ b/core/tests/file_encryption_tests.rs
@@ -3,6 +3,7 @@ use lockbook_core::service::file_encryption_service;
 use lockbook_crypto::symkey;
 use lockbook_models::file_metadata::FileType;
 use lockbook_models::tree::{FileMetaMapExt, FileMetaVecExt};
+use std::collections::HashMap;
 use test_utils::*;
 use uuid::Uuid;
 
@@ -13,7 +14,9 @@ fn encrypt_decrypt_metadatum() {
     let key = symkey::generate_key();
     let file = files::create(FileType::Folder, Uuid::new_v4(), "folder", &account.public_key());
 
-    let encrypted_file = file_encryption_service::encrypt_metadatum(&account, &key, &file).unwrap();
+    let encrypted_file =
+        file_encryption_service::encrypt_metadatum(&account, &account.public_key(), &key, &file)
+            .unwrap();
     let decrypted_file = file_encryption_service::decrypt_metadatum(&key, &encrypted_file).unwrap();
 
     assert_eq!(file, decrypted_file);
@@ -28,9 +31,11 @@ fn encrypt_decrypt_metadata() {
     let document = files::create(FileType::Folder, folder.id, "document", &account.public_key());
     let files = [root.clone(), folder.clone(), document.clone()].to_map();
 
-    let encrypted_files = file_encryption_service::encrypt_metadata(&account, &files).unwrap();
+    let encrypted_files =
+        file_encryption_service::encrypt_metadata(&account, &account.public_key(), &files).unwrap();
     let decrypted_files =
-        file_encryption_service::decrypt_metadata(&account, &encrypted_files).unwrap();
+        file_encryption_service::decrypt_metadata(&account, &encrypted_files, &mut HashMap::new())
+            .unwrap();
 
     assert_eq!(files.find(root.id).unwrap(), decrypted_files.find(root.id).unwrap(),);
     assert_eq!(files.find(folder.id).unwrap(), decrypted_files.find(folder.id).unwrap(),);

--- a/core/tests/file_service_tests.rs
+++ b/core/tests/file_service_tests.rs
@@ -15,10 +15,10 @@ macro_rules! assert_metadata_changes_count (
     ($core:expr, $total:literal) => {
         assert_eq!(
             $core.db.transaction(|tx| {
-                let tx = $core.context(tx).unwrap();
-                tx.get_all_metadata_changes()
-                .unwrap()
-                .len()
+                let ctx = $core.context(tx).unwrap();
+                ctx.get_all_metadata_changes()
+                    .unwrap()
+                    .len()
             }).unwrap(),
             $total
         );
@@ -29,10 +29,10 @@ macro_rules! assert_document_changes_count (
     ($core:expr, $total:literal) => {
         assert_eq!(
             $core.db.transaction(|tx| {
-                let mut tx = $core.context(tx).unwrap();
-                tx.get_all_with_document_changes(&$core.config)
-                .unwrap()
-                .len()
+                let mut ctx = $core.context(tx).unwrap();
+                ctx.get_all_with_document_changes(&$core.config)
+                    .unwrap()
+                    .len()
             }).unwrap(),
             $total
         );
@@ -44,8 +44,8 @@ macro_rules! assert_metadata_nonexistent (
         assert!(
             $core.db
                 .transaction(|tx| {
-                    let mut tx = $core.context(tx).unwrap();
-                    tx.maybe_get_metadata($source, $id)
+                    let mut ctx = $core.context(tx).unwrap();
+                    ctx.maybe_get_metadata($source, $id)
                 })
                 .unwrap()
                 .unwrap()
@@ -58,8 +58,8 @@ macro_rules! assert_metadata_eq (
     ($core:expr, $source:expr, $id:expr, $metadata:expr) => {
         assert_eq!(
             $core.db.transaction(|tx| {
-                let mut tx = $core.context(tx).unwrap();
-                tx.maybe_get_metadata($source, $id)
+                let mut ctx = $core.context(tx).unwrap();
+                ctx.maybe_get_metadata($source, $id)
             }).unwrap().unwrap(),
             Some($metadata.clone()),
         );
@@ -79,8 +79,8 @@ macro_rules! assert_metadata_count (
 ($core:expr, $source:expr, $total:literal) => {
     assert_eq!(
         $core.db.transaction(|tx| {
-            let mut tx = $core.context(tx).unwrap();
-            tx.get_all_metadata($source).unwrap().len()
+            let mut ctx = $core.context(tx).unwrap();
+            ctx.get_all_metadata($source).unwrap().len()
         }).unwrap(),
         $total
     );
@@ -90,8 +90,8 @@ macro_rules! assert_document_count (
 ($core:expr, $source:expr, $total:literal) => {
     assert_eq!(
         $core.db.transaction(|tx| {
-            let mut tx = $core.context(tx).unwrap();
-            tx.get_all_metadata($source).unwrap()
+            let mut ctx = $core.context(tx).unwrap();
+            ctx.get_all_metadata($source).unwrap()
         })
             .unwrap()
             .iter()
@@ -320,9 +320,9 @@ fn get_metadata() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            let root = tx.root().unwrap();
-            tx.get_metadata(RepoSource::Local, root.id).unwrap()
+            let mut ctx = core.context(tx).unwrap();
+            let root = ctx.root().unwrap();
+            ctx.get_metadata(RepoSource::Local, root.id).unwrap()
         })
         .unwrap();
 }
@@ -333,8 +333,8 @@ fn get_metadata_nonexistent() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            assert!(tx.get_metadata(RepoSource::Local, Uuid::new_v4()).is_err())
+            let mut ctx = core.context(tx).unwrap();
+            assert!(ctx.get_metadata(RepoSource::Local, Uuid::new_v4()).is_err())
         })
         .unwrap();
 }
@@ -349,8 +349,8 @@ fn get_metadata_local_falls_back_to_base() {
     let result = core
         .db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.get_metadata(RepoSource::Local, dir.id).unwrap()
+            let mut ctx = core.context(tx).unwrap();
+            ctx.get_metadata(RepoSource::Local, dir.id).unwrap()
         })
         .unwrap();
 
@@ -368,16 +368,16 @@ fn get_metadata_local_prefers_local() {
     let initial_doc = core
         .db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            let root = tx.root().unwrap().id;
-            let initial_doc = tx
+            let mut ctx = core.context(tx).unwrap();
+            let root = ctx.root().unwrap().id;
+            let initial_doc = ctx
                 .create_file(&core.config, "test", root, FileType::Folder)
                 .unwrap();
 
             let mut modified_doc = initial_doc.clone();
             modified_doc.decrypted_name += " 2";
 
-            tx.insert_metadatum(&core.config, RepoSource::Base, &modified_doc)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &modified_doc)
                 .unwrap();
 
             initial_doc
@@ -398,17 +398,17 @@ fn maybe_get_metadata() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            let root = tx.root().unwrap().id;
-            assert_matches!(tx.maybe_get_metadata(RepoSource::Local, root).unwrap(), Some(_));
-            assert_matches!(tx.maybe_get_metadata(RepoSource::Base, root).unwrap(), Some(_));
+            let mut ctx = core.context(tx).unwrap();
+            let root = ctx.root().unwrap().id;
+            assert_matches!(ctx.maybe_get_metadata(RepoSource::Local, root).unwrap(), Some(_));
+            assert_matches!(ctx.maybe_get_metadata(RepoSource::Base, root).unwrap(), Some(_));
             assert_matches!(
-                tx.maybe_get_metadata(RepoSource::Base, Uuid::new_v4())
+                ctx.maybe_get_metadata(RepoSource::Base, Uuid::new_v4())
                     .unwrap(),
                 None
             );
             assert_matches!(
-                tx.maybe_get_metadata(RepoSource::Local, Uuid::new_v4())
+                ctx.maybe_get_metadata(RepoSource::Local, Uuid::new_v4())
                     .unwrap(),
                 None
             );
@@ -426,10 +426,10 @@ fn insert_document() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"content")
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"content")
                 .unwrap();
         })
         .unwrap();
@@ -449,10 +449,10 @@ fn get_document() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"content")
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"content")
                 .unwrap();
             assert_eq!(
                 file_service::get_document(&core.config, RepoSource::Local, &document).unwrap(),
@@ -501,10 +501,10 @@ fn get_document_local_falls_back_to_base() {
     let result = core
         .db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"content")
                 .unwrap();
             file_service::get_document(&core.config, RepoSource::Local, &document).unwrap()
         })
@@ -526,12 +526,12 @@ fn get_document_local_prefers_local() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
                 .unwrap();
             assert_eq!(
                 file_service::get_document(&core.config, RepoSource::Local, &document).unwrap(),
@@ -556,10 +556,10 @@ fn maybe_get_document() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
                 .unwrap();
             assert_eq!(
                 file_service::maybe_get_document(&core.config, RepoSource::Local, &document)
@@ -603,12 +603,12 @@ fn new_idempotent() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
         })
         .unwrap();
@@ -618,8 +618,8 @@ fn new_idempotent() {
     assert!(core
         .db
         .transaction(|tx| {
-            let tx = core.context(tx).unwrap();
-            tx.get_all_metadata_changes().unwrap()
+            let ctx = core.context(tx).unwrap();
+            ctx.get_all_metadata_changes().unwrap()
         })
         .unwrap()[0]
         .old_parent_and_name
@@ -639,10 +639,10 @@ fn matching_base_and_local() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
         })
         .unwrap();
@@ -664,10 +664,10 @@ fn matching_local_and_base() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
         })
         .unwrap();
@@ -691,14 +691,14 @@ fn move_unmove() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
         })
         .unwrap();
@@ -713,8 +713,8 @@ fn move_unmove() {
     document.parent = folder.id;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
         })
         .unwrap()
         .unwrap();
@@ -724,8 +724,8 @@ fn move_unmove() {
     assert!(core
         .db
         .transaction(|tx| {
-            let tx = core.context(tx).unwrap();
-            tx.get_all_metadata_changes().unwrap()
+            let ctx = core.context(tx).unwrap();
+            ctx.get_all_metadata_changes().unwrap()
         })
         .unwrap()[0]
         .old_parent_and_name
@@ -762,14 +762,14 @@ fn rename_unrename() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
         })
         .unwrap();
@@ -784,8 +784,8 @@ fn rename_unrename() {
     document.decrypted_name = String::from("document 2");
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
         })
         .unwrap()
         .unwrap();
@@ -795,8 +795,8 @@ fn rename_unrename() {
     assert!(core
         .db
         .transaction(|tx| {
-            let tx = core.context(tx).unwrap();
-            tx.get_all_metadata_changes().unwrap()
+            let ctx = core.context(tx).unwrap();
+            ctx.get_all_metadata_changes().unwrap()
         })
         .unwrap()[0]
         .old_parent_and_name
@@ -809,8 +809,8 @@ fn rename_unrename() {
     document.decrypted_name = String::from("document");
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
         })
         .unwrap()
         .unwrap();
@@ -833,14 +833,14 @@ fn delete() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
         })
         .unwrap();
@@ -855,8 +855,8 @@ fn delete() {
     document.deleted = true;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
         })
         .unwrap()
         .unwrap();
@@ -866,8 +866,8 @@ fn delete() {
     assert!(core
         .db
         .transaction(|tx| {
-            let tx = core.context(tx).unwrap();
-            tx.get_all_metadata_changes().unwrap()
+            let ctx = core.context(tx).unwrap();
+            ctx.get_all_metadata_changes().unwrap()
         })
         .unwrap()[0]
         .old_parent_and_name
@@ -879,10 +879,10 @@ fn delete() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
     assert_document_count!(core, RepoSource::Base, 0);
@@ -900,14 +900,14 @@ fn multiple_metadata_edits() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
         })
         .unwrap();
@@ -925,12 +925,12 @@ fn multiple_metadata_edits() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document2)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document2)
                 .unwrap();
         })
         .unwrap();
@@ -952,8 +952,8 @@ fn document_edit() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
         })
         .unwrap()
         .unwrap();
@@ -967,8 +967,8 @@ fn document_edit() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
         })
         .unwrap()
         .unwrap();
@@ -978,8 +978,8 @@ fn document_edit() {
     assert_eq!(
         core.db
             .transaction(|tx| {
-                let mut tx = core.context(tx).unwrap();
-                tx.get_all_with_document_changes(&core.config).unwrap()
+                let mut ctx = core.context(tx).unwrap();
+                ctx.get_all_with_document_changes(&core.config).unwrap()
             })
             .unwrap()[0],
         document.id
@@ -999,8 +999,8 @@ fn document_edit_idempotent() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap()
         })
         .unwrap();
@@ -1013,12 +1013,12 @@ fn document_edit_idempotent() {
     assert_document_count!(core, RepoSource::Local, 0);
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1028,8 +1028,8 @@ fn document_edit_idempotent() {
     assert_eq!(
         core.db
             .transaction(|tx| {
-                let mut tx = core.context(tx).unwrap();
-                tx.get_all_with_document_changes(&core.config).unwrap()
+                let mut ctx = core.context(tx).unwrap();
+                ctx.get_all_with_document_changes(&core.config).unwrap()
             })
             .unwrap()[0],
         document.id
@@ -1049,10 +1049,10 @@ fn document_edit_revert() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1066,8 +1066,8 @@ fn document_edit_revert() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
         })
         .unwrap()
         .unwrap();
@@ -1077,8 +1077,8 @@ fn document_edit_revert() {
     assert_eq!(
         core.db
             .transaction(|tx| {
-                let mut tx = core.context(tx).unwrap();
-                tx.get_all_with_document_changes(&core.config).unwrap()
+                let mut ctx = core.context(tx).unwrap();
+                ctx.get_all_with_document_changes(&core.config).unwrap()
             })
             .unwrap()[0],
         document.id
@@ -1090,8 +1090,8 @@ fn document_edit_revert() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content")
         })
         .unwrap()
         .unwrap();
@@ -1112,10 +1112,10 @@ fn document_edit_manual_promote() {
     let document = files::create(FileType::Document, root.id, "document", &account.public_key());
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1128,8 +1128,8 @@ fn document_edit_manual_promote() {
     assert_document_count!(core, RepoSource::Local, 1);
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
                 .unwrap();
         })
         .unwrap();
@@ -1139,8 +1139,8 @@ fn document_edit_manual_promote() {
     assert_eq!(
         core.db
             .transaction(|tx| {
-                let mut tx = core.context(tx).unwrap();
-                tx.get_all_with_document_changes(&core.config).unwrap()
+                let mut ctx = core.context(tx).unwrap();
+                ctx.get_all_with_document_changes(&core.config).unwrap()
             })
             .unwrap()[0],
         document.id
@@ -1151,8 +1151,8 @@ fn document_edit_manual_promote() {
     assert_document_count!(core, RepoSource::Local, 1);
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content 2")
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content 2")
                 .unwrap();
         })
         .unwrap();
@@ -1178,16 +1178,16 @@ fn promote() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document2)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document2)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document2, b"document 2 content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document2, b"document 2 content")
                 .unwrap();
         })
         .unwrap();
@@ -1205,16 +1205,16 @@ fn promote() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document3)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document3)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document3, b"document 3 content")
+            ctx.insert_document(&core.config, RepoSource::Local, &document3, b"document 3 content")
                 .unwrap();
         })
         .unwrap();
@@ -1228,9 +1228,9 @@ fn promote() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.promote_metadata().unwrap();
-            tx.promote_documents(&core.config).unwrap();
+            let mut ctx = core.context(tx).unwrap();
+            ctx.promote_metadata().unwrap();
+            ctx.promote_documents(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1260,8 +1260,8 @@ fn prune_deleted() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
         })
         .unwrap();
@@ -1276,12 +1276,12 @@ fn prune_deleted() {
     document.deleted = true;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1305,10 +1305,10 @@ fn prune_deleted_document_edit() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1324,14 +1324,14 @@ fn prune_deleted_document_edit() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_document(&core.config, RepoSource::Local, &document, b"document content 2")
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1355,12 +1355,12 @@ fn prune_deleted_document_in_deleted_folder() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1375,12 +1375,12 @@ fn prune_deleted_document_in_deleted_folder() {
     folder.deleted = true;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1407,12 +1407,12 @@ fn prune_deleted_document_moved_from_deleted_folder() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1428,16 +1428,16 @@ fn prune_deleted_document_moved_from_deleted_folder() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1463,10 +1463,10 @@ fn prune_deleted_base_only() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1483,18 +1483,18 @@ fn prune_deleted_base_only() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document_local)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document_local)
                 .unwrap();
         })
         .unwrap();
     document.deleted = true;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1517,10 +1517,10 @@ fn prune_deleted_local_only() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1536,10 +1536,10 @@ fn prune_deleted_local_only() {
     document_deleted.deleted = true;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document_deleted)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document_deleted)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1563,12 +1563,12 @@ fn prune_deleted_document_moved_from_deleted_folder_local_only() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1586,14 +1586,14 @@ fn prune_deleted_document_moved_from_deleted_folder_local_only() {
     document_moved.parent = root.id;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &folder_deleted)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &folder_deleted)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &folder_deleted)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &folder_deleted)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document_moved)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document_moved)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1625,10 +1625,10 @@ fn prune_deleted_new_local_deleted_folder() {
     deleted_folder.deleted = true;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &deleted_folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &deleted_folder)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1649,10 +1649,10 @@ fn prune_deleted_new_local_deleted_folder_with_existing_moved_child() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1672,12 +1672,12 @@ fn prune_deleted_new_local_deleted_folder_with_existing_moved_child() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &deleted_folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &deleted_folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document_moved)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document_moved)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 
@@ -1700,10 +1700,10 @@ fn prune_deleted_new_local_deleted_folder_with_deleted_existing_moved_child() {
 
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Base, &document)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Base, &document)
                 .unwrap();
-            tx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
+            ctx.insert_document(&core.config, RepoSource::Base, &document, b"document content")
                 .unwrap();
         })
         .unwrap();
@@ -1723,12 +1723,12 @@ fn prune_deleted_new_local_deleted_folder_with_deleted_existing_moved_child() {
     document_moved_and_deleted.deleted = true;
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &deleted_folder)
+            let mut ctx = core.context(tx).unwrap();
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &deleted_folder)
                 .unwrap();
-            tx.insert_metadatum(&core.config, RepoSource::Local, &document_moved_and_deleted)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &document_moved_and_deleted)
                 .unwrap();
-            tx.prune_deleted(&core.config).unwrap();
+            ctx.prune_deleted(&core.config).unwrap();
         })
         .unwrap();
 

--- a/core/tests/integrity_tests.rs
+++ b/core/tests/integrity_tests.rs
@@ -34,6 +34,7 @@ fn test_no_account() {
 fn test_no_root() {
     let core = test_core_with_account();
     core.db.transaction(|tx| tx.base_metadata.clear()).unwrap();
+    core.db.transaction(|tx| tx.root.clear()).unwrap();
     assert_matches!(core.validate(), Err(NoRootFolder));
 }
 

--- a/core/tests/integrity_tests.rs
+++ b/core/tests/integrity_tests.rs
@@ -57,10 +57,10 @@ fn test_invalid_file_name_slash() {
     let doc = core.create_at_path(&path(&core, "document1.md")).unwrap();
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            let mut doc = tx.get_metadata(RepoSource::Local, doc.id).unwrap();
+            let mut ctx = core.context(tx).unwrap();
+            let mut doc = ctx.get_metadata(RepoSource::Local, doc.id).unwrap();
             doc.decrypted_name = String::from("na/me.md");
-            tx.insert_metadatum(&core.config, RepoSource::Local, &doc)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &doc)
                 .unwrap();
         })
         .unwrap();
@@ -74,10 +74,10 @@ fn test_invalid_file_name_empty() {
     let mut doc = core.create_at_path(&path(&core, "document1.md")).unwrap();
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            tx.get_metadata(RepoSource::Local, doc.id).unwrap();
+            let mut ctx = core.context(tx).unwrap();
+            ctx.get_metadata(RepoSource::Local, doc.id).unwrap();
             doc.decrypted_name = String::from("");
-            tx.insert_metadatum(&core.config, RepoSource::Local, &doc)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &doc)
                 .unwrap();
         })
         .unwrap();
@@ -130,10 +130,10 @@ fn test_name_conflict() {
     core.create_at_path(&path(&core, "document2.md")).unwrap();
     core.db
         .transaction(|tx| {
-            let mut tx = core.context(tx).unwrap();
-            let mut doc = tx.get_metadata(RepoSource::Local, doc.id).unwrap();
+            let mut ctx = core.context(tx).unwrap();
+            let mut doc = ctx.get_metadata(RepoSource::Local, doc.id).unwrap();
             doc.decrypted_name = String::from("document2.md");
-            tx.insert_metadatum(&core.config, RepoSource::Local, &doc)
+            ctx.insert_metadatum(&core.config, RepoSource::Local, &doc)
                 .unwrap();
         })
         .unwrap();

--- a/core/tests/integrity_tests.rs
+++ b/core/tests/integrity_tests.rs
@@ -57,6 +57,7 @@ fn test_invalid_file_name_slash() {
     let doc = core.create_at_path(&path(&core, "document1.md")).unwrap();
     core.db
         .transaction(|tx| {
+            let mut tx = core.context(tx).unwrap();
             let mut doc = tx.get_metadata(RepoSource::Local, doc.id).unwrap();
             doc.decrypted_name = String::from("na/me.md");
             tx.insert_metadatum(&core.config, RepoSource::Local, &doc)
@@ -73,6 +74,7 @@ fn test_invalid_file_name_empty() {
     let mut doc = core.create_at_path(&path(&core, "document1.md")).unwrap();
     core.db
         .transaction(|tx| {
+            let mut tx = core.context(tx).unwrap();
             tx.get_metadata(RepoSource::Local, doc.id).unwrap();
             doc.decrypted_name = String::from("");
             tx.insert_metadatum(&core.config, RepoSource::Local, &doc)
@@ -128,6 +130,7 @@ fn test_name_conflict() {
     core.create_at_path(&path(&core, "document2.md")).unwrap();
     core.db
         .transaction(|tx| {
+            let mut tx = core.context(tx).unwrap();
             let mut doc = tx.get_metadata(RepoSource::Local, doc.id).unwrap();
             doc.decrypted_name = String::from("document2.md");
             tx.insert_metadatum(&core.config, RepoSource::Local, &doc)

--- a/core/tests/new_account_tests.rs
+++ b/core/tests/new_account_tests.rs
@@ -12,9 +12,13 @@ fn random_account() -> Account {
 
 fn test_account(account: &Account) -> Result<NewAccountResponse, ApiError<NewAccountError>> {
     let root = files::create_root(account);
-    let root =
-        file_encryption_service::encrypt_metadatum(account, &root.decrypted_access_key, &root)
-            .unwrap();
+    let root = file_encryption_service::encrypt_metadatum(
+        account,
+        &account.public_key(),
+        &root.decrypted_access_key,
+        &root,
+    )
+    .unwrap();
     api_service::request(account, NewAccountRequest::new(account, &root))
 }
 #[test]

--- a/core/tests/sync_fuzzer.rs
+++ b/core/tests/sync_fuzzer.rs
@@ -206,7 +206,7 @@ impl Actions {
         |lhs, rhs| {
             if lhs.parent == lhs.id {
                 Ordering::Less
-            } else if rhs.id == rhs.parent {
+            } else if rhs.is_root() {
                 Ordering::Greater
             } else {
                 lhs.decrypted_name.cmp(&rhs.decrypted_name)

--- a/core/tests/sync_service_tests.rs
+++ b/core/tests/sync_service_tests.rs
@@ -3311,11 +3311,11 @@ fn deleted_path_is_released() {
 
     db1.db
         .transaction(|tx| {
-            let mut tx = db1.context(tx).unwrap();
+            let mut ctx = db1.context(tx).unwrap();
             let metadata =
-                &files::apply_delete(&(tx.get_all_metadata(RepoSource::Local).unwrap()), file1.id)
+                &files::apply_delete(&(ctx.get_all_metadata(RepoSource::Local).unwrap()), file1.id)
                     .unwrap();
-            tx.insert_metadatum(&db1.config, RepoSource::Local, metadata)
+            ctx.insert_metadatum(&db1.config, RepoSource::Local, metadata)
         })
         .unwrap()
         .unwrap();

--- a/core/tests/sync_service_tests.rs
+++ b/core/tests/sync_service_tests.rs
@@ -3311,12 +3311,11 @@ fn deleted_path_is_released() {
 
     db1.db
         .transaction(|tx| {
-            tx.insert_metadatum(
-                &db1.config,
-                RepoSource::Local,
-                &files::apply_delete(&tx.get_all_metadata(RepoSource::Local).unwrap(), file1.id)
-                    .unwrap(),
-            )
+            let mut tx = db1.context(tx).unwrap();
+            let metadata =
+                &files::apply_delete(&(tx.get_all_metadata(RepoSource::Local).unwrap()), file1.id)
+                    .unwrap();
+            tx.insert_metadatum(&db1.config, RepoSource::Local, metadata)
         })
         .unwrap()
         .unwrap();

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -174,10 +174,11 @@ pub async fn delete_account(
     });
     return_if_error!(tx);
 
-    let non_deleted_document_ids = all_files
+    let all_files = all_files
         .filter_not_deleted()
-        .map_err(|err| internal!("Could not get non-deleted files: {:?}", err))?
-        .documents();
+        .map_err(|err| internal!("Could not get non-deleted files: {:?}", err))?;
+
+    let non_deleted_document_ids = all_files.documents();
 
     for file in non_deleted_document_ids {
         let file = all_files

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -174,12 +174,15 @@ pub async fn delete_account(
     });
     return_if_error!(tx);
 
-    let non_deleted_document = all_files
+    let non_deleted_document_ids = all_files
         .filter_not_deleted()
         .map_err(|err| internal!("Could not get non-deleted files: {:?}", err))?
-        .filter_documents();
+        .documents();
 
-    for file in non_deleted_document.values() {
+    for file in non_deleted_document_ids {
+        let file = all_files
+            .find(file)
+            .map_err(|_| internal!("Could not find non-deleted file: {file}"))?;
         document_service::delete(context.server_state, file.id, file.content_version).await?;
     }
 

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -141,19 +141,20 @@ async fn apply_changes(
 
     check_uniqueness(con, &new_files).await?;
 
-    let implicitly_deleted_ids = metas
-        .filter_deleted()
+    let deleted_ids = metas
+        .deleted()
         .map_err(|_| Abort(ClientError(GetUpdatesRequired)))? // TODO this could be more descriptive
-        .into_iter()
-        .filter(|(_, f)| !f.deleted)
-        .map(|(_, f)| f.id);
+        .deleted;
 
-    for id in implicitly_deleted_ids {
-        if let Some(implicitly_deleted) = metas.maybe_find_mut(id) {
-            implicitly_deleted.deleted = true;
-            implicitly_deleted.metadata_version = now;
-            if implicitly_deleted.is_document() {
-                deleted_documents.push(implicitly_deleted.clone());
+    for id in deleted_ids {
+        if let Some(deleted) = metas.maybe_find_mut(id) {
+            // Check if implicitly deleted
+            if !deleted.deleted {
+                deleted.deleted = true;
+                deleted.metadata_version = now;
+                if deleted.is_document() {
+                    deleted_documents.push(deleted.clone());
+                }
             }
         }
     }

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -142,18 +142,18 @@ async fn apply_changes(
     check_uniqueness(con, &new_files).await?;
 
     let deleted_ids = metas
-        .deleted()
+        .deleted_status()
         .map_err(|_| Abort(ClientError(GetUpdatesRequired)))? // TODO this could be more descriptive
         .deleted;
 
     for id in deleted_ids {
-        if let Some(deleted) = metas.maybe_find_mut(id) {
+        if let Some(deleted_fm) = metas.maybe_find_mut(id) {
             // Check if implicitly deleted
-            if !deleted.deleted {
-                deleted.deleted = true;
-                deleted.metadata_version = now;
-                if deleted.is_document() {
-                    deleted_documents.push(deleted.clone());
+            if !deleted_fm.deleted {
+                deleted_fm.deleted = true;
+                deleted_fm.metadata_version = now;
+                if deleted_fm.is_document() {
+                    deleted_documents.push(deleted_fm.clone());
                 }
             }
         }

--- a/utils/dev/run-server.sh
+++ b/utils/dev/run-server.sh
@@ -43,4 +43,4 @@ mc mb -p --region=$FILES_DB_REGION filesdb/$FILES_DB_BUCKET
 mc policy set public filesdb/$FILES_DB_BUCKET
 
 echo "Compiling and running lockbook server..."
-cargo run
+cargo run --release


### PR DESCRIPTION
With @vvmirkovic's `HashMap` changes, we saw agorithmic speedups in some instances, but regressions in other areas. Those regressions are largely caused by `O(n)` operations being more expensive with `HashMap`s, probably due to the lack of cache locality. This PR addresses all regressions, now core is faster in all situations compared to vecs (10 metas or 2000 metas).

In this PR I profile core and:
+ Stop scanning for root when we know root's id already ([a12dad2](https://github.com/lockbook/lockbook/pull/1145/commits/a12dad26731dd7bc67dc8357cf2e18165abd7a95))
+ Deal in terms of ids instead of `cloning` file metadatas, rework some algorithms to be `O(n)` instead of `O(n2)` ([1e49ed8](https://github.com/lockbook/lockbook/pull/1145/commits/1e49ed8f4323987151145469d14a3ee6b01137ba))
+ Rework the deleted calculation to be faster, deal in terms of ids. Also, for specific allocation heavy functions (`stage`) offer an allocation free, consuming, alternative. Use that where possible ([dc8a69a](https://github.com/lockbook/lockbook/pull/1145/commits/dc8a69a882fdd2351d94d8b93cd7dbd1d5c810d0)).
+ Create a place for core to persist volatile state, currently used for caching crypto primitives. These are things we do not want to put in our Database, but we do not want to recompute them for every core call ([7e52102](https://github.com/lockbook/lockbook/pull/1145/commits/7e52102d9097339d0b20bdedf2e70ac71c8abe15))  

Things I'd like to do in a Separate PR:
+ Eliminate many `config` parameters, now that everything is `impl`'d on `RequestContext`. `RequestContext` contains it's own `config`.
+ Rework `tree.rs` to push allocations up to the user of the trait (functions will either return a reference, or an id).
+ Something that will happen when I'm a little more certain about how I want to go about it: `stage` is the workhorse of `tree.rs` and is used heavily in all parts of the stack. All the tree functions should be flexible in what types they operate on. They should be able to operate on `HashMap`s, or more unique data structures, perhaps like a `StagedMetadata` data structure. Which consumes two trees and retains all the information about sources and is able to answer questions about which file is present where. If the tree functions were then additionally implemented for `StagedMetadata`, `cycle` and `path_conflict` detection (and many other things) would be faster because they, themselves, wouldn't be constantly staging things.
+ Something that is unlikely to happen, but is interesting so I'll mention it anyways: [not all HashMap implementations are slow to iterate](https://crates.io/crates/indexmap) once the first two things are sorted out, if we're still seeking more gains we could look in this direction, in no case do we care about insertion order for any of our maps, if we can get gains by expressing that, could be good. I don't expect us to go down this route anytime soon.