### PR TITLE
core: search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "sha2 0.8.2",
  "strum",
  "strum_macros",
+ "sublime_fuzzy",
  "tempfile",
  "test_utils",
  "tracing",
@@ -3751,6 +3752,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sublime_fuzzy"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7986063f7c0ab374407e586d7048a3d5aac94f103f751088bf398e07cd5400"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +644,16 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2144,6 +2168,7 @@ dependencies = [
  "chrono",
  "cpuprofiler",
  "criterion",
+ "crossbeam",
  "diffy",
  "flate2",
  "fuzzy-matcher",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,6 +46,7 @@ lazy_static = "1.4.0"
 lockbook-models = { path = "libs/models" }
 lockbook-crypto = { path = "libs/crypto" }
 sublime_fuzzy = "0.7.0"
+crossbeam = "0.8.1"
 
 [profile.release]
 debug = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,6 +45,7 @@ hmdb = "0.1.12"
 lazy_static = "1.4.0"
 lockbook-models = { path = "libs/models" }
 lockbook-crypto = { path = "libs/crypto" }
+sublime_fuzzy = "0.7.0"
 
 [profile.release]
 debug = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,9 +30,7 @@ pub use crate::service::usage_service::{bytes_to_human, UsageItemMetric, UsageMe
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::thread::JoinHandle;
 
 use basic_human_duration::ChronoHumanDuration;
 use chrono::Duration;
@@ -50,7 +48,7 @@ use crate::model::errors::Error::UiError;
 use crate::model::repo::RepoSource;
 use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};
 use crate::service::log_service;
-use crate::service::search_service::{SearchRequest, SearchResult, SearchResultItem};
+use crate::service::search_service::{SearchResultItem, StartSearchInfo};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
@@ -439,13 +437,9 @@ impl Core {
         Ok(val?)
     }
 
-    #[instrument(level = "debug", skip(self, results_tx, search_rx), err(Debug))]
-    pub fn start_search(
-        &self, results_tx: Sender<SearchResult>, search_rx: Receiver<SearchRequest>,
-    ) -> Result<JoinHandle<()>, UnexpectedError> {
-        let val = self
-            .db
-            .transaction(|tx| self.context(tx)?.start_search(results_tx, search_rx))?;
+    #[instrument(level = "debug", skip(self), err(Debug))]
+    pub fn start_search(&self) -> Result<StartSearchInfo, UnexpectedError> {
+        let val = self.db.transaction(|tx| self.context(tx)?.start_search())?;
         Ok(val?)
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,7 +30,9 @@ pub use crate::service::usage_service::{bytes_to_human, UsageItemMetric, UsageMe
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread::JoinHandle;
 
 use basic_human_duration::ChronoHumanDuration;
 use chrono::Duration;
@@ -48,7 +50,7 @@ use crate::model::errors::Error::UiError;
 use crate::model::repo::RepoSource;
 use crate::repo::schema::{transaction, CoreV1, OneKey, Tx};
 use crate::service::log_service;
-use crate::service::search_service::SearchResultItem;
+use crate::service::search_service::{SearchRequest, SearchResult, SearchResultItem};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
@@ -434,6 +436,16 @@ impl Core {
         let val = self
             .db
             .transaction(|tx| self.context(tx)?.search_file_paths(input))?;
+        Ok(val?)
+    }
+
+    #[instrument(level = "debug", skip(self, results_tx, search_rx), err(Debug))]
+    pub fn start_search(
+        &self, results_tx: Sender<SearchResult>, search_rx: Receiver<SearchRequest>,
+    ) -> Result<JoinHandle<()>, UnexpectedError> {
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.start_search(results_tx, search_rx))?;
         Ok(val?)
     }
 

--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -34,6 +34,18 @@ impl From<hmdb::errors::Error> for UnexpectedError {
     }
 }
 
+impl<T> From<std::sync::PoisonError<T>> for UnexpectedError {
+    fn from(err: std::sync::PoisonError<T>) -> Self {
+        UnexpectedError(format!("{:#?}", err))
+    }
+}
+
+impl<T> From<std::sync::mpsc::SendError<T>> for UnexpectedError {
+    fn from(err: std::sync::mpsc::SendError<T>) -> Self {
+        UnexpectedError(format!("{:#?}", err))
+    }
+}
+
 impl Serialize for UnexpectedError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -40,20 +40,20 @@ impl<T> From<std::sync::PoisonError<T>> for UnexpectedError {
     }
 }
 
-impl<T> From<std::sync::mpsc::SendError<T>> for UnexpectedError {
-    fn from(err: std::sync::mpsc::SendError<T>) -> Self {
+impl From<crossbeam::channel::RecvError> for UnexpectedError {
+    fn from(err: crossbeam::channel::RecvError) -> Self {
         UnexpectedError(format!("{:#?}", err))
     }
 }
 
-impl From<std::sync::mpsc::RecvError> for UnexpectedError {
-    fn from(err: std::sync::mpsc::RecvError) -> Self {
+impl From<crossbeam::channel::RecvTimeoutError> for UnexpectedError {
+    fn from(err: crossbeam::channel::RecvTimeoutError) -> Self {
         UnexpectedError(format!("{:#?}", err))
     }
 }
 
-impl From<std::sync::mpsc::RecvTimeoutError> for UnexpectedError {
-    fn from(err: std::sync::mpsc::RecvTimeoutError) -> Self {
+impl<T> From<crossbeam::channel::SendError<T>> for UnexpectedError {
+    fn from(err: crossbeam::channel::SendError<T>) -> Self {
         UnexpectedError(format!("{:#?}", err))
     }
 }

--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -46,6 +46,18 @@ impl<T> From<std::sync::mpsc::SendError<T>> for UnexpectedError {
     }
 }
 
+impl From<std::sync::mpsc::RecvError> for UnexpectedError {
+    fn from(err: std::sync::mpsc::RecvError) -> Self {
+        UnexpectedError(format!("{:#?}", err))
+    }
+}
+
+impl From<std::sync::mpsc::RecvTimeoutError> for UnexpectedError {
+    fn from(err: std::sync::mpsc::RecvTimeoutError) -> Self {
+        UnexpectedError(format!("{:#?}", err))
+    }
+}
+
 impl Serialize for UnexpectedError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/core/src/model/filename.rs
+++ b/core/src/model/filename.rs
@@ -9,7 +9,7 @@ pub enum DocumentType {
 impl DocumentType {
     pub fn from_file_name_using_extension(name: &str) -> DocumentType {
         match name.split('.').last() {
-            Some("md") => DocumentType::Text,
+            Some("md") | Some("txt") => DocumentType::Text,
             Some("draw") => DocumentType::Drawing,
             _ => DocumentType::Other,
         }

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -336,10 +336,9 @@ impl RequestContext<'_, '_> {
 
                 index_offset = deleted_chars_len - 3;
 
-                new_paragraph = new_paragraph
+                new_paragraph = "..."
                     .chars()
-                    .skip(deleted_chars_len)
-                    .chain("...".chars())
+                    .chain(new_paragraph.chars().skip(deleted_chars_len))
                     .collect();
             }
 

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -336,8 +336,11 @@ impl RequestContext<'_, '_> {
 
                 index_offset = deleted_chars_len - 3;
 
-                new_paragraph = new_paragraph.chars().skip(deleted_chars_len).collect();
-                new_paragraph.insert_str(0, "...");
+                new_paragraph = new_paragraph
+                    .chars()
+                    .skip(deleted_chars_len)
+                    .chain("...".chars())
+                    .collect();
             }
 
             if new_paragraph.len() > IDEAL_CONTENT_MATCH_LENGTH + CONTENT_MATCH_PADDING + 3 {
@@ -349,14 +352,18 @@ impl RequestContext<'_, '_> {
                     IDEAL_CONTENT_MATCH_LENGTH - (last_match - index_offset)
                 };
 
-                new_paragraph = new_paragraph.chars().take(take_chars_len).collect();
-                new_paragraph.push_str("...");
+                new_paragraph = new_paragraph
+                    .chars()
+                    .take(take_chars_len)
+                    .chain("...".chars())
+                    .collect();
             }
 
             if new_paragraph.len() > MAX_CONTENT_MATCH_LENGTH {
                 new_paragraph = new_paragraph
                     .chars()
                     .take(MAX_CONTENT_MATCH_LENGTH)
+                    .chain("...".chars())
                     .collect();
 
                 new_indices = new_indices

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -1,18 +1,16 @@
 use crate::model::filename::DocumentType;
 use crate::model::repo::RepoSource;
 use crate::{CoreError, RequestContext, UnexpectedError};
-use crossbeam::channel;
-use crossbeam::channel::{Receiver, RecvTimeoutError, Sender};
+use crossbeam::channel::{self, Receiver, RecvTimeoutError, Sender};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use lockbook_models::file_metadata::DecryptedFiles;
 use lockbook_models::tree::FileMetadata;
 use serde::Serialize;
 use std::cmp::Ordering;
-use std::sync::atomic::AtomicBool;
-use std::sync::{atomic, Arc};
-use std::thread;
-use std::thread::JoinHandle;
+use std::sync::atomic::{self, AtomicBool};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use sublime_fuzzy::{FuzzySearch, Scoring};
 use uuid::Uuid;
@@ -81,8 +79,7 @@ impl RequestContext<'_, '_> {
                     match DocumentType::from_file_name_using_extension(&file.decrypted_name) {
                         DocumentType::Text => self
                             .read_document(self.config, RepoSource::Local, file.id)
-                            .map(|content| String::from(String::from_utf8_lossy(content.as_ref())))
-                            .map(Some)?,
+                            .map(|bytes| Some(String::from_utf8_lossy(&bytes).to_string()))?,
                         _ => None,
                     };
 

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -177,7 +177,7 @@ impl RequestContext<'_, '_> {
     ) {
         thread::spawn(move || {
             if let Err(search_err) =
-            RequestContext::search_loop(results_tx.clone(), files_info, should_continue, input)
+                RequestContext::search_loop(results_tx.clone(), files_info, should_continue, input)
             {
                 if let Err(err) = results_tx.send(SearchResult::Error(search_err)) {
                     warn!("Send failed: {:#?}", err);

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -177,7 +177,7 @@ impl RequestContext<'_, '_> {
     ) {
         thread::spawn(move || {
             if let Err(search_err) =
-                RequestContext::search_loop(results_tx.clone(), files_info, should_continue, input)
+            RequestContext::search_loop(results_tx.clone(), files_info, should_continue, input)
             {
                 if let Err(err) = results_tx.send(SearchResult::Error(search_err)) {
                     warn!("Send failed: {:#?}", err);
@@ -338,6 +338,7 @@ impl RequestContext<'_, '_> {
                         .chars()
                         .take(IDEAL_CONTENT_MATCH_LENGTH + CONTENT_MATCH_PADDING)
                         .collect();
+
                     new_paragraph.push_str("...");
                 } else {
                     if *first_match > CONTENT_MATCH_PADDING as usize {
@@ -356,13 +357,14 @@ impl RequestContext<'_, '_> {
                         new_paragraph.insert_str(0, "...");
                     }
 
-                    if new_indices.len() - last_match > CONTENT_MATCH_PADDING {
+                    if new_paragraph.len() > IDEAL_CONTENT_MATCH_LENGTH + CONTENT_MATCH_PADDING + 3
+                    {
                         let at_least_take = *last_match - index_offset + CONTENT_MATCH_PADDING;
 
                         let take_chars_len = if at_least_take > IDEAL_CONTENT_MATCH_LENGTH {
                             at_least_take
                         } else {
-                            new_paragraph.len() - (IDEAL_CONTENT_MATCH_LENGTH - last_match - 3)
+                            IDEAL_CONTENT_MATCH_LENGTH - (last_match - index_offset)
                         };
 
                         new_paragraph = new_paragraph.chars().take(take_chars_len).collect();
@@ -377,7 +379,7 @@ impl RequestContext<'_, '_> {
 
                         new_indices = new_indices
                             .into_iter()
-                            .filter(|index| *index < MAX_CONTENT_MATCH_LENGTH)
+                            .filter(|index| (*index - index_offset) < MAX_CONTENT_MATCH_LENGTH)
                             .collect()
                     }
                 }

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -1,9 +1,27 @@
 use crate::model::repo::RepoSource;
-use crate::{CoreError, RequestContext};
+use crate::{CoreError, RequestContext, UnexpectedError};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
+use lockbook_models::file_metadata::{DecryptedFiles, FileType};
+use serde::Serialize;
 use std::cmp::Ordering;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{atomic, Arc};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use sublime_fuzzy::{FuzzySearch, Scoring};
 use uuid::Uuid;
+
+const DEBOUNCE_MILLIS: u64 = 500;
+const LOWEST_CONTENT_SCORE_THRESHOLD: i64 = 170;
+
+const MAX_CONTENT_MATCH_LENGTH: usize = 400;
+const IDEAL_CONTENT_MATCH_LENGTH: usize = 150;
+const CONTENT_MATCH_PADDING: usize = 8;
+
+const QUERIED_EXTENSIONS: [&str; 2] = [".md", ".txt"];
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct SearchResultItem {
@@ -49,4 +67,361 @@ impl RequestContext<'_, '_> {
 
         Ok(results)
     }
+
+    pub fn start_search(
+        &mut self, results_tx: Sender<SearchResult>, search_rx: Receiver<SearchRequest>,
+    ) -> Result<JoinHandle<()>, CoreError> {
+        let files_not_deleted: DecryptedFiles =
+            self.get_all_not_deleted_metadata(RepoSource::Local)?;
+
+        let mut files_info = Vec::new();
+
+        for file in files_not_deleted.values() {
+            if file.file_type == FileType::Document {
+                let content = if QUERIED_EXTENSIONS
+                    .iter()
+                    .any(|extension| file.decrypted_name.as_str().ends_with(extension))
+                {
+                    Some(String::from(String::from_utf8_lossy(&self.read_document(
+                        self.config,
+                        RepoSource::Local,
+                        file.id,
+                    )?)))
+                } else {
+                    None
+                };
+
+                files_info.push(SearchableFileInfo {
+                    id: file.id,
+                    path: RequestContext::path_by_id_helper(&files_not_deleted, file.id)?,
+                    content,
+                })
+            }
+        }
+
+        Ok(thread::spawn(move || {
+            if let Err(search_err) = Self::search(&results_tx, search_rx, Arc::new(files_info)) {
+                if let Err(err) = results_tx.send(SearchResult::Error(search_err)) {
+                    warn!("Send failed: {:#?}", err);
+                }
+            }
+        }))
+    }
+
+    fn search(
+        results_tx: &Sender<SearchResult>, search_rx: Receiver<SearchRequest>,
+        files_info: Arc<Vec<SearchableFileInfo>>,
+    ) -> Result<(), UnexpectedError> {
+        let mut last_search = match search_rx.recv() {
+            Ok(last_search) => last_search,
+            Err(_) => return Ok(()),
+        };
+
+        let mut should_continue = Arc::new(AtomicBool::new(true));
+
+        match &last_search {
+            SearchRequest::Search { input } => {
+                RequestContext::spawn_search(
+                    results_tx.clone(),
+                    files_info.clone(),
+                    should_continue.clone(),
+                    input.clone(),
+                );
+            }
+            SearchRequest::EndSearch => return Ok(()),
+            SearchRequest::StopCurrentSearch => {}
+        };
+
+        let mut skip_channel_check = false;
+
+        loop {
+            if !skip_channel_check {
+                last_search = match search_rx.recv() {
+                    Ok(last_search) => last_search,
+                    Err(_) => return Ok(()),
+                };
+
+                should_continue.store(false, atomic::Ordering::Relaxed);
+            } else {
+                skip_channel_check = false;
+            }
+
+            thread::sleep(Duration::from_millis(DEBOUNCE_MILLIS));
+
+            if let Some(search) = search_rx.try_iter().last() {
+                last_search = search;
+                skip_channel_check = true;
+                continue;
+            }
+
+            match &last_search {
+                SearchRequest::Search { input } => {
+                    should_continue = Arc::new(AtomicBool::new(true));
+
+                    RequestContext::spawn_search(
+                        results_tx.clone(),
+                        files_info.clone(),
+                        should_continue.clone(),
+                        input.clone(),
+                    );
+                }
+                SearchRequest::EndSearch => return Ok(()),
+                SearchRequest::StopCurrentSearch => {}
+            };
+        }
+    }
+
+    fn spawn_search(
+        results_tx: Sender<SearchResult>, files_info: Arc<Vec<SearchableFileInfo>>,
+        should_continue: Arc<AtomicBool>, input: String,
+    ) {
+        thread::spawn(move || {
+            if let Err(search_err) =
+                RequestContext::search_loop(results_tx.clone(), files_info, should_continue, input)
+            {
+                if let Err(err) = results_tx.send(SearchResult::Error(search_err)) {
+                    warn!("Send failed: {:#?}", err);
+                }
+            }
+        });
+    }
+
+    fn search_loop(
+        results_tx: Sender<SearchResult>, files_info: Arc<Vec<SearchableFileInfo>>,
+        should_continue: Arc<AtomicBool>, search: String,
+    ) -> Result<(), UnexpectedError> {
+        let mut no_matches = true;
+
+        RequestContext::search_file_names(
+            &results_tx,
+            &should_continue,
+            &files_info,
+            &search,
+            &mut no_matches,
+        )?;
+
+        if should_continue.load(atomic::Ordering::Relaxed) {
+            RequestContext::search_file_contents(
+                &results_tx,
+                &should_continue,
+                &files_info,
+                &search,
+                &mut no_matches,
+            )?;
+
+            if no_matches && should_continue.load(atomic::Ordering::Relaxed) {
+                results_tx.send(SearchResult::NoMatch)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn search_file_names(
+        results_tx: &Sender<SearchResult>, should_continue: &Arc<AtomicBool>,
+        files_info: &Arc<Vec<SearchableFileInfo>>, search: &str, no_matches: &mut bool,
+    ) -> Result<(), UnexpectedError> {
+        for info in files_info.as_ref() {
+            if !should_continue.load(atomic::Ordering::Relaxed) {
+                return Ok(());
+            }
+
+            if let Some(fuzzy_match) = FuzzySearch::new(search, &info.path)
+                .case_insensitive()
+                .score_with(&Scoring::emphasize_distance())
+                .best_match()
+            {
+                if fuzzy_match.score().is_positive() {
+                    if *no_matches {
+                        *no_matches = false;
+                    }
+
+                    if !should_continue.load(atomic::Ordering::Relaxed) {
+                        return Ok(());
+                    }
+
+                    if results_tx
+                        .send(SearchResult::FileNameMatch {
+                            id: info.id,
+                            path: info.path.clone(),
+                            matched_indices: fuzzy_match.matched_indices().cloned().collect(),
+                            score: fuzzy_match.score() as i64,
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn search_file_contents(
+        results_tx: &Sender<SearchResult>, should_continue: &Arc<AtomicBool>,
+        files_info: &Arc<Vec<SearchableFileInfo>>, search: &str, no_matches: &mut bool,
+    ) -> Result<(), UnexpectedError> {
+        for info in files_info.as_ref() {
+            if !should_continue.load(atomic::Ordering::Relaxed) {
+                return Ok(());
+            }
+
+            if let Some(content) = &info.content {
+                let mut content_matches: Vec<ContentMatch> = Vec::new();
+
+                for paragraph in content.split("\n\n") {
+                    if let Some(fuzzy_match) = FuzzySearch::new(search, paragraph)
+                        .case_insensitive()
+                        .score_with(&Scoring::emphasize_distance())
+                        .best_match()
+                    {
+                        let score = fuzzy_match.score() as i64;
+
+                        if score >= LOWEST_CONTENT_SCORE_THRESHOLD {
+                            let (paragraph, matched_indices) =
+                                RequestContext::optimize_searched_text(
+                                    paragraph,
+                                    fuzzy_match.matched_indices().cloned().collect(),
+                                )?;
+
+                            content_matches.push(ContentMatch {
+                                paragraph,
+                                matched_indices,
+                                score,
+                            });
+                        }
+                    }
+                }
+
+                if !content_matches.is_empty() {
+                    if *no_matches {
+                        *no_matches = false;
+                    }
+
+                    if !should_continue.load(atomic::Ordering::Relaxed) {
+                        return Ok(());
+                    }
+
+                    if results_tx
+                        .send(SearchResult::FileContentMatches {
+                            id: info.id,
+                            path: info.path.clone(),
+                            content_matches,
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn optimize_searched_text(
+        paragraph: &str, matched_indices: Vec<usize>,
+    ) -> Result<(String, Vec<usize>), UnexpectedError> {
+        if paragraph.len() <= IDEAL_CONTENT_MATCH_LENGTH {
+            return Ok((paragraph.to_string(), matched_indices));
+        }
+
+        let mut index_offset: usize = 0;
+        let mut new_paragraph = paragraph.to_string();
+        let mut new_indices = matched_indices;
+
+        match (new_indices.first(), new_indices.last()) {
+            (Some(first_match), Some(last_match)) => {
+                if *last_match < IDEAL_CONTENT_MATCH_LENGTH {
+                    new_paragraph = new_paragraph
+                        .chars()
+                        .take(IDEAL_CONTENT_MATCH_LENGTH + CONTENT_MATCH_PADDING)
+                        .collect();
+                    new_paragraph.push_str("...");
+                } else {
+                    if *first_match > CONTENT_MATCH_PADDING as usize {
+                        let at_least_take =
+                            new_paragraph.len() - first_match + CONTENT_MATCH_PADDING;
+
+                        let deleted_chars_len = if at_least_take > IDEAL_CONTENT_MATCH_LENGTH {
+                            first_match - CONTENT_MATCH_PADDING
+                        } else {
+                            new_paragraph.len() - IDEAL_CONTENT_MATCH_LENGTH
+                        };
+
+                        index_offset = deleted_chars_len - 3;
+
+                        new_paragraph = new_paragraph.chars().skip(deleted_chars_len).collect();
+                        new_paragraph.insert_str(0, "...");
+                    }
+
+                    if new_indices.len() - last_match > CONTENT_MATCH_PADDING {
+                        let at_least_take = *last_match - index_offset + CONTENT_MATCH_PADDING;
+
+                        let take_chars_len = if at_least_take > IDEAL_CONTENT_MATCH_LENGTH {
+                            at_least_take
+                        } else {
+                            new_paragraph.len() - (IDEAL_CONTENT_MATCH_LENGTH - last_match - 3)
+                        };
+
+                        new_paragraph = new_paragraph.chars().take(take_chars_len).collect();
+                        new_paragraph.push_str("...");
+                    }
+
+                    if new_paragraph.len() > MAX_CONTENT_MATCH_LENGTH {
+                        new_paragraph = new_paragraph
+                            .chars()
+                            .take(MAX_CONTENT_MATCH_LENGTH)
+                            .collect();
+
+                        new_indices = new_indices
+                            .into_iter()
+                            .filter(|index| *index < MAX_CONTENT_MATCH_LENGTH)
+                            .collect()
+                    }
+                }
+
+                Ok((
+                    new_paragraph,
+                    new_indices
+                        .iter()
+                        .map(|index| *index - index_offset)
+                        .collect(),
+                ))
+            }
+            _ => {
+                warn!("A fuzzy match happened but there are no matched indices.");
+
+                Err(UnexpectedError("No matched indices.".to_string()))
+            }
+        }
+    }
+}
+
+struct SearchableFileInfo {
+    id: Uuid,
+    path: String,
+    content: Option<String>,
+}
+
+#[derive(Clone)]
+pub enum SearchRequest {
+    Search { input: String },
+    EndSearch,
+    StopCurrentSearch,
+}
+
+pub enum SearchResult {
+    Error(UnexpectedError),
+    FileNameMatch { id: Uuid, path: String, matched_indices: Vec<usize>, score: i64 },
+    FileContentMatches { id: Uuid, path: String, content_matches: Vec<ContentMatch> },
+    NoMatch,
+}
+
+#[derive(Serialize)]
+pub struct ContentMatch {
+    paragraph: String,
+    matched_indices: Vec<usize>,
+    score: i64,
 }

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -322,9 +322,8 @@ impl RequestContext<'_, '_> {
             new_paragraph = new_paragraph
                 .chars()
                 .take(IDEAL_CONTENT_MATCH_LENGTH + CONTENT_MATCH_PADDING)
+                .chain("...".chars())
                 .collect();
-
-            new_paragraph.push_str("...");
         } else {
             if *first_match > CONTENT_MATCH_PADDING as usize {
                 let at_least_take = new_paragraph.len() - first_match + CONTENT_MATCH_PADDING;

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -128,10 +128,10 @@ impl RequestContext<'_, '_> {
 
         loop {
             let search = RequestContext::recv_with_debounce(&search_rx, debounce_duration)?;
+            should_continue.store(false, atomic::Ordering::Relaxed);
 
             match search {
                 SearchRequest::Search { input } => {
-                    should_continue.store(false, atomic::Ordering::Relaxed);
                     should_continue = Arc::new(AtomicBool::new(true));
 
                     let results_tx = results_tx.clone();
@@ -149,13 +149,8 @@ impl RequestContext<'_, '_> {
                         }
                     });
                 }
-                SearchRequest::EndSearch => {
-                    should_continue.store(false, atomic::Ordering::Relaxed);
-                    return Ok(());
-                }
-                SearchRequest::StopCurrentSearch => {
-                    should_continue.store(false, atomic::Ordering::Relaxed)
-                }
+                SearchRequest::EndSearch => return Ok(()),
+                SearchRequest::StopCurrentSearch => {}
             }
         }
     }

--- a/core/tests/search_service_tests.rs
+++ b/core/tests/search_service_tests.rs
@@ -1,8 +1,6 @@
 use crossbeam::channel::{Receiver, Sender};
 use lockbook_core::service::search_service::{SearchRequest, SearchResult, SearchResultItem};
 use std::collections::HashSet;
-use std::thread;
-use std::time::Duration;
 use test_utils::*;
 
 const FILE_PATHS: [&str; 6] =

--- a/core/tests/search_service_tests.rs
+++ b/core/tests/search_service_tests.rs
@@ -1,15 +1,38 @@
-use lockbook_core::service::search_service::SearchResultItem;
+use lockbook_core::service::search_service::{SearchRequest, SearchResult, SearchResultItem};
+use std::collections::HashSet;
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread;
+use std::time::Duration;
 use test_utils::*;
+
+const FILE_PATHS: [&str; 6] =
+    ["/abc.md", "/abcd.md", "/abcde.md", "/dir/doc1", "/dir/doc2", "/dir/doc3"];
+const CONTENT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus \
+lorem purus, malesuada a dui a, auctor lobortis dolor. Proin ut placerat lectus. Vestibulum massa \
+orci, fermentum id nunc sit amet, scelerisque tempus enim. Duis tristique imperdiet ex. Curabitur \
+sagittis augue vel orci eleifend, sed cursus ante porta. Phasellus pellentesque vulputate ante id \
+fringilla. Suspendisse eu volutpat augue. Mauris massa nisl, venenatis eget viverra non, ultrices \
+vel enim.";
+
+const MATCHED_CONTENT_1: (&str, &str) = (
+    "consectetur adipiscing elit. Vivamus lorem purus, malesuada",
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lorem purus, \
+malesuada a dui a, auctor lobortis dolor. Proin ut placerat lectus. Vestibulum m...",
+);
+
+const MATCHED_CONTENT_2: (&str, &str) = (
+    "Mauris massa nisl, venenatis eget viverra",
+    ".... Phasellus pellentesque vulputate ante id fringilla. Suspendisse eu volutpat augue. \
+    Mauris massa nisl, venenatis eget viverra non, ultrices vel enim.",
+);
 
 #[test]
 fn test_matches() {
     let core = test_core_with_account();
 
-    vec!["/abc.md", "/abcd.md", "/abcde.md", "/dir/doc1", "/dir/doc2", "/dir/doc3"]
-        .into_iter()
-        .for_each(|item| {
-            core.create_at_path(item).unwrap();
-        });
+    FILE_PATHS.iter().for_each(|item| {
+        core.create_at_path(item).unwrap();
+    });
 
     let search_results = core.search_file_paths("").unwrap();
     assert!(search_results.is_empty());
@@ -32,4 +55,113 @@ fn assert_result_paths(results: &[SearchResultItem], paths: &[&str]) {
     for i in 0..results.len() {
         assert_eq!(results.get(i).unwrap().path, *paths.get(i).unwrap());
     }
+}
+
+fn assert_async_results_path(results: Vec<SearchResult>, paths: Vec<&str>) {
+    assert_eq!(results.len(), paths.len());
+
+    let results_set: HashSet<&str> = results
+        .iter()
+        .map(|result| match result {
+            SearchResult::FileNameMatch { path, .. } => path.as_str(),
+            _ => panic!("Non file name match, search_result: {:?}", result),
+        })
+        .collect();
+    let paths_set: HashSet<&str> = paths.into_iter().collect();
+
+    assert_eq!(results_set, paths_set)
+}
+
+#[test]
+fn test_async_name_matches() {
+    let core = test_core_with_account();
+
+    FILE_PATHS.iter().for_each(|item| {
+        core.create_at_path(item).unwrap();
+    });
+
+    let start_search = core.start_search().unwrap();
+
+    start_search
+        .search_tx
+        .send(SearchRequest::Search { input: "".to_string() })
+        .unwrap();
+    thread::sleep(Duration::from_secs(1));
+    let result = start_search.results_rx.try_recv().unwrap();
+    match result {
+        SearchResult::NoMatch => {}
+        _ => panic!("There should be no matched search results, search_result: {:?}", result),
+    }
+
+    start_search
+        .search_tx
+        .send(SearchRequest::Search { input: "a".to_string() })
+        .unwrap();
+    let results = vec![
+        start_search.results_rx.recv().unwrap(),
+        start_search.results_rx.recv().unwrap(),
+        start_search.results_rx.recv().unwrap(),
+    ];
+    assert_async_results_path(results, vec!["/abc.md", "/abcd.md", "/abcde.md"]);
+
+    start_search
+        .search_tx
+        .send(SearchRequest::Search { input: "dir".to_string() })
+        .unwrap();
+    let results = vec![
+        start_search.results_rx.recv().unwrap(),
+        start_search.results_rx.recv().unwrap(),
+        start_search.results_rx.recv().unwrap(),
+    ];
+    assert_async_results_path(results, vec!["/dir/doc1", "/dir/doc2", "/dir/doc3"]);
+
+    start_search
+        .search_tx
+        .send(SearchRequest::EndSearch)
+        .unwrap();
+}
+
+fn assert_async_content_match(
+    search_tx: &Sender<SearchRequest>, results_rx: &Receiver<SearchResult>, input: &str,
+    matched_text: &str,
+) {
+    search_tx
+        .send(SearchRequest::Search { input: input.to_string() })
+        .unwrap();
+    let result = results_rx.recv().unwrap();
+
+    match result {
+        SearchResult::FileContentMatches { content_matches, .. } => {
+            assert_eq!(content_matches[0].paragraph, matched_text)
+        }
+        _ => panic!("There should be a content match, search_result: {:?}", result),
+    }
+}
+
+#[test]
+fn test_async_content_matches() {
+    let core = test_core_with_account();
+
+    let file = core.create_at_path("/aaaaaaaaaa.md").unwrap();
+    core.write_document(file.id, CONTENT.as_bytes()).unwrap();
+
+    let start_search = core.start_search().unwrap();
+
+    assert_async_content_match(
+        &start_search.search_tx,
+        &start_search.results_rx,
+        MATCHED_CONTENT_1.0,
+        MATCHED_CONTENT_1.1,
+    );
+    assert_async_content_match(
+        &start_search.search_tx,
+        &start_search.results_rx,
+        MATCHED_CONTENT_2.0,
+        MATCHED_CONTENT_2.1,
+    );
+
+    start_search
+        .search_tx
+        .send(SearchRequest::EndSearch)
+        .unwrap();
 }

--- a/core/tests/search_service_tests.rs
+++ b/core/tests/search_service_tests.rs
@@ -1,6 +1,6 @@
+use crossbeam::channel::{Receiver, Sender};
 use lockbook_core::service::search_service::{SearchRequest, SearchResult, SearchResultItem};
 use std::collections::HashSet;
-use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 use std::time::Duration;
 use test_utils::*;
@@ -86,8 +86,7 @@ fn test_async_name_matches() {
         .search_tx
         .send(SearchRequest::Search { input: "".to_string() })
         .unwrap();
-    thread::sleep(Duration::from_secs(1));
-    let result = start_search.results_rx.try_recv().unwrap();
+    let result = start_search.results_rx.recv().unwrap();
     match result {
         SearchResult::NoMatch => {}
         _ => panic!("There should be no matched search results, search_result: {:?}", result),

--- a/docs/design-ux/search.md
+++ b/docs/design-ux/search.md
@@ -45,8 +45,8 @@ __Returned Window:__
 *Lorem ipsum dolor sit amet, consectetur adipiscing elit.* Vivamus lorem purus, malesuada a dui a, auctor lobortis dolor.
 Proin ut placerat lectus. Vest...
 ```
-3. The section matched on is greater than 150 characters, but most matched indices lie at the end of the area or 
-beginning. We remove the minimum number of characters, starting from the beginning, to get that 150-character window. 
+3. The section matched on is greater than 150 characters, but most matched indices lie at the beginning or end.
+We remove the minimum number of characters, starting from the beginning, to get that 150-character window. 
 Suppose there are not enough characters before the first matched index. In that case, we leave an 8-character buffer 
 before the first matched index and remove as many characters as possible after the last matched index, following the 
 same rules.

--- a/docs/design-ux/search.md
+++ b/docs/design-ux/search.md
@@ -76,7 +76,6 @@ imperdiet ex. Curabitur sagittis augue vel orci eleifend, sed cursus ante porta.
 id...
 ```
 
-
 # Text editor search
 
 Implementation will be upto the text editors in question, will perform similar to "Search this page" in your web

--- a/docs/design-ux/search.md
+++ b/docs/design-ux/search.md
@@ -23,6 +23,60 @@ After this tag based search, we should expand the search criteria and decrypt & 
 that's what the user desires. We should communicate the various steps of the search process to the user as the operation
 proceeds.
 
+## Content Search Text Splitting
+
+We don't apply our matching algorithm to all the text of a file. Instead, we split a file into sections separated by 
+`\n\n` (much like markdown). When a section has a match, we pre-process the text so that we only return the most 
+relevant part of the section to a client. Ideally, we want to produce a 150-character window containing all 
+matched indices.
+
+When processing the text, different situations may arise, and in each one, we produce that window of characters 
+differently.
+1. The section matched on is less than 150 characters, so we return the whole area.
+2. The matched indices are less than 150 characters, so we return the first 150 characters.
+```markdown
+Example
+__Matched section:__
+*Lorem ipsum dolor sit amet, consectetur adipiscing elit.* Vivamus lorem purus, malesuada a dui a, auctor lobortis dolor. 
+Proin ut placerat lectus. Vestibulum massa orci, fermentum id nunc sit amet, scelerisque tempus enim. Duis tristique 
+imperdiet ex. Curabitur sagittis augue vel orci eleifend, sed cursus ante porta. Phasellus pellentesque vulputate ante 
+id fringilla. Suspendisse eu volutpat augue. Mauris massa nisl, venenatis eget viverra non, ultrices vel enim.
+__Returned Window:__
+*Lorem ipsum dolor sit amet, consectetur adipiscing elit.* Vivamus lorem purus, malesuada a dui a, auctor lobortis dolor.
+Proin ut placerat lectus. Vest...
+```
+3. The section matched on is greater than 150 characters, but most matched indices lie at the end of the area or 
+beginning. We remove the minimum number of characters, starting from the beginning, to get that 150-character window. 
+Suppose there are not enough characters before the first matched index. In that case, we leave an 8-character buffer 
+before the first matched index and remove as many characters as possible after the last matched index, following the 
+same rules.
+```markdown
+Example
+__Matched section:__
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lorem purus, malesuada a dui a, auctor lobortis dolor.
+Proin ut placerat lectus. Vestibulum massa orci, *fermentum id nunc sit amet, scelerisque tempus enim.* Duis tristique
+imperdiet ex. Curabitur sagittis augue vel orci eleifend, sed cursus ante porta. Phasellus pellentesque vulputate ante
+id fringilla. Suspendisse eu volutpat augue. Mauris massa nisl, venenatis eget viverra non, ultrices vel enim.
+__Returned Window:__
+...a orci, *fermentum id nunc sit amet, scelerisque tempus enim.* Duis tristique imperdiet ex. Curabitur sagittis augue 
+vel orci eleifend, sed cursus a...
+```
+4. If we still have more than 150 characters after step 3, we will only take the first 400 characters and matched 
+indices; if it is less, we will leave it as is.
+```markdown
+Example
+__Matched section:__
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lorem purus, malesuada a dui a, auctor lobortis dolor.
+*Proin ut placerat lectus. Vestibulum massa orci, fermentum id nunc sit amet, scelerisque tempus enim. Duis tristique
+imperdiet ex. Curabitur sagittis augue vel orci eleifend, sed cursus ante porta. Phasellus pellentesque vulputate* ante
+id fringilla. Suspendisse eu volutpat augue. Mauris massa nisl, venenatis eget viverra non, ultrices vel enim.
+__Returned Window:__
+... dolor. *Proin ut placerat lectus. Vestibulum massa orci, fermentum id nunc sit amet, scelerisque tempus enim. Duis tristique
+imperdiet ex. Curabitur sagittis augue vel orci eleifend, sed cursus ante porta. Phasellus pellentesque vulputate* ante
+id...
+```
+
+
 # Text editor search
 
 Implementation will be upto the text editors in question, will perform similar to "Search this page" in your web


### PR DESCRIPTION
## Motivation

Searching is an essential feature for lockbook. We already implemented search, but it worked only with file names and returned after scanning all the files. This search implementation will allow a user to get file names and contents while returning the results asynchronously as they come.

## File of Interest
- `core/.../search_service.rs`: contains all the logic for this new implementation of search

## General Implementation

This iteration of search works off of channels to supply asynchronous matches. Two channels exist, one dealing with sending and receiving search queries and the other with sending and receiving search results. The search algorithm will start by copying all the contents of `.md` and `.txt` files into memory, storing the data in an `Arc`. Once it has all the data, the search moves off into a separate thread. There it will wait on its channels to receive search queries. Every search query creates a new thread where the results will be asynchronously streamed back to the clients using channels. Every new query stops the old query's thread. All the threads will end when a user wants to end their search.

## Search Algorithm
[This](https://crates.io/crates/sublime_fuzzy) is the search algorithm I used. I chose sublime's algorithm because it seemed to fit how we wanted to search function, with the way it [scored various matches](https://crates.io/crates/sublime_fuzzy). Not necessarily sure what the time complexity for this algorithm is since none of their docs mention it. Although, we can very easily switch to [this](https://crates.io/crates/fuzzy-matcher) algorithm, which we previously used.

fixes #1225
