### PR TITLE
core,egui: exporting account via qr code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,6 @@ dependencies = [
  "gtk4",
  "lockbook-core",
  "once_cell",
- "qrcode-generator",
  "regex",
  "serde",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ dependencies = [
  "libsecp256k1",
  "lockbook-shared",
  "num_cpus",
+ "qrcode-generator",
  "rand 0.8.5",
  "raqote",
  "reqwest",

--- a/clients/egui/src/account/modals/settings/account_tab.rs
+++ b/clients/egui/src/account/modals/settings/account_tab.rs
@@ -1,41 +1,114 @@
+use std::sync::mpsc;
+
 use eframe::egui;
-use egui_extras::{Size, StripBuilder};
+use egui_extras::{RetainedImage, Size, StripBuilder};
 use egui_winit::clipboard::Clipboard;
 
 pub struct AccountSettings {
-    pub export_result: Result<String, String>,
+    update_tx: mpsc::Sender<Update>,
+    update_rx: mpsc::Receiver<Update>,
+    export_result: Result<String, String>,
+    maybe_qr_result: Option<Result<RetainedImage, String>>,
+    generating_qr: bool,
+}
+
+impl AccountSettings {
+    pub fn new(export_result: Result<String, String>) -> Self {
+        let (update_tx, update_rx) = mpsc::channel();
+
+        Self { update_tx, update_rx, export_result, maybe_qr_result: None, generating_qr: false }
+    }
+}
+
+enum Update {
+    GenerateQr,
+    OpenQrCode(Result<RetainedImage, String>),
+    CloseQr,
 }
 
 impl super::SettingsModal {
     pub fn show_account_tab(&mut self, ui: &mut egui::Ui) {
-        match &self.account.export_result {
-            Ok(key) => {
-                ui.heading("Export Account");
-                ui.add_space(12.0);
-
-                ui.label(EXPORT_DESC);
-                ui.add_space(12.0);
-
-                StripBuilder::new(ui)
-                    .size(Size::remainder())
-                    .size(Size::remainder())
-                    .horizontal(|mut strip| {
-                        strip.cell(|ui| {
-                            if ui.button("Copy to Clipboard").clicked() {
-                                Clipboard::new(None).set(key.to_owned());
-                            }
-                        });
-                        strip.cell(|ui| {
-                            if ui.button("Show QR Code").clicked() {
-                                println!("show qr");
-                            }
-                        });
-                    });
-            }
-            Err(err) => {
-                ui.label(err);
+        while let Ok(update) = self.account.update_rx.try_recv() {
+            match update {
+                Update::GenerateQr => {
+                    self.account.generating_qr = true;
+                    self.generate_qr(ui.ctx());
+                }
+                Update::OpenQrCode(result) => {
+                    self.account.maybe_qr_result = Some(result);
+                    self.account.generating_qr = false;
+                }
+                Update::CloseQr => self.account.maybe_qr_result = None,
             }
         }
+
+        if let Some(qr_result) = &self.account.maybe_qr_result {
+            ui.vertical_centered(|ui| {
+                match qr_result {
+                    Ok(img) => {
+                        img.show_size(ui, egui::vec2(350.0, 350.0));
+                    }
+                    Err(err) => {
+                        ui.label(err);
+                    }
+                }
+                if ui.button("Done").clicked() {
+                    self.account.update_tx.send(Update::CloseQr).unwrap();
+                }
+            });
+        } else {
+            match &self.account.export_result {
+                Ok(key) => {
+                    ui.heading("Export Account");
+                    ui.add_space(12.0);
+
+                    ui.label(EXPORT_DESC);
+                    ui.add_space(12.0);
+
+                    StripBuilder::new(ui)
+                        .size(Size::remainder())
+                        .size(Size::remainder())
+                        .horizontal(|mut strip| {
+                            strip.cell(|ui| {
+                                if ui.button("Copy to Clipboard").clicked() {
+                                    Clipboard::new(None).set(key.to_owned());
+                                }
+                            });
+                            strip.cell(|ui| {
+                                let text = if self.account.generating_qr {
+                                    "Generating QR Code..."
+                                } else {
+                                    "Show QR Code"
+                                };
+                                if ui.button(text).clicked() {
+                                    // Can't simply call `self.generate_qr` here because of
+                                    // borrowing within closure errors, so we just queue an update
+                                    // for next frame.
+                                    self.account.update_tx.send(Update::GenerateQr).unwrap();
+                                }
+                            });
+                        });
+                }
+                Err(err) => {
+                    ui.label(err);
+                }
+            }
+        }
+    }
+
+    fn generate_qr(&self, ctx: &egui::Context) {
+        let core = self.core.clone();
+        let update_tx = self.account.update_tx.clone();
+        let ctx = ctx.clone();
+
+        std::thread::spawn(move || {
+            let result = core
+                .export_account_qr()
+                .map(|png| RetainedImage::from_image_bytes("qr", &png).unwrap())
+                .map_err(|err| format!("{:?}", err));
+            update_tx.send(Update::OpenQrCode(result)).unwrap();
+            ctx.request_repaint();
+        });
     }
 }
 

--- a/clients/egui/src/account/modals/settings/mod.rs
+++ b/clients/egui/src/account/modals/settings/mod.rs
@@ -51,7 +51,7 @@ impl SettingsModal {
         Some(Box::new(Self {
             core: core.clone(),
             settings: s.clone(),
-            account: AccountSettings { export_result },
+            account: AccountSettings::new(export_result),
             usage: UsageSettings {
                 sub_info_result,
                 metrics_result,

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -11,6 +11,5 @@ gtk = { package = "gtk4", version = "0.4.8", features = ["v4_6"] }
 gio = "0.15.1"
 sv5 = { package = "sourceview5", version = "0.4.1" }
 gdk-pixbuf = "0.15.4"
-qrcode-generator = "4.1.3"
 once_cell = "1.10.0"
 regex = "1.5.5"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,6 +45,7 @@ lazy_static = "1.4.0"
 sublime_fuzzy = "0.7.0"
 crossbeam = "0.8.1"
 lockbook-shared = { path = "libs/shared" }
+qrcode-generator = "4.1.6"
 
 [profile.release]
 debug = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -120,6 +120,14 @@ impl Core {
     }
 
     #[instrument(level = "debug", skip_all, err(Debug))]
+    pub fn export_account_qr(&self) -> Result<Vec<u8>, Error<AccountExportError>> {
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.export_account_qr())?;
+        Ok(val?)
+    }
+
+    #[instrument(level = "debug", skip_all, err(Debug))]
     pub fn get_account(&self) -> Result<Account, Error<GetAccountError>> {
         let account = self
             .db

--- a/core/src/service/account_service.rs
+++ b/core/src/service/account_service.rs
@@ -7,6 +7,7 @@ use lockbook_shared::account::Account;
 use lockbook_shared::api::{GetPublicKeyRequest, NewAccountRequest};
 use lockbook_shared::file_like::FileLike;
 use lockbook_shared::file_metadata::FileMetadata;
+use qrcode_generator::QrCodeEcc;
 
 impl RequestContext<'_, '_> {
     pub fn create_account(&mut self, username: &str, api_url: &str) -> CoreResult<Account> {
@@ -80,6 +81,12 @@ impl RequestContext<'_, '_> {
             .ok_or(CoreError::AccountNonexistent)?;
         let encoded: Vec<u8> = bincode::serialize(&account).map_err(core_err_unexpected)?;
         Ok(base64::encode(&encoded))
+    }
+
+    pub fn export_account_qr(&self) -> CoreResult<Vec<u8>> {
+        let acct_secret = self.export_account()?;
+        qrcode_generator::to_png_to_vec(&acct_secret, QrCodeEcc::Low, 1024)
+            .map_err(core_err_unexpected)
     }
 
     pub fn get_account(&self) -> CoreResult<&Account> {


### PR DESCRIPTION
This adds functionality to core to export account by returning the bytes of a qr code png so that clients can just worry about showing an image.

Closes #1308.