### PR TITLE
infra: improve run-server util script

### DIFF
--- a/utils/dev/run-server.sh
+++ b/utils/dev/run-server.sh
@@ -9,7 +9,7 @@ command -V mc
 projRoot=`git rev-parse --show-toplevel`
 
 cd $projRoot/server/server
-cargo check
+cargo build $@
 
 cd $projRoot
 if [ -z "$DATA_DIR" ]; then


### PR DESCRIPTION
This will run `cargo check` before starting `minio` and `redis-server`.

Additionally, an environment variable (`DATA_DIR`) is used for the data directory, and all script args are passed to `cargo run`, so running release in a directory named "__datadir" can be done with:
```shell
DATA_DIR="./__datadir" ./utils/dev/run-server.sh --release
```