### PR TITLE
core: parameterize client 

### DIFF
--- a/core/src/service/api_service.rs
+++ b/core/src/service/api_service.rs
@@ -1,4 +1,3 @@
-use lazy_static::lazy_static;
 use reqwest::blocking::Client as RequestClient;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -37,43 +36,54 @@ pub enum ApiError<E> {
     Deserialize(String),
 }
 
-lazy_static! {
-    static ref CLIENT: RequestClient = RequestClient::new();
+pub trait Requester {
+    fn request<
+        T: Request<Response = impl DeserializeOwned, Error = impl DeserializeOwned> + Serialize,
+    >(
+        &self, account: &Account, request: T,
+    ) -> Result<T::Response, ApiError<T::Error>>;
 }
 
-pub fn request<
-    T: Request<Response = impl DeserializeOwned, Error = impl DeserializeOwned> + Serialize,
->(
-    account: &Account, request: T,
-) -> Result<T::Response, ApiError<T::Error>> {
-    request_helper(account, request, get_code_version, get_time)
+#[derive(Debug, Clone)]
+pub struct Network {
+    pub client: RequestClient,
+    pub get_code_version: fn() -> &'static str,
+    pub get_time: fn() -> Timestamp,
 }
 
-pub fn request_helper<
-    T: Request<Response = impl DeserializeOwned, Error = impl DeserializeOwned> + Serialize,
->(
-    account: &Account, request: T, get_code_version: fn() -> &'static str,
-    get_time: fn() -> Timestamp,
-) -> Result<T::Response, ApiError<T::Error>> {
-    let signed_request =
-        pubkey::sign(&account.private_key, request, get_time).map_err(ApiError::Sign)?;
-    let serialized_request = serde_json::to_vec(&RequestWrapper {
-        signed_request,
-        client_version: String::from(get_code_version()),
-    })
-    .map_err(|err| ApiError::Serialize(err.to_string()))?;
-    let serialized_response = CLIENT
-        .request(T::METHOD, format!("{}{}", account.api_url, T::ROUTE).as_str())
-        .body(serialized_request)
-        .send()
-        .map_err(|err| {
-            warn!("Send failed: {:#?}", err);
-            ApiError::SendFailed(err.to_string())
-        })?
-        .bytes()
-        .map_err(|err| ApiError::ReceiveFailed(err.to_string()))?;
-    let response: Result<T::Response, ErrorWrapper<T::Error>> =
-        serde_json::from_slice(&serialized_response)
-            .map_err(|err| ApiError::Deserialize(err.to_string()))?;
-    response.map_err(ApiError::from)
+impl Default for Network {
+    fn default() -> Self {
+        Self { client: Default::default(), get_code_version, get_time }
+    }
+}
+
+impl Requester for Network {
+    fn request<
+        T: Request<Response = impl DeserializeOwned, Error = impl DeserializeOwned> + Serialize,
+    >(
+        &self, account: &Account, request: T,
+    ) -> Result<T::Response, ApiError<T::Error>> {
+        let signed_request =
+            pubkey::sign(&account.private_key, request, self.get_time).map_err(ApiError::Sign)?;
+        let serialized_request = serde_json::to_vec(&RequestWrapper {
+            signed_request,
+            client_version: String::from((self.get_code_version)()),
+        })
+        .map_err(|err| ApiError::Serialize(err.to_string()))?;
+        let serialized_response = self
+            .client
+            .request(T::METHOD, format!("{}{}", account.api_url, T::ROUTE).as_str())
+            .body(serialized_request)
+            .send()
+            .map_err(|err| {
+                warn!("Send failed: {:#?}", err);
+                ApiError::SendFailed(err.to_string())
+            })?
+            .bytes()
+            .map_err(|err| ApiError::ReceiveFailed(err.to_string()))?;
+        let response: Result<T::Response, ErrorWrapper<T::Error>> =
+            serde_json::from_slice(&serialized_response)
+                .map_err(|err| ApiError::Deserialize(err.to_string()))?;
+        response.map_err(ApiError::from)
+    }
 }

--- a/core/src/service/document_service.rs
+++ b/core/src/service/document_service.rs
@@ -1,10 +1,10 @@
-use crate::{CoreError, RequestContext};
+use crate::{CoreError, RequestContext, Requester};
 use crate::{CoreResult, OneKey};
 use lockbook_shared::crypto::DecryptedDocument;
 use lockbook_shared::tree_like::Stagable;
 use uuid::Uuid;
 
-impl RequestContext<'_, '_> {
+impl<Client: Requester> RequestContext<'_, '_, Client> {
     pub fn read_document(&mut self, id: Uuid) -> CoreResult<DecryptedDocument> {
         let tree = self
             .tx

--- a/core/src/service/drawing_service.rs
+++ b/core/src/service/drawing_service.rs
@@ -11,10 +11,10 @@ use lockbook_shared::tree_like::Stagable;
 use crate::model::drawing;
 use crate::model::drawing::SupportedImageFormats;
 use crate::model::errors::CoreError;
-use crate::RequestContext;
 use crate::{CoreResult, OneKey};
+use crate::{RequestContext, Requester};
 
-impl RequestContext<'_, '_> {
+impl<Client: Requester> RequestContext<'_, '_, Client> {
     pub fn get_drawing(&mut self, id: Uuid) -> CoreResult<Drawing> {
         let tree = self
             .tx

--- a/core/src/service/file_service.rs
+++ b/core/src/service/file_service.rs
@@ -1,4 +1,4 @@
-use crate::{CoreError, CoreResult, OneKey, RequestContext};
+use crate::{CoreError, CoreResult, OneKey, RequestContext, Requester};
 use lockbook_shared::file::File;
 use lockbook_shared::file_like::FileLike;
 use lockbook_shared::file_metadata::{FileType, Owner};
@@ -6,7 +6,7 @@ use lockbook_shared::tree_like::{Stagable, TreeLike};
 use std::iter;
 use uuid::Uuid;
 
-impl RequestContext<'_, '_> {
+impl<Client: Requester> RequestContext<'_, '_, Client> {
     pub fn create_file(
         &mut self, name: &str, parent: &Uuid, file_type: FileType,
     ) -> CoreResult<File> {

--- a/core/src/service/integrity_service.rs
+++ b/core/src/service/integrity_service.rs
@@ -6,12 +6,12 @@ use lockbook_shared::tree_like::{Stagable, TreeLike};
 
 use crate::model::drawing;
 use crate::model::errors::{TestRepoError, Warning};
-use crate::{OneKey, RequestContext};
+use crate::{OneKey, RequestContext, Requester};
 
 const UTF8_SUFFIXES: [&str; 12] =
     ["md", "txt", "text", "markdown", "sh", "zsh", "bash", "html", "css", "js", "csv", "rs"];
 
-impl RequestContext<'_, '_> {
+impl<Client: Requester> RequestContext<'_, '_, Client> {
     pub fn test_repo_integrity(&mut self) -> Result<Vec<Warning>, TestRepoError> {
         let mut tree = self
             .tx

--- a/core/src/service/path_service.rs
+++ b/core/src/service/path_service.rs
@@ -1,11 +1,11 @@
-use crate::OneKey;
 use crate::{CoreError, CoreResult, RequestContext};
+use crate::{OneKey, Requester};
 use lockbook_shared::file::File;
 use lockbook_shared::path_ops::Filter;
 use lockbook_shared::tree_like::Stagable;
 use uuid::Uuid;
 
-impl RequestContext<'_, '_> {
+impl<Client: Requester> RequestContext<'_, '_, Client> {
     pub fn create_link_at_path(&mut self, path: &str, target_id: Uuid) -> CoreResult<File> {
         let pub_key = self.get_public_key()?;
         let tree = self

--- a/core/src/service/usage_service.rs
+++ b/core/src/service/usage_service.rs
@@ -4,8 +4,7 @@ use lockbook_shared::api::{FileUsage, GetUsageRequest, GetUsageResponse};
 use lockbook_shared::file_like::FileLike;
 use lockbook_shared::tree_like::{Stagable, TreeLike};
 
-use crate::service::api_service;
-use crate::{CoreError, RequestContext};
+use crate::{CoreError, RequestContext, Requester};
 use crate::{CoreResult, OneKey};
 
 const BYTE: u64 = 1;
@@ -32,11 +31,11 @@ pub struct UsageItemMetric {
     pub readable: String,
 }
 
-impl RequestContext<'_, '_> {
+impl<Client: Requester> RequestContext<'_, '_, Client> {
     fn server_usage(&self) -> CoreResult<GetUsageResponse> {
         let acc = &self.get_account()?;
 
-        Ok(api_service::request(acc, GetUsageRequest {})?)
+        Ok(self.client.request(acc, GetUsageRequest {})?)
     }
 
     pub fn get_usage(&self) -> CoreResult<UsageMetrics> {

--- a/core/tests/billing_tests.rs
+++ b/core/tests/billing_tests.rs
@@ -1,5 +1,4 @@
-use lockbook_core::service::api_service;
-use lockbook_core::service::api_service::ApiError;
+use lockbook_core::service::api_service::{ApiError, Requester};
 use lockbook_shared::api::{
     CancelSubscriptionError, CancelSubscriptionRequest, PaymentMethod, StripeAccountTier,
     UpgradeAccountGooglePlayError, UpgradeAccountGooglePlayRequest, UpgradeAccountStripeError,
@@ -19,16 +18,22 @@ fn upgrade_account_google_play_already_premium() {
     let account = core.get_account().unwrap();
 
     // upgrade account tier to premium using stripe
-    api_service::request(
-        &account,
-        UpgradeAccountStripeRequest {
-            account_tier: generate_premium_account_tier(test_credit_cards::GOOD, None, None, None),
-        },
-    )
-    .unwrap();
+    core.client
+        .request(
+            &account,
+            UpgradeAccountStripeRequest {
+                account_tier: generate_premium_account_tier(
+                    test_credit_cards::GOOD,
+                    None,
+                    None,
+                    None,
+                ),
+            },
+        )
+        .unwrap();
 
     // try to upgrade to premium with android
-    let result = api_service::request(
+    let result = core.client.request(
         &account,
         UpgradeAccountGooglePlayRequest {
             purchase_token: "".to_string(),
@@ -51,7 +56,7 @@ fn upgrade_account_google_play_invalid_purchase_token() {
     let account = core.get_account().unwrap();
 
     // upgrade with bad purchase token
-    let result = api_service::request(
+    let result = core.client.request(
         &account,
         UpgradeAccountGooglePlayRequest {
             purchase_token: "".to_string(),
@@ -74,13 +79,19 @@ fn upgrade_account_to_premium() {
     let account = core.get_account().unwrap();
 
     // upgrade account tier to premium
-    api_service::request(
-        &account,
-        UpgradeAccountStripeRequest {
-            account_tier: generate_premium_account_tier(test_credit_cards::GOOD, None, None, None),
-        },
-    )
-    .unwrap();
+    core.client
+        .request(
+            &account,
+            UpgradeAccountStripeRequest {
+                account_tier: generate_premium_account_tier(
+                    test_credit_cards::GOOD,
+                    None,
+                    None,
+                    None,
+                ),
+            },
+        )
+        .unwrap();
 }
 
 #[test]
@@ -90,16 +101,22 @@ fn new_tier_is_old_tier() {
     let account = core.get_account().unwrap();
 
     // upgrade account tier to premium
-    api_service::request(
-        &account,
-        UpgradeAccountStripeRequest {
-            account_tier: generate_premium_account_tier(test_credit_cards::GOOD, None, None, None),
-        },
-    )
-    .unwrap();
+    core.client
+        .request(
+            &account,
+            UpgradeAccountStripeRequest {
+                account_tier: generate_premium_account_tier(
+                    test_credit_cards::GOOD,
+                    None,
+                    None,
+                    None,
+                ),
+            },
+        )
+        .unwrap();
 
     // upgrade account tier to premium
-    let result = api_service::request(
+    let result = core.client.request(
         &account,
         UpgradeAccountStripeRequest {
             account_tier: generate_premium_account_tier(test_credit_cards::GOOD, None, None, None),
@@ -121,7 +138,7 @@ fn card_does_not_exist() {
     let account = core.get_account().unwrap();
 
     // upgrade account tier to premium using an "old card"
-    let result = api_service::request(
+    let result = core.client.request(
         &account,
         UpgradeAccountStripeRequest {
             account_tier: StripeAccountTier::Premium(PaymentMethod::OldCard),
@@ -155,7 +172,7 @@ fn card_decline() {
 
     for (card_number, expected_err) in scenarios {
         // upgrade account tier to premium using bad card number
-        let result = api_service::request(
+        let result = core.client.request(
             &account,
             UpgradeAccountStripeRequest {
                 account_tier: generate_premium_account_tier(card_number, None, None, None),
@@ -210,7 +227,7 @@ fn invalid_cards() {
 
     for (card_number, maybe_exp_year, maybe_exp_month, maybe_cvc, expected_err) in scenarios {
         // upgrade account tier to premium using bad card information
-        let result = api_service::request(
+        let result = core.client.request(
             &account,
             UpgradeAccountStripeRequest {
                 account_tier: generate_premium_account_tier(
@@ -238,16 +255,24 @@ fn cancel_stripe_subscription() {
     let account = core.get_account().unwrap();
 
     // switch account tier to premium
-    api_service::request(
-        &account,
-        UpgradeAccountStripeRequest {
-            account_tier: generate_premium_account_tier(test_credit_cards::GOOD, None, None, None),
-        },
-    )
-    .unwrap();
+    core.client
+        .request(
+            &account,
+            UpgradeAccountStripeRequest {
+                account_tier: generate_premium_account_tier(
+                    test_credit_cards::GOOD,
+                    None,
+                    None,
+                    None,
+                ),
+            },
+        )
+        .unwrap();
 
     // cancel stripe subscription
-    api_service::request(&account, CancelSubscriptionRequest {}).unwrap();
+    core.client
+        .request(&account, CancelSubscriptionRequest {})
+        .unwrap();
 }
 
 #[test]
@@ -276,16 +301,22 @@ fn downgrade_denied() {
     }
 
     // switch account tier to premium
-    api_service::request(
-        &account,
-        UpgradeAccountStripeRequest {
-            account_tier: generate_premium_account_tier(test_credit_cards::GOOD, None, None, None),
-        },
-    )
-    .unwrap();
+    core.client
+        .request(
+            &account,
+            UpgradeAccountStripeRequest {
+                account_tier: generate_premium_account_tier(
+                    test_credit_cards::GOOD,
+                    None,
+                    None,
+                    None,
+                ),
+            },
+        )
+        .unwrap();
 
     // attempt to cancel subscription but fail
-    let result = api_service::request(&account, CancelSubscriptionRequest {});
+    let result = core.client.request(&account, CancelSubscriptionRequest {});
 
     assert_matches!(
         result,
@@ -308,7 +339,9 @@ fn downgrade_denied() {
     }
 
     // cancel subscription again
-    api_service::request(&account, CancelSubscriptionRequest {}).unwrap();
+    core.client
+        .request(&account, CancelSubscriptionRequest {})
+        .unwrap();
 }
 
 #[test]
@@ -318,7 +351,7 @@ fn cancel_subscription_not_premium() {
     let account = core.get_account().unwrap();
 
     // cancel subscription but the account is not premium
-    let result = api_service::request(&account, CancelSubscriptionRequest {});
+    let result = core.client.request(&account, CancelSubscriptionRequest {});
 
     assert_matches!(
         result,

--- a/core/tests/change_document_content_tests.rs
+++ b/core/tests/change_document_content_tests.rs
@@ -1,5 +1,4 @@
-use lockbook_core::service::api_service;
-use lockbook_core::service::api_service::ApiError;
+use lockbook_core::service::api_service::{ApiError, Requester};
 use lockbook_shared::api::*;
 use lockbook_shared::crypto::AESEncrypted;
 use lockbook_shared::file_metadata::FileDiff;
@@ -15,7 +14,9 @@ fn change_document_content() {
     let doc = core.db.local_metadata.get(&doc).unwrap().unwrap();
 
     // create document
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] }).unwrap();
+    core.client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] })
+        .unwrap();
 
     let doc1 = doc;
     let mut doc2 = doc1.clone();
@@ -23,14 +24,15 @@ fn change_document_content() {
 
     let diff = FileDiff::edit(&doc1, &doc2);
     // change document content
-    api_service::request(
-        &account,
-        ChangeDocRequest {
-            diff,
-            new_content: AESEncrypted { value: vec![], nonce: vec![], _t: Default::default() },
-        },
-    )
-    .unwrap();
+    core.client
+        .request(
+            &account,
+            ChangeDocRequest {
+                diff,
+                new_content: AESEncrypted { value: vec![], nonce: vec![], _t: Default::default() },
+            },
+        )
+        .unwrap();
 }
 
 #[test]
@@ -41,7 +43,9 @@ fn change_document_content_not_found() {
     let mut doc = core.db.local_metadata.get(&doc).unwrap().unwrap();
 
     // create document
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] }).unwrap();
+    core.client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] })
+        .unwrap();
 
     doc.timestamped_value.value.id = Uuid::new_v4();
     let doc1 = doc;
@@ -50,7 +54,7 @@ fn change_document_content_not_found() {
 
     let diff = FileDiff::edit(&doc1, &doc2);
     // change document content
-    let res = api_service::request(
+    let res = core.client.request(
         &account,
         ChangeDocRequest {
             diff,

--- a/core/tests/create_file_tests.rs
+++ b/core/tests/create_file_tests.rs
@@ -1,4 +1,4 @@
-use lockbook_core::service::api_service::{self, ApiError};
+use lockbook_core::service::api_service::{ApiError, Requester};
 use lockbook_shared::file_metadata::FileDiff;
 use lockbook_shared::{api::*, ValidationFailure};
 use test_utils::*;
@@ -11,7 +11,9 @@ fn create_document() {
     let id = core.create_at_path("test.md").unwrap().id;
     let doc = core.db.local_metadata.get(&id).unwrap().unwrap();
 
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] }).unwrap();
+    core.client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] })
+        .unwrap();
 }
 
 #[test]
@@ -24,8 +26,9 @@ fn create_document_duplicate_id() {
     core.sync(None).unwrap();
 
     // create document with same id and key
-    let result =
-        api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
+    let result = core
+        .client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
 
     assert_matches!(
         result,
@@ -46,8 +49,9 @@ fn create_document_duplicate_path() {
     // create document with same path
 
     doc.timestamped_value.value.id = Uuid::new_v4();
-    let result =
-        api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
+    let result = core
+        .client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
 
     assert_matches!(
         result,
@@ -66,8 +70,9 @@ fn create_document_parent_not_found() {
     let doc = core.db.local_metadata.get(&id).unwrap().unwrap();
 
     // create document
-    let result =
-        api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
+    let result = core
+        .client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
 
     assert_matches!(
         result,

--- a/core/tests/delete_file_tests.rs
+++ b/core/tests/delete_file_tests.rs
@@ -1,5 +1,4 @@
-use lockbook_core::service::api_service;
-use lockbook_core::service::api_service::ApiError;
+use lockbook_core::service::api_service::{ApiError, Requester};
 use lockbook_shared::api::*;
 use lockbook_shared::file_metadata::FileDiff;
 use test_utils::*;
@@ -15,7 +14,8 @@ fn delete_document() {
     // delete document
     let mut doc2 = doc1.clone();
     doc2.timestamped_value.value.is_deleted = true;
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::edit(&doc1, &doc2)] })
+    core.client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::edit(&doc1, &doc2)] })
         .unwrap();
 }
 
@@ -30,7 +30,7 @@ fn delete_document_not_found() {
     // delete document
     let mut doc2 = doc1.clone();
     doc2.timestamped_value.value.is_deleted = true;
-    let result = api_service::request(
+    let result = core.client.request(
         &account,
         UpsertRequest {
             // create document as if deleting an existing document
@@ -49,8 +49,9 @@ fn delete_document_new_document() {
     let mut doc = core.db.local_metadata.get(&doc).unwrap().unwrap();
     doc.timestamped_value.value.is_deleted = true;
 
-    let result =
-        api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
+    let result = core
+        .client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] });
     assert_matches!(result, Ok(_));
 }
 
@@ -66,7 +67,8 @@ fn delete_document_deleted() {
     // delete document
     let mut doc2 = doc.clone();
     doc2.timestamped_value.value.is_deleted = true;
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::edit(&doc, &doc2)] })
+    core.client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::edit(&doc, &doc2)] })
         .unwrap();
 }
 
@@ -79,10 +81,9 @@ fn delete_cannot_delete_root() {
 
     let mut root2 = root1.clone();
     root2.timestamped_value.value.is_deleted = true;
-    let result = api_service::request(
-        &account,
-        UpsertRequest { updates: vec![FileDiff::edit(&root1, &root2)] },
-    );
+    let result = core
+        .client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::edit(&root1, &root2)] });
     assert_matches!(
         result,
         Err(ApiError::<UpsertError>::Endpoint(UpsertError::RootModificationInvalid))

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -3,7 +3,7 @@ use crate::exhaustive_sync::trial::Action::*;
 use crate::exhaustive_sync::trial::Status::{Failed, Ready, Running, Succeeded};
 use crate::exhaustive_sync::utils::{find_by_name, random_filename, random_utf8};
 use lockbook_core::model::errors::MoveFileError;
-use lockbook_core::service::api_service;
+use lockbook_core::service::api_service::Requester;
 use lockbook_core::Core;
 use lockbook_core::Error::UiError;
 use lockbook_shared::api::DeleteAccountRequest;
@@ -314,9 +314,12 @@ impl Trial {
     fn cleanup(&self) {
         if let Ok(account) = &self.clients[0].get_account() {
             // Delete account in server
-            api_service::request(account, DeleteAccountRequest {}).unwrap_or_else(|err| {
-                println!("Failed to delete account: {} error : {:?}", account.username, err)
-            });
+            self.clients[0]
+                .client
+                .request(account, DeleteAccountRequest {})
+                .unwrap_or_else(|err| {
+                    println!("Failed to delete account: {} error : {:?}", account.username, err)
+                });
 
             // Delete account locally
             for client in &self.clients {

--- a/core/tests/get_subscription_info_tests.rs
+++ b/core/tests/get_subscription_info_tests.rs
@@ -1,4 +1,4 @@
-use lockbook_core::service::api_service;
+use lockbook_core::service::api_service::Requester;
 use lockbook_shared::api::{GetSubscriptionInfoRequest, UpgradeAccountStripeRequest};
 use test_utils::{generate_premium_account_tier, test_core_with_account, test_credit_cards};
 
@@ -8,22 +8,32 @@ fn get_subscription_info() {
     let account = core.get_account().unwrap();
 
     // get no subscription info
-    assert!(api_service::request(&account, GetSubscriptionInfoRequest {})
+    assert!(core
+        .client
+        .request(&account, GetSubscriptionInfoRequest {})
         .unwrap()
         .subscription_info
         .is_none());
 
     // upgrade with stripe
-    api_service::request(
-        &account,
-        UpgradeAccountStripeRequest {
-            account_tier: generate_premium_account_tier(test_credit_cards::GOOD, None, None, None),
-        },
-    )
-    .unwrap();
+    core.client
+        .request(
+            &account,
+            UpgradeAccountStripeRequest {
+                account_tier: generate_premium_account_tier(
+                    test_credit_cards::GOOD,
+                    None,
+                    None,
+                    None,
+                ),
+            },
+        )
+        .unwrap();
 
     // get existent subscription info
-    assert!(api_service::request(&account, GetSubscriptionInfoRequest {})
+    assert!(core
+        .client
+        .request(&account, GetSubscriptionInfoRequest {})
         .unwrap()
         .subscription_info
         .is_some());

--- a/core/tests/new_account_tests.rs
+++ b/core/tests/new_account_tests.rs
@@ -1,5 +1,4 @@
-use lockbook_core::service::api_service;
-use lockbook_core::service::api_service::ApiError;
+use lockbook_core::service::api_service::{ApiError, Network, Requester};
 use lockbook_shared::account::Account;
 use lockbook_shared::api::*;
 use lockbook_shared::file_metadata::FileMetadata;
@@ -15,7 +14,7 @@ fn test_account(account: &Account) -> Result<NewAccountResponse, ApiError<NewAcc
         .unwrap()
         .sign(account)
         .unwrap();
-    api_service::request(account, NewAccountRequest::new(account, &root))
+    Network::default().request(account, NewAccountRequest::new(account, &root))
 }
 #[test]
 fn new_account() {

--- a/core/tests/rename_file_tests.rs
+++ b/core/tests/rename_file_tests.rs
@@ -1,4 +1,4 @@
-use lockbook_core::service::api_service;
+use lockbook_core::service::api_service::Requester;
 use lockbook_shared::api::*;
 use lockbook_shared::file_like::FileLike;
 use lockbook_shared::file_metadata::FileDiff;
@@ -12,12 +12,15 @@ fn rename_document() {
     let doc = core.create_at_path("test.md").unwrap().id;
     let doc = core.db.local_metadata.get(&doc).unwrap().unwrap();
 
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] }).unwrap();
+    core.client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::new(&doc)] })
+        .unwrap();
 
     let old = doc.clone();
     core.rename_file(*doc.id(), &random_name()).unwrap();
     let new = core.db.local_metadata.get(doc.id()).unwrap().unwrap();
 
-    api_service::request(&account, UpsertRequest { updates: vec![FileDiff::edit(&old, &new)] })
+    core.client
+        .request(&account, UpsertRequest { updates: vec![FileDiff::edit(&old, &new)] })
         .unwrap();
 }


### PR DESCRIPTION
+ Parameterizes the networking components of core, so that when the fuzzer runs, it can:
  + create independent servers on the fly and run them in parallel
  + skip the networking stack and communicate directly in process with the server for lower latency and higher reliability
+ I was going to do `Box<dyn Requester>` but ran into [this limitation](https://doc.rust-lang.org/reference/items/traits.html#object-safety), `api_service::request` uses type parameters
> Not have any type parameters (although lifetime parameters are allowed),
+ type alias makes this not require any changes to existing clients, type aliasing `RequestContext` would allow this diff to be smaller, future tech debt for me to address.
