### PR TITLE
core: drawing prep and refactors

### DIFF
--- a/core/libs/models/src/drawing.rs
+++ b/core/libs/models/src/drawing.rs
@@ -36,7 +36,7 @@ impl Stroke {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ColorAlias {
     Black,
     Red,

--- a/core/libs/models/src/drawing.rs
+++ b/core/libs/models/src/drawing.rs
@@ -20,6 +20,22 @@ pub struct Stroke {
     pub alpha: f32,
 }
 
+impl Stroke {
+    pub fn new(color: ColorAlias) -> Self {
+        Self {
+            points_x: Vec::new(),
+            points_y: Vec::new(),
+            points_girth: Vec::new(),
+            color,
+            alpha: 1.0,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.points_x.is_empty() && self.points_y.is_empty() && self.points_girth.is_empty()
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub enum ColorAlias {
     Black,

--- a/core/libs/models/src/drawing.rs
+++ b/core/libs/models/src/drawing.rs
@@ -2,19 +2,13 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Drawing {
     pub scale: f32,
     pub translation_x: f32,
     pub translation_y: f32,
     pub strokes: Vec<Stroke>,
     pub theme: Option<HashMap<ColorAlias, ColorRGB>>,
-}
-
-impl Default for Drawing {
-    fn default() -> Self {
-        Drawing { scale: 0.0, translation_x: 0.0, translation_y: 0.0, strokes: vec![], theme: None }
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,7 +16,7 @@ pub use lockbook_models::account::Account;
 pub use lockbook_models::api::{PaymentMethod, PaymentPlatform};
 pub use lockbook_models::api::{StripeAccountTier, SubscriptionInfo};
 pub use lockbook_models::crypto::DecryptedDocument;
-pub use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
+pub use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing, Stroke};
 pub use lockbook_models::file_metadata::{DecryptedFileMetadata, FileType};
 pub use lockbook_models::tree::{FileMetaMapExt, FileMetaVecExt, FileMetadata};
 pub use lockbook_models::work_unit::{ClientWorkUnit, WorkUnit};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -370,14 +370,11 @@ impl Core {
         Ok(val?)
     }
 
-    #[instrument(level = "debug", skip(self, drawing_bytes), err(Debug))]
-    pub fn save_drawing_bytes(
-        &self, id: Uuid, drawing_bytes: &[u8],
-    ) -> Result<(), Error<SaveDrawingError>> {
-        let val = self.db.transaction(|tx| {
-            self.context(tx)?
-                .save_drawing_bytes(&self.config, id, drawing_bytes)
-        })?;
+    #[instrument(level = "debug", skip(self, d), err(Debug))]
+    pub fn save_drawing(&self, id: Uuid, d: &Drawing) -> Result<(), Error<SaveDrawingError>> {
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.save_drawing(&self.config, id, d))?;
         Ok(val?)
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -371,12 +371,12 @@ impl Core {
     }
 
     #[instrument(level = "debug", skip(self, drawing_bytes), err(Debug))]
-    pub fn save_drawing(
+    pub fn save_drawing_bytes(
         &self, id: Uuid, drawing_bytes: &[u8],
     ) -> Result<(), Error<SaveDrawingError>> {
         let val = self.db.transaction(|tx| {
             self.context(tx)?
-                .save_drawing(&self.config, id, drawing_bytes)
+                .save_drawing_bytes(&self.config, id, drawing_bytes)
         })?;
         Ok(val?)
     }

--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -1,12 +1,12 @@
 use std::fmt::{Display, Formatter};
 use std::io::ErrorKind;
 
-use lockbook_models::api;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use strum_macros::EnumIter;
 use uuid::Uuid;
 
+use lockbook_models::api;
 use lockbook_models::api::{GetPublicKeyError, GetUpdatesError, NewAccountError};
 use lockbook_models::tree::TreeError;
 
@@ -163,6 +163,12 @@ impl From<std::io::Error> for CoreError {
             ErrorKind::AlreadyExists => CoreError::DiskPathTaken,
             _ => core_err_unexpected(e),
         }
+    }
+}
+
+impl From<serde_json::Error> for CoreError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Unexpected(format!("{err}"))
     }
 }
 

--- a/core/src/pure_functions/drawing.rs
+++ b/core/src/pure_functions/drawing.rs
@@ -24,13 +24,10 @@ pub fn parse_drawing(drawing_bytes: &[u8]) -> Result<Drawing, CoreError> {
     if drawing_bytes.is_empty() {
         return Ok(Drawing::default());
     }
-    match serde_json::from_slice::<Drawing>(drawing_bytes) {
-        Ok(d) => Ok(d),
-        Err(e) => match e.classify() {
-            Category::Io => Err(CoreError::Unexpected(String::from("json io"))),
-            Category::Syntax | Category::Data | Category::Eof => Err(CoreError::DrawingInvalid),
-        },
-    }
+    serde_json::from_slice::<Drawing>(drawing_bytes).map_err(|err| match err.classify() {
+        Category::Io => CoreError::Unexpected(String::from("json io")),
+        Category::Syntax | Category::Data | Category::Eof => CoreError::DrawingInvalid,
+    })
 }
 
 #[derive(Deserialize, Debug)]

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -20,12 +20,12 @@ impl RequestContext<'_, '_> {
         drawing::parse_drawing(&drawing_bytes)
     }
 
-    pub fn save_drawing_bytes(
-        &mut self, config: &Config, id: Uuid, drawing_bytes: &[u8],
+    pub fn save_drawing(
+        &mut self, config: &Config, id: Uuid, d: &Drawing,
     ) -> Result<(), CoreError> {
-        drawing::parse_drawing(drawing_bytes)?; // validate drawing
         let metadata = self.get_not_deleted_metadata(RepoSource::Local, id)?;
-        self.insert_document(config, RepoSource::Local, &metadata, drawing_bytes)
+        let drawing_bytes = serde_json::to_vec(d)?;
+        self.insert_document(config, RepoSource::Local, &metadata, &drawing_bytes)
     }
 
     pub fn export_drawing(

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -20,7 +20,7 @@ impl RequestContext<'_, '_> {
         drawing::parse_drawing(&drawing_bytes)
     }
 
-    pub fn save_drawing(
+    pub fn save_drawing_bytes(
         &mut self, config: &Config, id: Uuid, drawing_bytes: &[u8],
     ) -> Result<(), CoreError> {
         drawing::parse_drawing(drawing_bytes)?; // validate drawing

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -1,14 +1,13 @@
-use crate::model::errors::CoreError;
 use std::collections::HashMap;
 
 use uuid::Uuid;
 
 use lockbook_models::drawing::{ColorAlias, ColorRGB, Drawing};
 
+use crate::model::errors::CoreError;
 use crate::model::repo::RepoSource;
-use crate::pure_functions::{drawing, files};
-
 use crate::pure_functions::drawing::SupportedImageFormats;
+use crate::pure_functions::{drawing, files};
 use crate::service::file_service;
 use crate::{Config, RequestContext};
 


### PR DESCRIPTION
I've been working on drawing for the forthcoming egui client, and therefore came across a few things to refactor relating to drawing code in core. Mostly just additional derives or helpful methods in the draw model.

However, the main thing is that I discovered the `save_drawing` function in core takes the JSON serialized bytes as an argument, which is odd since `get_drawing` returns a `Drawing`. So I refactored that to take a `Drawing` and have the drawing service take care of the JSON serialization.