### PR TITLE
fuzzer: add multiple users and sharing ops

### DIFF
--- a/core/libs/shared/src/core_ops.rs
+++ b/core/libs/shared/src/core_ops.rs
@@ -42,29 +42,29 @@ where
         let mut shares = Vec::new();
         for user_access_key in meta.user_access_keys() {
             if user_access_key.encrypted_by == user_access_key.encrypted_for {
-                continue
+                continue;
             }
             let mode = match user_access_key.mode {
                 UserAccessMode::Read => ShareMode::Read,
                 UserAccessMode::Write => ShareMode::Write,
-                UserAccessMode::Owner => { continue },
+                UserAccessMode::Owner => continue,
             };
-            shares.push(Share{
+            shares.push(Share {
                 mode,
-                shared_by: if user_access_key.encrypted_by == account.public_key() { account.username.clone() } else { String::from("<unknown>") },
-                shared_with: if user_access_key.encrypted_for == account.public_key() { account.username.clone() } else { String::from("<unknown>") }
+                shared_by: if user_access_key.encrypted_by == account.public_key() {
+                    account.username.clone()
+                } else {
+                    String::from("<unknown>")
+                },
+                shared_with: if user_access_key.encrypted_for == account.public_key() {
+                    account.username.clone()
+                } else {
+                    String::from("<unknown>")
+                },
             });
         }
 
-        Ok(File {
-            id,
-            parent,
-            name,
-            file_type,
-            last_modified,
-            last_modified_by,
-            shares,
-        })
+        Ok(File { id, parent, name, file_type, last_modified, last_modified_by, shares })
     }
 
     pub fn resolve_and_finalize<I>(&mut self, account: &Account, ids: I) -> SharedResult<Vec<File>>

--- a/core/tests/exhaustive_sync/experiment.rs
+++ b/core/tests/exhaustive_sync/experiment.rs
@@ -88,7 +88,8 @@ impl Experiment {
                 .spawn(move || loop {
                     match Self::grab_ready_trial_for_thread(thread_id, thread_state.clone()) {
                         (Some(mut work), _) => {
-                            let mutants = work.execute(thread_id);
+                            let mut mutants = work.execute(thread_id);
+                            mutants.reverse();
                             Self::publish_results(thread_id, thread_state.clone(), work, &mutants);
                         }
                         (None, true) => {

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -521,7 +521,7 @@ impl Default for Trial {
         Self {
             id: Uuid::new_v4(),
             devices_by_user: vec![],
-            target_devices_by_user: vec![2, 2],
+            target_devices_by_user: vec![1, 2, 3],
             target_steps: 10,
             steps: vec![],
             completed_steps: 0,

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -87,10 +87,10 @@ impl Trial {
             test_config(),
             AdminConfig { admins: usernames.iter().cloned().collect() },
         );
-        for user_index in 0..self.target_devices_by_user.len() {
+        for (user_index, target_devices) in self.target_devices_by_user.iter().enumerate() {
             let mut devices_by_user = Vec::new();
             let mut maybe_account_string: Option<String> = None;
-            for _device_index in 0..self.target_devices_by_user[user_index] {
+            for _device_index in 0..*target_devices {
                 let device = CoreIP::init_in_process(&test_config(), server.clone());
                 if let Some(ref account_string) = maybe_account_string {
                     device

--- a/core/tests/exhaustive_sync/trial.rs
+++ b/core/tests/exhaustive_sync/trial.rs
@@ -9,21 +9,21 @@ use lockbook_server_lib::config::AdminConfig;
 use lockbook_shared::file_metadata::FileType::{Document, Folder};
 use std::fmt::{Debug, Formatter};
 use std::time::Instant;
-use std::{fs, iter, thread};
+use std::{fs, thread};
 use test_utils::*;
 use uuid::Uuid;
 use variant_count::VariantCount;
 
 #[derive(VariantCount, Debug, Clone)]
 pub enum Action {
-    NewDocument { client: usize, parent: String, name: String },
-    NewMarkdownDocument { client: usize, parent: String, name: String },
-    NewFolder { client: usize, parent: String, name: String },
-    UpdateDocument { client: usize, name: String, new_content: String },
-    RenameFile { client: usize, name: String, new_name: String },
-    MoveDocument { client: usize, doc_name: String, destination_name: String },
-    AttemptFolderMove { client: usize, folder_name: String, destination_name: String },
-    DeleteFile { client: usize, name: String },
+    NewDocument { user_index: usize, device_index: usize, parent: String, name: String },
+    NewMarkdownDocument { user_index: usize, device_index: usize, parent: String, name: String },
+    NewFolder { user_index: usize, device_index: usize, parent: String, name: String },
+    UpdateDocument { user_index: usize, device_index: usize, name: String, new_content: String },
+    RenameFile { user_index: usize, device_index: usize, name: String, new_name: String },
+    MoveDocument { user_index: usize, device_index: usize, doc_name: String, destination_name: String },
+    AttemptFolderMove { user_index: usize, device_index: usize, folder_name: String, destination_name: String },
+    DeleteFile { user_index: usize, device_index: usize, name: String },
     SyncAndCheck,
 }
 
@@ -47,8 +47,8 @@ impl Status {
 #[derive(Clone)]
 pub struct Trial {
     pub id: Uuid,
-    pub clients: Vec<CoreIP>,
-    pub target_clients: usize,
+    pub devices_by_user: Vec<Vec<CoreIP>>,
+    pub target_devices_by_user: Vec<usize>,
     pub target_steps: usize,
     pub steps: Vec<Action>,
     pub completed_steps: usize,
@@ -62,7 +62,7 @@ impl Debug for Trial {
         let mut result = &mut f.debug_struct("Trial");
 
         result = result.field("id", &self.id);
-        result = result.field("target_clients", &self.target_clients);
+        result = result.field("target_clients", &self.target_devices_by_user);
         result = result.field("target_steps", &self.target_steps);
         result = result.field("steps", &self.steps);
         result = result.field("completed_steps", &self.completed_steps);
@@ -76,29 +76,33 @@ impl Debug for Trial {
 
 impl Trial {
     fn create_clients(&mut self) -> Result<(), Status> {
-        let username = random_name();
+        let mut usernames = Vec::new();
+        for _user_index in 0..self.target_devices_by_user.len() {
+            usernames.push(random_name());
+        }
         let server = InProcess::init(
             test_config(),
-            AdminConfig { admins: iter::once(username.clone()).collect() },
+            AdminConfig { admins: usernames.iter().cloned().collect() },
         );
-
-        for _ in 0..self.target_clients {
-            self.clients
-                .push(CoreIP::init_in_process(&test_config(), server.clone()));
-        }
-
-        self.clients[0]
-            .create_account(&username, &url())
-            .map_err(|err| Failed(format!("failed to create account: {:#?}", err)))?;
-        let account_string = &self.clients[0].export_account().unwrap();
-
-        for client in &self.clients[1..] {
-            client
-                .import_account(account_string)
-                .map_err(|err| Failed(format!("{:#?}", err)))?;
-            client
-                .sync(None)
-                .map_err(|err| Failed(format!("{:#?}", err)))?;
+        for user_index in 0..self.target_devices_by_user.len() {
+            let mut devices_by_user = Vec::new();
+            let mut maybe_account_string: Option<String> = None;
+            for _device_index in 0..self.target_devices_by_user[user_index] {
+                let device = CoreIP::init_in_process(&test_config(), server.clone());
+                if let Some(ref account_string) = maybe_account_string {
+                    device
+                        .import_account(account_string)
+                        .map_err(|err| Failed(format!("{:#?}", err)))?;
+                    device
+                        .sync(None)
+                        .map_err(|err| Failed(format!("{:#?}", err)))?;
+                } else {
+                    device.create_account(&usernames[user_index], &url()).map_err(|err| Failed(format!("failed to create account: {:#?}", err)))?;
+                    maybe_account_string = Some(device.export_account().unwrap());
+                }
+                devices_by_user.push(device);
+            }
+            self.devices_by_user.push(devices_by_user);
         }
 
         Ok(())
@@ -110,48 +114,48 @@ impl Trial {
             let step = self.steps[index].clone();
             additional_completed_steps += 1;
             match step {
-                NewDocument { client, parent, name } => {
-                    let db = &self.clients[client];
+                NewDocument { user_index, device_index, parent, name } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let parent = find_by_name(db, &parent).id;
                     if let Err(err) = db.create_file(&name, parent, Document) {
                         self.status = Failed(format!("{:#?}", err));
                         break 'steps;
                     }
                 }
-                NewMarkdownDocument { client, parent, name } => {
-                    let db = &self.clients[client];
+                NewMarkdownDocument { user_index, device_index, parent, name } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let parent = find_by_name(db, &parent).id;
                     if let Err(err) = db.create_file(&name, parent, Document) {
                         self.status = Failed(format!("{:#?}", err));
                         break 'steps;
                     }
                 }
-                NewFolder { client, parent, name } => {
-                    let db = &self.clients[client];
+                NewFolder { user_index, device_index, parent, name } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let parent = find_by_name(db, &parent).id;
                     if let Err(err) = db.create_file(&name, parent, Folder) {
                         self.status = Failed(format!("{:#?}", err));
                         break 'steps;
                     }
                 }
-                UpdateDocument { client, name, new_content } => {
-                    let db = &self.clients[client];
+                UpdateDocument { user_index, device_index, name, new_content } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let doc = find_by_name(db, &name).id;
                     if let Err(err) = db.write_document(doc, new_content.as_bytes()) {
                         self.status = Failed(format!("{:#?}", err));
                         break 'steps;
                     }
                 }
-                RenameFile { client, name, new_name } => {
-                    let db = &self.clients[client];
+                RenameFile { user_index, device_index, name, new_name } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let doc = find_by_name(db, &name).id;
                     if let Err(err) = db.rename_file(doc, &new_name) {
                         self.status = Failed(format!("{:#?}", err));
                         break 'steps;
                     }
                 }
-                MoveDocument { client, doc_name, destination_name } => {
-                    let db = &self.clients[client];
+                MoveDocument { user_index, device_index, doc_name, destination_name } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let doc = find_by_name(db, &doc_name).id;
                     let dest = find_by_name(db, &destination_name).id;
 
@@ -160,8 +164,8 @@ impl Trial {
                         break 'steps;
                     }
                 }
-                AttemptFolderMove { client, folder_name, destination_name } => {
-                    let db = &self.clients[client];
+                AttemptFolderMove { user_index, device_index, folder_name, destination_name } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let folder = find_by_name(db, &folder_name).id;
                     let destination_folder = find_by_name(db, &destination_name).id;
 
@@ -174,8 +178,8 @@ impl Trial {
                         }
                     }
                 }
-                DeleteFile { client, name } => {
-                    let db = &self.clients[client];
+                DeleteFile { user_index, device_index, name } => {
+                    let db = &self.devices_by_user[user_index][device_index];
                     let file = find_by_name(db, &name).id;
                     if let Err(err) = db.delete_file(file) {
                         self.status = Failed(format!("{:#?}", err));
@@ -184,43 +188,51 @@ impl Trial {
                 }
                 SyncAndCheck => {
                     for _ in 0..2 {
-                        for client in &self.clients {
-                            if let Err(err) = client.sync(None) {
-                                self.status = Failed(format!("{:#?}", err));
-                                break 'steps;
+                        for user_index in 0..self.target_devices_by_user.len() {
+                            for device_index in 0..self.target_devices_by_user[user_index] {
+                                let device = &self.devices_by_user[user_index][device_index];
+                                if let Err(err) = device.sync(None) {
+                                    self.status = Failed(format!("{:#?}", err));
+                                    break 'steps;
+                                }
                             }
                         }
                     }
 
-                    for row in &self.clients {
-                        for col in &self.clients {
-                            assert_dbs_equal(row, col);
-                            if !dbs_equal(row, col) {
+                    for user_index in 0..self.target_devices_by_user.len() {
+                        for device_index in 0..self.target_devices_by_user[user_index] {
+                            let device = &self.devices_by_user[user_index][device_index];
+                            if let Err(err) = device.validate() {
+                                self.status = Failed(format!("Repo integrity compromised: {:#?}", err));
+                                break 'steps;
+                            }
+
+                            if !device.calculate_work().unwrap().work_units.is_empty() {
                                 self.status = Failed(format!(
-                                    "db {} is not equal to {} after a sync. Server is {} & {}",
-                                    row.config.writeable_path,
-                                    col.config.writeable_path,
-                                    row.client.config.writeable_path,
-                                    col.client.config.writeable_path
+                                    "work units not empty, client: {}",
+                                    device.config.writeable_path
                                 ));
                                 break 'steps;
                             }
-                        }
-                        if let Err(err) = row.validate() {
-                            self.status = Failed(format!("Repo integrity compromised: {:#?}", err));
-                            break 'steps;
-                        }
 
-                        if !row.calculate_work().unwrap().work_units.is_empty() {
-                            self.status = Failed(format!(
-                                "work units not empty, client: {}",
-                                row.config.writeable_path
-                            ));
-                            break 'steps;
+                            for compare_device_index in 0..self.target_devices_by_user[user_index] {
+                                let compare_device = &self.devices_by_user[user_index][compare_device_index];
+                                assert_dbs_equal(device, compare_device);
+                                if !dbs_equal(device, compare_device) {
+                                    self.status = Failed(format!(
+                                        "db {} is not equal to {} after a sync. Server is {} & {}",
+                                        device.config.writeable_path,
+                                        compare_device.config.writeable_path,
+                                        device.client.config.writeable_path,
+                                        compare_device.client.config.writeable_path
+                                    ));
+                                    break 'steps;
+                                }
+                            }
                         }
                     }
 
-                    match self.clients[0].admin_validate_server() {
+                    match self.devices_by_user[0][0].admin_validate_server() {
                         Ok(validations) => {
                             if validations != Default::default() {
                                 self.status = Failed(format!(
@@ -238,6 +250,7 @@ impl Trial {
                 }
             }
         }
+
         self.completed_steps += additional_completed_steps;
         if self.status == Running && self.completed_steps == self.target_steps {
             self.status = Succeeded;
@@ -251,84 +264,96 @@ impl Trial {
             return mutants;
         }
 
-        for client_index in 0..self.clients.len() {
-            let client = &self.clients[client_index];
-            let all_files = client.list_metadatas().unwrap();
+        for user_index in 0..self.target_devices_by_user.len() {
+            for device_index in 0..self.target_devices_by_user[user_index] {
+                let client = &self.devices_by_user[user_index][device_index];
+                let all_files = client.list_metadatas().unwrap();
 
-            let mut folders = all_files.clone();
-            folders.retain(|f| f.is_folder());
+                let mut folders = all_files.clone();
+                folders.retain(|f| f.is_folder());
 
-            let mut docs = all_files.clone();
-            docs.retain(|f| f.is_document());
+                let mut docs = all_files.clone();
+                docs.retain(|f| f.is_document());
 
-            for file in all_files {
-                if file.id != file.parent {
-                    mutants.push(self.create_mutation(RenameFile {
-                        client: client_index,
-                        name: file.name.clone(),
-                        new_name: random_filename(),
-                    }));
+                for file in all_files {
+                    if file.id != file.parent {
+                        mutants.push(self.create_mutation(RenameFile {
+                            user_index,
+                            device_index,
+                            name: file.name.clone(),
+                            new_name: random_filename(),
+                        }));
 
-                    mutants.push(
-                        self.create_mutation(DeleteFile { client: client_index, name: file.name }),
-                    );
-                }
-            }
-
-            for folder in folders.clone() {
-                let parent_name =
-                    if folder.id == folder.parent { "root".to_string() } else { folder.name };
-
-                mutants.push(self.create_mutation(NewDocument {
-                    parent: parent_name.clone(),
-                    client: client_index,
-                    name: random_filename(),
-                }));
-
-                mutants.push(self.create_mutation(NewMarkdownDocument {
-                    parent: parent_name.clone(),
-                    client: client_index,
-                    name: random_filename() + ".md",
-                }));
-
-                mutants.push(self.create_mutation(NewFolder {
-                    parent: parent_name.clone(),
-                    client: client_index,
-                    name: random_filename(),
-                }));
-
-                for doc in docs.clone() {
-                    mutants.push(self.create_mutation(MoveDocument {
-                        client: client_index,
-                        doc_name: doc.name.clone(),
-                        destination_name: parent_name.clone(),
-                    }))
-                }
-
-                for folder2 in folders.clone() {
-                    if folder.id != folder.parent {
-                        let folder2_name = if folder2.id == folder2.parent {
-                            "root".to_string()
-                        } else {
-                            folder2.name
-                        };
-                        mutants.push(self.create_mutation(AttemptFolderMove {
-                            client: client_index,
-                            folder_name: parent_name.clone(),
-                            destination_name: folder2_name,
-                        }))
+                        mutants.push(
+                            self.create_mutation(DeleteFile {
+                                user_index,
+                                device_index, name: file.name }),
+                        );
                     }
                 }
-            }
 
-            for doc in docs.clone() {
-                mutants.push(self.create_mutation(UpdateDocument {
-                    client: client_index,
-                    name: doc.name.clone(),
-                    new_content: random_utf8(),
-                }));
+                for folder in folders.clone() {
+                    let parent_name =
+                        if folder.id == folder.parent { "root".to_string() } else { folder.name };
+
+                    mutants.push(self.create_mutation(NewDocument {
+                        user_index,
+                        device_index,
+                        parent: parent_name.clone(),
+                        name: random_filename(),
+                    }));
+
+                    mutants.push(self.create_mutation(NewMarkdownDocument {
+                        user_index,
+                        device_index,
+                        parent: parent_name.clone(),
+                        name: random_filename() + ".md",
+                    }));
+
+                    mutants.push(self.create_mutation(NewFolder {
+                        user_index,
+                        device_index,
+                        parent: parent_name.clone(),
+                        name: random_filename(),
+                    }));
+
+                    for doc in docs.clone() {
+                        mutants.push(self.create_mutation(MoveDocument {
+                            user_index,
+                            device_index,
+                            doc_name: doc.name.clone(),
+                            destination_name: parent_name.clone(),
+                        }))
+                    }
+
+                    for folder2 in folders.clone() {
+                        if folder.id != folder.parent {
+                            let folder2_name = if folder2.id == folder2.parent {
+                                "root".to_string()
+                            } else {
+                                folder2.name
+                            };
+                            mutants.push(self.create_mutation(AttemptFolderMove {
+                                user_index,
+                                device_index,
+                                folder_name: parent_name.clone(),
+                                destination_name: folder2_name,
+                            }))
+                        }
+                    }
+                }
+
+                for doc in docs.clone() {
+                    mutants.push(self.create_mutation(UpdateDocument {
+                        user_index,
+                        device_index,
+                        name: doc.name.clone(),
+                        new_content: random_utf8(),
+                    }));
+                }
             }
         }
+
         mutants.push(self.create_mutation(SyncAndCheck));
 
         mutants
@@ -357,18 +382,21 @@ impl Trial {
 
     fn cleanup(&self) {
         // Delete server
-        fs::remove_dir_all(&self.clients[0].client.config.writeable_path).unwrap_or_else(|err| {
+        fs::remove_dir_all(&self.devices_by_user[0][0].client.config.writeable_path).unwrap_or_else(|err| {
             println!(
                 "failed to cleanup file: {}, error: {}",
-                &self.clients[0].client.config.writeable_path, err
+                &self.devices_by_user[0][0].client.config.writeable_path, err
             )
         });
 
         // Delete account locally
-        for client in &self.clients {
-            fs::remove_dir_all(&client.config.writeable_path).unwrap_or_else(|err| {
-                println!("failed to cleanup file: {}, error: {}", client.config.writeable_path, err)
-            });
+        for user_index in 0..self.target_devices_by_user.len() {
+            for device_index in 0..self.target_devices_by_user[user_index] {
+                let client = &self.devices_by_user[user_index][device_index];
+                fs::remove_dir_all(&client.config.writeable_path).unwrap_or_else(|err| {
+                    println!("failed to cleanup file: {}, error: {}", client.config.writeable_path, err)
+                });
+            }
         }
     }
 
@@ -379,7 +407,7 @@ impl Trial {
         clone.completed_steps = 0;
         clone.start_time = Instant::now();
         clone.end_time = Instant::now();
-        clone.clients = vec![];
+        clone.devices_by_user = vec![];
         clone.id = Uuid::new_v4();
         clone
     }
@@ -413,8 +441,8 @@ impl Default for Trial {
     fn default() -> Self {
         Self {
             id: Uuid::new_v4(),
-            clients: vec![],
-            target_clients: 2,
+            devices_by_user: vec![],
+            target_devices_by_user: vec![2, 2],
             target_steps: 10,
             steps: vec![],
             completed_steps: 0,


### PR DESCRIPTION
I ran 100k trials locally without errors. ~TPS drops by about half for the initial trials, which are dominated by `SyncAndCheck`, which is now doing double the syncing and checking.~ I modified the order in which trials are run so that the initial TPS more closely matches the steady state TPS.

fixes https://github.com/lockbook/lockbook/issues/1398