### PR TITLE
shared: impl Display on FileType

### DIFF
--- a/core/libs/shared/src/file_metadata.rs
+++ b/core/libs/shared/src/file_metadata.rs
@@ -136,6 +136,12 @@ impl FromStr for FileType {
     }
 }
 
+impl fmt::Display for FileType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct FileDiff<F: FileLike> {
     pub old: Option<F>,


### PR DESCRIPTION
this allows devs to have `ToString` on `FileType`. it just uses the Debug text for now.