### PR TITLE
core: impl From<UnexpectedError> for String

### DIFF
--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -46,6 +46,12 @@ impl Serialize for UnexpectedError {
     }
 }
 
+impl From<UnexpectedError> for String {
+    fn from(v: UnexpectedError) -> Self {
+        v.0
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(tag = "tag", content = "content")]
 pub enum Error<U: Serialize> {


### PR DESCRIPTION
Personally, I'm working in a lot of scenarios where errors are converted to `String`s. So if I'm calling a function that returns `UnexpectedError`, I can just `?` now instead of explicitly calling `.map_err(|err| err.0)?`.