### PR TITLE
android: stop log crashes for large logs

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/LogActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/LogActivity.kt
@@ -1,9 +1,15 @@
 package app.lockbook.screen
 
 import android.os.Bundle
+import android.view.View
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.RecyclerView
 import app.lockbook.R
-import com.google.android.material.textview.MaterialTextView
+import com.afollestad.recyclical.ViewHolder
+import com.afollestad.recyclical.datasource.emptyDataSourceTyped
+import com.afollestad.recyclical.setup
+import com.afollestad.recyclical.withItem
 import java.io.File
 
 class LogActivity : AppCompatActivity() {
@@ -11,6 +17,8 @@ class LogActivity : AppCompatActivity() {
     companion object {
         const val LOG_FILE_NAME = "lockbook.log"
     }
+
+    var logSegments = emptyDataSourceTyped<LogTextViewHolderInfo>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -20,6 +28,25 @@ class LogActivity : AppCompatActivity() {
     }
 
     private fun getDebugContent() {
-        this.findViewById<MaterialTextView>(R.id.debug_text).text = File("$filesDir/$LOG_FILE_NAME").readText()
+        val debugTextView = findViewById<RecyclerView>(R.id.debug_text)
+        debugTextView.setup {
+            withDataSource(logSegments)
+
+            withItem<LogTextViewHolderInfo, LogViewHolder>(R.layout.log_segment_item) {
+                onBind(::LogViewHolder) { _, item ->
+                    logItem.text = item.textSegment
+                }
+            }
+        }
+
+        logSegments.set(File("$filesDir/$LOG_FILE_NAME").readText().split("\n").map { LogTextViewHolderInfo(it) })
     }
 }
+
+class LogViewHolder(itemView: View) : ViewHolder(itemView) {
+    val logItem: TextView = itemView.findViewById(R.id.log_item_text)
+}
+
+data class LogTextViewHolderInfo(
+    val textSegment: String
+)

--- a/clients/android/app/src/main/res/layout/activity_debug.xml
+++ b/clients/android/app/src/main/res/layout/activity_debug.xml
@@ -3,18 +3,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ScrollView
-        android:id="@+id/debug_scroller"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/debug_text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        android:paddingHorizontal="10dp"/>
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/debug_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="top|start"
-            android:textIsSelectable="true"
-            android:importantForAutofill="no" />
-
-    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/clients/android/app/src/main/res/layout/log_segment_item.xml
+++ b/clients/android/app/src/main/res/layout/log_segment_item.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textview.MaterialTextView android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:id="@+id/log_item_text"
+    android:textIsSelectable="true"
+    xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
Logs from core are megabytes in size. Although it doesn't take much to bring the contents of these logs into memory, putting them into a `TextView` is problematic. A `TextView` will attempt to render all the text at once, regardless of whether it is in view. This causes the crashes. 

My solution was to use `RecyclerView` to render only the logs on the screen.

fixes #1201