### PR TITLE
core,clients: remove NoAccount variants on most error enums

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/App.kt
+++ b/clients/android/app/src/main/java/app/lockbook/App.kt
@@ -79,9 +79,7 @@ class ForegroundBackgroundObserver(val context: Context) : DefaultLifecycleObser
         when (val getAccountResult = CoreModel.getAccount()) {
             is Ok -> onSuccess()
             is Err -> when (val error = getAccountResult.error) {
-                is CoreError.UiError -> when (error.content) {
-                    GetAccountError.NoAccount -> {}
-                }
+                is CoreError.UiError -> {}
                 is CoreError.Unexpected -> Timber.e("Error: ${error.content}")
             }
         }
@@ -99,7 +97,6 @@ class SyncWork(appContext: Context, workerParams: WorkerParameters) :
                 is CoreError.UiError -> when (error.content) {
                     SyncAllError.ClientUpdateRequired -> "Client update required."
                     SyncAllError.CouldNotReachServer -> "Could not reach server."
-                    SyncAllError.NoAccount -> "No account."
                 }
                 is CoreError.Unexpected -> {
                     "Unable to sync all files: ${error.content}"

--- a/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/Errors.kt
@@ -96,13 +96,11 @@ enum class InitError : UiCoreError
 
 @Serializable
 enum class GetUsageError : UiCoreError {
-    NoAccount,
     CouldNotReachServer,
     ClientUpdateRequired;
 
     override fun toLbError(res: Resources): LbError {
         return when (this) {
-            NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
             CouldNotReachServer -> LbError.newUserError(getString(res, R.string.could_not_reach_server))
             ClientUpdateRequired -> LbError.newUserError(getString(res, R.string.client_update_required))
         }
@@ -178,12 +176,10 @@ enum class GetRootError : UiCoreError {
 
 @Serializable
 enum class WriteToDocumentError : UiCoreError {
-    NoAccount,
     FileDoesNotExist,
     FolderTreatedAsDocument;
 
     override fun toLbError(res: Resources): LbError = when (this) {
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         FileDoesNotExist -> LbError.newUserError(getString(res, R.string.file_does_not_exist))
         FolderTreatedAsDocument -> LbError.newUserError(getString(res, R.string.folder_treated_as_document))
     }
@@ -191,7 +187,6 @@ enum class WriteToDocumentError : UiCoreError {
 
 @Serializable
 enum class CreateFileError : UiCoreError {
-    NoAccount,
     DocumentTreatedAsFolder,
     CouldNotFindAParent,
     FileNameNotAvailable,
@@ -199,7 +194,6 @@ enum class CreateFileError : UiCoreError {
     FileNameEmpty;
 
     override fun toLbError(res: Resources): LbError = when (this) {
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         DocumentTreatedAsFolder -> LbError.newUserError(getString(res, R.string.document_treated_as_folder))
         CouldNotFindAParent -> LbError.newUserError(getString(res, R.string.could_not_find_a_parent))
         FileNameNotAvailable -> LbError.newUserError(getString(res, R.string.file_name_not_available))
@@ -234,12 +228,10 @@ enum class FileDeleteError : UiCoreError {
 @Serializable
 enum class ReadDocumentError : UiCoreError {
     TreatedFolderAsDocument,
-    NoAccount,
     FileDoesNotExist;
 
     override fun toLbError(res: Resources): LbError = when (this) {
         TreatedFolderAsDocument -> LbError.newUserError(getString(res, R.string.folder_treated_as_document))
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         FileDoesNotExist -> LbError.newUserError(getString(res, R.string.file_does_not_exist))
     }
 }
@@ -247,14 +239,12 @@ enum class ReadDocumentError : UiCoreError {
 @Serializable
 enum class SaveDocumentToDiskError : UiCoreError {
     TreatedFolderAsDocument,
-    NoAccount,
     FileDoesNotExist,
     BadPath,
     FileAlreadyExistsInDisk;
 
     override fun toLbError(res: Resources): LbError = when (this) {
         TreatedFolderAsDocument -> LbError.newUserError(getString(res, R.string.folder_treated_as_document))
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         FileDoesNotExist -> LbError.newUserError(getString(res, R.string.file_does_not_exist))
         BadPath -> LbError.newUserError(getString(res, R.string.bad_path))
         FileAlreadyExistsInDisk -> LbError.newUserError(getString(res, R.string.file_already_exists_on_disk))
@@ -265,7 +255,6 @@ enum class SaveDocumentToDiskError : UiCoreError {
 enum class ExportDrawingToDiskError : UiCoreError {
     FolderTreatedAsDrawing,
     FileDoesNotExist,
-    NoAccount,
     InvalidDrawing,
     BadPath,
     FileAlreadyExistsInDisk;
@@ -273,7 +262,6 @@ enum class ExportDrawingToDiskError : UiCoreError {
     override fun toLbError(res: Resources): LbError = when (this) {
         FolderTreatedAsDrawing -> LbError.newUserError(getString(res, R.string.folder_treated_as_drawing))
         FileDoesNotExist -> LbError.newUserError(getString(res, R.string.file_does_not_exist))
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         InvalidDrawing -> LbError.newUserError(getString(res, R.string.invalid_drawing))
         BadPath -> LbError.newUserError(getString(res, R.string.bad_path))
         FileAlreadyExistsInDisk -> LbError.newUserError(getString(res, R.string.file_already_exists_on_disk))
@@ -299,7 +287,6 @@ enum class RenameFileError : UiCoreError {
 
 @Serializable
 enum class MoveFileError : UiCoreError {
-    NoAccount,
     FileDoesNotExist,
     DocumentTreatedAsFolder,
     TargetParentDoesNotExist,
@@ -308,7 +295,6 @@ enum class MoveFileError : UiCoreError {
     FolderMovedIntoItself;
 
     override fun toLbError(res: Resources): LbError = when (this) {
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         FileDoesNotExist -> LbError.newUserError(getString(res, R.string.file_does_not_exist))
         DocumentTreatedAsFolder -> LbError.newUserError(getString(res, R.string.document_treated_as_folder))
         TargetParentDoesNotExist -> LbError.newUserError(getString(res, R.string.could_not_find_a_parent))
@@ -320,12 +306,10 @@ enum class MoveFileError : UiCoreError {
 
 @Serializable
 enum class SyncAllError : UiCoreError {
-    NoAccount,
     CouldNotReachServer,
     ClientUpdateRequired;
 
     override fun toLbError(res: Resources): LbError = when (this) {
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         CouldNotReachServer -> LbError.newUserError(getString(res, R.string.could_not_reach_server))
         ClientUpdateRequired -> LbError.newUserError(getString(res, R.string.client_update_required))
     }
@@ -333,12 +317,10 @@ enum class SyncAllError : UiCoreError {
 
 @Serializable
 enum class CalculateWorkError : UiCoreError {
-    NoAccount,
     CouldNotReachServer,
     ClientUpdateRequired;
 
     override fun toLbError(res: Resources): LbError = when (this) {
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         CouldNotReachServer -> LbError.newUserError(getString(res, R.string.could_not_reach_server))
         ClientUpdateRequired -> LbError.newUserError(getString(res, R.string.client_update_required))
     }
@@ -393,13 +375,11 @@ enum class GetSubscriptionInfoError : UiCoreError {
 
 @Serializable
 enum class ExportFileError : UiCoreError {
-    NoAccount,
     ParentDoesNotExist,
     DiskPathTaken,
     DiskPathInvalid;
 
     override fun toLbError(res: Resources): LbError = when (this) {
-        NoAccount -> LbError.newUserError(getString(res, R.string.no_account))
         ParentDoesNotExist -> LbError.newUserError(getString(res, R.string.could_not_find_a_parent))
         // Used basic errors since specific errors are not useful to the user
         DiskPathTaken -> LbError.newUserError(getString(res, R.string.basic_error))

--- a/clients/android/app/src/test/java/app/lockbook/CreateFileTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/CreateFileTest.kt
@@ -99,13 +99,4 @@ class CreateFileTest {
             FileType.Folder
         ).unwrapErrorType(CreateFileError.FileNameNotAvailable)
     }
-
-    @Test
-    fun createFileNoAccount() {
-        CoreModel.createFile(
-            generateId(),
-            generateAlphaString(),
-            FileType.Document
-        ).unwrapErrorType(CreateFileError.NoAccount)
-    }
 }

--- a/clients/android/app/src/test/java/app/lockbook/ExportDrawingToDiskTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/ExportDrawingToDiskTest.kt
@@ -46,15 +46,6 @@ class ExportDrawingToDiskTest {
     }
 
     @Test
-    fun exportDrawingToDiskNoAccount() {
-        CoreModel.exportDrawingToDisk(
-            generateId(),
-            SupportedImageFormats.Jpeg,
-            generateFakeRandomPath()
-        ).unwrapErrorType(ExportDrawingToDiskError.NoAccount)
-    }
-
-    @Test
     fun exportDrawingToDiskFileDoesNotExist() {
         CoreModel.createAccount(generateAlphaString()).unwrapOk()
 

--- a/clients/android/app/src/test/java/app/lockbook/GetUsageTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/GetUsageTest.kt
@@ -2,7 +2,6 @@ package app.lockbook
 
 import app.lockbook.model.CoreModel
 import app.lockbook.util.Config
-import app.lockbook.util.GetUsageError
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -26,10 +25,5 @@ class GetUsageTest {
         CoreModel.createAccount(generateAlphaString()).unwrapOk()
 
         CoreModel.getUsage().unwrapOk()
-    }
-
-    @Test
-    fun getUsageNoAccount() {
-        CoreModel.getUsage().unwrapErrorType(GetUsageError.NoAccount)
     }
 }

--- a/clients/apple/Shared/Stateful Logic/SyncService.swift
+++ b/clients/apple/Shared/Stateful Logic/SyncService.swift
@@ -59,8 +59,6 @@ class SyncService: ObservableObject {
                         switch uiError {
                         case .CouldNotReachServer:
                             self.offline = true
-                        case .NoAccount:
-                            print("No account yet, but tried to sync, ignoring")
                         case .ClientUpdateRequired:
                             self.upgrade = true
                         }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FfiError.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/FfiError.swift
@@ -95,7 +95,6 @@ public enum GetAccountError: String, UiError {
 public enum CreateFileAtPathError: String, UiError {
     case DocumentTreatedAsFolder
     case FileAlreadyExists
-    case NoAccount
     case NoRoot
     case PathContainsEmptyFile
     case PathDoesntStartWithRoot
@@ -104,7 +103,6 @@ public enum CreateFileAtPathError: String, UiError {
 public enum WriteToDocumentError: String, UiError {
     case FileDoesNotExist
     case FolderTreatedAsDocument
-    case NoAccount
 }
 
 public enum CreateFileError: String, UiError {
@@ -113,7 +111,6 @@ public enum CreateFileError: String, UiError {
     case FileNameContainsSlash
     case FileNameEmpty
     case FileNameNotAvailable
-    case NoAccount
 }
 
 public enum GetRootError: String, UiError {
@@ -138,7 +135,6 @@ public enum GetFileByPathError: String, UiError {
 
 public enum ReadDocumentError: String, UiError {
     case FileDoesNotExist
-    case NoAccount
     case TreatedFolderAsDocument
 }
 
@@ -163,18 +159,15 @@ public enum MoveFileError: String, UiError {
     case DocumentTreatedAsFolder
     case FileDoesNotExist
     case FolderMovedIntoItself
-    case NoAccount
     case TargetParentDoesNotExist
     case TargetParentHasChildNamedThat
 }
 
 public enum SyncAllError: String, UiError {
-    case NoAccount
     case ClientUpdateRequired
     case CouldNotReachServer
 }
 public enum CalculateWorkError: String, UiError {
-    case NoAccount
     case CouldNotReachServer
     case ClientUpdateRequired
 }
@@ -182,7 +175,6 @@ public enum GetLastSyncedError: String, UiError {
     case Stub
 }
 public enum GetUsageError: String, UiError {
-    case NoAccount
     case CouldNotReachServer
     case ClientUpdateRequired
 }
@@ -196,14 +188,12 @@ public enum GetLocalChangesError: String, UiError {
 }
 
 public enum GetDrawingError: String, UiError {
-    case NoAccount
     case FolderTreatedAsDrawing
     case InvalidDrawing
     case FileDoesNotExist
 }
 
 public enum SaveDrawingError: String, UiError {
-    case NoAccount
     case FileDoesNotExist
     case FolderTreatedAsDrawing
     case InvalidDrawing
@@ -212,6 +202,5 @@ public enum SaveDrawingError: String, UiError {
 public enum ExportDrawingError: String, UiError {
     case FolderTreatedAsDrawing
     case FileDoesNotExist
-    case NoAccount
     case InvalidDrawing
 }

--- a/clients/cli/src/backup.rs
+++ b/clients/cli/src/backup.rs
@@ -52,7 +52,6 @@ pub fn backup(core: &Core) -> Result<(), CliError> {
 
     core.export_file(root.id, backup_dir.clone(), false, None)
         .map_err(|err| match err {
-            LbError::UiError(ExportFileError::NoAccount) => CliError::no_account(),
             LbError::UiError(ExportFileError::DiskPathTaken) => {
                 CliError::os_file_collision(backup_dir)
             }

--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -30,7 +30,6 @@ impl From<LbError<GetUsageError>> for CliError {
     fn from(e: LbError<GetUsageError>) -> Self {
         match e {
             LbError::UiError(err) => match err {
-                GetUsageError::NoAccount => Self::no_account(),
                 GetUsageError::CouldNotReachServer => Self::network_issue(),
                 GetUsageError::ClientUpdateRequired => Self::update_required(),
             },

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -37,7 +37,6 @@ pub fn copy(core: &Core, disk_paths: &[PathBuf], lb_path: &str) -> Result<(), Cl
     core.import_files(disk_paths, dest.id, &update_status)
         .map_err(|err| match err {
             LbError::UiError(err) => match err {
-                ImportFileError::NoAccount => CliError::no_account(),
                 ImportFileError::ParentDoesNotExist => CliError::file_not_found(lb_path),
                 ImportFileError::DocumentTreatedAsFolder => CliError::doc_treated_as_dir(lb_path),
             },
@@ -60,7 +59,6 @@ fn get_or_create_file(core: &Core, lb_path: &str) -> Result<DecryptedFileMetadat
         core.create_at_path(lb_path).map_err(|err| match err {
             LbError::UiError(err) => match err {
                 CreateFileAtPathError::FileAlreadyExists => CliError::file_exists(lb_path),
-                CreateFileAtPathError::NoAccount => CliError::no_account(),
                 CreateFileAtPathError::NoRoot => CliError::no_root(),
                 CreateFileAtPathError::PathContainsEmptyFile => {
                     CliError::path_has_empty_file(lb_path)

--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -26,7 +26,6 @@ pub fn edit(core: &Core, lb_path: &str) -> Result<(), CliError> {
             LbError::UiError(ReadDocumentError::TreatedFolderAsDocument) => {
                 CliError::dir_treated_as_doc(lb_path)
             }
-            LbError::UiError(ReadDocumentError::NoAccount) => CliError::no_account(),
             LbError::UiError(ReadDocumentError::FileDoesNotExist) | LbError::Unexpected(_) => {
                 CliError::unexpected(format!("reading encrypted doc: {:#?}", err))
             }

--- a/clients/cli/src/export_drawing.rs
+++ b/clients/cli/src/export_drawing.rs
@@ -28,7 +28,6 @@ pub fn export_drawing(core: &Core, lb_path: &str, format: &str) -> Result<(), Cl
         .map_err(|err| match err {
             LbError::UiError(err) => match err {
                 ExportDrawingError::FolderTreatedAsDrawing => CliError::dir_treated_as_doc(lb_path),
-                ExportDrawingError::NoAccount => CliError::no_account(),
                 ExportDrawingError::InvalidDrawing => {
                     CliError::invalid_drawing(file_metadata.decrypted_name)
                 }

--- a/clients/cli/src/move_file.rs
+++ b/clients/cli/src/move_file.rs
@@ -21,7 +21,6 @@ pub fn move_file(core: &Core, path1: &str, path2: &str) -> Result<(), CliError> 
     core.move_file(file_metadata.id, target_file_metadata.id)
         .map_err(|err| match err {
             LbError::UiError(err) => match err {
-                MoveFileError::NoAccount => CliError::no_account(),
                 MoveFileError::CannotMoveRoot => CliError::no_root_ops("move"),
                 MoveFileError::FileDoesNotExist => CliError::file_not_found(path1),
                 MoveFileError::TargetParentDoesNotExist => CliError::file_not_found(path2),

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -17,7 +17,6 @@ pub fn new(core: &Core, lb_path: &str) -> Result<(), CliError> {
 
     let file_metadata = core.create_at_path(lb_path).map_err(|err| match err {
         LbError::UiError(err) => match err {
-            CreateFileAtPathError::NoAccount => CliError::no_account(),
             CreateFileAtPathError::NoRoot => CliError::no_root(),
             CreateFileAtPathError::FileAlreadyExists => CliError::file_exists(lb_path),
             CreateFileAtPathError::PathContainsEmptyFile => CliError::path_has_empty_file(lb_path),

--- a/clients/cli/src/status.rs
+++ b/clients/cli/src/status.rs
@@ -11,7 +11,6 @@ pub fn status(core: &Core) -> Result<(), CliError> {
 
     let work = core.calculate_work().map_err(|err| match err {
         LbError::UiError(err) => match err {
-            CalculateWorkError::NoAccount => CliError::no_account(),
             CalculateWorkError::CouldNotReachServer => CliError::network_issue(),
             CalculateWorkError::ClientUpdateRequired => CliError::update_required(),
         },

--- a/clients/cli/src/sync.rs
+++ b/clients/cli/src/sync.rs
@@ -21,7 +21,6 @@ pub fn sync(core: &Core) -> Result<(), CliError> {
     core.sync(Some(Box::new(closure)))
         .map_err(|err| match err {
             LbError::UiError(err) => match err {
-                SyncAllError::NoAccount => CliError::no_account(),
                 SyncAllError::ClientUpdateRequired => CliError::update_required(),
                 SyncAllError::CouldNotReachServer => CliError::network_issue(),
             },

--- a/clients/cli/src/utils.rs
+++ b/clients/cli/src/utils.rs
@@ -163,7 +163,6 @@ pub fn save_temp_file_contents<P: AsRef<Path>>(
 
     core.write_document(id, &secret).map_err(|err| match err {
         LbError::UiError(err) => match err {
-            WriteToDocumentError::NoAccount => CliError::no_account(),
             WriteToDocumentError::FileDoesNotExist => CliError::unexpected("file doesn't exist"),
             WriteToDocumentError::FolderTreatedAsDocument => {
                 CliError::unexpected("can't write to folder")

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -145,7 +145,6 @@ impl From<Error<SyncAllError>> for SyncError {
                 match err {
                     SyncAllError::CouldNotReachServer => "Offline.",
                     SyncAllError::ClientUpdateRequired => "Client upgrade required.",
-                    SyncAllError::NoAccount => "No account found.",
                 }
                 .to_string(),
             ),

--- a/clients/linux/src/app/imp_export_files.rs
+++ b/clients/linux/src/app/imp_export_files.rs
@@ -142,7 +142,6 @@ fn export_err_to_string(err: lb::Error<lb::ExportFileError>) -> String {
 
     match err {
         lb::UiError(err) => match err {
-            NoAccount => "no account",
             ParentDoesNotExist => "parent lockbook file does not exist",
             DiskPathTaken => "destination path is taken",
             DiskPathInvalid => "destination path is invalid",

--- a/clients/linux/src/app/imp_import_files.rs
+++ b/clients/linux/src/app/imp_import_files.rs
@@ -176,7 +176,6 @@ fn import_err_to_string(err: lb::Error<lb::ImportFileError>) -> String {
     use lb::ImportFileError::*;
     match err {
         lb::UiError(err) => match err {
-            NoAccount => "no account!",
             ParentDoesNotExist => "destination does not exist",
             DocumentTreatedAsFolder => "destination is a document",
         }

--- a/clients/linux/src/app/imp_new_file.rs
+++ b/clients/linux/src/app/imp_new_file.rs
@@ -111,7 +111,6 @@ impl super::App {
                     use lb::CreateFileError::*;
                     match err {
                         lb::UiError(err) => match err {
-                            NoAccount => "No account!",
                             DocumentTreatedAsFolder => {
                                 "Can only create files within folders, not documents."
                             }

--- a/clients/linux/src/app/imp_open_file.rs
+++ b/clients/linux/src/app/imp_open_file.rs
@@ -112,7 +112,6 @@ fn read_doc_err_to_string(err: lb::Error<lb::ReadDocumentError>) -> String {
     match err {
         lb::UiError(err) => match err {
             TreatedFolderAsDocument => "treated folder as document",
-            NoAccount => "no account",
             FileDoesNotExist => "file does not exist",
         }
         .to_string(),
@@ -126,7 +125,6 @@ fn export_drawing_err_to_string(err: lb::Error<lb::ExportDrawingError>) -> Strin
         lb::UiError(err) => match err {
             FolderTreatedAsDrawing => "This is a folder, not a drawing.",
             FileDoesNotExist => "File doesn't exist.",
-            NoAccount => "No account!",
             InvalidDrawing => "Invalid drawing.",
         }
         .to_string(),

--- a/clients/linux/src/app/imp_save_file.rs
+++ b/clients/linux/src/app/imp_save_file.rs
@@ -29,7 +29,6 @@ impl super::App {
             .write_document(id, data.as_bytes())
             .map_err(|err| match err {
                 lb::Error::UiError(err) => match err {
-                    NoAccount => "no account",
                     FileDoesNotExist => "file does not exist",
                     FolderTreatedAsDocument => "folder treated as document",
                 }

--- a/clients/linux/src/app/imp_settings_dialog.rs
+++ b/clients/linux/src/app/imp_settings_dialog.rs
@@ -391,7 +391,6 @@ fn payment_err_to_string(err: lb::Error<lb::UpgradeAccountStripeError>) -> Strin
     use lb::UpgradeAccountStripeError::*;
     match err {
         lb::UiError(err) => match err {
-            NoAccount => "No account!",
             CouldNotReachServer => "Unable to connect to server.",
             OldCardDoesNotExist => "Could not find your current card.",
             AlreadyPremium => "You are already subscribed for this tier.",

--- a/clients/linux/src/app/imp_update_sync_status.rs
+++ b/clients/linux/src/app/imp_update_sync_status.rs
@@ -34,7 +34,6 @@ fn sync_status(api: Arc<dyn lb::Api>) -> Result<String, String> {
                 lb::Error::UiError(err) => match err {
                     CouldNotReachServer => "Offline.",
                     ClientUpdateRequired => "Client upgrade required.",
-                    NoAccount => "No account found.",
                 }
                 .to_string(),
                 lb::Error::Unexpected(msg) => msg,

--- a/clients/windows/core/CoreModel.cs
+++ b/clients/windows/core/CoreModel.cs
@@ -242,7 +242,6 @@ namespace Core {
             PathContainsEmptyFile,
             FileAlreadyExists,
             NoRoot,
-            NoAccount,
             DocumentTreatedAsFolder,
         }
         public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
@@ -253,7 +252,6 @@ namespace Core {
         public interface IResult { }
         public class Success : IResult { }
         public enum PossibleErrors {
-            NoAccount,
             FolderTreatedAsDocument,
             FileDoesNotExist
         }
@@ -267,7 +265,6 @@ namespace Core {
             public DecryptedFileMetadata newFile;
         }
         public enum PossibleErrors {
-            NoAccount,
             DocumentTreatedAsFolder,
             CouldNotFindAParent,
             FileNameNotAvailable,
@@ -309,7 +306,6 @@ namespace Core {
         }
         public enum PossibleErrors {
             TreatedFolderAsDocument,
-            NoAccount,
             FileDoesNotExist,
         }
         public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }
@@ -382,7 +378,6 @@ namespace Core {
         public interface IResult { }
         public class Success : IResult { }
         public enum PossibleErrors {
-            NoAccount,
             FileDoesNotExist,
             DocumentTreatedAsFolder,
             TargetParentHasChildNamedThat,
@@ -398,7 +393,6 @@ namespace Core {
         public interface IResult { }
         public class Success : IResult { }
         public enum PossibleErrors {
-            NoAccount,
             ClientUpdateRequired,
             CouldNotReachServer,
         }
@@ -412,7 +406,6 @@ namespace Core {
             public WorkCalculated workCalculated;
         }
         public enum PossibleErrors {
-            NoAccount,
             CouldNotReachServer,
             ClientUpdateRequired,
         }
@@ -450,7 +443,6 @@ namespace Core {
             public UsageMetrics usage;
         }
         public enum PossibleErrors {
-            NoAccount,
             CouldNotReachServer,
             ClientUpdateRequired,
         }
@@ -464,7 +456,6 @@ namespace Core {
             public string content;
         }
         public enum PossibleErrors {
-            NoAccount,
             FolderTreatedAsDrawing,
             InvalidDrawing,
             FileDoesNotExist,
@@ -479,7 +470,6 @@ namespace Core {
             public string content;
         }
         public enum PossibleErrors {
-            NoAccount,
             FileDoesNotExist,
             FolderTreatedAsDrawing,
             InvalidDrawing,
@@ -496,7 +486,6 @@ namespace Core {
         public enum PossibleErrors {
             FolderTreatedAsDrawing,
             FileDoesNotExist,
-            NoAccount,
             InvalidDrawing,
         }
         public class ExpectedError : ExpectedError<PossibleErrors>, IResult { }

--- a/clients/windows/lockbook/FileExplorer.xaml.cs
+++ b/clients/windows/lockbook/FileExplorer.xaml.cs
@@ -161,9 +161,6 @@ namespace lockbook {
                             App.ClientUpdateRequired = true;
                             App.Refresh();
                             break;
-                        case Core.CalculateWork.PossibleErrors.NoAccount:
-                            await App.ReloadAccount();
-                            break;
                     }
                     break;
             }
@@ -334,9 +331,6 @@ namespace lockbook {
                             App.ClientUpdateRequired = true;
                             App.Refresh();
                             break;
-                        case Core.SyncAll.PossibleErrors.NoAccount:
-                            await App.ReloadAccount();
-                            break;
                     }
                     break;
             }
@@ -428,9 +422,6 @@ namespace lockbook {
                     break;
                 case Core.MoveFile.ExpectedError error:
                     switch (error.Error) {
-                        case Core.MoveFile.PossibleErrors.NoAccount:
-                            await new MessageDialog("No account found! Please file a bug report.", "Unexpected Error!").ShowAsync();
-                            break;
                         case Core.MoveFile.PossibleErrors.DocumentTreatedAsFolder:
                             await new MessageDialog("You cannot move a file into a document", "Bad move destination!").ShowAsync();
                             break;
@@ -499,9 +490,6 @@ namespace lockbook {
                         break;
                     case Core.ReadDocument.ExpectedError error:
                         switch (error.Error) {
-                            case Core.ReadDocument.PossibleErrors.NoAccount:
-                                await new MessageDialog("No account found! Please file a bug report.", "Unexpected Error!").ShowAsync();
-                                break;
                             case Core.ReadDocument.PossibleErrors.TreatedFolderAsDocument:
                                 await new MessageDialog("You cannot read a folder, please file a bug report!", "Bad read target!").ShowAsync();
                                 break;
@@ -607,9 +595,6 @@ namespace lockbook {
                     break;
                 case Core.WriteDocument.ExpectedError error:
                     switch (error.Error) {
-                        case Core.WriteDocument.PossibleErrors.NoAccount:
-                            await new MessageDialog("No account found! Please file a bug report.", "Unexpected Error!").ShowAsync();
-                            break;
                         case Core.WriteDocument.PossibleErrors.FolderTreatedAsDocument:
                             await new MessageDialog("You cannot read a folder, please file a bug report!", "Bad read target!").ShowAsync();
                             break;

--- a/clients/windows/lockbook/Settings.xaml.cs
+++ b/clients/windows/lockbook/Settings.xaml.cs
@@ -63,9 +63,6 @@ namespace lockbook {
 
                 case Core.GetUsage.ExpectedError expectedError:
                     switch (expectedError.Error) {
-                        case Core.GetUsage.PossibleErrors.NoAccount:
-                            usageString = "No Account!";
-                            break;
                         case Core.GetUsage.PossibleErrors.CouldNotReachServer:
                             usageString = "Offline!";
                             break;

--- a/clients/windows/lockbook/SignUp.xaml.cs
+++ b/clients/windows/lockbook/SignUp.xaml.cs
@@ -110,9 +110,6 @@ namespace lockbook {
                                 case Core.SyncAll.PossibleErrors.ClientUpdateRequired:
                                     ImportAccountError = "Update required.";
                                     break;
-                                case Core.SyncAll.PossibleErrors.NoAccount:
-                                    ImportAccountError = "Successfully imported account but failed to load it. Try restarting the app. If the problem persists, please file a bug report.";
-                                    break;
                             }
                             break;
                     }

--- a/clients/windows/test/CoreServiceTest.cs
+++ b/clients/windows/test/CoreServiceTest.cs
@@ -270,11 +270,10 @@ namespace test {
         }
 
         [TestMethod]
-        public void SyncAllNoAccount() {
+        public void SyncAllUnexpected() {
             var coreService = NewCoreService();
             var syncAllResult = coreService.SyncAll().WaitResult();
-            Assert.AreEqual(Core.SyncAll.PossibleErrors.NoAccount,
-                CastOrDie(syncAllResult, out Core.SyncAll.ExpectedError _).Error);
+            CastOrDie(syncAllResult, out Core.SyncAll.UnexpectedError _);
         }
 
         [TestMethod]
@@ -289,11 +288,10 @@ namespace test {
         }
 
         [TestMethod]
-        public void CalculateWorkNoAccount() {
+        public void CalculateWorkUnexpected() {
             var coreService = NewCoreService();
             var calculateWorkResult = coreService.CalculateWork().WaitResult();
-            Assert.AreEqual(Core.CalculateWork.PossibleErrors.NoAccount,
-                CastOrDie(calculateWorkResult, out Core.CalculateWork.ExpectedError _).Error);
+            CastOrDie(calculateWorkResult, out Core.CalculateWork.UnexpectedError _);
         }
 
         [TestMethod]
@@ -319,11 +317,10 @@ namespace test {
         }
 
         [TestMethod]
-        public void GetUsageNoAccount() {
+        public void GetUsageUnexpected() {
             var coreService = NewCoreService();
             var getUsageResult = coreService.GetUsage().WaitResult();
-            Assert.AreEqual(Core.GetUsage.PossibleErrors.NoAccount,
-                CastOrDie(getUsageResult, out Core.GetUsage.ExpectedError _).Error);
+            CastOrDie(getUsageResult, out Core.GetUsage.UnexpectedError _);
         }
 
         [TestMethod]
@@ -341,11 +338,10 @@ namespace test {
         }
 
         [TestMethod]
-        public void CreateFileNoAccount() {
+        public void CreateFileUnexpected() {
             var coreService = NewCoreService();
             var createFileResult = coreService.CreateFile("TestFile", Guid.NewGuid().ToString(), FileType.Document).WaitResult();
-            Assert.AreEqual(Core.CreateFile.PossibleErrors.NoAccount,
-                CastOrDie(createFileResult, out Core.CreateFile.ExpectedError _).Error);
+            CastOrDie(createFileResult, out Core.CreateFile.UnexpectedError _);
         }
 
         [TestMethod]
@@ -432,7 +428,7 @@ namespace test {
         }
 
         [TestMethod]
-        public void WriteDocNoAccount() {
+        public void WriteDocUnexpected() {
             var coreService = NewCoreService();
             var username = RandomUsername();
             var createAccountResult = coreService.CreateAccount(username, apiUrl).WaitResult();
@@ -448,8 +444,7 @@ namespace test {
             coreService = NewCoreService();
 
             var writeDocResult = coreService.WriteDocument(fileId, "content").WaitResult();
-            Assert.AreEqual(Core.WriteDocument.PossibleErrors.NoAccount,
-                CastOrDie(writeDocResult, out Core.WriteDocument.ExpectedError _).Error);
+            CastOrDie(writeDocResult, out Core.WriteDocument.UnexpectedError _);
         }
 
         [TestMethod]
@@ -475,7 +470,7 @@ namespace test {
         }
 
         [TestMethod]
-        public void ReadDocNoAccount() {
+        public void ReadDocUnexpected() {
             var coreService = NewCoreService();
             var username = RandomUsername();
             var createAccountResult = coreService.CreateAccount(username, apiUrl).WaitResult();
@@ -491,8 +486,7 @@ namespace test {
             coreService = NewCoreService();
 
             var readDocResult = coreService.ReadDocument(fileId).WaitResult();
-            Assert.AreEqual(Core.ReadDocument.PossibleErrors.NoAccount,
-                CastOrDie(readDocResult, out Core.ReadDocument.ExpectedError _).Error);
+            CastOrDie(readDocResult, out Core.ReadDocument.UnexpectedError _);
         }
 
         [TestMethod]
@@ -565,7 +559,7 @@ namespace test {
         }
 
         [TestMethod]
-        public void MoveFileNoAccount() {
+        public void MoveFileUnexpected() {
             var coreService = NewCoreService();
             var username = RandomUsername();
             var createAccountResult = coreService.CreateAccount(username, apiUrl).WaitResult();
@@ -583,8 +577,7 @@ namespace test {
             coreService = NewCoreService();
 
             var moveFileResult = coreService.MoveFile(file.id, folder.id).WaitResult();
-            Assert.AreEqual(Core.MoveFile.PossibleErrors.NoAccount,
-                CastOrDie(moveFileResult, out Core.MoveFile.ExpectedError _).Error);
+            CastOrDie(moveFileResult, out Core.MoveFile.UnexpectedError _);
         }
 
         [TestMethod]

--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -270,7 +270,6 @@ impl From<CoreError> for Error<GetAccountError> {
 #[derive(Debug, Serialize, EnumIter)]
 pub enum CreateFileAtPathError {
     FileAlreadyExists,
-    NoAccount,
     NoRoot,
     PathDoesntStartWithRoot,
     PathContainsEmptyFile,
@@ -287,7 +286,6 @@ impl From<CoreError> for Error<CreateFileAtPathError> {
                 UiError(CreateFileAtPathError::PathContainsEmptyFile)
             }
             CoreError::RootNonexistent => UiError(CreateFileAtPathError::NoRoot),
-            CoreError::AccountNonexistent => UiError(CreateFileAtPathError::NoAccount),
             CoreError::PathTaken => UiError(CreateFileAtPathError::FileAlreadyExists),
             CoreError::FileNotFolder => UiError(CreateFileAtPathError::DocumentTreatedAsFolder),
             _ => unexpected!("{:#?}", e),
@@ -311,7 +309,6 @@ impl From<CoreError> for Error<GetFileByPathError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum CreateFileError {
-    NoAccount,
     DocumentTreatedAsFolder,
     CouldNotFindAParent,
     FileNameNotAvailable,
@@ -322,7 +319,6 @@ pub enum CreateFileError {
 impl From<CoreError> for Error<CreateFileError> {
     fn from(e: CoreError) -> Self {
         match e {
-            CoreError::AccountNonexistent => UiError(CreateFileError::NoAccount),
             CoreError::FileNonexistent => UiError(CreateFileError::CouldNotFindAParent),
             CoreError::PathTaken => UiError(CreateFileError::FileNameNotAvailable),
             CoreError::FileNotFolder => UiError(CreateFileError::DocumentTreatedAsFolder),
@@ -336,7 +332,6 @@ impl From<CoreError> for Error<CreateFileError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum WriteToDocumentError {
-    NoAccount,
     FileDoesNotExist,
     FolderTreatedAsDocument,
 }
@@ -344,7 +339,6 @@ pub enum WriteToDocumentError {
 impl From<CoreError> for Error<WriteToDocumentError> {
     fn from(e: CoreError) -> Self {
         match e {
-            CoreError::AccountNonexistent => UiError(WriteToDocumentError::NoAccount),
             CoreError::FileNonexistent => UiError(WriteToDocumentError::FileDoesNotExist),
             CoreError::FileNotDocument => UiError(WriteToDocumentError::FolderTreatedAsDocument),
             _ => unexpected!("{:#?}", e),
@@ -415,7 +409,6 @@ impl From<CoreError> for Error<FileDeleteError> {
 #[derive(Debug, Serialize, EnumIter)]
 pub enum ReadDocumentError {
     TreatedFolderAsDocument,
-    NoAccount,
     FileDoesNotExist,
 }
 
@@ -423,7 +416,6 @@ impl From<CoreError> for Error<ReadDocumentError> {
     fn from(e: CoreError) -> Self {
         match e {
             CoreError::FileNotDocument => UiError(ReadDocumentError::TreatedFolderAsDocument),
-            CoreError::AccountNonexistent => UiError(ReadDocumentError::NoAccount),
             CoreError::FileNonexistent => UiError(ReadDocumentError::FileDoesNotExist),
             _ => unexpected!("{:#?}", e),
         }
@@ -433,7 +425,6 @@ impl From<CoreError> for Error<ReadDocumentError> {
 #[derive(Debug, Serialize, EnumIter)]
 pub enum SaveDocumentToDiskError {
     TreatedFolderAsDocument,
-    NoAccount,
     FileDoesNotExist,
     BadPath,
     FileAlreadyExistsInDisk,
@@ -443,7 +434,6 @@ impl From<CoreError> for Error<SaveDocumentToDiskError> {
     fn from(e: CoreError) -> Self {
         match e {
             CoreError::FileNotDocument => UiError(SaveDocumentToDiskError::TreatedFolderAsDocument),
-            CoreError::AccountNonexistent => UiError(SaveDocumentToDiskError::NoAccount),
             CoreError::FileNonexistent => UiError(SaveDocumentToDiskError::FileDoesNotExist),
             CoreError::DiskPathInvalid => UiError(SaveDocumentToDiskError::BadPath),
             CoreError::DiskPathTaken => UiError(SaveDocumentToDiskError::FileAlreadyExistsInDisk),
@@ -480,7 +470,6 @@ pub enum MoveFileError {
     DocumentTreatedAsFolder,
     FileDoesNotExist,
     FolderMovedIntoItself,
-    NoAccount,
     TargetParentDoesNotExist,
     TargetParentHasChildNamedThat,
 }
@@ -492,7 +481,6 @@ impl From<CoreError> for Error<MoveFileError> {
             CoreError::FileNotFolder => UiError(MoveFileError::DocumentTreatedAsFolder),
             CoreError::FileNonexistent => UiError(MoveFileError::FileDoesNotExist),
             CoreError::FolderMovedIntoSelf => UiError(MoveFileError::FolderMovedIntoItself),
-            CoreError::AccountNonexistent => UiError(MoveFileError::NoAccount),
             CoreError::FileParentNonexistent => UiError(MoveFileError::TargetParentDoesNotExist),
             CoreError::PathTaken => UiError(MoveFileError::TargetParentHasChildNamedThat),
             _ => unexpected!("{:#?}", e),
@@ -502,7 +490,6 @@ impl From<CoreError> for Error<MoveFileError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum SyncAllError {
-    NoAccount,
     ClientUpdateRequired,
     CouldNotReachServer,
 }
@@ -510,7 +497,6 @@ pub enum SyncAllError {
 impl From<CoreError> for Error<SyncAllError> {
     fn from(e: CoreError) -> Self {
         match e {
-            CoreError::AccountNonexistent => UiError(SyncAllError::NoAccount),
             CoreError::ServerUnreachable => UiError(SyncAllError::CouldNotReachServer),
             CoreError::ClientUpdateRequired => UiError(SyncAllError::ClientUpdateRequired),
             _ => unexpected!("{:#?}", e),
@@ -560,7 +546,6 @@ impl From<ApiError<api::ChangeDocumentContentError>> for CoreError {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum CalculateWorkError {
-    NoAccount,
     CouldNotReachServer,
     ClientUpdateRequired,
 }
@@ -568,7 +553,6 @@ pub enum CalculateWorkError {
 impl From<CoreError> for Error<CalculateWorkError> {
     fn from(e: CoreError) -> Self {
         match e {
-            CoreError::AccountNonexistent => UiError(CalculateWorkError::NoAccount),
             CoreError::ServerUnreachable => UiError(CalculateWorkError::CouldNotReachServer),
             CoreError::ClientUpdateRequired => UiError(CalculateWorkError::ClientUpdateRequired),
             _ => unexpected!("{:#?}", e),
@@ -578,7 +562,6 @@ impl From<CoreError> for Error<CalculateWorkError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum GetUsageError {
-    NoAccount,
     CouldNotReachServer,
     ClientUpdateRequired,
 }
@@ -586,7 +569,6 @@ pub enum GetUsageError {
 impl From<CoreError> for Error<GetUsageError> {
     fn from(e: CoreError) -> Self {
         match e {
-            CoreError::AccountNonexistent => UiError(GetUsageError::NoAccount),
             CoreError::ServerUnreachable => UiError(GetUsageError::CouldNotReachServer),
             CoreError::ClientUpdateRequired => UiError(GetUsageError::ClientUpdateRequired),
             _ => unexpected!("{:#?}", e),
@@ -606,7 +588,6 @@ impl From<ApiError<api::GetUsageError>> for CoreError {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum GetDrawingError {
-    NoAccount,
     FolderTreatedAsDrawing,
     InvalidDrawing,
     FileDoesNotExist,
@@ -617,7 +598,6 @@ impl From<CoreError> for Error<GetDrawingError> {
         match e {
             CoreError::DrawingInvalid => UiError(GetDrawingError::InvalidDrawing),
             CoreError::FileNotDocument => UiError(GetDrawingError::FolderTreatedAsDrawing),
-            CoreError::AccountNonexistent => UiError(GetDrawingError::NoAccount),
             CoreError::FileNonexistent => UiError(GetDrawingError::FileDoesNotExist),
             _ => unexpected!("{:#?}", e),
         }
@@ -626,7 +606,6 @@ impl From<CoreError> for Error<GetDrawingError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum SaveDrawingError {
-    NoAccount,
     FileDoesNotExist,
     FolderTreatedAsDrawing,
     InvalidDrawing,
@@ -636,7 +615,6 @@ impl From<CoreError> for Error<SaveDrawingError> {
     fn from(e: CoreError) -> Self {
         match e {
             CoreError::DrawingInvalid => UiError(SaveDrawingError::InvalidDrawing),
-            CoreError::AccountNonexistent => UiError(SaveDrawingError::NoAccount),
             CoreError::FileNonexistent => UiError(SaveDrawingError::FileDoesNotExist),
             CoreError::FileNotDocument => UiError(SaveDrawingError::FolderTreatedAsDrawing),
             _ => unexpected!("{:#?}", e),
@@ -648,7 +626,6 @@ impl From<CoreError> for Error<SaveDrawingError> {
 pub enum ExportDrawingError {
     FolderTreatedAsDrawing,
     FileDoesNotExist,
-    NoAccount,
     InvalidDrawing,
 }
 
@@ -656,7 +633,6 @@ impl From<CoreError> for Error<ExportDrawingError> {
     fn from(e: CoreError) -> Self {
         match e {
             CoreError::DrawingInvalid => UiError(ExportDrawingError::InvalidDrawing),
-            CoreError::AccountNonexistent => UiError(ExportDrawingError::NoAccount),
             CoreError::FileNonexistent => UiError(ExportDrawingError::FileDoesNotExist),
             CoreError::FileNotDocument => UiError(ExportDrawingError::FolderTreatedAsDrawing),
             _ => unexpected!("{:#?}", e),
@@ -668,7 +644,6 @@ impl From<CoreError> for Error<ExportDrawingError> {
 pub enum ExportDrawingToDiskError {
     FolderTreatedAsDrawing,
     FileDoesNotExist,
-    NoAccount,
     InvalidDrawing,
     BadPath,
     FileAlreadyExistsInDisk,
@@ -678,7 +653,6 @@ impl From<CoreError> for Error<ExportDrawingToDiskError> {
     fn from(e: CoreError) -> Self {
         match e {
             CoreError::DrawingInvalid => UiError(ExportDrawingToDiskError::InvalidDrawing),
-            CoreError::AccountNonexistent => UiError(ExportDrawingToDiskError::NoAccount),
             CoreError::FileNonexistent => UiError(ExportDrawingToDiskError::FileDoesNotExist),
             CoreError::FileNotDocument => UiError(ExportDrawingToDiskError::FolderTreatedAsDrawing),
             CoreError::DiskPathInvalid => UiError(ExportDrawingToDiskError::BadPath),
@@ -690,7 +664,6 @@ impl From<CoreError> for Error<ExportDrawingToDiskError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum ImportFileError {
-    NoAccount,
     ParentDoesNotExist,
     DocumentTreatedAsFolder,
 }
@@ -698,7 +671,6 @@ pub enum ImportFileError {
 impl From<CoreError> for Error<ImportFileError> {
     fn from(e: CoreError) -> Self {
         match e {
-            CoreError::AccountNonexistent => UiError(ImportFileError::NoAccount),
             CoreError::FileNonexistent => UiError(ImportFileError::ParentDoesNotExist),
             CoreError::FileNotFolder => UiError(ImportFileError::DocumentTreatedAsFolder),
             _ => unexpected!("{:#?}", e),
@@ -708,7 +680,6 @@ impl From<CoreError> for Error<ImportFileError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum ExportFileError {
-    NoAccount,
     ParentDoesNotExist,
     DiskPathTaken,
     DiskPathInvalid,
@@ -717,7 +688,6 @@ pub enum ExportFileError {
 impl From<CoreError> for Error<ExportFileError> {
     fn from(e: CoreError) -> Self {
         match e {
-            CoreError::AccountNonexistent => UiError(ExportFileError::NoAccount),
             CoreError::FileNonexistent => UiError(ExportFileError::ParentDoesNotExist),
             CoreError::DiskPathInvalid => UiError(ExportFileError::DiskPathInvalid),
             CoreError::DiskPathTaken => UiError(ExportFileError::DiskPathTaken),
@@ -728,7 +698,6 @@ impl From<CoreError> for Error<ExportFileError> {
 
 #[derive(Debug, Serialize, EnumIter)]
 pub enum UpgradeAccountStripeError {
-    NoAccount,
     CouldNotReachServer,
     OldCardDoesNotExist,
     AlreadyPremium,
@@ -770,7 +739,6 @@ impl From<CoreError> for Error<UpgradeAccountStripeError> {
             CoreError::CurrentUsageIsMoreThanNewTier => {
                 UiError(UpgradeAccountStripeError::CurrentUsageIsMoreThanNewTier)
             }
-            CoreError::AccountNonexistent => UiError(UpgradeAccountStripeError::NoAccount),
             CoreError::ExistingRequestPending => {
                 UiError(UpgradeAccountStripeError::ExistingRequestPending)
             }


### PR DESCRIPTION
In many places, we propagate non-existent account errors up to `UiError`s where they would make more sense as unexpected errors. For example, if a client manages to attempt a document write without an account, that's highly unexpected behavior. The only client where this is even possible is the CLI, and we already safeguard this there, making any subsequent `NoAccount` error checks redundant.