### PR TITLE
server: restore performance after sharing

### DIFF
--- a/core/libs/shared/src/server_ops.rs
+++ b/core/libs/shared/src/server_ops.rs
@@ -12,11 +12,12 @@ use crate::signed_file::SignedFile;
 use crate::tree_like::TreeLike;
 use crate::{SharedError, SharedResult};
 
-impl<'a, 'b, OwnedFiles, SharedFiles, Files>
-    LazyTree<ServerTree<'a, 'b, OwnedFiles, SharedFiles, Files>>
+impl<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>
+    LazyTree<ServerTree<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>>
 where
     OwnedFiles: SchemaEvent<Owner, HashSet<Uuid>>,
     SharedFiles: SchemaEvent<Owner, HashSet<Uuid>>,
+    FileChildren: SchemaEvent<Uuid, HashSet<Uuid>>,
     Files: SchemaEvent<Uuid, ServerFile>,
 {
     /// Validates a diff prior to staging it. Performs individual validations, then validations that
@@ -24,7 +25,10 @@ where
     pub fn stage_diff(
         mut self, changes: Vec<FileDiff<SignedFile>>,
     ) -> SharedResult<
-        LazyStaged1<ServerTree<'a, 'b, OwnedFiles, SharedFiles, Files>, Vec<ServerFile>>,
+        LazyStaged1<
+            ServerTree<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>,
+            Vec<ServerFile>,
+        >,
     > {
         self.tree.ids.extend(changes.iter().map(|diff| *diff.id()));
 

--- a/core/libs/shared/src/server_ops.rs
+++ b/core/libs/shared/src/server_ops.rs
@@ -12,16 +12,20 @@ use crate::signed_file::SignedFile;
 use crate::tree_like::TreeLike;
 use crate::{SharedError, SharedResult};
 
-impl<'a, 'b, Log1, Log2> LazyTree<ServerTree<'a, 'b, Log1, Log2>>
+impl<'a, 'b, OwnedFiles, SharedFiles, Files>
+    LazyTree<ServerTree<'a, 'b, OwnedFiles, SharedFiles, Files>>
 where
-    Log1: SchemaEvent<Owner, HashSet<Uuid>>,
-    Log2: SchemaEvent<Uuid, ServerFile>,
+    OwnedFiles: SchemaEvent<Owner, HashSet<Uuid>>,
+    SharedFiles: SchemaEvent<Owner, HashSet<Uuid>>,
+    Files: SchemaEvent<Uuid, ServerFile>,
 {
     /// Validates a diff prior to staging it. Performs individual validations, then validations that
     /// require a tree
     pub fn stage_diff(
         mut self, changes: Vec<FileDiff<SignedFile>>,
-    ) -> SharedResult<LazyStaged1<ServerTree<'a, 'b, Log1, Log2>, Vec<ServerFile>>> {
+    ) -> SharedResult<
+        LazyStaged1<ServerTree<'a, 'b, OwnedFiles, SharedFiles, Files>, Vec<ServerFile>>,
+    > {
         self.tree.ids.extend(changes.iter().map(|diff| *diff.id()));
 
         // Check new.id == old.id

--- a/core/libs/shared/src/server_ops.rs
+++ b/core/libs/shared/src/server_ops.rs
@@ -12,6 +12,9 @@ use crate::signed_file::SignedFile;
 use crate::tree_like::TreeLike;
 use crate::{SharedError, SharedResult};
 
+type LazyServerStaged1<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files> =
+    LazyStaged1<ServerTree<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>, Vec<ServerFile>>;
+
 impl<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>
     LazyTree<ServerTree<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>>
 where
@@ -24,12 +27,7 @@ where
     /// require a tree
     pub fn stage_diff(
         mut self, changes: Vec<FileDiff<SignedFile>>,
-    ) -> SharedResult<
-        LazyStaged1<
-            ServerTree<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>,
-            Vec<ServerFile>,
-        >,
-    > {
+    ) -> SharedResult<LazyServerStaged1<'a, 'b, OwnedFiles, SharedFiles, FileChildren, Files>> {
         self.tree.ids.extend(changes.iter().map(|diff| *diff.id()));
 
         // Check new.id == old.id

--- a/core/libs/shared/src/server_tree.rs
+++ b/core/libs/shared/src/server_tree.rs
@@ -155,36 +155,9 @@ where
         maybe_prior
     }
 
-    fn remove(&mut self, id: Uuid) -> Option<Self::F> {
+    fn remove(&mut self, _id: Uuid) -> Option<Self::F> {
         error!("remove metadata called in server!");
-        if let Some(deleted) = self.files.delete(id) {
-            // maintain index: owned_files
-            if let Some(owned) = self.owned_files.get(&deleted.owner()) {
-                let mut new_owned = owned.clone();
-                let removed = new_owned.remove(&id);
-                self.owned_files.insert(deleted.owner(), new_owned);
-                if removed {
-                    return self.files.delete(id);
-                }
-            } else {
-                error!("File removed with unknown owner")
-            }
-
-            // maintain index: shared_files
-            for user_access_key in deleted.user_access_keys() {
-                let sharee = Owner(user_access_key.encrypted_for);
-                if let Some(mut shared) = self.shared_files.delete(sharee) {
-                    shared.remove(&id);
-                    self.shared_files.insert(sharee, shared);
-                } else {
-                    error!("File removed with unknown sharee")
-                }
-            }
-
-            Some(deleted)
-        } else {
-            None
-        }
+        None
     }
 }
 

--- a/core/libs/shared/src/server_tree.rs
+++ b/core/libs/shared/src/server_tree.rs
@@ -139,7 +139,7 @@ where
         if self.file_children.get(f.parent()).is_none() {
             self.file_children.insert(*f.parent(), HashSet::new());
         }
-        if maybe_prior.as_ref().map(|f| *f.parent()) != Some(id) {
+        if maybe_prior.as_ref().map(|f| *f.parent()) != Some(*f.parent()) {
             if let Some(ref prior) = maybe_prior {
                 if let Some(mut children) = self.file_children.delete(*prior.parent()) {
                     children.remove(&id);

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -1,7 +1,7 @@
 use crate::schema::Account;
 use crate::utils::username_is_valid;
 use crate::ServerError::ClientError;
-use crate::{document_service, RequestContext, ServerError, ServerState, ServerV1, Tx};
+use crate::{document_service, RequestContext, Server, ServerError, ServerState, Tx};
 use hmdb::transaction::Transaction;
 use libsecp256k1::PublicKey;
 use lockbook_shared::account::Username;
@@ -216,7 +216,7 @@ pub async fn delete_account_helper(
 }
 
 pub fn is_admin<E: Debug>(
-    db: &ServerV1, public_key: &PublicKey, admins: &HashSet<Username>,
+    db: &Server, public_key: &PublicKey, admins: &HashSet<Username>,
 ) -> Result<bool, ServerError<E>> {
     let is_admin = match db.accounts.get(&Owner(*public_key))? {
         None => false,

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -172,6 +172,7 @@ pub async fn delete_account_helper(
                 Owner(*public_key),
                 &mut tx.owned_files,
                 &mut tx.shared_files,
+                &mut tx.file_children,
                 &mut tx.metas,
             )?
             .to_lazy();

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -167,8 +167,13 @@ pub async fn delete_account_helper(
 ) -> Result<(), ServerError<DeleteAccountHelperError>> {
     let all_files: Result<Vec<(Uuid, DocumentHmac)>, ServerError<DeleteAccountHelperError>> =
         server_state.index_db.transaction(|tx| {
-            let mut tree =
-                ServerTree::new(Owner(*public_key), &mut tx.owned_files, &mut tx.metas)?.to_lazy();
+            let mut tree = ServerTree::new(
+                Owner(*public_key),
+                &mut tx.owned_files,
+                &mut tx.shared_files,
+                &mut tx.metas,
+            )?
+            .to_lazy();
             let mut docs_to_delete = vec![];
             let metas_to_delete = tree.owned_ids();
 

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -191,8 +191,10 @@ pub async fn delete_account_helper(
                 }
             }
             tx.owned_files.delete(Owner(*public_key));
+            tx.shared_files.delete(Owner(*public_key));
             for id in metas_to_delete {
                 tx.metas.delete(id);
+                tx.file_children.delete(id);
             }
 
             if !server_state.config.is_prod() {

--- a/server/server/src/account_service.rs
+++ b/server/server/src/account_service.rs
@@ -67,6 +67,7 @@ pub async fn new_account(
         tx.accounts.insert(owner, account);
         tx.usernames.insert(username, owner);
         tx.owned_files.insert(owner, owned_files);
+        tx.shared_files.insert(owner, HashSet::new());
         tx.metas.insert(*root.id(), root.clone());
 
         Ok(NewAccountResponse { last_synced: root.version })

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -423,13 +423,13 @@ pub async fn admin_disappear_file(
                 internal!(
                     "Attempted to disappear a file, the parent was not present, id: {}, parent: {:?}",
                     context.request.id,
-                    parent
+                    meta.parent()
                 )
             })?;
             if !file_children.remove(&context.request.id) {
                 error!(
                     "attempted to disappear a file, the parent didn't have it as a child, id: {}, parent: {:?}",
-                    context.request.id, parent
+                    context.request.id, meta.parent()
                 );
             }
             tx.file_children.insert(*meta.parent(), file_children);

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -31,6 +31,7 @@ pub async fn upsert_file_metadata(
                 req_owner,
                 &mut tx.owned_files,
                 &mut tx.shared_files,
+                &mut tx.file_children,
                 &mut tx.metas,
             )?
             .to_lazy();
@@ -101,9 +102,14 @@ pub async fn change_doc(
 
         let direct_access = meta_owner.0 == req_pk;
 
-        let mut tree =
-            ServerTree::new(meta_owner, &mut tx.owned_files, &mut tx.shared_files, &mut tx.metas)?
-                .to_lazy();
+        let mut tree = ServerTree::new(
+            meta_owner,
+            &mut tx.owned_files,
+            &mut tx.shared_files,
+            &mut tx.file_children,
+            &mut tx.metas,
+        )?
+        .to_lazy();
 
         let mut share_access = false;
 
@@ -169,9 +175,14 @@ pub async fn change_doc(
 
         let meta_owner = meta.owner();
 
-        let mut tree =
-            ServerTree::new(meta_owner, &mut tx.owned_files, &mut tx.shared_files, &mut tx.metas)?
-                .to_lazy();
+        let mut tree = ServerTree::new(
+            meta_owner,
+            &mut tx.owned_files,
+            &mut tx.shared_files,
+            &mut tx.file_children,
+            &mut tx.metas,
+        )?
+        .to_lazy();
         let new_size = request.new_content.value.len() as u64;
 
         if tree.calculate_deleted(request.diff.new.id())? {
@@ -230,9 +241,14 @@ pub async fn get_document(
 
         let direct_access = meta_owner.0 == context.public_key;
 
-        let mut tree =
-            ServerTree::new(meta_owner, &mut tx.owned_files, &mut tx.shared_files, &mut tx.metas)?
-                .to_lazy();
+        let mut tree = ServerTree::new(
+            meta_owner,
+            &mut tx.owned_files,
+            &mut tx.shared_files,
+            &mut tx.file_children,
+            &mut tx.metas,
+        )?
+        .to_lazy();
 
         let mut share_access = false;
 
@@ -292,9 +308,14 @@ pub async fn get_updates(
             .map(|owner| **owner)
             .collect::<Vec<_>>();
         for owner in owners {
-            let mut tree =
-                ServerTree::new(owner, &mut tx.owned_files, &mut tx.shared_files, &mut tx.metas)?
-                    .to_lazy();
+            let mut tree = ServerTree::new(
+                owner,
+                &mut tx.owned_files,
+                &mut tx.shared_files,
+                &mut tx.file_children,
+                &mut tx.metas,
+            )?
+            .to_lazy();
 
             let mut result_ids = HashSet::new();
             if owner.0 == context.public_key {
@@ -409,9 +430,14 @@ pub async fn admin_server_validate(
                 .get(&request.username)
                 .ok_or(ClientError(AdminServerValidateError::UserNotFound))?;
 
-            let mut tree =
-                ServerTree::new(owner, &mut tx.owned_files, &mut tx.shared_files, &mut tx.metas)?
-                    .to_lazy();
+            let mut tree = ServerTree::new(
+                owner,
+                &mut tx.owned_files,
+                &mut tx.shared_files,
+                &mut tx.file_children,
+                &mut tx.metas,
+            )?
+            .to_lazy();
 
             for id in tree.owned_ids() {
                 if !tree.calculate_deleted(&id)? {

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -12,7 +12,7 @@ use crate::account_service::GetUsageHelperError;
 use crate::billing::billing_service::StripeWebhookError;
 use crate::billing::stripe_client::SimplifiedStripeError;
 use crate::billing::stripe_model::{StripeDeclineCodeCatcher, StripeKnownDeclineCode};
-use crate::schema::{transaction, ServerV1};
+use crate::schema::v2::{transaction, Server};
 use crate::ServerError::ClientError;
 
 static CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -20,7 +20,7 @@ static CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 #[derive(Clone)]
 pub struct ServerState {
     pub config: config::Config,
-    pub index_db: ServerV1,
+    pub index_db: Server,
     pub stripe_client: stripe::Client,
     pub google_play_client: AndroidPublisher,
 }
@@ -44,7 +44,7 @@ impl<E: Debug> From<Error> for ServerError<E> {
     }
 }
 
-type Tx<'a> = transaction::ServerV1<'a>;
+type Tx<'a> = transaction::Server<'a>;
 
 #[macro_export]
 macro_rules! internal {

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -29,6 +29,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let source_index_db =
             lockbook_server_lib::schema::ServerV1::init(&cfg.index_db.db_location)
                 .expect("Failed to load index_db");
+
+        for (owner, ids) in source_index_db.owned_files.get_all().unwrap() {
+            for id in ids {
+                if source_index_db.metas.get(&id).unwrap().is_none() {
+                    let username = source_index_db
+                        .accounts
+                        .get(&owner)
+                        .unwrap()
+                        .unwrap()
+                        .username;
+                    println!("USER {:?} MISSING OWNED FILE {:?}", username, id);
+                }
+            }
+        }
+
         source_index_db
             .transaction(|source_tx| index_db.transaction(|tx| v2::migrate(source_tx, tx)))
             .expect("Failed to migrate index_db")

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         source_index_db
             .transaction(|source_tx| index_db.transaction(|tx| v2::migrate(source_tx, tx)))
             .expect("Failed to migrate index_db")
-            .expect("Failed to migrate index_db"); // todo: ???
+            .expect("Failed to migrate index_db");
         info!("migration complete");
     }
 

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -24,30 +24,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let google_play_client = get_google_play_client(&cfg.billing.google.service_account_key).await;
     let index_db = v2::Server::init(&cfg.index_db.db_location).expect("Failed to load index_db");
 
-    let migrate = true; // todo: environment variable? check if current version already populated?
-    if migrate {
+    if index_db.accounts.get_all().unwrap().is_empty() {
+        info!("starting migration");
         let source_index_db =
             lockbook_server_lib::schema::ServerV1::init(&cfg.index_db.db_location)
                 .expect("Failed to load index_db");
-
-        for (owner, ids) in source_index_db.owned_files.get_all().unwrap() {
-            for id in ids {
-                if source_index_db.metas.get(&id).unwrap().is_none() {
-                    let username = source_index_db
-                        .accounts
-                        .get(&owner)
-                        .unwrap()
-                        .unwrap()
-                        .username;
-                    println!("USER {:?} MISSING OWNED FILE {:?}", username, id);
-                }
-            }
-        }
 
         source_index_db
             .transaction(|source_tx| index_db.transaction(|tx| v2::migrate(source_tx, tx)))
             .expect("Failed to migrate index_db")
             .expect("Failed to migrate index_db"); // todo: ???
+        info!("migration complete");
     }
 
     if index_db.incomplete_write() {

--- a/server/server/src/metrics.rs
+++ b/server/server/src/metrics.rs
@@ -1,4 +1,4 @@
-use crate::{ServerError, ServerState, ServerV1};
+use crate::{Server, ServerError, ServerState};
 use lazy_static::lazy_static;
 
 use hmdb::transaction::Transaction;
@@ -10,7 +10,7 @@ use tracing::*;
 use uuid::Uuid;
 
 use crate::billing::billing_model::BillingPlatform;
-use crate::transaction::ServerV1 as TransactionalServerV1;
+use crate::transaction::Server as TransactionalServer;
 use lockbook_shared::file_like::FileLike;
 use lockbook_shared::file_metadata::Owner;
 use lockbook_shared::server_tree::ServerTree;
@@ -134,7 +134,7 @@ pub async fn start(state: ServerState) -> Result<(), ServerError<MetricsError>> 
 }
 
 pub async fn get_user_billing_platform(
-    db: &ServerV1, owner: &Owner,
+    db: &Server, owner: &Owner,
 ) -> Result<Option<BillingPlatform>, ServerError<MetricsError>> {
     let account = db
         .accounts
@@ -178,7 +178,7 @@ pub async fn get_user_info(
 }
 
 fn get_bytes_and_documents_count(
-    db: &mut TransactionalServerV1, owner: Owner, ids: Vec<Uuid>,
+    db: &mut TransactionalServer, owner: Owner, ids: Vec<Uuid>,
 ) -> Result<(i64, u64), ServerError<MetricsError>> {
     let mut total_documents = 0;
     let mut total_bytes = 0;

--- a/server/server/src/metrics.rs
+++ b/server/server/src/metrics.rs
@@ -148,9 +148,14 @@ pub async fn get_user_info(
     state: &ServerState, owner: Owner,
 ) -> Result<(i64, i64, bool), ServerError<MetricsError>> {
     state.index_db.transaction(|tx| {
-        let mut tree =
-            ServerTree::new(owner, &mut tx.owned_files, &mut tx.shared_files, &mut tx.metas)?
-                .to_lazy();
+        let mut tree = ServerTree::new(
+            owner,
+            &mut tx.owned_files,
+            &mut tx.shared_files,
+            &mut tx.file_children,
+            &mut tx.metas,
+        )?
+        .to_lazy();
 
         let metadatas = tree.all_files()?;
         let mut ids = Vec::new();

--- a/server/server/src/metrics.rs
+++ b/server/server/src/metrics.rs
@@ -148,7 +148,9 @@ pub async fn get_user_info(
     state: &ServerState, owner: Owner,
 ) -> Result<(i64, i64, bool), ServerError<MetricsError>> {
     state.index_db.transaction(|tx| {
-        let mut tree = ServerTree::new(owner, &mut tx.owned_files, &mut tx.metas)?.to_lazy();
+        let mut tree =
+            ServerTree::new(owner, &mut tx.owned_files, &mut tx.shared_files, &mut tx.metas)?
+                .to_lazy();
 
         let metadatas = tree.all_files()?;
         let mut ids = Vec::new();

--- a/server/server/src/schema.rs
+++ b/server/server/src/schema.rs
@@ -15,6 +15,7 @@ hmdb::schema! {
         owned_files: <Owner, HashSet<Uuid>>,
         shared_files: <Owner, HashSet<Uuid>>,
         metas: <Uuid, ServerFile>,
+        file_children: <Uuid, HashSet<Uuid>>,
         sizes: <Uuid, u64>,
         google_play_ids: <String, Owner>,
         stripe_ids: <String, Owner>

--- a/server/server/src/schema.rs
+++ b/server/server/src/schema.rs
@@ -8,22 +8,96 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OneKey;
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Account {
+    pub username: String,
+    pub billing_info: SubscriptionProfile,
+}
+
 hmdb::schema! {
     ServerV1 {
         usernames: <String, Owner>,
         accounts: <Owner, Account>,
         owned_files: <Owner, HashSet<Uuid>>,
-        shared_files: <Owner, HashSet<Uuid>>,
         metas: <Uuid, ServerFile>,
-        file_children: <Uuid, HashSet<Uuid>>,
         sizes: <Uuid, u64>,
         google_play_ids: <String, Owner>,
         stripe_ids: <String, Owner>
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Account {
-    pub username: String,
-    pub billing_info: SubscriptionProfile,
+pub mod v2 {
+    use super::Account;
+    use lockbook_shared::file_like::FileLike;
+    use lockbook_shared::file_metadata::Owner;
+    use lockbook_shared::server_file::ServerFile;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    hmdb::schema! {
+        Server {
+            usernames: <String, Owner>,
+            accounts: <Owner, Account>,
+            owned_files: <Owner, HashSet<Uuid>>,
+            shared_files: <Owner, HashSet<Uuid>>,
+            metas: <Uuid, ServerFile>,
+            file_children: <Uuid, HashSet<Uuid>>,
+            sizes: <Uuid, u64>,
+            google_play_ids: <String, Owner>,
+            stripe_ids: <String, Owner>
+        }
+    }
+
+    pub fn migrate(
+        source: &mut super::transaction::ServerV1, destination: &mut transaction::Server,
+    ) {
+        // copy existing tables
+        for (k, v) in source.usernames.get_all() {
+            destination.usernames.insert(k.clone(), v.clone());
+        }
+        for (k, v) in source.accounts.get_all() {
+            destination.accounts.insert(k.clone(), v.clone());
+        }
+        for (k, v) in source.owned_files.get_all() {
+            destination.owned_files.insert(k.clone(), v.clone());
+        }
+        for (k, v) in source.metas.get_all() {
+            destination.metas.insert(k.clone(), v.clone());
+        }
+        for (k, v) in source.sizes.get_all() {
+            destination.sizes.insert(k.clone(), v.clone());
+        }
+        for (k, v) in source.google_play_ids.get_all() {
+            destination.google_play_ids.insert(k.clone(), v.clone());
+        }
+        for (k, v) in source.stripe_ids.get_all() {
+            destination.stripe_ids.insert(k.clone(), v.clone());
+        }
+
+        // populate new indexes
+        let mut shared_files = HashMap::new();
+        let mut file_children = HashMap::new();
+        for owner in source.owned_files.keys() {
+            shared_files.insert(*owner, HashSet::new());
+        }
+        for (id, file) in source.metas.get_all() {
+            file_children.insert(*id, HashSet::new());
+            if let Some(shared_files) = shared_files.get_mut(&file.owner()) {
+                shared_files.insert(*id);
+            }
+        }
+        for (id, file) in source.metas.get_all() {
+            if let Some(file_children) = file_children.get_mut(file.parent()) {
+                file_children.insert(*id);
+            }
+        }
+        println!("migration: indexed shares of {} users", shared_files.len());
+        for (k, v) in shared_files {
+            destination.shared_files.insert(k, v);
+        }
+        println!("migration: indexed children of {} files", file_children.len());
+        for (k, v) in file_children {
+            destination.file_children.insert(k, v);
+        }
+    }
 }

--- a/server/server/src/schema.rs
+++ b/server/server/src/schema.rs
@@ -13,6 +13,7 @@ hmdb::schema! {
         usernames: <String, Owner>,
         accounts: <Owner, Account>,
         owned_files: <Owner, HashSet<Uuid>>,
+        shared_files: <Owner, HashSet<Uuid>>,
         metas: <Uuid, ServerFile>,
         sizes: <Uuid, u64>,
         google_play_ids: <String, Owner>,

--- a/server/server/src/schema.rs
+++ b/server/server/src/schema.rs
@@ -32,6 +32,7 @@ pub mod v2 {
     use lockbook_shared::file_metadata::Owner;
     use lockbook_shared::server_file::ServerFile;
     use std::collections::HashSet;
+    use tracing::info;
     use uuid::Uuid;
 
     hmdb::schema! {
@@ -53,35 +54,39 @@ pub mod v2 {
     ) {
         // copy existing tables
         for (k, v) in source.usernames.get_all() {
-            destination.usernames.insert(k.clone(), v.clone());
+            destination.usernames.insert(k.clone(), *v);
         }
         for (k, v) in source.accounts.get_all() {
-            destination.accounts.insert(k.clone(), v.clone());
-        }
-        for (k, v) in source.owned_files.get_all() {
-            destination.owned_files.insert(k.clone(), v.clone());
+            destination.accounts.insert(*k, v.clone());
         }
         for (k, v) in source.metas.get_all() {
-            destination.metas.insert(k.clone(), v.clone());
+            destination.metas.insert(*k, v.clone());
         }
         for (k, v) in source.sizes.get_all() {
-            destination.sizes.insert(k.clone(), v.clone());
+            if source.metas.get(k).is_some() {
+                destination.sizes.insert(*k, *v);
+            }
         }
         for (k, v) in source.google_play_ids.get_all() {
-            destination.google_play_ids.insert(k.clone(), v.clone());
+            destination.google_play_ids.insert(k.clone(), *v);
         }
         for (k, v) in source.stripe_ids.get_all() {
-            destination.stripe_ids.insert(k.clone(), v.clone());
+            destination.stripe_ids.insert(k.clone(), *v);
         }
 
-        // populate new indexes
+        // populate new indexes (and regenerate owned files, which is corrupt)
+        let mut owned_files = HashMap::new();
         let mut shared_files = HashMap::new();
         let mut file_children = HashMap::new();
-        for owner in source.owned_files.keys() {
+        for owner in source.accounts.keys() {
+            owned_files.insert(*owner, HashSet::new());
             shared_files.insert(*owner, HashSet::new());
         }
         for (id, file) in source.metas.get_all() {
             file_children.insert(*id, HashSet::new());
+            if let Some(owned_files) = owned_files.get_mut(&file.owner()) {
+                owned_files.insert(*id);
+            }
             for user_access_key in file.user_access_keys() {
                 if user_access_key.encrypted_for != user_access_key.encrypted_by {
                     if let Some(shared_files) =
@@ -97,11 +102,15 @@ pub mod v2 {
                 file_children.insert(*id);
             }
         }
-        println!("migration: indexed shares of {} users", shared_files.len());
+        info!("migration: indexed owned files of {} users", owned_files.len());
+        for (k, v) in owned_files {
+            destination.owned_files.insert(k, v);
+        }
+        info!("migration: indexed shared files of {} users", shared_files.len());
         for (k, v) in shared_files {
             destination.shared_files.insert(k, v);
         }
-        println!("migration: indexed children of {} files", file_children.len());
+        info!("migration: indexed children of {} files", file_children.len());
         for (k, v) in file_children {
             destination.file_children.insert(k, v);
         }

--- a/server/server/src/schema.rs
+++ b/server/server/src/schema.rs
@@ -82,8 +82,14 @@ pub mod v2 {
         }
         for (id, file) in source.metas.get_all() {
             file_children.insert(*id, HashSet::new());
-            if let Some(shared_files) = shared_files.get_mut(&file.owner()) {
-                shared_files.insert(*id);
+            for user_access_key in file.user_access_keys() {
+                if user_access_key.encrypted_for != user_access_key.encrypted_by {
+                    if let Some(shared_files) =
+                        shared_files.get_mut(&Owner(user_access_key.encrypted_for))
+                    {
+                        shared_files.insert(*id);
+                    }
+                }
             }
         }
         for (id, file) in source.metas.get_all() {


### PR DESCRIPTION
Adds, maintains, and uses indexes for shared files and file children on server. Fuzzer TPS at ~120 TPS on my x64 Macbook Pro (up from 0, presumably at least a 100x performance improvement). Core and Server now spend plurality CPU time on cryptographic operations. CI finishes more than 1 minute faster.

logs from local fuzzer run:
```
     Running tests/exhaustive_sync_check.rs (/Users/travis/Code/lockbook/target/release/deps/exhaustive_sync_check-7c4b9c922d339528)

running 1 test
Done: 0, Errors: 0, TPS: 0, Started: just now, Possibly Stalled: []
Done: 526, Errors: 0, TPS: 105, Started: just now, Possibly Stalled: []
Done: 1057, Errors: 0, TPS: 105, Started: just now, Possibly Stalled: []
Done: 1584, Errors: 0, TPS: 105, Started: just now, Possibly Stalled: []
Done: 2158, Errors: 0, TPS: 107, Started: just now, Possibly Stalled: []
Done: 2750, Errors: 0, TPS: 110, Started: just now, Possibly Stalled: []
Done: 3346, Errors: 0, TPS: 111, Started: just now, Possibly Stalled: []
Done: 3958, Errors: 0, TPS: 113, Started: just now, Possibly Stalled: []
Done: 4526, Errors: 0, TPS: 113, Started: just now, Possibly Stalled: []
Done: 5114, Errors: 0, TPS: 113, Started: just now, Possibly Stalled: []
Done: 5827, Errors: 0, TPS: 116, Started: just now, Possibly Stalled: []
Done: 6513, Errors: 0, TPS: 118, Started: just now, Possibly Stalled: []
```

<details>
  <summary>Server CPU flamegraph</summary>
  <img width="1135" alt="image" src="https://user-images.githubusercontent.com/6198756/190869706-675ef324-6368-4272-8ee4-76987622b6a1.png">
</details>

fixes: #1291