### PR TITLE
apple: ipad hidden file tree message

### DIFF
--- a/clients/apple/iOS/FileTreeView.swift
+++ b/clients/apple/iOS/FileTreeView.swift
@@ -32,6 +32,25 @@ struct FileTreeView: View {
         }
         if let item = currentDoc.selectedItem {
             DocumentView(meta: item)
+        } else {
+            GeometryReader { geometry in
+                if geometry.size.height > geometry.size.width {
+                    VStack {
+                        Image(systemName: "rectangle.portrait.lefthalf.inset.filled")
+                            .font(.system(size: 60))
+                            .padding(.bottom, 10)
+
+                        
+                        Text("No document is open. Expand the file tree by swiping from the left edge of the screen or clicking the button on the top left corner of the screen.")
+                            .font(.title2)
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: 350)
+                    }
+                    .padding(.horizontal)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                }
+            }
         }
     }
 }

--- a/clients/apple/iOS/FileTreeView.swift
+++ b/clients/apple/iOS/FileTreeView.swift
@@ -41,14 +41,13 @@ struct FileTreeView: View {
                             .padding(.bottom, 10)
 
                         
-                        Text("No document is open. Expand the file tree by swiping from the left edge of the screen or clicking the button on the top left corner of the screen.")
+                        Text("No document is open. Expand the file tree by swiping from the left edge of the screen or clicking the button on the top left corner.")
                             .font(.title2)
                             .multilineTextAlignment(.center)
                             .frame(maxWidth: 350)
                     }
                     .padding(.horizontal)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-
                 }
             }
         }


### PR DESCRIPTION
In portrait on startup, the apple ipad client cannot see its file tree. This is because the file tree is a hidden drawer and no file is open so the screen appears empty.

I added a message on that screen so the understands what is going on.

<details>

![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2023-01-16 at 18 16 26](https://user-images.githubusercontent.com/20663038/212778842-0015d3f1-d0cf-454c-98f2-660b92135b69.png)
</details>