### PR TITLE
android: max width texteditor

### DIFF
--- a/clients/android/app/src/main/res/layout/fragment_text_editor.xml
+++ b/clients/android/app/src/main/res/layout/fragment_text_editor.xml
@@ -28,8 +28,10 @@
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/text_editor_text_field"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:maxWidth="900sp"
             android:gravity="top|start"
             android:hint="@string/text_editor_hint"
             android:importantForAutofill="no"
@@ -103,7 +105,6 @@
         android:id="@+id/markdown_viewer_scroller"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_margin="15dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -112,8 +113,10 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/markdown_viewer"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:maxWidth="900sp"
             android:textIsSelectable="true"
             android:gravity="top|start" />
 


### PR DESCRIPTION
The text editor now has a max width. This max width will get bigger for larger text, and smaller for smaller text. Regular mobile devices will not see any difference.

**Screenshots**
<details>

Regular Text Size
![Screenshot_20220627-120223_Lockbook.png](https://user-images.githubusercontent.com/20663038/175985744-3643f857-fc16-49eb-8bca-de2e477611f7.png)

Large Text Size
![Screenshot_20220627-120314_Lockbook.png](https://user-images.githubusercontent.com/20663038/175985614-38f0e4f0-eacc-420c-92e0-7c615d904e36.png)

Small Text Size
![Screenshot_20220627-120300_Lockbook.png](https://user-images.githubusercontent.com/20663038/175985672-c1e22da6-2e30-46e2-8dd5-9ef171ce7314.png)

</details>

closes #1168 