### PR TITLE
egui: improve appearance of opened doc tabs

### DIFF
--- a/clients/egui/src/account/workspace.rs
+++ b/clients/egui/src/account/workspace.rs
@@ -1,6 +1,9 @@
 use eframe::egui;
 use egui_extras::RetainedImage;
 
+use crate::theme::Icon;
+use crate::widgets::separator;
+
 use super::{Tab, TabContent};
 
 pub struct Workspace {
@@ -41,12 +44,16 @@ impl Workspace {
         self.tabs.get(self.active_tab)
     }
 
-    pub fn close_current_tab(&mut self) {
-        self.tabs.remove(self.active_tab);
+    pub fn close_tab(&mut self, i: usize) {
+        self.tabs.remove(i);
         let n_tabs = self.tabs.len();
         if self.active_tab >= n_tabs && n_tabs > 0 {
             self.active_tab = n_tabs - 1;
         }
+    }
+
+    pub fn close_current_tab(&mut self) {
+        self.close_tab(self.active_tab);
     }
 
     pub fn goto_tab_id(&mut self, id: lb::Uuid) -> bool {
@@ -68,6 +75,112 @@ impl Workspace {
     }
 }
 
+enum TabLabelResponse {
+    Clicked,
+    Closed,
+}
+
+fn tab_label(ui: &mut egui::Ui, t: &Tab, is_active: bool) -> Option<TabLabelResponse> {
+    let mut lbl_resp = None;
+
+    let padding = egui::vec2(15.0, 15.0);
+    let wrap_width = ui.available_width();
+
+    let text: egui::WidgetText = (&t.name).into();
+    let text = text.into_galley(ui, Some(false), wrap_width, egui::TextStyle::Body);
+
+    let x_icon = Icon::CLOSE.size(16.0);
+
+    let w = text.size().x + padding.x * 3.0 + x_icon.size + 1.0;
+    let h = text.size().y + padding.y * 2.0;
+
+    let (rect, resp) = ui.allocate_exact_size((w, h).into(), egui::Sense::hover());
+
+    if ui.is_rect_visible(rect) {
+        let visuals = &ui.style().interact(&resp).clone();
+
+        let close_btn_pos =
+            egui::pos2(rect.max.x - padding.x - x_icon.size, rect.center().y - x_icon.size / 2.0);
+
+        let close_btn_rect =
+            egui::Rect::from_min_size(close_btn_pos, egui::vec2(x_icon.size, x_icon.size))
+                .expand(2.0);
+
+        let mut close_hovered = false;
+        let pointer_pos = ui.input().pointer.hover_pos();
+        if let Some(pos) = pointer_pos {
+            if close_btn_rect.contains(pos) {
+                close_hovered = true;
+            }
+        }
+
+        let bg = if resp.hovered() && !close_hovered {
+            ui.visuals().widgets.hovered.bg_fill
+        } else {
+            ui.visuals().widgets.noninteractive.bg_fill
+        };
+        ui.painter().rect(rect, 0.0, bg, egui::Stroke::none());
+
+        let text_pos = egui::pos2(rect.min.x + padding.x, rect.center().y - 0.5 * text.size().y);
+
+        text.paint_with_visuals(ui.painter(), text_pos, visuals);
+
+        if close_hovered {
+            ui.painter().rect(
+                close_btn_rect,
+                0.0,
+                ui.visuals().widgets.hovered.bg_fill,
+                egui::Stroke::none(),
+            );
+        }
+
+        let icon_draw_pos = egui::pos2(
+            rect.max.x - padding.x - x_icon.size - 1.0,
+            rect.center().y - x_icon.size / 4.1 - 1.0,
+        );
+
+        let icon: egui::WidgetText = (&x_icon).into();
+        icon.into_galley(ui, Some(false), wrap_width, egui::TextStyle::Body)
+            .paint_with_visuals(ui.painter(), icon_draw_pos, visuals);
+
+        let close_resp = ui.interact(
+            close_btn_rect,
+            egui::Id::new(format!("close-btn-{}", t.id)),
+            egui::Sense::click(),
+        );
+        // First, we check if the close button was clicked.
+        if close_resp.clicked() {
+            lbl_resp = Some(TabLabelResponse::Closed);
+        } else {
+            // Then, we check if the tab label was clicked so that a close button click
+            // wouldn't also count here.
+            let resp = resp.interact(egui::Sense::click());
+            if resp.clicked() {
+                lbl_resp = Some(TabLabelResponse::Clicked);
+            } else if resp.middle_clicked() {
+                lbl_resp = Some(TabLabelResponse::Closed);
+            }
+        }
+
+        if is_active {
+            ui.painter().hline(
+                rect.min.x + 0.5..=rect.max.x - 1.0,
+                rect.max.y - 2.0,
+                egui::Stroke::new(4.0, ui.visuals().widgets.active.bg_fill),
+            );
+        }
+
+        let sep_stroke = if resp.hovered() && !close_hovered {
+            egui::Stroke::new(1.0, egui::Color32::TRANSPARENT)
+        } else {
+            ui.visuals().widgets.noninteractive.bg_stroke
+        };
+        ui.painter().vline(rect.max.x, rect.y_range(), sep_stroke);
+    }
+
+    lbl_resp
+}
+
 impl super::AccountScreen {
     pub fn show_workspace(&mut self, frame: &mut eframe::Frame, ui: &mut egui::Ui) {
         ui.set_enabled(!self.is_any_modal_open());
@@ -86,18 +199,37 @@ impl super::AccountScreen {
     fn show_tabs(&mut self, frame: &mut eframe::Frame, ui: &mut egui::Ui) {
         ui.vertical(|ui| {
             if self.workspace.tabs.len() > 1 {
-                ui.horizontal(|ui| {
-                    for (i, t) in self.workspace.tabs.iter().enumerate() {
-                        if ui
-                            .selectable_label(self.workspace.active_tab == i, &t.name)
-                            .clicked()
+                ui.scope(|ui| {
+                    ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
+
+                    ui.horizontal(|ui| {
+                        let ws = &mut self.workspace;
+
+                        for (i, maybe_resp) in ws
+                            .tabs
+                            .iter()
+                            .enumerate()
+                            .map(|(i, t)| tab_label(ui, t, ws.active_tab == i))
+                            .collect::<Vec<Option<TabLabelResponse>>>()
+                            .iter()
+                            .enumerate()
                         {
-                            self.workspace.active_tab = i;
-                            frame.set_window_title(&t.name);
+                            if let Some(resp) = maybe_resp {
+                                match resp {
+                                    TabLabelResponse::Clicked => {
+                                        ws.active_tab = i;
+                                        frame.set_window_title(&ws.tabs[i].name);
+                                    }
+                                    TabLabelResponse::Closed => ws.close_tab(i),
+                                }
+                                ui.ctx().request_repaint();
+                            }
                         }
-                    }
+                    });
+
+                    separator(ui);
                 });
-                ui.separator();
+            } else {
                 ui.add_space(5.0);
             }
 

--- a/clients/egui/src/theme/icons.rs
+++ b/clients/egui/src/theme/icons.rs
@@ -4,7 +4,7 @@ pub const MATERIAL_ICON_FONT: &[u8] = include_bytes!("../../material-icons-outli
 
 pub struct Icon {
     icon: &'static str,
-    size: f32,
+    pub size: f32,
     color: Option<egui::Color32>,
     weak: bool,
 }
@@ -17,9 +17,10 @@ impl Icon {
     pub const ACCOUNT: Self = ic("\u{e7ff}"); // Person Outline
     pub const ARROW_CIRCLE_DOWN: Self = ic("\u{f181}"); // Arrow Circle Down
     pub const CHECK_CIRCLE: Self = ic("\u{e86c}"); // Check Circle
-    pub const CIRCLE: Self = ic("\u{ef4a}"); // Circle
     pub const CANCEL: Self = ic("\u{e5c9}"); // Cancel
     pub const CANCEL_PRESENTATION: Self = ic("\u{e0e9}"); // Cancel Presentation
+    pub const CIRCLE: Self = ic("\u{ef4a}"); // Circle
+    pub const CLOSE: Self = ic("\u{e5cd}"); // Close
     pub const CODE: Self = ic("\u{e86f}"); // Code
     pub const CONTENT_COPY: Self = ic("\u{e14d}"); // Content Copy
     pub const DOC_UNKNOWN: Self = ic("\u{e06f}"); // Note


### PR DESCRIPTION
This significantly improves the tabs we use for opened docs. Not only is it more polished, but there are also close buttons for each tab that work as expected (meaning clicking close won't focus the tab you are closing like the current gtk client). They also close on middle-click.

Before:

![image](https://user-images.githubusercontent.com/6127189/188035822-5bc069ca-6d90-45d8-9c9f-288ee7b7d63d.png)

After:

![image](https://user-images.githubusercontent.com/6127189/188035651-7ca4cfa0-5e68-44a1-98c2-2fff2cd54ad1.png)

Closes #1312.