### PR TITLE
core: fix resharing files

### DIFF
--- a/libs/core/libs/shared/src/core_ops.rs
+++ b/libs/core/libs/shared/src/core_ops.rs
@@ -224,10 +224,15 @@ where
             ShareMode::Write => UserAccessMode::Write,
             ShareMode::Read => UserAccessMode::Read,
         };
-        let mut file = self.find(&id)?.timestamped_value.value.clone();
         if self.calculate_deleted(&id)? {
             return Err(SharedError::FileNonexistent);
         }
+        let id = if let FileType::Link { target } = self.find(&id)?.file_type() {
+            target
+        } else {
+            id
+        };
+        let mut file = self.find(&id)?.timestamped_value.value.clone();
         validate::not_root(&file)?;
         if mode == ShareMode::Write && file.owner.0 != owner.0 {
             return Err(SharedError::InsufficientPermission);

--- a/libs/core/libs/shared/src/core_ops.rs
+++ b/libs/core/libs/shared/src/core_ops.rs
@@ -227,11 +227,8 @@ where
         if self.calculate_deleted(&id)? {
             return Err(SharedError::FileNonexistent);
         }
-        let id = if let FileType::Link { target } = self.find(&id)?.file_type() {
-            target
-        } else {
-            id
-        };
+        let id =
+            if let FileType::Link { target } = self.find(&id)?.file_type() { target } else { id };
         let mut file = self.find(&id)?.timestamped_value.value.clone();
         validate::not_root(&file)?;
         if mode == ShareMode::Write && file.owner.0 != owner.0 {

--- a/libs/core/libs/shared/src/validate.rs
+++ b/libs/core/libs/shared/src/validate.rs
@@ -190,9 +190,10 @@ where
             let meta = self.find(&link)?;
             if let FileType::Link { target: _ } = meta.file_type() {
                 if meta.is_shared() {
-                    return Err(SharedError::ValidationFailure(
-                        ValidationFailure::SharedLink { link, shared_ancestor: link },
-                    ));
+                    return Err(SharedError::ValidationFailure(ValidationFailure::SharedLink {
+                        link,
+                        shared_ancestor: link,
+                    }));
                 }
                 for ancestor in self.ancestors(&link)? {
                     if self.find(&ancestor)?.is_shared() {

--- a/libs/core/libs/shared/src/validate.rs
+++ b/libs/core/libs/shared/src/validate.rs
@@ -187,7 +187,13 @@ where
 
     pub fn assert_no_shared_links(&self) -> SharedResult<()> {
         for link in self.owned_ids() {
-            if let FileType::Link { target: _ } = self.find(&link)?.file_type() {
+            let meta = self.find(&link)?;
+            if let FileType::Link { target: _ } = meta.file_type() {
+                if meta.is_shared() {
+                    return Err(SharedError::ValidationFailure(
+                        ValidationFailure::SharedLink { link, shared_ancestor: link },
+                    ));
+                }
                 for ancestor in self.ancestors(&link)? {
                     if self.find(&ancestor)?.is_shared() {
                         return Err(SharedError::ValidationFailure(

--- a/libs/core/tests/sync_service_share_tests.rs
+++ b/libs/core/tests/sync_service_share_tests.rs
@@ -1,6 +1,6 @@
 use lockbook_core::Core;
-use lockbook_shared::file::ShareMode;
 use lockbook_core::{Error, ShareFileError};
+use lockbook_shared::file::ShareMode;
 use test_utils::*;
 
 /// Tests that setup one device each on two accounts, share a file from one to the other, sync both, then accept
@@ -498,12 +498,16 @@ fn test_share_link_write() {
     cores[2].sync(None).unwrap();
 
     let passalong = cores[0].create_at_path("/passalong.md").unwrap();
-    cores[0].share_file(passalong.id, &accounts[1].username, ShareMode::Write).unwrap();
+    cores[0]
+        .share_file(passalong.id, &accounts[1].username, ShareMode::Write)
+        .unwrap();
     cores[0].sync(None).unwrap();
 
     cores[1].sync(None).unwrap();
     assert::all_pending_shares(&cores[1], &["passalong.md"]);
-    let link = cores[1].create_link_at_path("/passalong.md", passalong.id).unwrap();
+    let link = cores[1]
+        .create_link_at_path("/passalong.md", passalong.id)
+        .unwrap();
     assert::all_paths(&cores[1], &["/", "/passalong.md"]);
     assert_matches!(
         cores[1].share_file(link.id, &accounts[2].username, ShareMode::Write), // this succeeded and now correctly fails (was sharing link instead of target)
@@ -527,14 +531,20 @@ fn test_share_link_read() {
     cores[2].sync(None).unwrap();
 
     let passalong = cores[0].create_at_path("/passalong.md").unwrap();
-    cores[0].share_file(passalong.id, &accounts[1].username, ShareMode::Read).unwrap();
+    cores[0]
+        .share_file(passalong.id, &accounts[1].username, ShareMode::Read)
+        .unwrap();
     cores[0].sync(None).unwrap();
 
     cores[1].sync(None).unwrap();
     assert::all_pending_shares(&cores[1], &["passalong.md"]);
-    let link = cores[1].create_link_at_path("/passalong.md", passalong.id).unwrap();
+    let link = cores[1]
+        .create_link_at_path("/passalong.md", passalong.id)
+        .unwrap();
     assert::all_paths(&cores[1], &["/", "/passalong.md"]);
-    cores[1].share_file(link.id, &accounts[2].username, ShareMode::Read).unwrap();
+    cores[1]
+        .share_file(link.id, &accounts[2].username, ShareMode::Read)
+        .unwrap();
     cores[1].sync(None).unwrap();
 
     cores[2].sync(None).unwrap();

--- a/libs/core/tests/validate_tests.rs
+++ b/libs/core/tests/validate_tests.rs
@@ -1,37 +1,21 @@
-use hmdb::transaction::{Transaction, TransactionTable};
-use lockbook_core::repo::schema_v2::helper_log::{base_metadata, local_metadata};
-use lockbook_shared::account::Account;
-use lockbook_shared::file::File;
+use hmdb::transaction::Transaction;
+use lockbook_shared::access_info::{UserAccessInfo, UserAccessMode};
+use lockbook_shared::file::ShareMode;
 use lockbook_shared::file_metadata::{FileType, Owner};
-use lockbook_shared::signed_file::SignedFile;
 use lockbook_shared::tree_like::TreeLike;
 use lockbook_shared::{symkey, SharedError, SharedResult, ValidationFailure};
 use test_utils::*;
 use uuid::Uuid;
 
-type BaseMetadata<'a> = TransactionTable<'a, Uuid, SignedFile, base_metadata>;
-type LocalMetadata<'a> = TransactionTable<'a, Uuid, SignedFile, local_metadata>;
-
-fn run(
-    f: fn(Account, Owner, File, &mut BaseMetadata, &mut LocalMetadata) -> SharedResult<()>,
-) -> SharedResult<()> {
-    let core = test_core_with_account();
-    let account = core.get_account().unwrap();
-    let owner = Owner(account.public_key());
-    let root = core.get_root().unwrap();
-    core.db
-        .transaction::<_, SharedResult<_>>(|tx| {
-            f(account, owner, root, &mut tx.base_metadata, &mut tx.local_metadata)
-        })
-        .unwrap()
-}
-
 #[test]
 fn create_two_files_with_same_path() {
-    assert_matches!(
-        run(|account, owner, root, base_metadata, local_metadata| {
-            let tree = base_metadata.stage(local_metadata).to_lazy();
-
+    let core = test_core_with_account();
+    let account = core.get_account().unwrap();
+    let root = core.get_root().unwrap();
+    let result = core
+        .db
+        .transaction::<_, SharedResult<_>>(|tx| {
+            let tree = tx.base_metadata.stage(&mut tx.local_metadata).to_lazy();
             let mut tree = tree.stage(Vec::new());
             tree.create_unvalidated(
                 Uuid::new_v4(),
@@ -51,11 +35,70 @@ fn create_two_files_with_same_path() {
                 &account,
             )
             .unwrap();
-            tree.validate(owner)?;
-            tree.promote();
+            tree.validate(Owner(account.public_key()))?;
 
             Ok(())
-        }),
+        })
+        .unwrap();
+
+    assert_matches!(
+        result,
         Err(SharedError::ValidationFailure(ValidationFailure::PathConflict(_)))
+    );
+}
+
+#[test]
+fn directly_shared_link() {
+    let cores = vec![test_core_with_account(), test_core_with_account()];
+    let accounts = cores
+        .iter()
+        .map(|core| core.get_account().unwrap())
+        .collect::<Vec<_>>();
+
+    let shared_doc = cores[0].create_at_path("/shared-doc").unwrap();
+    cores[0]
+        .share_file(shared_doc.id, &accounts[1].username, ShareMode::Write)
+        .unwrap();
+    cores[0].sync(None).unwrap();
+
+    cores[1].sync(None).unwrap();
+    let link = cores[1]
+        .create_link_at_path("/link", shared_doc.id)
+        .unwrap();
+
+    let result = cores[1]
+        .db
+        .transaction::<_, SharedResult<_>>(|tx| {
+            // probably for the best that this is how ugly the code has to get to produce this situation
+            let mut link = tx
+                .local_metadata
+                .get(&link.id)
+                .unwrap()
+                .timestamped_value
+                .value
+                .clone();
+            link.user_access_keys.push(
+                UserAccessInfo::encrypt(
+                    &accounts[1],
+                    &accounts[1].public_key(),
+                    &accounts[0].public_key(),
+                    &symkey::generate_key(),
+                    UserAccessMode::Write,
+                )
+                .unwrap(),
+            );
+            tx.local_metadata
+                .insert(link.id, link.sign(&accounts[1]).unwrap());
+
+            let mut tree = tx.base_metadata.stage(&mut tx.local_metadata).to_lazy();
+            tree.validate(Owner(accounts[1].public_key()))?;
+
+            Ok(())
+        })
+        .unwrap();
+
+    assert_matches!(
+        result,
+        Err(SharedError::ValidationFailure(ValidationFailure::SharedLink { .. }))
     );
 }


### PR DESCRIPTION
* validate was not catching directly shared links
* sharing a link should be interpreted as sharing its target but wasn't

fixes #1461 