### PR TITLE
infra: support rust 1.63

### DIFF
--- a/clients/cli/src/billing.rs
+++ b/clients/cli/src/billing.rs
@@ -11,7 +11,7 @@ use lockbook_core::StripeAccountTier;
 
 use crate::CliError;
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, PartialEq, Eq, StructOpt)]
 pub enum Billing {
     /// Prints out information about your current tier
     Status,

--- a/clients/cli/src/debug.rs
+++ b/clients/cli/src/debug.rs
@@ -7,7 +7,7 @@ use crate::error::CliError;
 use crate::selector::select_meta;
 use crate::{error, Uuid};
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, PartialEq, Eq, StructOpt)]
 pub enum Debug {
     /// Prints metadata associated with a file
     Info {

--- a/clients/cli/src/share.rs
+++ b/clients/cli/src/share.rs
@@ -3,7 +3,7 @@ use crate::CliError;
 use lockbook_core::{Core, FileType, ShareMode, Uuid};
 use structopt::StructOpt;
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, PartialEq, Eq, StructOpt)]
 pub enum Share {
     /// Share a specified document with a user. If neither a path or id
     /// is specified, an interactivve selector will be launched

--- a/clients/linux/src/settings.rs
+++ b/clients/linux/src/settings.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::io;
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub struct Settings {
     pub hidden_tree_cols: Vec<String>,

--- a/clients/linux/src/ui/filetree.rs
+++ b/clients/linux/src/ui/filetree.rs
@@ -19,7 +19,7 @@ pub struct FileTree {
     pub overlay: gtk::Overlay,
 }
 
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum FileTreeCol {
     IconAndName,
     Id,

--- a/core/libs/shared/src/account.rs
+++ b/core/libs/shared/src/account.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub type Username = String;
 pub type ApiUrl = String;
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Account {
     pub username: Username,
     pub api_url: ApiUrl,

--- a/core/libs/shared/src/api.rs
+++ b/core/libs/shared/src/api.rs
@@ -23,7 +23,7 @@ pub struct RequestWrapper<T: Request> {
     pub client_version: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum ErrorWrapper<E> {
     Endpoint(E),
     ClientUpdateRequired,
@@ -83,7 +83,7 @@ pub struct ChangeDocRequest {
     pub new_content: EncryptedDocument,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum ChangeDocError {
     HmacMissing,
     DocumentNotFound,
@@ -100,18 +100,18 @@ impl Request for ChangeDocRequest {
     const ROUTE: &'static str = "/change-document-content";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetDocRequest {
     pub id: Uuid,
     pub hmac: DocumentHmac,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetDocumentResponse {
     pub content: EncryptedDocument,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum GetDocumentError {
     DocumentNotFound,
     NotPermissioned,
@@ -124,17 +124,17 @@ impl Request for GetDocRequest {
     const ROUTE: &'static str = "/get-document";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetPublicKeyRequest {
     pub username: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetPublicKeyResponse {
     pub key: PublicKey,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum GetPublicKeyError {
     InvalidUsername,
     UserNotFound,
@@ -147,10 +147,10 @@ impl Request for GetPublicKeyRequest {
     const ROUTE: &'static str = "/get-public-key";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetUsageRequest {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetUsageResponse {
     pub usages: Vec<FileUsage>,
     pub cap: u64,
@@ -162,13 +162,13 @@ impl GetUsageResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct FileUsage {
     pub file_id: Uuid,
     pub size_bytes: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum GetUsageError {
     UserNotFound,
 }
@@ -180,7 +180,7 @@ impl Request for GetUsageRequest {
     const ROUTE: &'static str = "/get-usage";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetUpdatesRequest {
     pub since_metadata_version: u64,
 }
@@ -191,7 +191,7 @@ pub struct GetUpdatesResponse {
     pub file_metadata: Vec<SignedFile>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum GetUpdatesError {
     UserNotFound,
 }
@@ -221,12 +221,12 @@ impl NewAccountRequest {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct NewAccountResponse {
     pub last_synced: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum NewAccountError {
     UsernameTaken,
     PublicKeyTaken,
@@ -242,13 +242,13 @@ impl Request for NewAccountRequest {
     const ROUTE: &'static str = "/new-account";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetBuildInfoRequest {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum GetBuildInfoError {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetBuildInfoResponse {
     pub build_version: &'static str,
     pub git_commit_hash: &'static str,
@@ -261,10 +261,10 @@ impl Request for GetBuildInfoRequest {
     const ROUTE: &'static str = "/get-build-info";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct DeleteAccountRequest {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum DeleteAccountError {
     UserNotFound,
 }
@@ -276,26 +276,26 @@ impl Request for DeleteAccountRequest {
     const ROUTE: &'static str = "/delete-account";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum PaymentMethod {
     NewCard { number: String, exp_year: i32, exp_month: i32, cvc: String },
     OldCard,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum StripeAccountTier {
     Premium(PaymentMethod),
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct UpgradeAccountStripeRequest {
     pub account_tier: StripeAccountTier,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct UpgradeAccountStripeResponse {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum UpgradeAccountStripeError {
     OldCardDoesNotExist,
     AlreadyPremium,
@@ -319,16 +319,16 @@ impl Request for UpgradeAccountStripeRequest {
     const ROUTE: &'static str = "/upgrade-account-stripe";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct UpgradeAccountGooglePlayRequest {
     pub purchase_token: String,
     pub account_id: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct UpgradeAccountGooglePlayResponse {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum UpgradeAccountGooglePlayError {
     AlreadyPremium,
     InvalidPurchaseToken,
@@ -343,13 +343,13 @@ impl Request for UpgradeAccountGooglePlayRequest {
     const ROUTE: &'static str = "/upgrade-account-google-play";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct CancelSubscriptionRequest {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct CancelSubscriptionResponse {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum CancelSubscriptionError {
     NotPremium,
     AlreadyCanceled,
@@ -365,23 +365,23 @@ impl Request for CancelSubscriptionRequest {
     const ROUTE: &'static str = "/cancel-subscription";
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetSubscriptionInfoRequest {}
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct SubscriptionInfo {
     pub payment_platform: PaymentPlatform,
     pub period_end: UnixTimeMillis,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(tag = "tag")]
 pub enum PaymentPlatform {
     Stripe { card_last_4_digits: String },
     GooglePlay { account_state: GooglePlayAccountState },
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum GooglePlayAccountState {
     Ok,
     Canceled,
@@ -389,12 +389,12 @@ pub enum GooglePlayAccountState {
     OnHold,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GetSubscriptionInfoResponse {
     pub subscription_info: Option<SubscriptionInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum GetSubscriptionInfoError {
     UserNotFound,
 }

--- a/core/libs/shared/src/crypto.rs
+++ b/core/libs/shared/src/crypto.rs
@@ -9,7 +9,7 @@ pub type AESKey = [u8; 32];
 pub type DecryptedDocument = Vec<u8>;
 pub type EncryptedDocument = AESEncrypted<DecryptedDocument>;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct AESEncrypted<T: DeserializeOwned> {
     #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
@@ -26,7 +26,7 @@ impl<T: DeserializeOwned> AESEncrypted<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Timestamped<T> {
     pub value: T,
     pub timestamp: i64,

--- a/core/libs/shared/src/document_repo.rs
+++ b/core/libs/shared/src/document_repo.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use tracing::*;
 use uuid::Uuid;
 
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RepoSource {
     Local, // files with local edits applied
     Base,  // files at latest known state when client and server matched

--- a/core/libs/shared/src/file.rs
+++ b/core/libs/shared/src/file.rs
@@ -16,7 +16,7 @@ pub struct Share {
     pub shared_with: Username,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct File {
     pub id: Uuid,
     pub parent: Uuid,

--- a/core/libs/shared/src/file_metadata.rs
+++ b/core/libs/shared/src/file_metadata.rs
@@ -158,7 +158,7 @@ impl fmt::Debug for FileDiff {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Diff {
     New,
     Id,

--- a/core/libs/shared/src/filename.rs
+++ b/core/libs/shared/src/filename.rs
@@ -16,7 +16,7 @@ impl DocumentType {
     }
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NameComponents {
     pub name: String,
     pub variant: Option<usize>,

--- a/core/libs/shared/src/lib.rs
+++ b/core/libs/shared/src/lib.rs
@@ -34,7 +34,7 @@ use hmac::crypto_mac::{InvalidKeyLength, MacError};
 
 pub type SharedResult<T> = Result<T, SharedError>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SharedError {
     InsufficientPermission,
     PathContainsEmptyFileName,

--- a/core/libs/shared/src/path_ops.rs
+++ b/core/libs/shared/src/path_ops.rs
@@ -191,7 +191,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Filter {
     DocumentsOnly,
     FoldersOnly,

--- a/core/libs/shared/src/work_unit.rs
+++ b/core/libs/shared/src/work_unit.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::file::File;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "tag", content = "content")]
 pub enum WorkUnit {
     LocalChange { metadata: File },

--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -105,7 +105,7 @@ macro_rules! unexpected_only {
 
 pub type CoreResult<T> = Result<T, CoreError>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CoreError {
     AccountExists,
     AccountNonexistent,

--- a/core/src/service/api_service.rs
+++ b/core/src/service/api_service.rs
@@ -22,7 +22,7 @@ impl<E> From<ErrorWrapper<E>> for ApiError<E> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ApiError<E> {
     Endpoint(E),
     ClientUpdateRequired,

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -26,7 +26,7 @@ pub struct UsageMetrics {
     pub data_cap: UsageItemMetric,
 }
 
-#[derive(Serialize, PartialEq, Debug)]
+#[derive(Serialize, PartialEq, Eq, Debug)]
 pub struct UsageItemMetric {
     pub exact: u64,
     pub readable: String,

--- a/server/admin/src/main.rs
+++ b/server/admin/src/main.rs
@@ -25,7 +25,7 @@ enum Subcommands {
     DeleteAccount { username: String },
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, PartialEq, Eq, StructOpt)]
 #[structopt(about = "Toggleable features for lockbook server.")]
 pub enum FeatureFlag {
     NewAccount {


### PR DESCRIPTION
I got rid of Clippy warnings that were stopping us from moving to this version.