### PR TITLE
android, core: fix search crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,9 +1604,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1629,15 +1629,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1678,21 +1678,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/core/src/service/search_service.rs
+++ b/core/src/service/search_service.rs
@@ -372,7 +372,7 @@ impl RequestContext<'_, '_> {
                 let take_chars_len = if at_least_take > IDEAL_CONTENT_MATCH_LENGTH {
                     at_least_take
                 } else {
-                    IDEAL_CONTENT_MATCH_LENGTH - (last_match - index_offset)
+                    IDEAL_CONTENT_MATCH_LENGTH
                 };
 
                 new_paragraph = new_paragraph

--- a/core/tests/search_service_tests.rs
+++ b/core/tests/search_service_tests.rs
@@ -24,6 +24,12 @@ const MATCHED_CONTENT_2: (&str, &str) = (
     Mauris massa nisl, venenatis eget viverra non, ultrices vel enim.",
 );
 
+const MATCHED_CONTENT_3: (&str, &str) = (
+    "scelerisque tempus",
+    "...t amet, scelerisque tempus enim. Duis tristique imperdiet ex. Curabitur sagittis augue \
+    vel orci eleifend, sed cursus ante porta. Phasellus pellente...",
+);
+
 #[test]
 fn test_matches() {
     let core = test_core_with_account();
@@ -155,6 +161,12 @@ fn test_async_content_matches() {
         &start_search.results_rx,
         MATCHED_CONTENT_2.0,
         MATCHED_CONTENT_2.1,
+    );
+    assert_async_content_match(
+        &start_search.search_tx,
+        &start_search.results_rx,
+        MATCHED_CONTENT_3.0,
+        MATCHED_CONTENT_3.1,
     );
 
     start_search


### PR DESCRIPTION
Search was crashing on android. The problem ended up being with the content window being miss-computed, and thus the matched indices were false. Sometimes, the matched indices would be larger than the content window, thus giving an out of bounds error.

The crash happened in android, but it was caused by core.

fixes #1293 