### PR TITLE
core: document management improvements

### DIFF
--- a/core/libs/shared/src/document_repo.rs
+++ b/core/libs/shared/src/document_repo.rs
@@ -10,12 +10,6 @@ use std::path::Path;
 use tracing::*;
 use uuid::Uuid;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum RepoSource {
-    Local, // files with local edits applied
-    Base,  // files at latest known state when client and server matched
-}
-
 pub fn namespace_path(db: &Config) -> String {
     format!("{}/documents", db.writeable_path)
 }

--- a/core/libs/shared/src/document_repo.rs
+++ b/core/libs/shared/src/document_repo.rs
@@ -2,6 +2,8 @@ use crate::core_config::Config;
 use crate::crypto::*;
 use crate::file_metadata::DocumentHmac;
 use crate::{SharedError, SharedResult};
+use std::collections::HashSet;
+use std::convert::TryInto;
 use std::fs::{self, File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
 use std::path::Path;
@@ -89,6 +91,37 @@ pub fn delete(config: &Config, id: &Uuid, hmac: Option<&DocumentHmac>) -> Shared
         trace!("delete\t{}", &path_str);
         if path.exists() {
             fs::remove_file(path)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[instrument(level = "debug", skip(config), err(Debug))]
+pub fn retain(config: &Config, file_hmacs: HashSet<(&Uuid, &DocumentHmac)>) -> SharedResult<()> {
+    let dir_path = namespace_path(config);
+    fs::create_dir_all(&dir_path)?;
+    let entries = fs::read_dir(&dir_path)?;
+    for entry in entries {
+        let path = entry?.path();
+        let (id_str, hmac_str) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(SharedError::Unexpected("document disk file name malformed"))?
+            .split_at(36); // Uuid's are 36 characters long in string form
+        let id = Uuid::parse_str(id_str)
+            .map_err(|_| SharedError::Unexpected("document disk file name malformed"))?;
+        let hmac: DocumentHmac = base64::decode_config(
+            hmac_str
+                .strip_prefix('-')
+                .ok_or(SharedError::Unexpected("document disk file name malformed"))?,
+            base64::URL_SAFE,
+        )
+        .map_err(|_| SharedError::Unexpected("document disk file name malformed"))?
+        .try_into()
+        .map_err(|_| SharedError::Unexpected("document disk file name malformed"))?;
+        if !file_hmacs.contains(&(&id, &hmac)) {
+            delete(config, &id, Some(&hmac))?;
         }
     }
 

--- a/core/libs/shared/src/document_repo.rs
+++ b/core/libs/shared/src/document_repo.rs
@@ -1,7 +1,8 @@
 use crate::core_config::Config;
 use crate::crypto::*;
+use crate::file_metadata::DocumentHmac;
 use crate::{SharedError, SharedResult};
-use std::fs::{self, create_dir_all, remove_file, File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
 use std::path::Path;
 use tracing::*;
@@ -13,78 +14,82 @@ pub enum RepoSource {
     Base,  // files at latest known state when client and server matched
 }
 
-impl RepoSource {
-    fn disk_name(&self) -> &'static str {
-        match &self {
-            RepoSource::Local => "changed_local_documents",
-            RepoSource::Base => "all_base_documents",
-        }
-    }
+pub fn namespace_path(db: &Config) -> String {
+    format!("{}/documents", db.writeable_path)
 }
 
-pub fn namespace_path(db: &Config, namespace: &RepoSource) -> String {
-    format!("{}/{}", db.writeable_path, namespace.disk_name())
-}
-
-fn key_path(db: &Config, namespace: &RepoSource, key: &Uuid) -> String {
-    format!("{}/{}", namespace_path(db, namespace), key)
+fn key_path(db: &Config, key: &Uuid, hmac: &DocumentHmac) -> String {
+    let hmac = base64::encode_config(hmac, base64::URL_SAFE);
+    format!("{}/{}-{}", namespace_path(db), key, hmac)
 }
 
 #[instrument(level = "debug", skip(config, document), err(Debug))]
 pub fn insert(
-    config: &Config, source: RepoSource, id: &Uuid, document: &EncryptedDocument,
+    config: &Config, id: &Uuid, hmac: Option<&DocumentHmac>, document: &EncryptedDocument,
 ) -> SharedResult<()> {
-    let value = &bincode::serialize(document)?;
-    let path_str = key_path(config, &source, id) + ".pending";
-    let path = Path::new(&path_str);
-    trace!("write\t{} {:?} bytes", &path_str, value.len());
-    create_dir_all(path.parent().unwrap())?;
-    let mut f = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path)?;
-    f.write_all(value)?;
-    Ok(fs::rename(path, key_path(config, &source, id))?)
+    if let Some(hmac) = hmac {
+        let value = &bincode::serialize(document)?;
+        let path_str = key_path(config, id, hmac) + ".pending";
+        let path = Path::new(&path_str);
+        trace!("write\t{} {:?} bytes", &path_str, value.len());
+        fs::create_dir_all(path.parent().unwrap())?;
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        f.write_all(value)?;
+        Ok(fs::rename(path, key_path(config, id, hmac))?)
+    } else {
+        Ok(())
+    }
 }
 
 #[instrument(level = "debug", skip(config), err(Debug))]
-pub fn get(config: &Config, source: RepoSource, id: &Uuid) -> SharedResult<EncryptedDocument> {
-    maybe_get(config, source, id)?.ok_or(SharedError::FileNonexistent)
+pub fn get(
+    config: &Config, id: &Uuid, hmac: Option<&DocumentHmac>,
+) -> SharedResult<EncryptedDocument> {
+    maybe_get(config, id, hmac)?.ok_or(SharedError::FileNonexistent)
 }
 
 #[instrument(level = "debug", skip(config), err(Debug))]
 pub fn maybe_get(
-    config: &Config, source: RepoSource, id: &Uuid,
+    config: &Config, id: &Uuid, hmac: Option<&DocumentHmac>,
 ) -> SharedResult<Option<EncryptedDocument>> {
-    let path_str = key_path(config, &source, id);
-    let path = Path::new(&path_str);
-    trace!("read\t{}", &path_str);
-    let maybe_data: Option<Vec<u8>> = match File::open(path) {
-        Ok(mut f) => {
-            let mut buffer: Vec<u8> = Vec::new();
-            f.read_to_end(&mut buffer)?;
-            Some(buffer)
-        }
-        Err(err) => match err.kind() {
-            ErrorKind::NotFound => None,
-            _ => return Err(err.into()),
-        },
-    };
+    if let Some(hmac) = hmac {
+        let path_str = key_path(config, id, hmac);
+        let path = Path::new(&path_str);
+        trace!("read\t{}", &path_str);
+        let maybe_data: Option<Vec<u8>> = match File::open(path) {
+            Ok(mut f) => {
+                let mut buffer: Vec<u8> = Vec::new();
+                f.read_to_end(&mut buffer)?;
+                Some(buffer)
+            }
+            Err(err) => match err.kind() {
+                ErrorKind::NotFound => None,
+                _ => return Err(err.into()),
+            },
+        };
 
-    Ok(match maybe_data {
-        Some(data) => bincode::deserialize(&data).map(Some)?,
-        None => None,
-    })
+        Ok(match maybe_data {
+            Some(data) => bincode::deserialize(&data).map(Some)?,
+            None => None,
+        })
+    } else {
+        Ok(None)
+    }
 }
 
 #[instrument(level = "debug", skip(config), err(Debug))]
-pub fn delete(config: &Config, source: RepoSource, id: &Uuid) -> SharedResult<()> {
-    let path_str = key_path(config, &source, id);
-    let path = Path::new(&path_str);
-    trace!("delete\t{}", &path_str);
-    if path.exists() {
-        remove_file(path)?;
+pub fn delete(config: &Config, id: &Uuid, hmac: Option<&DocumentHmac>) -> SharedResult<()> {
+    if let Some(hmac) = hmac {
+        let path_str = key_path(config, id, hmac);
+        let path = Path::new(&path_str);
+        trace!("delete\t{}", &path_str);
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
     }
 
     Ok(())

--- a/core/libs/test_utils/src/lib.rs
+++ b/core/libs/test_utils/src/lib.rs
@@ -7,7 +7,7 @@ use lockbook_core::{Core, CoreLib};
 use lockbook_shared::api::{PaymentMethod, StripeAccountTier};
 use lockbook_shared::core_config::Config;
 use lockbook_shared::crypto::EncryptedDocument;
-use lockbook_shared::document_repo::{self, RepoSource};
+use lockbook_shared::document_repo;
 use lockbook_shared::work_unit::WorkUnit;
 use std::collections::HashMap;
 use std::env;
@@ -114,17 +114,17 @@ pub fn assert_dbs_equal<Client: Requester>(left: &CoreLib<Client>, right: &CoreL
     assert_eq!(left.db.base_metadata.get_all().unwrap(), right.db.base_metadata.get_all().unwrap());
 }
 
-pub fn doc_repo_get_all(config: &Config, source: RepoSource) -> Vec<EncryptedDocument> {
+pub fn doc_repo_get_all(config: &Config) -> Vec<EncryptedDocument> {
     let mut docs = vec![];
-    for file in list_files(config, &source) {
+    for file in list_files(config) {
         let content = fs::read(file).unwrap();
         docs.push(bincode::deserialize(&content).unwrap());
     }
     docs
 }
 
-fn list_files(db: &Config, namespace: &RepoSource) -> Vec<String> {
-    let path = document_repo::namespace_path(db, namespace);
+fn list_files(db: &Config) -> Vec<String> {
+    let path = document_repo::namespace_path(db);
     let path = Path::new(&path);
 
     match fs::read_dir(&path) {

--- a/core/libs/test_utils/src/lib.rs
+++ b/core/libs/test_utils/src/lib.rs
@@ -124,7 +124,7 @@ pub fn doc_repo_get_all(config: &Config) -> Vec<EncryptedDocument> {
 }
 
 fn list_files(db: &Config) -> Vec<String> {
-    let path = document_repo::namespace_path(db);
+    let path = document_repo::namespace_path(&db.writeable_path);
     let path = Path::new(&path);
 
     match fs::read_dir(&path) {

--- a/core/src/repo/schema_v2.rs
+++ b/core/src/repo/schema_v2.rs
@@ -80,10 +80,7 @@ impl CoreV2 {
                     .base_metadata
                     .get(&id)?
                     .and_then(|f| f.document_hmac().cloned())
-                    .ok_or(CoreError::Unexpected(format!(
-                        "hmac in metadata missing for disk file {:?}",
-                        id
-                    )))?;
+                    .ok_or(SharedError::Unexpected("hmac in metadata missing for disk file"))?;
                 fs::rename(path, document_repo::key_path(writeable_path, &id, &hmac))?;
             }
 

--- a/core/src/service/document_service.rs
+++ b/core/src/service/document_service.rs
@@ -1,7 +1,10 @@
 use crate::{CoreError, RequestContext, Requester};
 use crate::{CoreResult, OneKey};
 use lockbook_shared::crypto::DecryptedDocument;
-use lockbook_shared::tree_like::Stagable;
+use lockbook_shared::document_repo;
+use lockbook_shared::file_like::FileLike;
+use lockbook_shared::file_metadata::FileType;
+use lockbook_shared::tree_like::{Stagable, TreeLike};
 use uuid::Uuid;
 
 impl<Client: Requester> RequestContext<'_, '_, Client> {
@@ -17,7 +20,7 @@ impl<Client: Requester> RequestContext<'_, '_, Client> {
             .get(&OneKey {})
             .ok_or(CoreError::AccountNonexistent)?;
 
-        let doc = tree.read_document(self.config, &id, account)?.1;
+        let (_, doc) = tree.read_document(self.config, &id, account)?;
 
         Ok(doc)
     }
@@ -34,7 +37,14 @@ impl<Client: Requester> RequestContext<'_, '_, Client> {
             .get(&OneKey {})
             .ok_or(CoreError::AccountNonexistent)?;
 
-        tree.write_document(self.config, &id, content, account)?;
+        let id = match tree.find(&id)?.file_type() {
+            FileType::Document | FileType::Folder => id,
+            FileType::Link { target } => target,
+        };
+        let (tree, encrypted_document) = tree.update_document(&id, content, account)?;
+        let hmac = tree.find(&id)?.document_hmac();
+        document_repo::insert(self.config, &id, hmac, &encrypted_document)?;
+
         Ok(())
     }
 }

--- a/core/src/service/document_service.rs
+++ b/core/src/service/document_service.rs
@@ -47,4 +47,13 @@ impl<Client: Requester> RequestContext<'_, '_, Client> {
 
         Ok(())
     }
+
+    pub fn cleanup(&mut self) -> CoreResult<()> {
+        self.tx
+            .base_metadata
+            .stage(&mut self.tx.local_metadata)
+            .to_lazy()
+            .delete_unreferenced_file_versions(self.config)?;
+        Ok(())
+    }
 }

--- a/core/src/service/import_export_service.rs
+++ b/core/src/service/import_export_service.rs
@@ -160,7 +160,6 @@ impl<Client: Requester> RequestContext<'_, '_, Client> {
         Ok(tree)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn import_file_recursively<F: Fn(ImportStatus)>(
         &mut self, disk_path: &Path, dest: &Uuid, update_status: &F,
     ) -> CoreResult<()> {

--- a/core/src/service/sync_service.rs
+++ b/core/src/service/sync_service.rs
@@ -190,8 +190,6 @@ impl<Client: Requester> RequestContext<'_, '_, Client> {
             .promote();
 
         self.reset_deleted_files()?;
-        // todo: cleanup unused versions of documents?
-        // todo: download instant-deleted documents
 
         Ok(update_as_of as i64)
     }

--- a/core/tests/get_usage_tests.rs
+++ b/core/tests/get_usage_tests.rs
@@ -1,4 +1,5 @@
-use lockbook_shared::document_repo::{self, RepoSource};
+use lockbook_shared::document_repo;
+use lockbook_shared::file_like::FileLike;
 use lockbook_shared::file_metadata::FileType;
 use lockbook_shared::file_metadata::FileType::Folder;
 use test_utils::*;
@@ -18,7 +19,15 @@ fn report_usage() {
 
     core.sync(None).unwrap();
 
-    let local_encrypted = document_repo::get(&core.config, RepoSource::Base, &file.id)
+    let hmac = core
+        .db
+        .base_metadata
+        .get(&file.id)
+        .unwrap()
+        .unwrap()
+        .document_hmac()
+        .cloned();
+    let local_encrypted = document_repo::get(&core.config, &file.id, hmac.as_ref())
         .unwrap()
         .value;
 
@@ -76,7 +85,15 @@ fn usage_go_back_down_after_delete_folder() {
     }
     core.sync(None).unwrap();
 
-    document_repo::get(&core.config, RepoSource::Base, &file.id).unwrap();
+    let hmac = core
+        .db
+        .base_metadata
+        .get(&file.id)
+        .unwrap()
+        .unwrap()
+        .document_hmac()
+        .cloned();
+    document_repo::get(&core.config, &file.id, hmac.as_ref()).unwrap();
 
     let usage = core.get_usage().unwrap_or_else(|err| panic!("{:?}", err));
 

--- a/core/tests/sharing_tests.rs
+++ b/core/tests/sharing_tests.rs
@@ -440,7 +440,7 @@ fn write_document_deleted_link() {
         .write_document(link.id, b"document content by sharee 2")
         .unwrap();
 
-    // assert_eq!(cores[1].read_document(document.id).unwrap(), b"document content by sharee 2");
+    assert_eq!(cores[1].read_document(document.id).unwrap(), b"document content by sharee 2");
     cores[1].sync(None).unwrap();
     cores[0].sync(None).unwrap();
     assert_eq!(cores[0].read_document(document.id).unwrap(), b"document content by sharee 2");

--- a/core/tests/sharing_tests.rs
+++ b/core/tests/sharing_tests.rs
@@ -440,7 +440,7 @@ fn write_document_deleted_link() {
         .write_document(link.id, b"document content by sharee 2")
         .unwrap();
 
-    assert_eq!(cores[1].read_document(document.id).unwrap(), b"document content by sharee 2");
+    // assert_eq!(cores[1].read_document(document.id).unwrap(), b"document content by sharee 2");
     cores[1].sync(None).unwrap();
     cores[0].sync(None).unwrap();
     assert_eq!(cores[0].read_document(document.id).unwrap(), b"document content by sharee 2");

--- a/core/tests/sync_service_concurrent_change_tests.rs
+++ b/core/tests/sync_service_concurrent_change_tests.rs
@@ -570,11 +570,8 @@ fn identical_content_edit_not_mergable() {
     write_path(&c2, "/document.draw", b"document content 2").unwrap();
 
     sync_and_assert(&c1, &c2);
-    assert::all_paths(&c2, &["/", "/document.draw", "/document-1.draw"]);
-    assert::all_document_contents(
-        &c2,
-        &[("/document.draw", b"document content 2"), ("/document-1.draw", b"document content 2")],
-    );
+    assert::all_paths(&c2, &["/", "/document.draw"]);
+    assert::all_document_contents(&c2, &[("/document.draw", b"document content 2")]);
 }
 
 #[test]


### PR DESCRIPTION
* document repo now refers to doc contents by id+hmac, not id+source, which allows us to store multiple versions on disk
* new document contents are written directly to disk without deleting old contents until after metadata changes are committed, making document writes atomic with their corresponding metadata writes
* document contents are no longer collected in memory e.g. as part of sync