### PR TITLE
infra: create releaser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,6 +3164,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "releaser"
+version = "0.1.0"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,6 +3166,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 [[package]]
 name = "releaser"
 version = "0.1.0"
+dependencies = [
+ "structopt",
+]
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
 	"clients/linux",
 	"clients/cli",
 	"utils/dev-tool",
+	"utils/releaser"
 ]

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+structopt = "0.3.13"

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -3,7 +3,5 @@ name = "releaser"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 structopt = "0.3.13"

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "releaser"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/utils/releaser/src/main.rs
+++ b/utils/releaser/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/utils/releaser/src/main.rs
+++ b/utils/releaser/src/main.rs
@@ -1,3 +1,15 @@
+mod server;
+mod utils;
+
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+enum Releaser {
+    DeployServer,
+}
+
 fn main() {
-    println!("Hello, world!");
+    match Releaser::from_args() {
+        Releaser::DeployServer => server::deploy_server(),
+    }
 }

--- a/utils/releaser/src/server.rs
+++ b/utils/releaser/src/server.rs
@@ -1,0 +1,53 @@
+use crate::utils::CommandRunner;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+pub fn deploy_server() {
+    build_server();
+    backup_old_server();
+    replace_old_server();
+    restart_server();
+    check_server_status();
+}
+
+fn build_server() {
+    println!("Building server");
+    Command::new("cargo")
+        .args(["build", "-p", "lockbook-server", "--release"])
+        .assert_success();
+}
+
+fn backup_old_server() {
+    println!("Backing up currently running server");
+    Command::new("ssh")
+        .args(["root@api.prod.lockbook.net", "cp", "/usr/bin/lockbook-server", "/root/old-server"])
+        .assert_success()
+}
+
+fn replace_old_server() {
+    println!("scp'ing new server into /root/new-server");
+    Command::new("scp")
+        .args(["target/release/lockbook-server", "root@api.prod.lockbook.net:/root/new-server"])
+        .assert_success();
+
+    println!("mv new-server /usr/bin");
+    Command::new("ssh")
+        .args(["root@api.prod.lockbook.net", "mv", "/root/new-server", "/usr/bin/"])
+        .assert_success()
+}
+
+fn restart_server() {
+    println!("starting new server");
+    Command::new("ssh")
+        .args(["root@api.prod.lockbook.net", "systemctl", "restart", "lockbook-server.service"])
+        .assert_success()
+}
+
+fn check_server_status() {
+    thread::sleep(Duration::from_secs(5));
+    println!("checking on server status");
+    Command::new("curl")
+        .args(["https://api.prod.lockbook.net/get-build-info"])
+        .assert_success()
+}

--- a/utils/releaser/src/utils.rs
+++ b/utils/releaser/src/utils.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+pub trait CommandRunner {
+    fn assert_success(&mut self);
+}
+
+impl CommandRunner for Command {
+    fn assert_success(&mut self) {
+        if !self.status().unwrap().success() {
+            panic!()
+        }
+    }
+}


### PR DESCRIPTION
Push a button to:
+ [x] Build server
+ [x] Release it to our server

In a different PR this will also release the various clients we have to the various distribution channels we use.

I didn't make it part of the existing devtool because the only thing I'd want from there is probably the `assert_success` bits. But even building apple for CI (linux) is different from building it for release. So I figured an isolated binary is probably going to be a better time for me.