### PR TITLE
core: assorted test fixes

### DIFF
--- a/clients/android/app/src/test/java/app/lockbook/MoveFileTest.kt
+++ b/clients/android/app/src/test/java/app/lockbook/MoveFileTest.kt
@@ -135,7 +135,13 @@ class MoveFileTest {
 
         val rootFileMetadata = CoreModel.getRoot().unwrapOk()
 
-        CoreModel.moveFile(rootFileMetadata.id, rootFileMetadata.id)
+        val folder = CoreModel.createFile(
+            rootFileMetadata.id,
+            generateAlphaString(),
+            FileType.Folder
+        ).unwrapOk()
+
+        CoreModel.moveFile(rootFileMetadata.id, folder.id)
             .unwrapErrorType(MoveFileError.CannotMoveRoot)
     }
 

--- a/clients/cli/src/debug.rs
+++ b/clients/cli/src/debug.rs
@@ -120,7 +120,8 @@ fn validate(core: &Core) -> Result<(), CliError> {
             TestRepoError::SharedLink { .. }
             | TestRepoError::DuplicateLink { .. }
             | TestRepoError::BrokenLink(_)
-            | TestRepoError::OwnedLink(_) => {
+            | TestRepoError::OwnedLink(_)
+            | TestRepoError::FileWithDifferentOwnerParent(_) => {
                 CliError::unexpected(format!("unexpected error: {:#?}", err))
             }
         },

--- a/core/libs/shared/src/file_like.rs
+++ b/core/libs/shared/src/file_like.rs
@@ -8,7 +8,7 @@ use crate::secret_filename::SecretFileName;
 use crate::server_file::ServerFile;
 use crate::signed_file::SignedFile;
 
-pub trait FileLike: PartialEq + Debug + Clone {
+pub trait FileLike: PartialEq + Debug + Clone + AsRef<FileMetadata> {
     fn id(&self) -> &Uuid;
     fn file_type(&self) -> FileType;
     fn parent(&self) -> &Uuid;

--- a/core/libs/shared/src/file_metadata.rs
+++ b/core/libs/shared/src/file_metadata.rs
@@ -151,7 +151,6 @@ impl<F: FileLike> fmt::Debug for FileDiff<F> {
                 Diff::Deleted => result.field("new_deleted", &self.new.explicitly_deleted()),
                 Diff::Hmac => result.field("new_hmac", &self.new.document_hmac()),
                 Diff::UserKeys => result.field("new_user_keys", &true),
-                Diff::FolderKeys => result.field("new_folder_keys", &true),
             };
         }
         result.finish()
@@ -168,7 +167,6 @@ pub enum Diff {
     Deleted,
     Hmac,
     UserKeys,
-    FolderKeys,
 }
 
 impl<F: FileLike> FileDiff<F> {
@@ -214,9 +212,6 @@ impl<F: FileLike> FileDiff<F> {
                     changes.push(UserKeys);
                 }
 
-                if old.folder_access_key() != new.folder_access_key() {
-                    changes.push(FolderKeys);
-                }
                 changes
             }
         }

--- a/core/libs/shared/src/lazy.rs
+++ b/core/libs/shared/src/lazy.rs
@@ -219,7 +219,7 @@ impl<T: Stagable> LazyTree<T> {
 
     /// Returns ids of files for which the argument is an ancestor—the files' children, recursively. Does not include the argument.
     /// This function tolerates cycles.
-    pub fn descendents(&mut self, id: &Uuid) -> SharedResult<HashSet<Uuid>> {
+    pub fn descendants(&mut self, id: &Uuid) -> SharedResult<HashSet<Uuid>> {
         // todo: caching?
         let mut result = HashSet::new();
         let mut to_process = vec![*id];
@@ -297,6 +297,7 @@ pub enum ValidationFailure {
     Cycle(HashSet<Uuid>),
     PathConflict(HashSet<Uuid>),
     NonFolderWithChildren(Uuid),
+    FileWithDifferentOwnerParent(Uuid),
     NonDecryptableFileName(Uuid),
     SharedLink { link: Uuid, shared_ancestor: Uuid },
     DuplicateLink { target: Uuid },

--- a/core/libs/shared/src/lib.rs
+++ b/core/libs/shared/src/lib.rs
@@ -36,7 +36,7 @@ pub type SharedResult<T> = Result<T, SharedError>;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SharedError {
-    InsufficientPermission,
+    InsufficientPermission, // todo: this is a duplicate of NotPermissioned
     PathContainsEmptyFileName,
     PathTaken,
     RootNonexistent,

--- a/core/libs/shared/src/server_ops.rs
+++ b/core/libs/shared/src/server_ops.rs
@@ -33,22 +33,6 @@ where
             }
         }
 
-        // Check for updates to root
-        for change in &changes {
-            if let Some(file) = self.maybe_find(change.new.id()) {
-                if file.is_root() {
-                    return Err(SharedError::RootModificationInvalid);
-                }
-            }
-        }
-
-        // Check for root creations
-        for change in &changes {
-            if change.new.is_root() {
-                return Err(SharedError::DiffMalformed);
-            }
-        }
-
         // Check for changes to digest
         for change in &changes {
             match &change.old {
@@ -84,15 +68,6 @@ where
                         return Err(SharedError::OldVersionRequired);
                     }
                 }
-            }
-        }
-
-        // Check for updates to deleted files
-        for change in &changes {
-            if self.maybe_find(change.new.id()).is_some()
-                && self.calculate_deleted(change.new.id())?
-            {
-                return Err(SharedError::DeletedFileUpdated);
             }
         }
 

--- a/core/libs/shared/src/server_tree.rs
+++ b/core/libs/shared/src/server_tree.rs
@@ -42,7 +42,7 @@ where
         let mut tree = metas.to_lazy();
         let mut descendants_of_shared_ids = shared_ids.clone();
         for id in shared_ids {
-            descendants_of_shared_ids.extend(tree.descendents(&id)?);
+            descendants_of_shared_ids.extend(tree.descendants(&id)?);
         }
         Ok(Self { ids: descendants_of_shared_ids, owned, metas })
     }

--- a/core/libs/shared/src/validate.rs
+++ b/core/libs/shared/src/validate.rs
@@ -243,7 +243,9 @@ where
             }
             // newly root
             if self.find(&id)?.is_root() {
-                return Err(SharedError::RootModificationInvalid);
+                return Err(SharedError::ValidationFailure(ValidationFailure::Cycle(
+                    vec![id].into_iter().collect(),
+                )));
             }
         }
         Ok(())

--- a/core/src/model/errors.rs
+++ b/core/src/model/errors.rs
@@ -179,10 +179,12 @@ impl From<SharedError> for CoreError {
             PathTaken => CoreError::PathTaken,
             FileNameContainsSlash => CoreError::FileNameContainsSlash,
             RootModificationInvalid => CoreError::RootModificationInvalid,
+            DeletedFileUpdated => CoreError::FileNonexistent,
             FileNameEmpty => CoreError::FileNameEmpty,
             FileNotFolder => CoreError::FileNotFolder,
             FileNotDocument => CoreError::FileNotDocument,
             InsufficientPermission => CoreError::InsufficientPermission,
+            NotPermissioned => CoreError::InsufficientPermission,
             ValidationFailure(lockbook_shared::ValidationFailure::Cycle(_)) => {
                 CoreError::FolderMovedIntoSelf
             }
@@ -200,6 +202,9 @@ impl From<SharedError> for CoreError {
             }
             ValidationFailure(lockbook_shared::ValidationFailure::OwnedLink(_)) => {
                 CoreError::LinkTargetIsOwned
+            }
+            ValidationFailure(lockbook_shared::ValidationFailure::NonFolderWithChildren(_)) => {
+                CoreError::FileNotFolder
             }
             _ => CoreError::Unexpected(format!("unexpected shared error {:?}", err)),
         }
@@ -1042,6 +1047,7 @@ pub enum TestRepoError {
     FileNameContainsSlash(Uuid),
     PathConflict(HashSet<Uuid>),
     NonDecryptableFileName(Uuid),
+    FileWithDifferentOwnerParent(Uuid),
     SharedLink { link: Uuid, shared_ancestor: Uuid },
     DuplicateLink { target: Uuid },
     BrokenLink(Uuid),
@@ -1072,6 +1078,9 @@ impl From<SharedError> for TestRepoError {
                 }
                 ValidationFailure::BrokenLink(id) => TestRepoError::BrokenLink(id),
                 ValidationFailure::OwnedLink(id) => TestRepoError::OwnedLink(id),
+                ValidationFailure::FileWithDifferentOwnerParent(id) => {
+                    TestRepoError::FileWithDifferentOwnerParent(id)
+                }
             },
             _ => TestRepoError::Shared(err),
         }

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -30,7 +30,7 @@ impl RequestContext<'_, '_> {
             return Err(TestRepoError::NoRootFolder);
         }
 
-        tree.validate(Owner(account.public_key()))?;
+        tree = tree.validate(Owner(account.public_key()))?;
 
         for id in tree.owned_ids() {
             let name = tree.name(&id, account)?;

--- a/core/src/service/share_service.rs
+++ b/core/src/service/share_service.rs
@@ -61,7 +61,7 @@ impl RequestContext<'_, '_> {
         )?);
 
         let mut tree = tree.stage(Some(file.sign(account)?));
-        tree.validate(Owner(account.public_key()))?;
+        tree = tree.validate(Owner(account.public_key()))?;
         tree.promote();
 
         Ok(())
@@ -143,7 +143,7 @@ impl RequestContext<'_, '_> {
             Some(user_access) => {
                 user_access.deleted = true;
                 let mut new_tree = tree.stage(Some(file.sign(account)?));
-                new_tree.validate(owner)?;
+                new_tree = new_tree.validate(owner)?;
                 tree = new_tree.promote();
             }
         }
@@ -156,7 +156,7 @@ impl RequestContext<'_, '_> {
                     let mut link = link.timestamped_value.value.clone();
                     link.is_deleted = true;
                     let mut tree = tree.stage(Some(link.sign(account)?));
-                    tree.validate(owner)?;
+                    tree = tree.validate(owner)?;
                     tree.promote();
                     break;
                 }

--- a/core/tests/delete_and_list_tests.rs
+++ b/core/tests/delete_and_list_tests.rs
@@ -144,3 +144,13 @@ fn test_delete_list_files() {
 
     assert!(files.is_empty());
 }
+
+#[test]
+fn test_write_delete_sync_doc() {
+    let core = test_core_with_account();
+
+    let doc = core.create_at_path("test.md").unwrap().id;
+    core.write_document(doc, &[1, 2, 3]).unwrap();
+    core.delete_file(doc).unwrap();
+    core.sync(None).unwrap();
+}

--- a/core/tests/move_file_tests.rs
+++ b/core/tests/move_file_tests.rs
@@ -66,8 +66,14 @@ fn move_document_deleted() {
     let mut doc2 = doc1.clone();
     doc2.timestamped_value.value.is_deleted = true;
     doc2.timestamped_value.value.parent = *folder.id();
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::edit(&doc1, &doc2)] })
-        .unwrap();
+    let result = api_service::request(
+        &account,
+        UpsertRequest { updates: vec![FileDiff::edit(&doc1, &doc2)] },
+    );
+    assert_matches!(
+        result,
+        Err(ApiError::<UpsertError>::Endpoint(UpsertError::DeletedFileUpdated))
+    );
 }
 
 #[test]
@@ -123,7 +129,10 @@ fn move_folder_into_itself() {
         &account,
         UpsertRequest { updates: vec![FileDiff::edit(&folder, &new)] },
     );
-    assert_matches!(result, Err(ApiError::<UpsertError>::Endpoint(UpsertError::DiffMalformed)));
+    assert_matches!(
+        result,
+        Err(ApiError::<UpsertError>::Endpoint(UpsertError::RootModificationInvalid))
+    );
 }
 
 #[test]

--- a/core/tests/move_file_tests.rs
+++ b/core/tests/move_file_tests.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use lockbook_shared::api::*;
 use lockbook_shared::file_like::FileLike;
 use lockbook_shared::file_metadata::FileDiff;
+use lockbook_shared::ValidationFailure;
 
 #[test]
 fn move_document() {
@@ -131,7 +132,9 @@ fn move_folder_into_itself() {
     );
     assert_matches!(
         result,
-        Err(ApiError::<UpsertError>::Endpoint(UpsertError::RootModificationInvalid))
+        Err(ApiError::<UpsertError>::Endpoint(UpsertError::Validation(ValidationFailure::Cycle(
+            _
+        ))))
     );
 }
 

--- a/core/tests/sharing_tests.rs
+++ b/core/tests/sharing_tests.rs
@@ -58,6 +58,9 @@ fn write_document_write_share() {
 
     cores[1].sync(None).unwrap();
     cores[1]
+        .create_file("document_link", roots[1].id, FileType::Link { target: document0.id })
+        .unwrap();
+    cores[1]
         .write_document(document0.id, b"document content by sharee")
         .unwrap();
     assert_eq!(cores[1].read_document(document0.id).unwrap(), b"document content by sharee");
@@ -929,9 +932,6 @@ fn move_write_shared_folder() {
     cores[0].sync(None).unwrap();
 
     cores[1].sync(None).unwrap();
-    cores[1]
-        .create_file("folder_link", roots[1].id, FileType::Link { target: folder.id })
-        .unwrap();
     let child_folder = cores[1]
         .create_file("child_folder", roots[1].id, FileType::Folder)
         .unwrap();

--- a/core/tests/sharing_tests.rs
+++ b/core/tests/sharing_tests.rs
@@ -58,9 +58,6 @@ fn write_document_write_share() {
 
     cores[1].sync(None).unwrap();
     cores[1]
-        .create_file("document_link", roots[1].id, FileType::Link { target: document0.id })
-        .unwrap();
-    cores[1]
         .write_document(document0.id, b"document content by sharee")
         .unwrap();
     assert_eq!(cores[1].read_document(document0.id).unwrap(), b"document content by sharee");

--- a/core/tests/sync_service_new_unsynced_client_tests.rs
+++ b/core/tests/sync_service_new_unsynced_client_tests.rs
@@ -88,7 +88,7 @@ fn delete() {
     c1.sync(None).unwrap();
 
     let c2 = another_client(&c1);
-    assert::server_work_paths(&c2, &["/", "/document"]);
+    assert::server_work_paths(&c2, &["/"]);
     assert_stuff(&c2);
 }
 
@@ -100,7 +100,7 @@ fn delete_parent() {
     c1.sync(None).unwrap();
 
     let c2 = another_client(&c1);
-    assert::server_work_paths(&c2, &["/", "/parent/", "/parent/document"]);
+    assert::server_work_paths(&c2, &["/"]);
     assert_stuff(&c2);
 }
 
@@ -112,9 +112,6 @@ fn delete_grandparent() {
     c1.sync(None).unwrap();
 
     let c2 = another_client(&c1);
-    assert::server_work_paths(
-        &c2,
-        &["/", "/grandparent/parent/document", "/grandparent/parent/", "/grandparent/"],
-    );
+    assert::server_work_paths(&c2, &["/"]);
     assert_stuff(&c2);
 }

--- a/core/tests/sync_service_share_tests.rs
+++ b/core/tests/sync_service_share_tests.rs
@@ -149,6 +149,43 @@ fn move_file_b() {
 }
 
 #[test]
+fn move_file_with_child() {
+    let cores = vec![test_core_with_account(), test_core_with_account()];
+    let accounts = cores
+        .iter()
+        .map(|core| core.get_account().unwrap())
+        .collect::<Vec<_>>();
+
+    let folder = cores[0].create_at_path("folder/").unwrap();
+    cores[0]
+        .share_file(folder.id, &accounts[1].username, ShareMode::Write)
+        .unwrap();
+    cores[0].sync(None).unwrap();
+
+    cores[1].sync(None).unwrap();
+    let shares = cores[1].get_pending_shares().unwrap();
+    cores[1].create_link_at_path("link", shares[0].id).unwrap();
+    let folder2 = cores[1].create_at_path("folder2/").unwrap();
+    let document = cores[1].create_at_path("folder2/document").unwrap();
+    cores[1]
+        .write_document(document.id, b"document content")
+        .unwrap();
+    cores[1].move_file(folder2.id, folder.id).unwrap();
+    cores[1].sync(None).unwrap();
+
+    cores[0].sync(None).unwrap();
+
+    assert_stuff(&cores[0], &cores[1]);
+    assert::all_paths(
+        &cores[0],
+        &["/", "/folder/", "/folder/folder2/", "/folder/folder2/document"],
+    );
+    assert::all_paths(&cores[1], &["/", "/link/", "/link/folder2/", "/link/folder2/document"]);
+    assert::all_document_contents(&cores[0], &[("/folder/folder2/document", b"document content")]);
+    assert::all_document_contents(&cores[1], &[("/link/folder2/document", b"document content")]);
+}
+
+#[test]
 fn synced_files() {
     let cores = vec![test_core_with_account(), test_core_with_account()];
     let accounts = cores

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-cargo run -p releaser --release -- deploy-server

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+cargo run -p releaser --release -- deploy-server


### PR DESCRIPTION
test fixes:
* deleting a new modified document
* moving a folder with modified document children into a shared folder
* new deleted documents are no longer pushed

other fixes:
* root and deletion validations moved to shared code
* base/local copy on write semantics weren't being respected for documents
* certain document merge conflict resolutions would incorrectly raise validation errors