### PR TITLE
core,clients: improve core reexports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,7 +2168,6 @@ version = "0.1.0"
 dependencies = [
  "fuzzy-matcher",
  "lockbook-core",
- "lockbook-models",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "backtrace",
  "base64 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,6 @@ dependencies = [
  "chrono",
  "hotwatch",
  "lockbook-core",
- "lockbook-models",
  "qr2term",
  "serde_json",
  "structopt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,7 +2169,6 @@ dependencies = [
  "fuzzy-matcher",
  "lockbook-core",
  "lockbook-models",
- "uuid",
 ]
 
 [[package]]
@@ -2296,7 +2295,6 @@ dependencies = [
  "qr2term",
  "serde_json",
  "structopt",
- "uuid",
 ]
 
 [[package]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/main.rs"
 lockbook-core = { path = "../../core" }
 lockbook-models = { path = "../../core/libs/models" }
 structopt = "0.3.13"
-uuid = "0.8"
 serde_json = "1.0.44"
 chrono = "0.4"
 qr2term = "0.3.0"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/main.rs"
 
 [dependencies]
 lockbook-core = { path = "../../core" }
-lockbook-models = { path = "../../core/libs/models" }
 structopt = "0.3.13"
 serde_json = "1.0.44"
 chrono = "0.4"

--- a/clients/cli/src/backup.rs
+++ b/clients/cli/src/backup.rs
@@ -3,10 +3,10 @@ use std::{env, fs};
 
 use chrono::{DateTime, Utc};
 
-use lockbook_core::service::path_service::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::ExportFileError;
+use lockbook_core::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
 use lockbook_core::GetRootError;
 
 use crate::error::CliError;

--- a/clients/cli/src/backup.rs
+++ b/clients/cli/src/backup.rs
@@ -3,11 +3,11 @@ use std::{env, fs};
 
 use chrono::{DateTime, Utc};
 
-use lockbook_core::ExportFileError;
-use lockbook_core::GetRootError;
 use lockbook_core::service::path_service::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::ExportFileError;
+use lockbook_core::GetRootError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/backup.rs
+++ b/clients/cli/src/backup.rs
@@ -3,8 +3,8 @@ use std::{env, fs};
 
 use chrono::{DateTime, Utc};
 
-use lockbook_core::model::errors::ExportFileError;
-use lockbook_core::model::errors::GetRootError;
+use lockbook_core::ExportFileError;
+use lockbook_core::GetRootError;
 use lockbook_core::service::path_service::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;

--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -1,4 +1,4 @@
-use lockbook_core::model::errors::GetUsageError;
+use lockbook_core::GetUsageError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/calculate_usage.rs
+++ b/clients/cli/src/calculate_usage.rs
@@ -1,6 +1,6 @@
-use lockbook_core::GetUsageError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::GetUsageError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -6,10 +6,10 @@ use lockbook_core::service::import_export_service::ImportStatus;
 use lockbook_core::Core;
 use lockbook_core::CoreError;
 use lockbook_core::CreateFileAtPathError;
+use lockbook_core::DecryptedFileMetadata;
 use lockbook_core::Error as LbError;
 use lockbook_core::GetFileByPathError;
 use lockbook_core::ImportFileError;
-use lockbook_models::file_metadata::DecryptedFileMetadata;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -2,7 +2,6 @@ use std::cell::Cell;
 use std::io::Write;
 use std::path::PathBuf;
 
-use lockbook_core::service::import_export_service::ImportStatus;
 use lockbook_core::Core;
 use lockbook_core::CoreError;
 use lockbook_core::CreateFileAtPathError;
@@ -10,6 +9,7 @@ use lockbook_core::DecryptedFileMetadata;
 use lockbook_core::Error as LbError;
 use lockbook_core::GetFileByPathError;
 use lockbook_core::ImportFileError;
+use lockbook_core::ImportStatus;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -2,13 +2,13 @@ use std::cell::Cell;
 use std::io::Write;
 use std::path::PathBuf;
 
-use lockbook_core::CreateFileAtPathError;
-use lockbook_core::GetFileByPathError;
-use lockbook_core::ImportFileError;
 use lockbook_core::service::import_export_service::ImportStatus;
 use lockbook_core::Core;
 use lockbook_core::CoreError;
+use lockbook_core::CreateFileAtPathError;
 use lockbook_core::Error as LbError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::ImportFileError;
 use lockbook_models::file_metadata::DecryptedFileMetadata;
 
 use crate::error::CliError;

--- a/clients/cli/src/copy.rs
+++ b/clients/cli/src/copy.rs
@@ -2,9 +2,9 @@ use std::cell::Cell;
 use std::io::Write;
 use std::path::PathBuf;
 
-use lockbook_core::model::errors::CreateFileAtPathError;
-use lockbook_core::model::errors::GetFileByPathError;
-use lockbook_core::model::errors::ImportFileError;
+use lockbook_core::CreateFileAtPathError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::ImportFileError;
 use lockbook_core::service::import_export_service::ImportStatus;
 use lockbook_core::Core;
 use lockbook_core::CoreError;

--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::io::Write;
 
-use lockbook_core::model::errors::GetFileByPathError;
-use lockbook_core::model::errors::ReadDocumentError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::ReadDocumentError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -1,10 +1,10 @@
 use std::fs;
 use std::io::Write;
 
-use lockbook_core::GetFileByPathError;
-use lockbook_core::ReadDocumentError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::ReadDocumentError;
 
 use crate::error::CliError;
 use crate::utils::{

--- a/clients/cli/src/error.rs
+++ b/clients/cli/src/error.rs
@@ -2,8 +2,8 @@ use std::fmt;
 use std::io;
 use std::path::Path;
 
-use lockbook_core::GetAccountError;
 use lockbook_core::Error as LbError;
+use lockbook_core::GetAccountError;
 use lockbook_core::UnexpectedError;
 
 pub struct CliError {

--- a/clients/cli/src/error.rs
+++ b/clients/cli/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::io;
 use std::path::Path;
 
-use lockbook_core::model::errors::GetAccountError;
+use lockbook_core::GetAccountError;
 use lockbook_core::Error as LbError;
 use lockbook_core::UnexpectedError;
 

--- a/clients/cli/src/export_drawing.rs
+++ b/clients/cli/src/export_drawing.rs
@@ -1,11 +1,11 @@
 use std::io;
 use std::io::Write;
 
-use lockbook_core::ExportDrawingError;
-use lockbook_core::GetFileByPathError;
 use lockbook_core::pure_functions::drawing::SupportedImageFormats;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::ExportDrawingError;
+use lockbook_core::GetFileByPathError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/export_drawing.rs
+++ b/clients/cli/src/export_drawing.rs
@@ -1,11 +1,11 @@
 use std::io;
 use std::io::Write;
 
-use lockbook_core::pure_functions::drawing::SupportedImageFormats;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::ExportDrawingError;
 use lockbook_core::GetFileByPathError;
+use lockbook_core::SupportedImageFormats;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/export_drawing.rs
+++ b/clients/cli/src/export_drawing.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::io::Write;
 
-use lockbook_core::model::errors::ExportDrawingError;
-use lockbook_core::model::errors::GetFileByPathError;
+use lockbook_core::ExportDrawingError;
+use lockbook_core::GetFileByPathError;
 use lockbook_core::pure_functions::drawing::SupportedImageFormats;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;

--- a/clients/cli/src/export_private_key.rs
+++ b/clients/cli/src/export_private_key.rs
@@ -1,4 +1,4 @@
-use lockbook_core::model::errors::AccountExportError;
+use lockbook_core::AccountExportError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/import_private_key.rs
+++ b/clients/cli/src/import_private_key.rs
@@ -1,6 +1,6 @@
-use lockbook_core::ImportError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::ImportError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/import_private_key.rs
+++ b/clients/cli/src/import_private_key.rs
@@ -1,4 +1,4 @@
-use lockbook_core::model::errors::ImportError;
+use lockbook_core::ImportError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/list.rs
+++ b/clients/cli/src/list.rs
@@ -1,5 +1,5 @@
-use lockbook_core::service::path_service::Filter;
 use lockbook_core::Core;
+use lockbook_core::Filter;
 
 use crate::error::CliError;
 use crate::utils::print_last_successful_sync;

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 
 use structopt::StructOpt;
 
-use lockbook_core::service::path_service::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
 use lockbook_core::Config;
 use lockbook_core::Core;
+use lockbook_core::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
 
 use crate::error::CliError;
 

--- a/clients/cli/src/move_file.rs
+++ b/clients/cli/src/move_file.rs
@@ -1,5 +1,5 @@
-use lockbook_core::model::errors::GetFileByPathError;
-use lockbook_core::model::errors::MoveFileError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::MoveFileError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/move_file.rs
+++ b/clients/cli/src/move_file.rs
@@ -1,7 +1,7 @@
-use lockbook_core::GetFileByPathError;
-use lockbook_core::MoveFileError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::MoveFileError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -1,9 +1,9 @@
 use std::fs;
 
-use lockbook_core::CreateFileAtPathError;
-use lockbook_core::FileDeleteError;
 use lockbook_core::Core;
+use lockbook_core::CreateFileAtPathError;
 use lockbook_core::Error as LbError;
+use lockbook_core::FileDeleteError;
 use lockbook_models::tree::FileMetadata;
 
 use crate::error::CliError;

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -4,7 +4,7 @@ use lockbook_core::Core;
 use lockbook_core::CreateFileAtPathError;
 use lockbook_core::Error as LbError;
 use lockbook_core::FileDeleteError;
-use lockbook_models::tree::FileMetadata;
+use lockbook_core::FileMetadata;
 
 use crate::error::CliError;
 use crate::utils::{

--- a/clients/cli/src/new.rs
+++ b/clients/cli/src/new.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
-use lockbook_core::model::errors::CreateFileAtPathError;
-use lockbook_core::model::errors::FileDeleteError;
+use lockbook_core::CreateFileAtPathError;
+use lockbook_core::FileDeleteError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_models::tree::FileMetadata;

--- a/clients/cli/src/new_account.rs
+++ b/clients/cli/src/new_account.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::{env, io};
 
-use lockbook_core::model::errors::CreateAccountError;
+use lockbook_core::CreateAccountError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/new_account.rs
+++ b/clients/cli/src/new_account.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 use std::{env, io};
 
-use lockbook_core::CreateAccountError;
 use lockbook_core::Core;
+use lockbook_core::CreateAccountError;
 use lockbook_core::Error as LbError;
 
 use crate::error::CliError;

--- a/clients/cli/src/print.rs
+++ b/clients/cli/src/print.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::io::Write;
 
-use lockbook_core::model::errors::GetFileByPathError;
+use lockbook_core::GetFileByPathError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/print.rs
+++ b/clients/cli/src/print.rs
@@ -1,9 +1,9 @@
 use std::io;
 use std::io::Write;
 
-use lockbook_core::GetFileByPathError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::GetFileByPathError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/remove.rs
+++ b/clients/cli/src/remove.rs
@@ -4,9 +4,9 @@ use std::io::Write;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::FileDeleteError;
+use lockbook_core::FileMetadata;
 use lockbook_core::GetAndGetChildrenError;
 use lockbook_core::GetFileByPathError;
-use lockbook_core::FileMetadata;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/remove.rs
+++ b/clients/cli/src/remove.rs
@@ -6,7 +6,7 @@ use lockbook_core::Error as LbError;
 use lockbook_core::FileDeleteError;
 use lockbook_core::GetAndGetChildrenError;
 use lockbook_core::GetFileByPathError;
-use lockbook_models::tree::FileMetadata;
+use lockbook_core::FileMetadata;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/remove.rs
+++ b/clients/cli/src/remove.rs
@@ -1,9 +1,9 @@
 use std::io;
 use std::io::Write;
 
-use lockbook_core::model::errors::FileDeleteError;
-use lockbook_core::model::errors::GetAndGetChildrenError;
-use lockbook_core::model::errors::GetFileByPathError;
+use lockbook_core::FileDeleteError;
+use lockbook_core::GetAndGetChildrenError;
+use lockbook_core::GetFileByPathError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_models::tree::FileMetadata;

--- a/clients/cli/src/remove.rs
+++ b/clients/cli/src/remove.rs
@@ -1,11 +1,11 @@
 use std::io;
 use std::io::Write;
 
+use lockbook_core::Core;
+use lockbook_core::Error as LbError;
 use lockbook_core::FileDeleteError;
 use lockbook_core::GetAndGetChildrenError;
 use lockbook_core::GetFileByPathError;
-use lockbook_core::Core;
-use lockbook_core::Error as LbError;
 use lockbook_models::tree::FileMetadata;
 
 use crate::error::CliError;

--- a/clients/cli/src/rename.rs
+++ b/clients/cli/src/rename.rs
@@ -1,7 +1,7 @@
-use lockbook_core::GetFileByPathError;
-use lockbook_core::RenameFileError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::RenameFileError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/rename.rs
+++ b/clients/cli/src/rename.rs
@@ -1,5 +1,5 @@
-use lockbook_core::model::errors::GetFileByPathError;
-use lockbook_core::model::errors::RenameFileError;
+use lockbook_core::GetFileByPathError;
+use lockbook_core::RenameFileError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 

--- a/clients/cli/src/status.rs
+++ b/clients/cli/src/status.rs
@@ -1,4 +1,4 @@
-use lockbook_core::model::errors::CalculateWorkError;
+use lockbook_core::CalculateWorkError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_models::work_unit::WorkUnit;

--- a/clients/cli/src/status.rs
+++ b/clients/cli/src/status.rs
@@ -1,7 +1,7 @@
 use lockbook_core::CalculateWorkError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
-use lockbook_models::work_unit::WorkUnit;
+use lockbook_core::WorkUnit;
 
 use crate::error::CliError;
 use crate::utils::print_last_successful_sync;

--- a/clients/cli/src/sync.rs
+++ b/clients/cli/src/sync.rs
@@ -2,7 +2,7 @@ use lockbook_core::service::sync_service::SyncProgress;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::SyncAllError;
-use lockbook_models::work_unit::ClientWorkUnit;
+use lockbook_core::ClientWorkUnit;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/sync.rs
+++ b/clients/cli/src/sync.rs
@@ -1,7 +1,7 @@
-use lockbook_core::SyncAllError;
 use lockbook_core::service::sync_service::SyncProgress;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::SyncAllError;
 use lockbook_models::work_unit::ClientWorkUnit;
 
 use crate::error::CliError;

--- a/clients/cli/src/sync.rs
+++ b/clients/cli/src/sync.rs
@@ -1,8 +1,8 @@
 use lockbook_core::service::sync_service::SyncProgress;
+use lockbook_core::ClientWorkUnit;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::SyncAllError;
-use lockbook_core::ClientWorkUnit;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/sync.rs
+++ b/clients/cli/src/sync.rs
@@ -1,4 +1,4 @@
-use lockbook_core::model::errors::SyncAllError;
+use lockbook_core::SyncAllError;
 use lockbook_core::service::sync_service::SyncProgress;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;

--- a/clients/cli/src/sync.rs
+++ b/clients/cli/src/sync.rs
@@ -1,8 +1,8 @@
-use lockbook_core::service::sync_service::SyncProgress;
 use lockbook_core::ClientWorkUnit;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::SyncAllError;
+use lockbook_core::SyncProgress;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/tree.rs
+++ b/clients/cli/src/tree.rs
@@ -1,5 +1,5 @@
 use lockbook_core::Core;
-use lockbook_models::tree::{FileMetaMapExt, FileMetaVecExt};
+use lockbook_core::{FileMetaMapExt, FileMetaVecExt};
 
 use crate::error::CliError;
 

--- a/clients/cli/src/utils.rs
+++ b/clients/cli/src/utils.rs
@@ -3,7 +3,7 @@ use std::{env, fs};
 
 use hotwatch::{Event, Hotwatch};
 
-use lockbook_core::model::errors::WriteToDocumentError;
+use lockbook_core::WriteToDocumentError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::Uuid;

--- a/clients/cli/src/utils.rs
+++ b/clients/cli/src/utils.rs
@@ -3,10 +3,10 @@ use std::{env, fs};
 
 use hotwatch::{Event, Hotwatch};
 
-use lockbook_core::WriteToDocumentError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
 use lockbook_core::Uuid;
+use lockbook_core::WriteToDocumentError;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/utils.rs
+++ b/clients/cli/src/utils.rs
@@ -2,11 +2,11 @@ use std::path::PathBuf;
 use std::{env, fs};
 
 use hotwatch::{Event, Hotwatch};
-use uuid::Uuid;
 
 use lockbook_core::model::errors::WriteToDocumentError;
 use lockbook_core::Core;
 use lockbook_core::Error as LbError;
+use lockbook_core::Uuid;
 
 use crate::error::CliError;
 

--- a/clients/cli/src/validate.rs
+++ b/clients/cli/src/validate.rs
@@ -1,4 +1,4 @@
-use lockbook_core::model::errors::{TestRepoError, Warning};
+use lockbook_core::{TestRepoError, Warning};
 use lockbook_core::Core;
 use lockbook_core::Uuid;
 

--- a/clients/cli/src/validate.rs
+++ b/clients/cli/src/validate.rs
@@ -1,6 +1,6 @@
-use lockbook_core::{TestRepoError, Warning};
 use lockbook_core::Core;
 use lockbook_core::Uuid;
+use lockbook_core::{TestRepoError, Warning};
 
 use crate::error::CliError;
 

--- a/clients/cli/src/validate.rs
+++ b/clients/cli/src/validate.rs
@@ -1,7 +1,6 @@
-use uuid::Uuid;
-
 use lockbook_core::model::errors::{TestRepoError, Warning};
 use lockbook_core::Core;
+use lockbook_core::Uuid;
 
 use crate::error::CliError;
 

--- a/clients/linux/lb-api/Cargo.toml
+++ b/clients/linux/lb-api/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 [dependencies]
 lockbook-core = { path = "../../../core" }
 lockbook-models = { path = "../../../core/libs/models" }
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
 fuzzy-matcher = "0.3.7"

--- a/clients/linux/lb-api/Cargo.toml
+++ b/clients/linux/lb-api/Cargo.toml
@@ -5,5 +5,4 @@ edition = "2021"
 
 [dependencies]
 lockbook-core = { path = "../../../core" }
-lockbook-models = { path = "../../../core/libs/models" }
 fuzzy-matcher = "0.3.7"

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -1,10 +1,5 @@
 mod search;
 
-pub use lockbook_models::api::PaymentMethod;
-pub use lockbook_models::api::PaymentPlatform;
-pub use lockbook_models::api::StripeAccountTier;
-pub use lockbook_models::api::SubscriptionInfo;
-
 pub use lockbook_core::Account;
 pub use lockbook_core::ClientWorkUnit;
 pub use lockbook_core::Config;
@@ -19,6 +14,7 @@ pub use lockbook_core::UnexpectedError;
 pub use lockbook_core::Uuid;
 pub use lockbook_core::DEFAULT_API_LOCATION;
 pub use lockbook_core::{ColorAlias, ColorRGB};
+pub use lockbook_core::{PaymentMethod, PaymentPlatform, StripeAccountTier, SubscriptionInfo};
 
 pub use lockbook_core::AccountExportError as ExportAccountError;
 pub use lockbook_core::CalculateWorkError;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -188,9 +188,7 @@ impl Api for DefaultApi {
         match self.core.get_account() {
             Ok(acct) => Ok(Some(acct)),
             Err(err) => match err {
-                Error::UiError(lockbook_core::GetAccountError::NoAccount) => {
-                    Ok(None)
-                }
+                Error::UiError(lockbook_core::GetAccountError::NoAccount) => Ok(None),
                 Error::Unexpected(msg) => Err(msg),
             },
         }

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -7,15 +7,15 @@ pub use lockbook_models::api::StripeAccountTier;
 pub use lockbook_models::api::SubscriptionInfo;
 pub use lockbook_models::crypto::DecryptedDocument;
 pub use lockbook_models::drawing::{ColorAlias, ColorRGB};
-pub use lockbook_models::file_metadata::DecryptedFileMetadata as FileMetadata;
-pub use lockbook_models::file_metadata::FileType;
 
 pub use lockbook_core::ClientWorkUnit;
 pub use lockbook_core::Config;
 pub use lockbook_core::CoreError;
+pub use lockbook_core::DecryptedFileMetadata as FileMetadata;
 pub use lockbook_core::Error;
 pub use lockbook_core::Error::UiError;
 pub use lockbook_core::Error::Unexpected;
+pub use lockbook_core::FileType;
 pub use lockbook_core::UnexpectedError;
 pub use lockbook_core::Uuid;
 pub use lockbook_core::DEFAULT_API_LOCATION;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -40,15 +40,14 @@ pub use lockbook_core::WriteToDocumentError as WriteDocumentError;
 
 pub use lockbook_core::SupportedImageFormats;
 
-pub use lockbook_core::service::billing_service::CreditCardLast4Digits;
-pub use lockbook_core::service::import_export_service::ImportExportFileInfo;
-pub use lockbook_core::service::import_export_service::ImportStatus;
-pub use lockbook_core::service::path_service::Filter;
-pub use lockbook_core::service::sync_service::SyncProgress;
-pub use lockbook_core::service::sync_service::WorkCalculated;
-pub use lockbook_core::service::usage_service::bytes_to_human;
-pub use lockbook_core::service::usage_service::UsageItemMetric;
-pub use lockbook_core::service::usage_service::UsageMetrics;
+pub use lockbook_core::bytes_to_human;
+pub use lockbook_core::Filter;
+pub use lockbook_core::ImportExportFileInfo;
+pub use lockbook_core::ImportStatus;
+pub use lockbook_core::SyncProgress;
+pub use lockbook_core::UsageItemMetric;
+pub use lockbook_core::UsageMetrics;
+pub use lockbook_core::WorkCalculated;
 
 pub use search::SearchResultItem;
 pub use search::Searcher;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -20,27 +20,27 @@ pub use lockbook_core::UnexpectedError;
 pub use lockbook_core::Uuid;
 pub use lockbook_core::DEFAULT_API_LOCATION;
 
-pub use lockbook_core::model::errors::AccountExportError as ExportAccountError;
-pub use lockbook_core::model::errors::CalculateWorkError;
-pub use lockbook_core::model::errors::CreateAccountError;
-pub use lockbook_core::model::errors::CreateFileError;
-pub use lockbook_core::model::errors::ExportDrawingError;
-pub use lockbook_core::model::errors::ExportFileError;
-pub use lockbook_core::model::errors::FileDeleteError;
-pub use lockbook_core::model::errors::GetAndGetChildrenError;
-pub use lockbook_core::model::errors::GetFileByIdError;
-pub use lockbook_core::model::errors::GetFileByPathError;
-pub use lockbook_core::model::errors::GetRootError;
-pub use lockbook_core::model::errors::GetSubscriptionInfoError;
-pub use lockbook_core::model::errors::GetUsageError;
-pub use lockbook_core::model::errors::ImportError as ImportAccountError;
-pub use lockbook_core::model::errors::ImportFileError;
-pub use lockbook_core::model::errors::MoveFileError;
-pub use lockbook_core::model::errors::ReadDocumentError;
-pub use lockbook_core::model::errors::RenameFileError;
-pub use lockbook_core::model::errors::SyncAllError;
-pub use lockbook_core::model::errors::UpgradeAccountStripeError;
-pub use lockbook_core::model::errors::WriteToDocumentError as WriteDocumentError;
+pub use lockbook_core::AccountExportError as ExportAccountError;
+pub use lockbook_core::CalculateWorkError;
+pub use lockbook_core::CreateAccountError;
+pub use lockbook_core::CreateFileError;
+pub use lockbook_core::ExportDrawingError;
+pub use lockbook_core::ExportFileError;
+pub use lockbook_core::FileDeleteError;
+pub use lockbook_core::GetAndGetChildrenError;
+pub use lockbook_core::GetFileByIdError;
+pub use lockbook_core::GetFileByPathError;
+pub use lockbook_core::GetRootError;
+pub use lockbook_core::GetSubscriptionInfoError;
+pub use lockbook_core::GetUsageError;
+pub use lockbook_core::ImportError as ImportAccountError;
+pub use lockbook_core::ImportFileError;
+pub use lockbook_core::MoveFileError;
+pub use lockbook_core::ReadDocumentError;
+pub use lockbook_core::RenameFileError;
+pub use lockbook_core::SyncAllError;
+pub use lockbook_core::UpgradeAccountStripeError;
+pub use lockbook_core::WriteToDocumentError as WriteDocumentError;
 
 pub use lockbook_core::pure_functions::drawing::SupportedImageFormats;
 
@@ -188,7 +188,7 @@ impl Api for DefaultApi {
         match self.core.get_account() {
             Ok(acct) => Ok(Some(acct)),
             Err(err) => match err {
-                Error::UiError(lockbook_core::model::errors::GetAccountError::NoAccount) => {
+                Error::UiError(lockbook_core::GetAccountError::NoAccount) => {
                     Ok(None)
                 }
                 Error::Unexpected(msg) => Err(msg),

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -63,7 +63,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use lockbook_models::tree::FileMetadata as FileMetadataExt;
+use lockbook_core::FileMetadata as FileMetadataExt;
 
 use lockbook_core::model::filename::NameComponents;
 use lockbook_core::Core;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -1,7 +1,5 @@
 mod search;
 
-pub use uuid::Uuid;
-
 pub use lockbook_models::account::Account;
 pub use lockbook_models::api::PaymentMethod;
 pub use lockbook_models::api::PaymentPlatform;
@@ -19,6 +17,7 @@ pub use lockbook_core::Error;
 pub use lockbook_core::Error::UiError;
 pub use lockbook_core::Error::Unexpected;
 pub use lockbook_core::UnexpectedError;
+pub use lockbook_core::Uuid;
 pub use lockbook_core::DEFAULT_API_LOCATION;
 
 pub use lockbook_core::model::errors::AccountExportError as ExportAccountError;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -4,13 +4,12 @@ pub use lockbook_models::api::PaymentMethod;
 pub use lockbook_models::api::PaymentPlatform;
 pub use lockbook_models::api::StripeAccountTier;
 pub use lockbook_models::api::SubscriptionInfo;
-pub use lockbook_models::crypto::DecryptedDocument;
-pub use lockbook_models::drawing::{ColorAlias, ColorRGB};
 
 pub use lockbook_core::Account;
 pub use lockbook_core::ClientWorkUnit;
 pub use lockbook_core::Config;
 pub use lockbook_core::CoreError;
+pub use lockbook_core::DecryptedDocument;
 pub use lockbook_core::DecryptedFileMetadata as FileMetadata;
 pub use lockbook_core::Error;
 pub use lockbook_core::Error::UiError;
@@ -19,6 +18,7 @@ pub use lockbook_core::FileType;
 pub use lockbook_core::UnexpectedError;
 pub use lockbook_core::Uuid;
 pub use lockbook_core::DEFAULT_API_LOCATION;
+pub use lockbook_core::{ColorAlias, ColorRGB};
 
 pub use lockbook_core::AccountExportError as ExportAccountError;
 pub use lockbook_core::CalculateWorkError;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -9,8 +9,8 @@ pub use lockbook_models::crypto::DecryptedDocument;
 pub use lockbook_models::drawing::{ColorAlias, ColorRGB};
 pub use lockbook_models::file_metadata::DecryptedFileMetadata as FileMetadata;
 pub use lockbook_models::file_metadata::FileType;
-pub use lockbook_models::work_unit::ClientWorkUnit;
 
+pub use lockbook_core::ClientWorkUnit;
 pub use lockbook_core::Config;
 pub use lockbook_core::CoreError;
 pub use lockbook_core::Error;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -1,53 +1,12 @@
 mod search;
 
-pub use lockbook_core::Account;
-pub use lockbook_core::ClientWorkUnit;
-pub use lockbook_core::Config;
-pub use lockbook_core::CoreError;
-pub use lockbook_core::DecryptedDocument;
+pub use lockbook_core::AccountExportError as ExportAccountError;
 pub use lockbook_core::DecryptedFileMetadata as FileMetadata;
-pub use lockbook_core::Error;
 pub use lockbook_core::Error::UiError;
 pub use lockbook_core::Error::Unexpected;
-pub use lockbook_core::FileType;
-pub use lockbook_core::UnexpectedError;
-pub use lockbook_core::Uuid;
-pub use lockbook_core::DEFAULT_API_LOCATION;
-pub use lockbook_core::{ColorAlias, ColorRGB};
-pub use lockbook_core::{PaymentMethod, PaymentPlatform, StripeAccountTier, SubscriptionInfo};
-
-pub use lockbook_core::AccountExportError as ExportAccountError;
-pub use lockbook_core::CalculateWorkError;
-pub use lockbook_core::CreateAccountError;
-pub use lockbook_core::CreateFileError;
-pub use lockbook_core::ExportDrawingError;
-pub use lockbook_core::ExportFileError;
-pub use lockbook_core::FileDeleteError;
-pub use lockbook_core::GetAndGetChildrenError;
-pub use lockbook_core::GetFileByIdError;
-pub use lockbook_core::GetFileByPathError;
-pub use lockbook_core::GetRootError;
-pub use lockbook_core::GetSubscriptionInfoError;
-pub use lockbook_core::GetUsageError;
 pub use lockbook_core::ImportError as ImportAccountError;
-pub use lockbook_core::ImportFileError;
-pub use lockbook_core::MoveFileError;
-pub use lockbook_core::ReadDocumentError;
-pub use lockbook_core::RenameFileError;
-pub use lockbook_core::SyncAllError;
-pub use lockbook_core::UpgradeAccountStripeError;
 pub use lockbook_core::WriteToDocumentError as WriteDocumentError;
-
-pub use lockbook_core::SupportedImageFormats;
-
-pub use lockbook_core::bytes_to_human;
-pub use lockbook_core::Filter;
-pub use lockbook_core::ImportExportFileInfo;
-pub use lockbook_core::ImportStatus;
-pub use lockbook_core::SyncProgress;
-pub use lockbook_core::UsageItemMetric;
-pub use lockbook_core::UsageMetrics;
-pub use lockbook_core::WorkCalculated;
+pub use lockbook_core::*;
 
 pub use search::SearchResultItem;
 pub use search::Searcher;
@@ -58,10 +17,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use lockbook_core::FileMetadata as FileMetadataExt;
-
 use lockbook_core::model::filename::NameComponents;
-use lockbook_core::Core;
+use lockbook_core::FileMetadata as FileMetadataExt;
 
 pub trait Api: Send + Sync {
     fn create_account(

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -1,6 +1,5 @@
 mod search;
 
-pub use lockbook_models::account::Account;
 pub use lockbook_models::api::PaymentMethod;
 pub use lockbook_models::api::PaymentPlatform;
 pub use lockbook_models::api::StripeAccountTier;
@@ -8,6 +7,7 @@ pub use lockbook_models::api::SubscriptionInfo;
 pub use lockbook_models::crypto::DecryptedDocument;
 pub use lockbook_models::drawing::{ColorAlias, ColorRGB};
 
+pub use lockbook_core::Account;
 pub use lockbook_core::ClientWorkUnit;
 pub use lockbook_core::Config;
 pub use lockbook_core::CoreError;

--- a/clients/linux/lb-api/src/lib.rs
+++ b/clients/linux/lb-api/src/lib.rs
@@ -42,7 +42,7 @@ pub use lockbook_core::SyncAllError;
 pub use lockbook_core::UpgradeAccountStripeError;
 pub use lockbook_core::WriteToDocumentError as WriteDocumentError;
 
-pub use lockbook_core::pure_functions::drawing::SupportedImageFormats;
+pub use lockbook_core::SupportedImageFormats;
 
 pub use lockbook_core::service::billing_service::CreditCardLast4Digits;
 pub use lockbook_core::service::import_export_service::ImportExportFileInfo;

--- a/clients/linux/lb-api/src/search.rs
+++ b/clients/linux/lb-api/src/search.rs
@@ -3,7 +3,8 @@ use std::fmt;
 
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
-use uuid::Uuid;
+
+use crate::Uuid;
 
 pub struct Searcher {
     paths: Vec<(Uuid, String)>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,10 @@ pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
 
 pub use crate::model::errors::*;
 pub use crate::pure_functions::drawing::SupportedImageFormats;
+pub use crate::service::import_export_service::{ImportExportFileInfo, ImportStatus};
+pub use crate::service::path_service::Filter;
+pub use crate::service::sync_service::{SyncProgress, WorkCalculated};
+pub use crate::service::usage_service::{bytes_to_human, UsageItemMetric, UsageMetrics};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -42,12 +46,8 @@ use lockbook_models::crypto::AESKey;
 use crate::model::errors::Error::UiError;
 use crate::model::repo::RepoSource;
 use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};
-use crate::service::import_export_service::{ImportExportFileInfo, ImportStatus};
 use crate::service::log_service;
-use crate::service::path_service::Filter;
 use crate::service::search_service::SearchResultItem;
-use crate::service::sync_service::{SyncProgress, WorkCalculated};
-use crate::service::usage_service::{UsageItemMetric, UsageMetrics};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,5 @@
 #![recursion_limit = "256"]
 
-extern crate reqwest;
 #[macro_use]
 extern crate tracing;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,12 @@ extern crate reqwest;
 #[macro_use]
 extern crate tracing;
 
+pub mod external_interface;
+pub mod model;
+pub mod pure_functions;
+pub mod repo;
+pub mod service;
+
 pub use crate::model::errors::*;
 pub use uuid::Uuid;
 
@@ -520,12 +526,6 @@ impl_get_variants!(
     ExportDrawingToDiskError,
     SaveDocumentToDiskError,
 );
-
-pub mod external_interface;
-pub mod model;
-pub mod pure_functions;
-pub mod repo;
-pub mod service;
 
 pub static DEFAULT_API_LOCATION: &str = "https://api.prod.lockbook.net";
 pub static CORE_CODE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,8 @@ pub mod service;
 pub use uuid::Uuid;
 
 pub use lockbook_models::account::Account;
+pub use lockbook_models::api::{PaymentMethod, PaymentPlatform};
+pub use lockbook_models::api::{StripeAccountTier, SubscriptionInfo};
 pub use lockbook_models::crypto::DecryptedDocument;
 pub use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
 pub use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
@@ -35,7 +37,6 @@ use serde_json::{json, value::Value};
 use strum::IntoEnumIterator;
 
 use lockbook_crypto::clock_service;
-use lockbook_models::api::{StripeAccountTier, SubscriptionInfo};
 use lockbook_models::crypto::AESKey;
 
 use crate::model::errors::Error::UiError;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,14 +9,14 @@ pub mod pure_functions;
 pub mod repo;
 pub mod service;
 
+pub use uuid::Uuid;
+
 pub use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
-pub use lockbook_models::tree::{FileMetadata, FileMetaMapExt, FileMetaVecExt};
+pub use lockbook_models::tree::{FileMetaMapExt, FileMetaVecExt, FileMetadata};
 pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
 
 pub use crate::model::errors::*;
 pub use crate::pure_functions::drawing::SupportedImageFormats;
-
-pub use uuid::Uuid;
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,8 @@ pub mod service;
 pub use uuid::Uuid;
 
 pub use lockbook_models::account::Account;
+pub use lockbook_models::crypto::DecryptedDocument;
+pub use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
 pub use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 pub use lockbook_models::tree::{FileMetaMapExt, FileMetaVecExt, FileMetadata};
 pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
@@ -34,8 +36,7 @@ use strum::IntoEnumIterator;
 
 use lockbook_crypto::clock_service;
 use lockbook_models::api::{StripeAccountTier, SubscriptionInfo};
-use lockbook_models::crypto::{AESKey, DecryptedDocument};
-use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
+use lockbook_models::crypto::AESKey;
 
 use crate::model::errors::Error::UiError;
 use crate::model::repo::RepoSource;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,8 @@ pub mod pure_functions;
 pub mod repo;
 pub mod service;
 
+pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
+
 pub use crate::model::errors::*;
 pub use crate::pure_functions::drawing::SupportedImageFormats;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod pure_functions;
 pub mod repo;
 pub mod service;
 
+pub use lockbook_models::tree::{FileMetadata, FileMetaMapExt, FileMetaVecExt};
 pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
 
 pub use crate::model::errors::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod service;
 
 pub use uuid::Uuid;
 
+pub use lockbook_models::account::Account;
 pub use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 pub use lockbook_models::tree::{FileMetaMapExt, FileMetaVecExt, FileMetadata};
 pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
@@ -32,7 +33,6 @@ use serde_json::{json, value::Value};
 use strum::IntoEnumIterator;
 
 use lockbook_crypto::clock_service;
-use lockbook_models::account::Account;
 use lockbook_models::api::{StripeAccountTier, SubscriptionInfo};
 use lockbook_models::crypto::{AESKey, DecryptedDocument};
 use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,9 +4,8 @@ extern crate reqwest;
 #[macro_use]
 extern crate tracing;
 
+pub use crate::model::errors::*;
 pub use uuid::Uuid;
-
-pub use model::errors::{CoreError, Error, UnexpectedError};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -29,7 +28,6 @@ use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
 use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 
 use crate::model::errors::Error::UiError;
-use crate::model::errors::*;
 use crate::model::repo::RepoSource;
 use crate::pure_functions::drawing::SupportedImageFormats;
 use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,38 +4,40 @@ extern crate reqwest;
 #[macro_use]
 extern crate tracing;
 
-use crate::model::errors::*;
-use crate::model::repo::RepoSource;
-use crate::path_service::Filter;
-use crate::pure_functions::drawing::SupportedImageFormats;
-use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};
-use crate::service::import_export_service::{ImportExportFileInfo, ImportStatus};
-use crate::service::search_service::SearchResultItem;
-use crate::service::sync_service::SyncProgress;
-use crate::service::usage_service::{UsageItemMetric, UsageMetrics};
-use crate::service::{path_service, sync_service};
-use crate::sync_service::WorkCalculated;
+pub use model::errors::{CoreError, Error, UnexpectedError};
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
+
 use basic_human_duration::ChronoHumanDuration;
 use chrono::Duration;
 use hmdb::log::Reader;
 use hmdb::transaction::Transaction;
 use libsecp256k1::PublicKey;
+use serde::Deserialize;
+use serde_json::{json, value::Value};
+use strum::IntoEnumIterator;
+use uuid::Uuid;
+
 use lockbook_crypto::clock_service;
 use lockbook_models::account::Account;
 use lockbook_models::api::{StripeAccountTier, SubscriptionInfo};
 use lockbook_models::crypto::{AESKey, DecryptedDocument};
 use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
 use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
-use model::errors::Error::UiError;
-pub use model::errors::{CoreError, Error, UnexpectedError};
-use serde::Deserialize;
-use serde_json::{json, value::Value};
-use service::log_service;
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex, MutexGuard};
-use strum::IntoEnumIterator;
-use uuid::Uuid;
+
+use crate::model::errors::Error::UiError;
+use crate::model::errors::*;
+use crate::model::repo::RepoSource;
+use crate::pure_functions::drawing::SupportedImageFormats;
+use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};
+use crate::service::import_export_service::{ImportExportFileInfo, ImportStatus};
+use crate::service::log_service;
+use crate::service::path_service::Filter;
+use crate::service::search_service::SearchResultItem;
+use crate::service::sync_service::{SyncProgress, WorkCalculated};
+use crate::service::usage_service::{UsageItemMetric, UsageMetrics};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,11 +3,12 @@
 #[macro_use]
 extern crate tracing;
 
-pub mod external_interface;
 pub mod model;
 pub mod pure_functions;
 pub mod repo;
 pub mod service;
+
+mod external_interface;
 
 pub use uuid::Uuid;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,8 @@ pub mod repo;
 pub mod service;
 
 pub use crate::model::errors::*;
+pub use crate::pure_functions::drawing::SupportedImageFormats;
+
 pub use uuid::Uuid;
 
 use std::collections::HashMap;
@@ -34,7 +36,6 @@ use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 
 use crate::model::errors::Error::UiError;
 use crate::model::repo::RepoSource;
-use crate::pure_functions::drawing::SupportedImageFormats;
 use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};
 use crate::service::import_export_service::{ImportExportFileInfo, ImportStatus};
 use crate::service::log_service;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod pure_functions;
 pub mod repo;
 pub mod service;
 
+pub use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 pub use lockbook_models::tree::{FileMetadata, FileMetaMapExt, FileMetaVecExt};
 pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};
 
@@ -35,7 +36,6 @@ use lockbook_models::account::Account;
 use lockbook_models::api::{StripeAccountTier, SubscriptionInfo};
 use lockbook_models::crypto::{AESKey, DecryptedDocument};
 use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
-use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 
 use crate::model::errors::Error::UiError;
 use crate::model::repo::RepoSource;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,8 @@ extern crate reqwest;
 #[macro_use]
 extern crate tracing;
 
+pub use uuid::Uuid;
+
 pub use model::errors::{CoreError, Error, UnexpectedError};
 
 use std::collections::HashMap;
@@ -18,7 +20,6 @@ use libsecp256k1::PublicKey;
 use serde::Deserialize;
 use serde_json::{json, value::Value};
 use strum::IntoEnumIterator;
-use uuid::Uuid;
 
 use lockbook_crypto::clock_service;
 use lockbook_models::account::Account;

--- a/core/src/service/billing_service.rs
+++ b/core/src/service/billing_service.rs
@@ -8,8 +8,6 @@ use lockbook_models::api::{
     UpgradeAccountGooglePlayRequest, UpgradeAccountStripeError, UpgradeAccountStripeRequest,
 };
 
-pub type CreditCardLast4Digits = String;
-
 impl RequestContext<'_, '_> {
     pub fn upgrade_account_stripe(&self, account_tier: StripeAccountTier) -> Result<(), CoreError> {
         let account = self.get_account()?;


### PR DESCRIPTION
Currently, a rust developer who wants to use core must include not only `lockbook_core` in their Cargo.toml, but also `lockbook_models` and `uuid`, leading to a somewhat clumsy setup. This PR re-exports essential things from core so that someone using core (currently the `cli` and `linux` clients) only needs to depend on the `lockbook_core` crate.