### PR TITLE
core, server: core version should be stored in the header of the request 

### DIFF
--- a/core/src/service/api_service.rs
+++ b/core/src/service/api_service.rs
@@ -71,7 +71,7 @@ impl Requester for Network {
             .client
             .request(T::METHOD, format!("{}{}", account.api_url, T::ROUTE).as_str())
             .body(serialized_request)
-            .header("Accept", client_version)
+            .header("Accept-Version", client_version)
             .send()
             .map_err(|err| {
                 warn!("Send failed: {:#?}", err);

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! internal {
     }};
 }
 
-pub fn verify_client_version<Req: Request>(
+pub fn handle_version<Req: Request>(
     version: &Option<String>,
 ) -> Result<(), ErrorWrapper<Req::Error>> {
     let versions = vec!["0.5.5", "0.5.6"];

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -59,10 +59,14 @@ macro_rules! internal {
 pub fn verify_client_version<Req: Request>(
     version: &Option<String>,
 ) -> Result<(), ErrorWrapper<Req::Error>> {
+    let versions = vec!["0.5.5", "0.5.6"];
     match version.as_deref() {
-        Some("0.5.5") => Ok(()),
-        Some("0.5.6") => Ok(()),
-        None => Ok(()),
+        Some(x) if versions.contains(&x) => {
+            router_service::CORE_VERSION_COUNTER
+                .with_label_values(&[x])
+                .inc();
+            Ok(())
+        }
         _ => Err(ErrorWrapper::<Req::Error>::ClientUpdateRequired),
     }
 }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -56,6 +56,16 @@ macro_rules! internal {
     }};
 }
 
+pub fn verify_client_version_header<Req: Request>(
+    version: &String
+) -> Result<(), ErrorWrapper<Req::Error>> {
+    match version as &str {
+        "0.5.5" => Ok(()),
+        "0.5.6" => Ok(()),
+        _ => Err(ErrorWrapper::<Req::Error>::ClientUpdateRequired),
+    }
+}
+
 pub fn verify_client_version<Req: Request>(
     request: &RequestWrapper<Req>,
 ) -> Result<(), ErrorWrapper<Req::Error>> {

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -56,20 +56,10 @@ macro_rules! internal {
     }};
 }
 
-pub fn verify_client_version_header<Req: Request>(
+pub fn verify_client_version<Req: Request>(
     version: &String,
 ) -> Result<(), ErrorWrapper<Req::Error>> {
     match version as &str {
-        "0.5.5" => Ok(()),
-        "0.5.6" => Ok(()),
-        _ => Err(ErrorWrapper::<Req::Error>::ClientUpdateRequired),
-    }
-}
-
-pub fn verify_client_version<Req: Request>(
-    request: &RequestWrapper<Req>,
-) -> Result<(), ErrorWrapper<Req::Error>> {
-    match &request.client_version as &str {
         "0.5.5" => Ok(()),
         "0.5.6" => Ok(()),
         _ => Err(ErrorWrapper::<Req::Error>::ClientUpdateRequired),

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! internal {
 }
 
 pub fn verify_client_version_header<Req: Request>(
-    version: &String
+    version: &String,
 ) -> Result<(), ErrorWrapper<Req::Error>> {
     match version as &str {
         "0.5.5" => Ok(()),

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -59,11 +59,10 @@ macro_rules! internal {
 pub fn verify_client_version<Req: Request>(
     version: &Option<String>,
 ) -> Result<(), ErrorWrapper<Req::Error>> {
-
     match version.as_deref() {
         Some("0.5.5") => Ok(()),
         Some("0.5.6") => Ok(()),
-        None => Ok(()), 
+        None => Ok(()),
         _ => Err(ErrorWrapper::<Req::Error>::ClientUpdateRequired),
     }
 }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -57,11 +57,13 @@ macro_rules! internal {
 }
 
 pub fn verify_client_version<Req: Request>(
-    version: &String,
+    version: &Option<String>,
 ) -> Result<(), ErrorWrapper<Req::Error>> {
-    match version as &str {
-        "0.5.5" => Ok(()),
-        "0.5.6" => Ok(()),
+
+    match version.as_deref() {
+        Some("0.5.5") => Ok(()),
+        Some("0.5.6") => Ok(()),
+        None => Ok(()), 
         _ => Err(ErrorWrapper::<Req::Error>::ClientUpdateRequired),
     }
 }

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -8,7 +8,9 @@ use lazy_static::lazy_static;
 use lockbook_shared::api::*;
 use lockbook_shared::api::{ErrorWrapper, Request, RequestWrapper};
 use lockbook_shared::SharedError;
-use prometheus::{register_histogram_vec, HistogramVec, TextEncoder};
+use prometheus::{
+    register_counter_vec, register_histogram_vec, CounterVec, HistogramVec, TextEncoder,
+};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -25,7 +27,7 @@ lazy_static! {
         &["request"]
     )
     .unwrap();
-    pub static ref CORE_VERSION_HISTOGRAM: HistogramVec = register_histogram_vec!(
+    pub static ref CORE_VERSION_COUNTER: CounterVec = register_counter_vec!(
         "lockbook_server_core_version",
         "Lockbook server's supplied core version",
         &["request"]

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -3,10 +3,7 @@ use crate::billing::billing_service;
 use crate::billing::billing_service::*;
 use crate::file_service::*;
 use crate::utils::get_build_info;
-use crate::{
-    router_service, verify_auth, verify_client_version, verify_client_version_header, ServerError,
-    ServerState,
-};
+use crate::{router_service, verify_auth, verify_client_version, ServerError, ServerState};
 use lazy_static::lazy_static;
 use lockbook_shared::api::*;
 use lockbook_shared::api::{ErrorWrapper, Request, RequestWrapper};
@@ -296,17 +293,12 @@ pub fn deserialize_and_check<Req>(
 where
     Req: Request + DeserializeOwned + Serialize,
 {
-    match verify_client_version_header::<Req>(&version) {
-        Ok(_) => (),
-        Err(_) => warn!("Client update required"),
-    };
+    verify_client_version::<Req>(&version)?;
 
     let request = serde_json::from_slice(request.as_ref()).map_err(|err| {
         warn!("Request parsing failure: {}", err);
         ErrorWrapper::<Req::Error>::BadRequest
     })?;
-
-    verify_client_version(&request)?;
 
     verify_auth(server_state, &request).map_err(|err| match err {
         SharedError::SignatureExpired(_) | SharedError::SignatureInTheFuture(_) => {

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -29,7 +29,7 @@ lazy_static! {
     .unwrap();
     pub static ref CORE_VERSION_COUNTER: CounterVec = register_counter_vec!(
         "lockbook_server_core_version",
-        "Lockbook server's supplied core version",
+        "Core version request attempts",
         &["request"]
     )
     .unwrap();

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -25,6 +25,12 @@ lazy_static! {
         &["request"]
     )
     .unwrap();
+    pub static ref CORE_VERSION_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "lockbook_server_core_version",
+        "Lockbook server's supplied core version",
+        &["request"]
+    )
+    .unwrap();
 }
 
 #[macro_export]

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -300,7 +300,6 @@ where
         ErrorWrapper::<Req::Error>::BadRequest
     })?;
 
-    
     verify_auth(server_state, &request).map_err(|err| match err {
         SharedError::SignatureExpired(_) | SharedError::SignatureInTheFuture(_) => {
             warn!("expired auth");

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -3,7 +3,10 @@ use crate::billing::billing_service;
 use crate::billing::billing_service::*;
 use crate::file_service::*;
 use crate::utils::get_build_info;
-use crate::{router_service, verify_auth, verify_client_version_header, verify_client_version, ServerError, ServerState};
+use crate::{
+    router_service, verify_auth, verify_client_version, verify_client_version_header, ServerError,
+    ServerState,
+};
 use lazy_static::lazy_static;
 use lockbook_shared::api::*;
 use lockbook_shared::api::{ErrorWrapper, Request, RequestWrapper};
@@ -304,7 +307,7 @@ where
     })?;
 
     verify_client_version(&request)?;
-    
+
     verify_auth(server_state, &request).map_err(|err| match err {
         SharedError::SignatureExpired(_) | SharedError::SignatureInTheFuture(_) => {
             warn!("expired auth");

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -3,7 +3,7 @@ use crate::billing::billing_service;
 use crate::billing::billing_service::*;
 use crate::file_service::*;
 use crate::utils::get_build_info;
-use crate::{router_service, verify_auth, verify_client_version, ServerError, ServerState};
+use crate::{handle_version, router_service, verify_auth, ServerError, ServerState};
 use lazy_static::lazy_static;
 use lockbook_shared::api::*;
 use lockbook_shared::api::{ErrorWrapper, Request, RequestWrapper};
@@ -301,7 +301,7 @@ pub fn deserialize_and_check<Req>(
 where
     Req: Request + DeserializeOwned + Serialize,
 {
-    verify_client_version::<Req>(&version)?;
+    handle_version::<Req>(&version)?;
 
     let request = serde_json::from_slice(request.as_ref()).map_err(|err| {
         warn!("Request parsing failure: {}", err);


### PR DESCRIPTION
## Approach 
Changes were made on two fronts:
1. In the routes handler located in `router_service.rs` >  `core_req!`, a warp header filter was added for an `Accept` header which stores the core version. 
2. the `Requester` in `api_service.rs` was changed to inject the core version as an `Accept` header. As far as I understand, most core requests sent to the server pass through  `fn request` in `impl Requester for Network`

### Tests
no tests were written. I'd love to have a discussion about the granularity of tests that we maintain. @Parth suggested a test for requests missing an `Accept` header, but I don't know if or why that's necessary. isn't the purpose of warp filters to validate the request? 


fixes: #1239 