### PR TITLE
egui: update tree and editor state after sync

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -142,6 +142,8 @@ impl AccountScreen {
                             frame.set_window_title(&tab.name);
                         }
                     }
+                    // If any of this file's children are open, we need to update their restore
+                    // paths in case a sync deletes them.
                     for tab in &mut self.workspace.tabs {
                         if let Some(new_path) = new_child_paths.get(&tab.id) {
                             tab.path = new_path.clone();

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -439,6 +439,9 @@ impl AccountScreen {
                 let node = parent.remove(f.id).unwrap();
                 let target_node = self.tree.root.find_mut(target).unwrap();
                 target_node.insert_node(node);
+                if let Some(tab) = self.workspace.get_mut_tab_by_id(f.id) {
+                    tab.path = self.core.get_path_by_id(f.id).unwrap();
+                }
                 ctx.request_repaint();
             }
         }

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -49,6 +49,7 @@ impl super::AccountScreen {
                 Ok(_) => {
                     self.sync.status = Ok("just now".to_owned());
                     self.sync.phase = SyncPhase::IdleGood;
+                    self.refresh_tree_and_workspace(ctx);
                     self.refresh_sync_status(ctx);
                 }
                 Err(err) => {

--- a/clients/egui/src/account/tabs/image_viewer.rs
+++ b/clients/egui/src/account/tabs/image_viewer.rs
@@ -2,14 +2,16 @@ use eframe::egui;
 use egui_extras::RetainedImage;
 
 pub struct ImageViewer {
+    pub bytes: Vec<u8>,
     img: RetainedImage,
 }
 
 impl ImageViewer {
     pub fn boxed(id: impl Into<String>, bytes: &[u8]) -> Box<Self> {
-        let img = RetainedImage::from_image_bytes(id, bytes).unwrap();
+        let bytes = Vec::from(bytes);
+        let img = RetainedImage::from_image_bytes(id, &bytes).unwrap();
 
-        Box::new(Self { img })
+        Box::new(Self { bytes, img })
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {

--- a/clients/egui/src/account/tabs/mod.rs
+++ b/clients/egui/src/account/tabs/mod.rs
@@ -8,11 +8,10 @@ pub use image_viewer::ImageViewer;
 pub use markdown::Markdown;
 pub use plain_text::PlainText;
 
-use eframe::egui;
-
 pub struct Tab {
     pub id: lb::Uuid,
     pub name: String,
+    pub path: String,
     pub failure: Option<TabFailure>,
     pub content: Option<TabContent>,
 }
@@ -25,17 +24,9 @@ pub enum TabContent {
 }
 
 pub enum TabFailure {
+    DeletedFromSync,
     SimpleMisc(String),
     Unexpected(String),
-}
-
-impl TabFailure {
-    pub fn show(&self, ui: &mut egui::Ui) {
-        match self {
-            Self::SimpleMisc(msg) => ui.label(msg),
-            Self::Unexpected(msg) => ui.label(msg),
-        };
-    }
 }
 
 impl From<lb::Error<lb::ReadDocumentError>> for TabFailure {
@@ -47,8 +38,26 @@ impl From<lb::Error<lb::ReadDocumentError>> for TabFailure {
     }
 }
 
+impl From<lb::Error<lb::WriteToDocumentError>> for TabFailure {
+    fn from(err: lb::Error<lb::WriteToDocumentError>) -> Self {
+        match err {
+            lb::Error::UiError(err) => Self::SimpleMisc(format!("{:?}", err)),
+            lb::Error::Unexpected(msg) => Self::Unexpected(msg),
+        }
+    }
+}
+
 impl From<lb::Error<lb::GetDrawingError>> for TabFailure {
     fn from(err: lb::Error<lb::GetDrawingError>) -> Self {
+        match err {
+            lb::Error::UiError(err) => Self::SimpleMisc(format!("{:?}", err)),
+            lb::Error::Unexpected(msg) => Self::Unexpected(msg),
+        }
+    }
+}
+
+impl From<lb::Error<lb::SaveDrawingError>> for TabFailure {
+    fn from(err: lb::Error<lb::SaveDrawingError>) -> Self {
         match err {
             lb::Error::UiError(err) => Self::SimpleMisc(format!("{:?}", err)),
             lb::Error::Unexpected(msg) => Self::Unexpected(msg),

--- a/clients/egui/src/account/tree/mod.rs
+++ b/clients/egui/src/account/tree/mod.rs
@@ -24,6 +24,26 @@ impl FileTree {
         Self { root, state }
     }
 
+    pub fn expand_to(&mut self, id: lb::Uuid) {
+        if let Some(node) = self.root.find(id) {
+            // Select only the target file.
+            self.state.selected.clear();
+            self.state.selected.insert(id);
+
+            // Expand all target file parents.
+            let mut id = node.file.parent;
+            while let Some(node) = self.root.find(id) {
+                self.state.expanded.insert(id);
+                if node.file.id == self.root.file.id {
+                    break;
+                }
+                id = node.file.parent;
+            }
+        } else {
+            eprintln!("couldn't find node with id {}", id);
+        }
+    }
+
     pub fn show(&mut self, ui: &mut egui::Ui) -> NodeResponse {
         ui.vertical(|ui| {
             ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);

--- a/clients/egui/src/account/tree/mod.rs
+++ b/clients/egui/src/account/tree/mod.rs
@@ -24,9 +24,9 @@ impl FileTree {
 
         let mut root = TreeNode::from((root_meta, 0));
         root.populate_from(&all_metas);
-        root.is_expanded = true;
 
-        let state = TreeState::default();
+        let mut state = TreeState::default();
+        state.expanded.insert(root.file.id);
 
         Self { root, state }
     }

--- a/clients/egui/src/account/tree/mod.rs
+++ b/clients/egui/src/account/tree/mod.rs
@@ -2,9 +2,10 @@ mod node;
 mod response;
 mod state;
 
+pub use self::node::TreeNode;
+
 use eframe::egui;
 
-use self::node::TreeNode;
 use self::response::NodeResponse;
 use self::state::*;
 
@@ -15,15 +16,7 @@ pub struct FileTree {
 
 impl FileTree {
     pub fn new(all_metas: Vec<lb::File>) -> Self {
-        let mut all_metas = all_metas;
-
-        let root_meta = match all_metas.iter().position(|fm| fm.parent == fm.id) {
-            Some(i) => all_metas.swap_remove(i),
-            None => panic!("unable to find root in metadata list"),
-        };
-
-        let mut root = TreeNode::from((root_meta, 0));
-        root.populate_from(&all_metas);
+        let root = create_root_node(all_metas);
 
         let mut state = TreeState::default();
         state.expanded.insert(root.file.id);
@@ -105,6 +98,19 @@ impl FileTree {
             .map(|id| self.root.find(*id).unwrap().file.clone())
             .collect()
     }
+}
+
+pub fn create_root_node(all_metas: Vec<lb::File>) -> TreeNode {
+    let mut all_metas = all_metas;
+
+    let root_meta = match all_metas.iter().position(|fm| fm.parent == fm.id) {
+        Some(i) => all_metas.swap_remove(i),
+        None => panic!("unable to find root in metadata list"),
+    };
+
+    let mut root = TreeNode::from((root_meta, 0));
+    root.populate_from(&all_metas);
+    root
 }
 
 fn clear_children(state: &mut TreeState, node: &mut TreeNode) {

--- a/clients/egui/src/account/tree/state.rs
+++ b/clients/egui/src/account/tree/state.rs
@@ -6,6 +6,7 @@ pub struct TreeState {
     pub id: egui::Id,
     pub max_node_width: f32,
     pub selected: HashSet<lb::Uuid>,
+    pub expanded: HashSet<lb::Uuid>,
     pub renaming: NodeRenamingState,
     pub dnd: TreeDragAndDropState,
 }
@@ -16,6 +17,7 @@ impl Default for TreeState {
             id: egui::Id::new("filetree"),
             max_node_width: 0.0,
             selected: HashSet::new(),
+            expanded: HashSet::new(),
             dnd: TreeDragAndDropState::default(),
             renaming: NodeRenamingState::default(),
         }

--- a/clients/egui/src/account/workspace.rs
+++ b/clients/egui/src/account/workspace.rs
@@ -347,10 +347,7 @@ fn restore_tab(core: &Arc<lb::Core>, tree: &mut FileTree, tab: &mut Tab) {
                 }
                 tree.expand_to(file.id);
             }
-            Err(msg) => {
-                tab.failure = Some(TabFailure::Unexpected(msg));
-                return;
-            }
+            Err(msg) => tab.failure = Some(TabFailure::Unexpected(msg)),
         };
     }
 }

--- a/clients/egui/src/account/workspace.rs
+++ b/clients/egui/src/account/workspace.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use eframe::egui;
 use egui_extras::RetainedImage;
 
 use crate::theme::Icon;
 use crate::widgets::separator;
 
-use super::{Tab, TabContent};
+use super::{FileTree, Tab, TabContent, TabFailure};
 
 pub struct Workspace {
     pub tabs: Vec<Tab>,
@@ -21,9 +23,14 @@ impl Workspace {
         }
     }
 
-    pub fn open_tab(&mut self, id: lb::Uuid, name: &str) {
-        self.tabs
-            .push(Tab { id, name: name.to_owned(), failure: None, content: None });
+    pub fn open_tab(&mut self, id: lb::Uuid, name: &str, path: &str) {
+        self.tabs.push(Tab {
+            id,
+            name: name.to_owned(),
+            path: path.to_owned(),
+            failure: None,
+            content: None,
+        });
         self.active_tab = self.tabs.len() - 1;
     }
 
@@ -236,7 +243,31 @@ impl super::AccountScreen {
             ui.centered_and_justified(|ui| {
                 if let Some(tab) = self.workspace.tabs.get_mut(self.workspace.active_tab) {
                     if let Some(fail) = &tab.failure {
-                        fail.show(ui);
+                        match fail {
+                            TabFailure::DeletedFromSync => {
+                                ui.vertical_centered(|ui| {
+                                    ui.add_space(50.0);
+                                    ui.label(&format!(
+                                        "This file ({}) was deleted after syncing.",
+                                        tab.path
+                                    ));
+
+                                    ui.add_space(10.0);
+                                    ui.label("Would you like to restore it?");
+
+                                    ui.add_space(15.0);
+                                    if ui.button("Yes, Restore Me").clicked() {
+                                        restore_tab(&self.core, &mut self.tree, tab);
+                                    }
+                                });
+                            }
+                            TabFailure::SimpleMisc(msg) => {
+                                ui.label(msg);
+                            }
+                            TabFailure::Unexpected(msg) => {
+                                ui.label(msg);
+                            }
+                        };
                     } else if let Some(content) = &mut tab.content {
                         match content {
                             TabContent::Drawing(draw) => draw.show(ui),
@@ -271,6 +302,74 @@ impl super::AccountScreen {
             }
         }
     }
+}
+
+fn restore_tab(core: &Arc<lb::Core>, tree: &mut FileTree, tab: &mut Tab) {
+    let file = match core.create_at_path(&tab.path) {
+        Ok(f) => f,
+        Err(err) => {
+            tab.failure = Some(TabFailure::Unexpected(format!("{:?}", err)));
+            return;
+        }
+    };
+
+    // We create a new file to restore a document, so the tab needs the new ID.
+    tab.id = file.id;
+
+    if let Some(content) = &tab.content {
+        // Save the document content.
+        let save_result = if let TabContent::Drawing(d) = content {
+            core.save_drawing(file.id, &d.drawing)
+                .map_err(TabFailure::from)
+        } else {
+            let bytes = match content {
+                TabContent::Image(img) => &img.bytes,
+                TabContent::Markdown(md) => md.content.as_bytes(),
+                TabContent::PlainText(txt) => txt.content.as_bytes(),
+                _ => &[],
+            };
+            core.write_document(file.id, bytes)
+                .map_err(TabFailure::from)
+        };
+
+        // Set a new TabFailure if the content couldn't successfully be saved.
+        tab.failure = save_result.err();
+
+        // Ensure each parent folder is in the tree and then expand to the file.
+        match get_parents(core, file.id) {
+            Ok(parents) => {
+                let mut node = &mut tree.root;
+                for p in parents {
+                    if node.find(p.id).is_none() {
+                        node.insert(p.clone());
+                    }
+                    node = node.find_mut(p.id).unwrap();
+                }
+                tree.expand_to(file.id);
+            }
+            Err(msg) => {
+                tab.failure = Some(TabFailure::Unexpected(msg));
+                return;
+            }
+        };
+    }
+}
+
+// Gets all parents except root in descending order.
+fn get_parents(core: &Arc<lb::Core>, id: lb::Uuid) -> Result<Vec<lb::File>, String> {
+    let mut parents = Vec::new();
+    let mut id = id;
+    loop {
+        let file = core
+            .get_file_by_id(id)
+            .map_err(|err| format!("{:?}", err))?;
+        if file.id == file.parent {
+            break;
+        }
+        id = file.parent;
+        parents.insert(0, file);
+    }
+    Ok(parents)
 }
 
 const LOGO_BACKDROP: &[u8] = include_bytes!("../../lockbook-backdrop.png");


### PR DESCRIPTION
The egui client now:
* updates file tree state after a sync
* updates editor state after a sync
* updates editor state after an opened document is renamed
* has the ability to "restore" an opened document that was deleted during a sync

Closes #1313.