### PR TITLE
core: resolve paths for links instead of linked files

### DIFF
--- a/core/libs/shared/src/validate.rs
+++ b/core/libs/shared/src/validate.rs
@@ -210,8 +210,7 @@ where
     }
 
     // note: a link to a deleted file is not considered broken, because then you would not be able
-    // to delete a folder linked to by another user. todo: make sure links to deleted folders are
-    // deleted on pull/merge
+    // to delete a file linked to by another user.
     pub fn assert_no_broken_links(&self) -> SharedResult<()> {
         for link in self.owned_ids() {
             if let FileType::Link { target } = self.find(&link)?.file_type() {

--- a/core/tests/sharing_tests.rs
+++ b/core/tests/sharing_tests.rs
@@ -846,8 +846,7 @@ fn get_path_by_id_link() {
         .create_link_at_path("received-folder", folder.id)
         .unwrap();
 
-    let result = core1.get_path_by_id(link.id);
-    assert_matches!(result, Err(_));
+    assert_eq!(core1.get_path_by_id(link.id).unwrap(), "/received-folder/");
 }
 
 #[test]

--- a/core/tests/sync_service_concurrent_change_tests.rs
+++ b/core/tests/sync_service_concurrent_change_tests.rs
@@ -1083,7 +1083,7 @@ fn delete_then_create_link() {
     cores[1][1].sync(None).unwrap();
     cores[1][1].delete_file(document.id).unwrap();
 
-    sync_and_assert(&cores[1][0], &cores[1][1]);
+    sync_and_assert(&cores[1][1], &cores[1][0]); // note: order reversed from above test
 
     assert::all_paths(&cores[1][0], &["/"]);
 }


### PR DESCRIPTION
This updates the `{path,id}_by_{id,path}` functions to match `resolve_and_finalize` and fixes resulting test failures. This also fixes an issue where cli was trying to rename the targeted file instead of the link when renaming a shared folder, resulting in an inappropriate `NotPermissioned` error (I suspect this is an error on other clients that have sharing implemented as well).