### PR TITLE
server: support sandbox testing requests

### DIFF
--- a/server/server/src/billing/app_store_client.rs
+++ b/server/server/src/billing/app_store_client.rs
@@ -20,6 +20,8 @@ const TYP: &str = "JWT";
 const AUDIENCE: &str = "appstoreconnect-v1";
 const BUNDLE_ID: &str = "app.lockbook";
 
+pub const ORIGINAL_TRANS_ID_NOT_FOUND_ERR_CODE: u64 = 4040005;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Claims {
     iss: String,
@@ -82,7 +84,7 @@ pub async fn get_sub_status(
         400 | 404 => {
             let error: ErrorBody = resp.json().await?;
 
-            if error.error_code == 4040005 {
+            if error.error_code == ORIGINAL_TRANS_ID_NOT_FOUND_ERR_CODE {
                 debug!(
                     "Could not verify subscription from apple's production servers, trying sandbox"
                 );

--- a/server/server/src/billing/app_store_model.rs
+++ b/server/server/src/billing/app_store_model.rs
@@ -121,3 +121,10 @@ pub struct LastTransactionItem {
     pub status: u16,
     pub signed_transaction_info: String,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorBody {
+    pub error_code: u64,
+    pub error_message: String,
+}

--- a/server/server/src/config.rs
+++ b/server/server/src/config.rs
@@ -1,4 +1,3 @@
-use crate::billing::app_store_client::{SUB_STATUS_PROD, SUB_STATUS_SANDBOX};
 use crate::config::Environment::{Local, Prod, Unknown};
 use lockbook_shared::account::Username;
 use std::collections::HashSet;
@@ -236,7 +235,6 @@ pub struct AppleConfig {
     pub asc_shared_secret: String,
     pub apple_root_cert: Vec<u8>,
     pub monthly_sub_group_id: String,
-    pub sub_statuses_url: String,
 }
 
 impl AppleConfig {
@@ -244,8 +242,6 @@ impl AppleConfig {
         let is_apple_prod = env_or_empty("IS_APPLE_PROD")
             .map(|is_apple_prod| is_apple_prod.parse().unwrap())
             .unwrap_or(false);
-        let sub_statuses_url =
-            if is_apple_prod { SUB_STATUS_PROD } else { SUB_STATUS_SANDBOX }.to_string();
 
         let apple_root_cert =
             env_or_empty("APPLE_ROOT_CERT_PATH").map(|cert_path| fs::read(cert_path).unwrap());
@@ -274,7 +270,6 @@ impl AppleConfig {
             } else {
                 apple_root_cert.unwrap_or_default()
             },
-            sub_statuses_url,
             monthly_sub_group_id: env_or_panic("APPLE_MONTHLY_SUB_GROUP_ID"),
         }
     }


### PR DESCRIPTION
The app store verifies our Storekit implementation by testing it out themselves. They do this using "sandbox testing," which utilizes our production server.

Formerly, this was not supported since I believed our production server would not need to have testing capabilities, but since then I have learned apple's app review team may need it.