### PR TITLE
egui: fix build.rs

### DIFF
--- a/clients/egui/build.rs
+++ b/clients/egui/build.rs
@@ -1,11 +1,6 @@
 #[cfg(windows)]
-fn main() -> io::Result<()> {
-    use std::io;
-    use winres::WindowsResource;
-
-    WindowsResource::new().set_icon("lockbook.ico").compile()?;
-
-    Ok(())
+fn main() -> std::io::Result<()> {
+    winres::WindowsResource::new().set_icon("lockbook.ico").compile()
 }
 
 #[cfg(not(windows))]

--- a/clients/egui/build.rs
+++ b/clients/egui/build.rs
@@ -1,12 +1,12 @@
-use std::io;
-
 #[cfg(windows)]
-use winres::WindowsResource;
-
 fn main() -> io::Result<()> {
-    #[cfg(windows)]
-    {
-        WindowsResource::new().set_icon("lockbook.ico").compile()?;
-    }
+    use std::io;
+    use winres::WindowsResource;
+
+    WindowsResource::new().set_icon("lockbook.ico").compile()?;
+
     Ok(())
 }
+
+#[cfg(not(windows))]
+fn main() {}


### PR DESCRIPTION
The egui `build.rs` was structured in such a way that cargo builds on linux weren't being cached properly.