### PR TITLE
linux: re-implement titlebar search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 name = "lb-api"
 version = "0.1.0"
 dependencies = [
+ "fuzzy-matcher",
  "lockbook-core",
  "lockbook-models",
  "uuid",

--- a/clients/linux/lb-api/Cargo.toml
+++ b/clients/linux/lb-api/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 lockbook-core = { path = "../../../core" }
 lockbook-models = { path = "../../../core/libs/models" }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
+fuzzy-matcher = "0.3.7"

--- a/clients/linux/lb-api/src/search.rs
+++ b/clients/linux/lb-api/src/search.rs
@@ -1,0 +1,65 @@
+use std::cmp::Ordering;
+use std::fmt;
+
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use uuid::Uuid;
+
+pub struct Searcher {
+    paths: Vec<(Uuid, String)>,
+    matcher: SkimMatcherV2,
+}
+
+impl Searcher {
+    pub fn new(paths: Vec<(Uuid, String)>) -> Self {
+        let matcher = SkimMatcherV2::default();
+
+        Self { paths, matcher }
+    }
+
+    pub fn search(&self, input: &str) -> Vec<SearchResultItem> {
+        if input.is_empty() {
+            return Vec::new();
+        }
+
+        let mut results = Vec::new();
+        for (id, path) in &self.paths {
+            if let Some(score) = self.matcher.fuzzy_match(path, input) {
+                results.push(SearchResultItem { id: *id, path: path.to_string(), score });
+            }
+        }
+        results.sort();
+        results
+    }
+}
+
+impl fmt::Debug for Searcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Searcher")
+            .field("paths", &self.paths)
+            .finish()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct SearchResultItem {
+    pub id: Uuid,
+    pub path: String,
+    pub score: i64,
+}
+
+impl Ord for SearchResultItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.score.cmp(&other.score) {
+            Ordering::Greater => Ordering::Less,
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => self.path.cmp(&other.path),
+        }
+    }
+}
+
+impl PartialOrd for SearchResultItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -8,7 +8,6 @@ impl super::App {
         let app = self.clone();
         self.titlebar.receive_search_ops(move |op| {
             match op {
-                ui::SearchOp::Update => app.update_search(),
                 ui::SearchOp::Exec => app.exec_search(),
             }
             glib::Continue(true)
@@ -17,25 +16,20 @@ impl super::App {
 
     pub fn open_search(&self) {
         self.titlebar.toggle_search_on();
-    }
 
-    fn update_search(&self) {
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
-        // Do the work of getting the search results in a separate thread.
-        let input = self.titlebar.search_input();
         let api = self.api.clone();
         std::thread::spawn(move || {
-            let result = api.search_file_paths(&input);
+            let result = api.searcher(Some(lb::Filter::DocumentsOnly));
             tx.send(result).unwrap();
         });
 
-        // Act on the search results when they arrive.
         let app = self.clone();
-        rx.attach(None, move |result| {
-            match result {
-                Ok(data) => app.repopulate_search_results(&data),
-                Err(err) => app.show_err_dialog(&format!("{:?}", err)),
+        rx.attach(None, move |searcher_result| {
+            match searcher_result {
+                Ok(searcher) => app.titlebar.set_searcher(searcher),
+                Err(msg) => app.show_err_dialog(&msg),
             }
             glib::Continue(false)
         });

--- a/clients/linux/src/app/imp_search.rs
+++ b/clients/linux/src/app/imp_search.rs
@@ -15,6 +15,7 @@ impl super::App {
     }
 
     pub fn open_search(&self) {
+        self.titlebar.set_searcher(None);
         self.titlebar.toggle_search_on();
 
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
@@ -28,7 +29,7 @@ impl super::App {
         let app = self.clone();
         rx.attach(None, move |searcher_result| {
             match searcher_result {
-                Ok(searcher) => app.titlebar.set_searcher(searcher),
+                Ok(searcher) => app.titlebar.set_searcher(Some(searcher)),
                 Err(msg) => app.show_err_dialog(&msg),
             }
             glib::Continue(false)

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -14,6 +14,7 @@ mod usage_tier;
 mod usage_upgrade;
 
 mod image_tab;
+mod search_field;
 mod tab;
 mod text_editor;
 mod toggle_group;
@@ -40,6 +41,7 @@ pub use usage_tier::UsageTier;
 pub use usage_upgrade::UpgradePaymentFlow;
 
 pub use image_tab::ImageTab;
+pub use search_field::SearchField;
 pub use tab::Tab;
 pub use text_editor::TextEditor;
 pub use toggle_group::ToggleGroup;

--- a/clients/linux/src/ui/search_field.rs
+++ b/clients/linux/src/ui/search_field.rs
@@ -1,0 +1,236 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk::gdk;
+use gtk::prelude::*;
+
+use crate::ui;
+use crate::ui::icons;
+
+#[derive(Clone, Debug, Default)]
+pub struct SearchField {
+    pub searcher: Rc<RefCell<Option<lb::Searcher>>>,
+    pub real_input: Rc<RefCell<String>>,
+    pub entry: gtk::Entry,
+    pub result_list_cntr: gtk::Box,
+    pub result_list: gtk::ListBox,
+    pub loading: gtk::Spinner,
+    no_results: gtk::Label,
+    on_activate: Rc<RefCell<Func>>,
+    on_blur: Rc<RefCell<Func>>,
+}
+
+impl SearchField {
+    pub fn init(&self) {
+        self.result_list.set_hexpand(true);
+        self.result_list.connect_row_activated({
+            let on_activate = self.on_activate.clone();
+            move |_, _| on_activate.borrow().0()
+        });
+
+        self.result_list.connect_row_selected({
+            let entry = self.entry.clone();
+            let real_input = self.real_input.clone();
+
+            move |_, maybe_row| {
+                if let Some(row) = maybe_row {
+                    let path = row
+                        .child()
+                        .unwrap()
+                        .downcast_ref::<ui::SearchRow>()
+                        .unwrap()
+                        .path();
+                    entry.set_text(&path);
+                    entry.select_region(0, -1);
+                } else {
+                    // fill in user entered text
+                    entry.set_text(&real_input.borrow());
+                    entry.set_position(-1);
+                }
+            }
+        });
+
+        let result_area_inner = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        result_area_inner.set_width_request(400);
+        result_area_inner.add_css_class("contents");
+        result_area_inner.append(&self.result_list);
+
+        self.result_list_cntr
+            .set_orientation(gtk::Orientation::Vertical);
+        self.result_list_cntr.add_css_class("view");
+        self.result_list_cntr.set_width_request(400);
+        self.result_list_cntr.set_halign(gtk::Align::Center);
+        self.result_list_cntr.set_valign(gtk::Align::Start);
+        self.result_list_cntr.append(&result_area_inner);
+
+        self.entry.set_width_request(400);
+        self.entry.set_primary_icon_name(Some(icons::SEARCH));
+
+        let focus = gtk::EventControllerFocus::new();
+        focus.connect_enter({
+            let result_list_cntr = self.result_list_cntr.clone();
+            move |_| result_list_cntr.show()
+        });
+        focus.connect_leave({
+            let result_list_cntr = self.result_list_cntr.clone();
+            move |_| result_list_cntr.hide()
+        });
+        self.entry.add_controller(&focus);
+
+        let search_key_press = gtk::EventControllerKey::new();
+        search_key_press.set_propagation_phase(gtk::PropagationPhase::Capture);
+        search_key_press.connect_key_pressed({
+            let this = self.clone();
+
+            move |_, key, code, _| {
+                if key == gdk::Key::Escape {
+                    this.on_blur.borrow().0();
+                    this.entry.set_text("");
+                    while let Some(row) = this.result_list.row_at_index(0) {
+                        this.result_list.remove(&row);
+                    }
+                    *this.searcher.borrow_mut() = None;
+                    this.loading.hide();
+                    this.no_results.hide();
+                } else if code == ARROW_DOWN {
+                    let next_index = this
+                        .result_list
+                        .selected_row()
+                        .map(|row| row.index() + 1)
+                        .unwrap_or_default();
+                    if next_index == 0 {
+                        *this.real_input.borrow_mut() = this.entry.text().to_string();
+                    }
+                    this.result_list
+                        .select_row(this.result_list.row_at_index(next_index).as_ref());
+                } else if code == ARROW_UP {
+                    let mut prev_index = this
+                        .result_list
+                        .selected_row()
+                        .map(|row| row.index() - 1)
+                        .unwrap_or(-2);
+                    if prev_index == -2 {
+                        prev_index = n_listbox_rows(&this.result_list) as i32;
+                        *this.real_input.borrow_mut() = this.entry.text().to_string();
+                    }
+                    this.result_list
+                        .select_row(this.result_list.row_at_index(prev_index).as_ref());
+                } else if code == ENTER {
+                    this.on_activate.borrow().0();
+                }
+                gtk::Inhibit(false)
+            }
+        });
+        search_key_press.connect_key_released({
+            let this = self.clone();
+
+            move |_, _, code, _| match code {
+                ALT_L | ALT_R | CTRL_L | CTRL_R | ARROW_DOWN | ARROW_UP | ENTER => {}
+                _ => this.run_search(),
+            }
+        });
+        self.entry.add_controller(&search_key_press);
+
+        self.loading.hide();
+        self.loading.set_halign(gtk::Align::Start);
+        self.loading.set_margin_top(8);
+        self.loading.set_margin_bottom(8);
+        self.loading.set_margin_start(8);
+        self.result_list_cntr.append(&self.loading);
+
+        self.no_results.hide();
+        self.no_results.set_halign(gtk::Align::Start);
+        self.no_results.set_markup("<i>No matches found!</i>");
+        self.no_results.set_margin_top(8);
+        self.no_results.set_margin_bottom(8);
+        self.no_results.set_margin_start(8);
+        self.result_list_cntr.append(&self.no_results);
+    }
+
+    pub fn set_searcher(&self, searcher: Option<lb::Searcher>) {
+        *self.searcher.borrow_mut() = searcher;
+        self.loading.hide();
+        if self.searcher.borrow().is_some() {
+            self.run_search();
+        }
+    }
+
+    pub fn connect_activate<F: Fn() + 'static>(&self, f: F) {
+        *self.on_activate.borrow_mut() = Func(Box::new(f))
+    }
+
+    pub fn connect_blur<F: Fn() + 'static>(&self, f: F) {
+        *self.on_blur.borrow_mut() = Func(Box::new(f))
+    }
+
+    pub fn run_search(&self) {
+        let input = self.entry.text().to_string();
+        if let Some(searcher) = &*self.searcher.borrow() {
+            // clear any stale results.
+            while let Some(row) = self.result_list.row_at_index(0) {
+                self.result_list.remove(&row);
+            }
+
+            // if a searcher is present but there's no input, show and do nothing.
+            if input.is_empty() {
+                self.no_results.hide();
+                return;
+            }
+
+            let results = searcher.search(&input);
+            if results.is_empty() {
+                self.no_results.show();
+            } else {
+                self.no_results.hide();
+                for res in results {
+                    let row = ui::SearchRow::new();
+                    row.set_data(res.id, &res.path);
+                    self.result_list.append(&row);
+                }
+            }
+
+            if self.loading.is_spinning() {
+                self.loading.stop();
+            }
+            self.loading.hide();
+        } else if !input.is_empty() {
+            if !self.loading.is_spinning() {
+                self.loading.start();
+            }
+            self.loading.show();
+        }
+    }
+}
+
+fn n_listbox_rows(list: &gtk::ListBox) -> u32 {
+    let mut n = 0;
+    loop {
+        if list.row_at_index(n + 1).is_none() {
+            break;
+        }
+        n += 1;
+    }
+    n as u32
+}
+
+struct Func(Box<dyn Fn()>);
+
+impl Default for Func {
+    fn default() -> Self {
+        Self(Box::new(|| {}))
+    }
+}
+
+impl std::fmt::Debug for Func {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Func").finish()
+    }
+}
+
+const ALT_L: u32 = 64;
+const ALT_R: u32 = 108;
+const CTRL_L: u32 = 37;
+const CTRL_R: u32 = 105;
+const ARROW_UP: u32 = 111;
+const ARROW_DOWN: u32 = 116;
+const ENTER: u32 = 36;

--- a/clients/linux/src/ui/titlebar.rs
+++ b/clients/linux/src/ui/titlebar.rs
@@ -1,13 +1,18 @@
+use std::cell::RefCell;
+
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
+
+use crate::ui;
+use crate::ui::icons;
 
 pub enum SearchOp {
     Exec,
 }
 
 glib::wrapper! {
-    pub struct Titlebar(ObjectSubclass<imp::Titlebar>)
+    pub struct Titlebar(ObjectSubclass<TitlebarImp>)
         @extends gtk::Widget, gtk::HeaderBar,
         @implements gtk::Accessible;
 }
@@ -26,24 +31,12 @@ impl Titlebar {
         if !btn.is_active() {
             btn.emit_clicked();
         } else {
-            self.imp().search_box.grab_focus();
+            self.imp().search_field.entry.grab_focus();
         }
     }
 
     pub fn set_searcher(&self, searcher: Option<lb::Searcher>) {
-        *self.imp().searcher.borrow_mut() = searcher;
-        if self.imp().searcher.borrow().is_some()
-            && !self.imp().search_box.text().to_string().is_empty()
-        {
-            imp::search(
-                &self.imp().searcher,
-                &self.imp().search_box,
-                &self.imp().result_list,
-                &self.imp().loading,
-                &self.imp().no_results,
-            );
-        }
-        self.imp().loading.hide();
+        self.imp().search_field.set_searcher(searcher);
     }
 
     pub fn clear_search(&self) {
@@ -51,9 +44,9 @@ impl Titlebar {
         if btn.is_active() {
             btn.emit_clicked();
         }
-        self.imp().search_box.set_text("");
-        *self.imp().real_input.borrow_mut() = "".to_string();
-        *self.imp().searcher.borrow_mut() = None;
+        self.imp().search_field.entry.set_text("");
+        *self.imp().search_field.real_input.borrow_mut() = "".to_string();
+        *self.imp().search_field.searcher.borrow_mut() = None;
     }
 
     pub fn receive_search_ops<F: FnMut(SearchOp) -> glib::Continue + 'static>(&self, f: F) {
@@ -61,11 +54,11 @@ impl Titlebar {
     }
 
     pub fn search_result_list(&self) -> gtk::ListBox {
-        self.imp().result_list.clone()
+        self.imp().search_field.result_list.clone()
     }
 
     pub fn search_result_area(&self) -> &gtk::Box {
-        &self.imp().result_list_cntr
+        &self.imp().search_field.result_list_cntr
     }
 
     pub fn base(&self) -> &gtk::HeaderBar {
@@ -79,326 +72,138 @@ impl Default for Titlebar {
     }
 }
 
-mod imp {
-    use std::cell::RefCell;
-    use std::rc::Rc;
+#[derive(Debug)]
+pub struct TitlebarImp {
+    title: gtk::Label,
 
-    use gtk::gdk;
-    use gtk::glib;
-    use gtk::prelude::*;
-    use gtk::subclass::prelude::*;
+    search_field: ui::SearchField,
+    search_op_rx: RefCell<Option<glib::Receiver<SearchOp>>>,
+    search_op_tx: glib::Sender<SearchOp>,
 
-    use crate::ui;
-    use crate::ui::icons;
+    app_menu_btn: gtk::MenuButton,
+    search_btn: gtk::ToggleButton,
 
-    use super::SearchOp;
+    center: gtk::Stack,
+    base: gtk::HeaderBar,
+}
 
-    #[derive(Debug, Default)]
-    pub struct Titlebar {
-        pub searcher: Rc<RefCell<Option<lb::Searcher>>>,
-
-        pub search_op_rx: RefCell<Option<glib::Receiver<SearchOp>>>,
-        pub search_op_tx: RefCell<Option<glib::Sender<SearchOp>>>,
-
-        pub app_menu_btn: gtk::MenuButton,
-        pub search_btn: gtk::ToggleButton,
-
-        pub title: gtk::Label,
-
-        pub real_input: Rc<RefCell<String>>,
-        pub search_box: gtk::Entry,
-        pub result_list_cntr: gtk::Box,
-        pub result_list: gtk::ListBox,
-        pub loading: gtk::Spinner,
-        pub no_results: gtk::Label,
-
-        pub center: gtk::Stack,
-        pub base: gtk::HeaderBar,
-    }
-
-    pub fn search(
-        maybe_searcher: &Rc<RefCell<Option<lb::Searcher>>>, search_box: &gtk::Entry,
-        result_list: &gtk::ListBox, loading: &gtk::Spinner, no_results: &gtk::Label,
-    ) {
-        if let Some(searcher) = &*maybe_searcher.borrow() {
-            // clear any stale results.
-            while let Some(row) = result_list.row_at_index(0) {
-                result_list.remove(&row);
-            }
-
-            // if a searcher is present but there's no input, show and do nothing.
-            let input = search_box.text().to_string();
-            if input.is_empty() {
-                no_results.hide();
-                return;
-            }
-
-            let results = searcher.search(&input);
-            if results.is_empty() {
-                no_results.show();
-            } else {
-                no_results.hide();
-                for res in results {
-                    let row = ui::SearchRow::new();
-                    row.set_data(res.id, &res.path);
-                    result_list.append(&row);
-                }
-            }
-
-            if loading.is_spinning() {
-                loading.stop();
-            }
-            loading.hide();
-        } else {
-            if !loading.is_spinning() {
-                loading.start();
-            }
-            loading.show();
+impl Default for TitlebarImp {
+    fn default() -> Self {
+        let (search_op_tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
+        Self {
+            title: Default::default(),
+            search_field: Default::default(),
+            search_op_rx: RefCell::new(Some(rx)),
+            search_op_tx,
+            app_menu_btn: Default::default(),
+            search_btn: Default::default(),
+            center: Default::default(),
+            base: Default::default(),
         }
     }
+}
 
-    #[glib::object_subclass]
-    impl ObjectSubclass for Titlebar {
-        const NAME: &'static str = "Titlebar";
-        type Type = super::Titlebar;
-        type ParentType = gtk::Widget;
+#[glib::object_subclass]
+impl ObjectSubclass for TitlebarImp {
+    const NAME: &'static str = "Titlebar";
+    type Type = super::Titlebar;
+    type ParentType = gtk::Widget;
 
-        fn class_init(c: &mut Self::Class) {
-            c.set_layout_manager_type::<gtk::BinLayout>();
-        }
+    fn class_init(c: &mut Self::Class) {
+        c.set_layout_manager_type::<gtk::BinLayout>();
     }
+}
 
-    impl ObjectImpl for Titlebar {
-        fn constructed(&self, obj: &Self::Type) {
-            self.parent_constructed(obj);
+impl ObjectImpl for TitlebarImp {
+    fn constructed(&self, obj: &Self::Type) {
+        self.parent_constructed(obj);
 
-            let (search_op_tx, search_op_rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
-            *self.search_op_tx.borrow_mut() = Some(search_op_tx.clone());
-            *self.search_op_rx.borrow_mut() = Some(search_op_rx);
+        self.title.set_markup("<b>Lockbook</b>");
 
-            self.app_menu_btn.set_icon_name("open-menu-symbolic");
-            self.app_menu_btn.set_popover(Some(&app_menu_popover()));
-
-            self.title.set_markup("<b>Lockbook</b>");
-
-            self.search_btn.set_icon_name(icons::SEARCH);
-            self.search_btn.connect_clicked({
-                let center = self.center.clone();
-                let search_box = self.search_box.clone();
-
-                move |search_btn| {
-                    let is_search = search_btn.is_active();
-                    if is_search {
-                        center.set_transition_type(gtk::StackTransitionType::SlideUp);
-                        center.set_visible_child_name("search");
-                        search_box.grab_focus();
-                    } else {
-                        center.set_transition_type(gtk::StackTransitionType::SlideDown);
-                        center.set_visible_child_name("title");
-                    }
-                    search_btn.set_active(is_search);
-                }
-            });
-
-            self.result_list.set_hexpand(true);
-            self.result_list.connect_row_activated({
-                let search_op_tx = search_op_tx.clone();
-                move |_, _| search_op_tx.send(SearchOp::Exec).unwrap()
-            });
-            self.result_list.connect_row_selected({
-                let search_box = self.search_box.clone();
-                let real_input = self.real_input.clone();
-
-                move |_, maybe_row| {
-                    if let Some(row) = maybe_row {
-                        let path = row
-                            .child()
-                            .unwrap()
-                            .downcast_ref::<ui::SearchRow>()
-                            .unwrap()
-                            .path();
-                        search_box.set_text(&path);
-                        search_box.select_region(0, -1);
-                    } else {
-                        // fill in user entered text
-                        search_box.set_text(&real_input.borrow());
-                        search_box.set_position(-1);
-                    }
-                }
-            });
-
-            let result_area_inner = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-            result_area_inner.set_width_request(400);
-            result_area_inner.add_css_class("contents");
-            result_area_inner.append(&self.result_list);
-
-            self.result_list_cntr
-                .set_orientation(gtk::Orientation::Vertical);
-            self.result_list_cntr.add_css_class("view");
-            self.result_list_cntr.set_width_request(400);
-            self.result_list_cntr.set_halign(gtk::Align::Center);
-            self.result_list_cntr.set_valign(gtk::Align::Start);
-            self.result_list_cntr.append(&result_area_inner);
-
-            self.search_box.set_width_request(400);
-            self.search_box.set_primary_icon_name(Some(icons::SEARCH));
-
-            let focus = gtk::EventControllerFocus::new();
-            focus.connect_enter({
-                let result_list_cntr = self.result_list_cntr.clone();
-                move |_| result_list_cntr.show()
-            });
-            focus.connect_leave({
-                let result_list_cntr = self.result_list_cntr.clone();
-                move |_| result_list_cntr.hide()
-            });
-            self.search_box.add_controller(&focus);
-
-            let search_key_press = gtk::EventControllerKey::new();
-            search_key_press.set_propagation_phase(gtk::PropagationPhase::Capture);
-            search_key_press.connect_key_pressed({
-                let search_box = self.search_box.clone();
-                let search_btn = self.search_btn.clone();
-                let result_list = self.result_list.clone();
-                let real_input = self.real_input.clone();
-                let searcher = self.searcher.clone();
-                let loading = self.loading.clone();
-                let no_results = self.no_results.clone();
-
-                move |_, key, code, _| {
-                    if key == gdk::Key::Escape {
-                        search_btn.grab_focus();
-                        search_btn.emit_clicked();
-                        search_box.set_text("");
-                        while let Some(row) = result_list.row_at_index(0) {
-                            result_list.remove(&row);
-                        }
-                        *searcher.borrow_mut() = None;
-                        loading.hide();
-                        no_results.hide();
-                    } else if code == ARROW_DOWN {
-                        let next_index = result_list
-                            .selected_row()
-                            .map(|row| row.index() + 1)
-                            .unwrap_or_default();
-                        if next_index == 0 {
-                            *real_input.borrow_mut() = search_box.text().to_string();
-                        }
-                        result_list.select_row(result_list.row_at_index(next_index).as_ref());
-                    } else if code == ARROW_UP {
-                        let mut prev_index = result_list
-                            .selected_row()
-                            .map(|row| row.index() - 1)
-                            .unwrap_or(-2);
-                        if prev_index == -2 {
-                            prev_index = n_listbox_rows(&result_list) as i32;
-                            *real_input.borrow_mut() = search_box.text().to_string();
-                        }
-                        result_list.select_row(result_list.row_at_index(prev_index).as_ref());
-                    } else if code == ENTER {
-                        search_op_tx.send(SearchOp::Exec).unwrap();
-                    }
-                    gtk::Inhibit(false)
-                }
-            });
-            search_key_press.connect_key_released({
-                let search_box = self.search_box.clone();
-                let maybe_searcher = self.searcher.clone();
-                let result_list = self.result_list.clone();
-                let loading = self.loading.clone();
-                let no_results = self.no_results.clone();
-
-                move |_, _, code, _| match code {
-                    ALT_L | ALT_R | CTRL_L | CTRL_R | ARROW_DOWN | ARROW_UP | ENTER => {}
-                    _ => search(&maybe_searcher, &search_box, &result_list, &loading, &no_results),
-                }
-            });
-            self.search_box.add_controller(&search_key_press);
-
-            self.loading.hide();
-            self.loading.set_halign(gtk::Align::Start);
-            self.loading.set_margin_top(8);
-            self.loading.set_margin_bottom(8);
-            self.loading.set_margin_start(8);
-            self.result_list_cntr.append(&self.loading);
-
-            self.no_results.hide();
-            self.no_results.set_halign(gtk::Align::Start);
-            self.no_results.set_markup("<i>No matches found!</i>");
-            self.no_results.set_margin_top(8);
-            self.no_results.set_margin_bottom(8);
-            self.no_results.set_margin_start(8);
-            self.result_list_cntr.append(&self.no_results);
-
-            self.center.set_transition_duration(350);
-            self.center.add_named(&self.title, Some("title"));
-            self.center.add_named(&self.search_box, Some("search"));
-
-            self.base.set_title_widget(Some(&self.center));
-            self.base.pack_end(&self.app_menu_btn);
-            self.base.pack_end(&self.search_btn);
-            self.base.set_parent(obj);
-        }
-
-        fn dispose(&self, _obj: &Self::Type) {
-            self.base.unparent();
-        }
-    }
-
-    impl WidgetImpl for Titlebar {}
-
-    fn app_menu_popover() -> gtk::Popover {
-        let p = gtk::Popover::new();
-
-        let btn_sync = ui::MenuItemBuilder::new()
-            .action("app.sync")
-            .icon(icons::SYNC)
-            .label("Sync")
-            .accel("Alt - S")
-            .popsdown(&p)
-            .build();
-
-        let btn_prefs = ui::MenuItemBuilder::new()
-            .action("app.settings")
-            .icon(icons::SETTINGS)
-            .label("Settings")
-            .accel("Ctrl - ,")
-            .popsdown(&p)
-            .build();
-
-        let btn_about = ui::MenuItemBuilder::new()
-            .action("app.about")
-            .icon(icons::ABOUT)
-            .label("About")
-            .popsdown(&p)
-            .build();
-
-        let app_menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        app_menu.append(&btn_sync);
-        app_menu.append(&btn_prefs);
-        app_menu.append(&btn_about);
-
-        p.set_halign(gtk::Align::Center);
-        p.set_child(Some(&app_menu));
-        p
-    }
-
-    fn n_listbox_rows(list: &gtk::ListBox) -> u32 {
-        let mut n = 0;
-        loop {
-            if list.row_at_index(n + 1).is_none() {
-                break;
+        self.search_field.init();
+        self.search_field.connect_activate({
+            let ch = self.search_op_tx.clone();
+            move || ch.send(SearchOp::Exec).unwrap()
+        });
+        self.search_field.connect_blur({
+            let search_btn = self.search_btn.clone();
+            move || {
+                search_btn.grab_focus();
+                search_btn.emit_clicked();
             }
-            n += 1;
-        }
-        n as u32
+        });
+
+        self.app_menu_btn.set_icon_name("open-menu-symbolic");
+        self.app_menu_btn.set_popover(Some(&app_menu_popover()));
+
+        self.search_btn.set_icon_name(icons::SEARCH);
+        self.search_btn.connect_clicked({
+            let center = self.center.clone();
+
+            move |search_btn| {
+                let is_search = search_btn.is_active();
+                if is_search {
+                    center.set_transition_type(gtk::StackTransitionType::SlideUp);
+                    center.set_visible_child_name("search");
+                    center.activate_action("app.open-search", None).unwrap();
+                } else {
+                    center.set_transition_type(gtk::StackTransitionType::SlideDown);
+                    center.set_visible_child_name("title");
+                }
+                search_btn.set_active(is_search);
+            }
+        });
+
+        self.center.set_transition_duration(350);
+        self.center.add_named(&self.title, Some("title"));
+        self.center
+            .add_named(&self.search_field.entry, Some("search"));
+
+        self.base.set_title_widget(Some(&self.center));
+        self.base.pack_end(&self.app_menu_btn);
+        self.base.pack_end(&self.search_btn);
+        self.base.set_parent(obj);
     }
 
-    const ALT_L: u32 = 64;
-    const ALT_R: u32 = 108;
-    const CTRL_L: u32 = 37;
-    const CTRL_R: u32 = 105;
-    const ARROW_UP: u32 = 111;
-    const ARROW_DOWN: u32 = 116;
-    const ENTER: u32 = 36;
+    fn dispose(&self, _obj: &Self::Type) {
+        self.base.unparent();
+    }
+}
+
+impl WidgetImpl for TitlebarImp {}
+
+fn app_menu_popover() -> gtk::Popover {
+    let p = gtk::Popover::new();
+
+    let btn_sync = ui::MenuItemBuilder::new()
+        .action("app.sync")
+        .icon(icons::SYNC)
+        .label("Sync")
+        .accel("Alt - S")
+        .popsdown(&p)
+        .build();
+
+    let btn_prefs = ui::MenuItemBuilder::new()
+        .action("app.settings")
+        .icon(icons::SETTINGS)
+        .label("Settings")
+        .accel("Ctrl - ,")
+        .popsdown(&p)
+        .build();
+
+    let btn_about = ui::MenuItemBuilder::new()
+        .action("app.about")
+        .icon(icons::ABOUT)
+        .label("About")
+        .popsdown(&p)
+        .build();
+
+    let app_menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    app_menu.append(&btn_sync);
+    app_menu.append(&btn_prefs);
+    app_menu.append(&btn_about);
+
+    p.set_halign(gtk::Align::Center);
+    p.set_child(Some(&app_menu));
+    p
 }

--- a/core/src/service/path_service.rs
+++ b/core/src/service/path_service.rs
@@ -166,7 +166,7 @@ impl Tx<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Filter {
     DocumentsOnly,
     FoldersOnly,


### PR DESCRIPTION
Re-implement how files paths are searched. Instead of using core search service on each keystroke, the filtered paths are gathered once at the beginning.

Also, only search docs via titlebar, so closes #1130.