### PR TITLE
core,server,admin: remove useless extern crate statements

### DIFF
--- a/clients/admin/src/main.rs
+++ b/clients/admin/src/main.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 mod account;
 mod disappear;
 mod error;

--- a/core/libs/shared/src/symkey.rs
+++ b/core/libs/shared/src/symkey.rs
@@ -1,11 +1,9 @@
-extern crate rand;
-
-use self::rand::rngs::OsRng;
-use self::rand::RngCore;
 use crate::crypto::*;
 use crate::{SharedError, SharedResult};
 use aead::{generic_array::GenericArray, Aead, NewAead};
 use aes_gcm::Aes256Gcm;
+use rand::rngs::OsRng;
+use rand::RngCore;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -1,8 +1,5 @@
 #![recursion_limit = "256"]
 
-extern crate chrono;
-extern crate tokio;
-
 use hmdb::log::{LogCompacter, Reader};
 use hmdb::transaction::Transaction;
 use lockbook_server_lib::billing::google_play_client::get_google_play_client;


### PR DESCRIPTION
I don't believe these `extern crate` statements serve any purpose whatsoever.