### PR TITLE
linux: snap package fix

### DIFF
--- a/utils/dev/snap-packages/lockbook-desktop/snap/snapcraft.yaml
+++ b/utils/dev/snap-packages/lockbook-desktop/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: lockbook-desktop
-base: core20
+base: core22
 version: '0.4.3'
 summary: The linux gui version of Lockbook
 description: |
@@ -7,20 +7,22 @@ description: |
 grade: stable
 confinement: strict
 
-apps:
-  lockbook-desktop:
-    command: bin/lockbook-desktop
-    extensions: [gnome-3-38]
-    plugs:
-      - network
-      - home
-
 parts:
   lockbook-desktop:
     plugin: rust
     source: https://github.com/lockbook/lockbook.git
+    source-tag: 0.4.3
     build-packages:
+      - cargo
       - git
-      - libgtksourceview-3.0-dev
+      - libgtksourceview-5-dev
       - libgspell-1-dev
     rust-path: ["clients/linux"]
+
+apps:
+  lockbook-desktop:
+    command: bin/lockbook-desktop
+    extensions: [gnome]
+    plugs:
+      - network
+      - home

--- a/utils/dev/snap-packages/lockbook/snap/snapcraft.yaml
+++ b/utils/dev/snap-packages/lockbook/snap/snapcraft.yaml
@@ -7,17 +7,18 @@ description: |
 grade: stable
 confinement: strict
 
+parts:
+  lockbook:
+    plugin: rust
+    source: https://github.com/lockbook/lockbook.git
+    source-tag: 0.4.3
+    build-packages:
+      - git
+    rust-path: ["clients/cli"]
+
 apps:
   lockbook:
     command: bin/lockbook
     plugs:
       - network
       - home
-
-parts:
-  lockbook:
-    plugin: rust
-    source: https://github.com/lockbook/lockbook.git
-    build-packages:
-      - git
-    rust-path: ["clients/cli"]


### PR DESCRIPTION
The snap package for lockbook-desktop has not been up to date due to the lack of gtk4 support in the snapcraft store. Recently though, this has changed and we are now able to build the package.

We also added source tags to the `snapcraft.yaml` so only the release we want is built.

fixes #1172