### PR TITLE
infra: refine fuzzer termination condition

### DIFF
--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -55,7 +55,7 @@ impl Experiment {
                 state.running.insert(thread, (Instant::now(), found.id));
                 (Some(found), true)
             }
-            None => (None, !state.running.is_empty()),
+            None => (None, !state.running.is_empty() && !state.pending.is_empty()),
         }
     }
 

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -107,7 +107,10 @@ impl Experiment {
         loop {
             {
                 let experiments = state.lock().unwrap();
-                if experiments.pending.is_empty() && experiments.done > 0 {
+                if experiments.pending.is_empty()
+                    && experiments.running.is_empty()
+                    && experiments.done > 0
+                {
                     println!("done printing info");
                     break;
                 }

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -88,7 +88,7 @@ impl Experiment {
                 .spawn(move || loop {
                     match Self::grab_ready_trial_for_thread(thread_id, thread_state.clone()) {
                         (Some(mut work), _) => {
-                            let mutants = work.execute();
+                            let mutants = work.execute(thread_id);
                             Self::publish_results(thread_id, thread_state.clone(), work, &mutants);
                         }
                         (None, true) => {

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -55,7 +55,7 @@ impl Experiment {
                 state.running.insert(thread, (Instant::now(), found.id));
                 (Some(found), true)
             }
-            None => (None, !state.running.is_empty() && !state.pending.is_empty()),
+            None => (None, !state.running.is_empty() || !state.pending.is_empty()),
         }
     }
 

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -92,7 +92,6 @@ impl Experiment {
                             Self::publish_results(thread_id, thread_state.clone(), work, &mutants);
                         }
                         (None, true) => {
-                            println!("no work found, sleeping");
                             thread::sleep(time::Duration::from_millis(100));
                         }
                         (None, false) => {
@@ -109,6 +108,7 @@ impl Experiment {
             {
                 let experiments = state.lock().unwrap();
                 if experiments.pending.is_empty() && experiments.done > 0 {
+                    println!("done printing info");
                     break;
                 }
                 println!(

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -92,9 +92,13 @@ impl Experiment {
                             Self::publish_results(thread_id, thread_state.clone(), work, &mutants);
                         }
                         (None, true) => {
+                            println!("no work found, sleeping");
                             thread::sleep(time::Duration::from_millis(100));
                         }
-                        (None, false) => break,
+                        (None, false) => {
+                            println!("no work found, stopping");
+                            break;
+                        }
                     }
                 })
                 .unwrap();

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -293,7 +293,7 @@ impl Trial {
     pub fn execute(&mut self, th_id: usize) -> Vec<Trial> {
         self.start_time = Instant::now();
         self.status = if let Err(err) = self.create_clients() { err } else { Running };
-        println!("Executing in {th_id}");
+        self.persist(th_id);
         let mut all_mutations = vec![];
 
         while self.status == Running {

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -293,7 +293,7 @@ impl Trial {
     pub fn execute(&mut self, th_id: usize) -> Vec<Trial> {
         self.start_time = Instant::now();
         self.status = if let Err(err) = self.create_clients() { err } else { Running };
-        self.persist(th_id);
+        println!("Executing in {th_id}");
         let mut all_mutations = vec![];
 
         while self.status == Running {

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -290,10 +290,10 @@ impl Trial {
         mutants
     }
 
-    pub fn execute(&mut self) -> Vec<Trial> {
+    pub fn execute(&mut self, th_id: usize) -> Vec<Trial> {
         self.start_time = Instant::now();
         self.status = if let Err(err) = self.create_clients() { err } else { Running };
-
+        self.persist(th_id);
         let mut all_mutations = vec![];
 
         while self.status == Running {


### PR DESCRIPTION
fuzzer would just wait for no current experiments to be running, but in reality it should additionally check if there are any pending experiments