### PR TITLE
admin: rebuild indexes on demand

### DIFF
--- a/clients/admin/src/indexes.rs
+++ b/clients/admin/src/indexes.rs
@@ -8,7 +8,7 @@ pub enum CliIndex {
     OwnedFiles,
 }
 
-fn rebuild(core: &Core, index: CliIndex) -> Res<()> {
+pub fn rebuild(core: &Core, index: CliIndex) -> Res<()> {
     match index {
         CliIndex::OwnedFiles => core.admin_rebuild_index(ServerIndex::OwnedFiles)?,
     }

--- a/clients/admin/src/indexes.rs
+++ b/clients/admin/src/indexes.rs
@@ -1,0 +1,17 @@
+use crate::Res;
+
+use structopt::StructOpt;
+use lockbook_core::{Core, ServerIndex};
+
+#[derive(Debug, PartialEq, Eq, StructOpt)]
+pub enum CliIndex {
+    OwnedFiles
+}
+
+fn rebuild(core: &Core, index: CliIndex) -> Res<()> {
+    match index {
+        CliIndex::OwnedFiles => core.admin_rebuild_index(ServerIndex::OwnedFiles)?
+    }
+
+    Ok(())
+}

--- a/clients/admin/src/indexes.rs
+++ b/clients/admin/src/indexes.rs
@@ -1,16 +1,16 @@
 use crate::Res;
 
-use structopt::StructOpt;
 use lockbook_core::{Core, ServerIndex};
+use structopt::StructOpt;
 
 #[derive(Debug, PartialEq, Eq, StructOpt)]
 pub enum CliIndex {
-    OwnedFiles
+    OwnedFiles,
 }
 
 fn rebuild(core: &Core, index: CliIndex) -> Res<()> {
     match index {
-        CliIndex::OwnedFiles => core.admin_rebuild_index(ServerIndex::OwnedFiles)?
+        CliIndex::OwnedFiles => core.admin_rebuild_index(ServerIndex::OwnedFiles)?,
     }
 
     Ok(())

--- a/clients/admin/src/main.rs
+++ b/clients/admin/src/main.rs
@@ -3,6 +3,7 @@ mod disappear;
 mod error;
 mod info;
 mod validate;
+mod indexes;
 
 use std::env;
 
@@ -10,6 +11,7 @@ use structopt::StructOpt;
 
 use crate::error::Error;
 use lockbook_core::{Config, Core, Uuid};
+use crate::indexes::CliIndex;
 
 #[derive(Debug, PartialEq, Eq, StructOpt)]
 pub enum Admin {
@@ -53,6 +55,8 @@ pub enum Admin {
         public_key: Option<String>,
     },
 
+    RebuildIndex(CliIndex),
+
     /// Prints information about a file as it appears on the server
     FileInfo { id: Uuid },
 }
@@ -79,6 +83,7 @@ pub fn main() {
         Admin::ValidateAccount { username } => validate::account(&core, username),
         Admin::ValidateServer => validate::server(&core),
         Admin::FileInfo { id } => info::file(&core, id),
+        Admin::RebuildIndex(index) => indexes::rebuild(&core, index)
     };
 
     if result.is_err() {

--- a/clients/admin/src/main.rs
+++ b/clients/admin/src/main.rs
@@ -1,34 +1,40 @@
 mod account;
 mod disappear;
 mod error;
+mod indexes;
 mod info;
 mod validate;
-mod indexes;
 
 use std::env;
 
 use structopt::StructOpt;
 
 use crate::error::Error;
-use lockbook_core::{Config, Core, Uuid};
 use crate::indexes::CliIndex;
+use lockbook_core::{Config, Core, Uuid};
 
 #[derive(Debug, PartialEq, Eq, StructOpt)]
 pub enum Admin {
     /// Disappear a user
     ///
     /// Frees up their username
-    DisappearAccount { username: String },
+    DisappearAccount {
+        username: String,
+    },
 
     /// Disappear a file
     ///
     /// When you delete a file you flip that file's is_deleted flag to false. In a disaster recovery
     /// scenario, you may want to *disappear* a file so that it never existed. This is useful in a
     /// scenario where your server let in an invalid file.
-    DisappearFile { id: Uuid },
+    DisappearFile {
+        id: Uuid,
+    },
 
     /// Validates file trees of all users on the server and prints any failures
-    ValidateAccount { username: String },
+    ValidateAccount {
+        username: String,
+    },
 
     /// Performs server-wide integrity checks
     ValidateServer,
@@ -58,7 +64,9 @@ pub enum Admin {
     RebuildIndex(CliIndex),
 
     /// Prints information about a file as it appears on the server
-    FileInfo { id: Uuid },
+    FileInfo {
+        id: Uuid,
+    },
 }
 
 type Res<T> = Result<T, Error>;
@@ -83,7 +91,7 @@ pub fn main() {
         Admin::ValidateAccount { username } => validate::account(&core, username),
         Admin::ValidateServer => validate::server(&core),
         Admin::FileInfo { id } => info::file(&core, id),
-        Admin::RebuildIndex(index) => indexes::rebuild(&core, index)
+        Admin::RebuildIndex(index) => indexes::rebuild(&core, index),
     };
 
     if result.is_err() {

--- a/libs/core/libs/shared/src/api.rs
+++ b/libs/core/libs/shared/src/api.rs
@@ -564,7 +564,8 @@ pub struct AdminValidateServer {
     // accounts
     pub users_with_validation_failures: HashMap<Username, AdminValidateAccount>,
     // index integrity
-    pub usernames_mapped_to_wrong_accounts: HashMap<String, String>, // mapped username -> account username
+    pub usernames_mapped_to_wrong_accounts: HashMap<String, String>,
+    // mapped username -> account username
     pub usernames_mapped_to_nonexistent_accounts: HashMap<String, Owner>,
     pub usernames_unmapped_to_accounts: HashSet<String>,
     pub owners_mapped_to_unowned_files: HashMap<Owner, HashSet<Uuid>>,
@@ -693,3 +694,26 @@ impl Request for AdminFileInfoRequest {
 
 // number of milliseconds that have elapsed since the unix epoch
 pub type UnixTimeMillis = u64;
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
+pub enum ServerIndex {
+    OwnedFiles,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AdminRebuildIndexRequest {
+    pub index: ServerIndex,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum AdminRebuildIndexError {
+    NotPermissioned,
+
+}
+
+impl Request for AdminRebuildIndexRequest {
+    type Response = ();
+    type Error = AdminRebuildIndexError;
+    const METHOD: Method = Method::POST;
+    const ROUTE: &'static str = "/admin-rebuild-index";
+}

--- a/libs/core/libs/shared/src/api.rs
+++ b/libs/core/libs/shared/src/api.rs
@@ -708,7 +708,6 @@ pub struct AdminRebuildIndexRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum AdminRebuildIndexError {
     NotPermissioned,
-
 }
 
 impl Request for AdminRebuildIndexRequest {

--- a/libs/core/src/lib.rs
+++ b/libs/core/src/lib.rs
@@ -16,6 +16,7 @@ pub use libsecp256k1::PublicKey;
 pub use uuid::Uuid;
 
 pub use lockbook_shared::account::Account;
+pub use lockbook_shared::api::ServerIndex;
 pub use lockbook_shared::api::{
     AccountFilter, AccountIdentifier, AppStoreAccountState, GooglePlayAccountState, PaymentMethod,
     PaymentPlatform, StripeAccountTier, SubscriptionInfo,
@@ -34,7 +35,6 @@ pub use lockbook_shared::tree_like::TreeLike;
 pub use lockbook_shared::tree_like::TreeLikeMut;
 pub use lockbook_shared::usage::bytes_to_human;
 pub use lockbook_shared::work_unit::{ClientWorkUnit, WorkUnit};
-pub use lockbook_shared::api::ServerIndex;
 
 pub use crate::model::drawing::SupportedImageFormats;
 pub use crate::model::errors::*;
@@ -49,7 +49,9 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use hmdb::transaction::Transaction as _;
 use itertools::Itertools;
 use lockbook_shared::account::Username;
-use lockbook_shared::api::{AccountInfo, AdminFileInfoResponse, AdminValidateAccount, AdminValidateServer};
+use lockbook_shared::api::{
+    AccountInfo, AdminFileInfoResponse, AdminValidateAccount, AdminValidateServer,
+};
 use lockbook_shared::clock;
 use lockbook_shared::crypto::AESKey;
 use serde_json::{json, value::Value};
@@ -490,9 +492,9 @@ impl<Client: Requester> CoreLib<Client> {
     }
 
     #[instrument(
-    level = "debug",
-    skip(self, original_transaction_id, app_account_token),
-    err(Debug)
+        level = "debug",
+        skip(self, original_transaction_id, app_account_token),
+        err(Debug)
     )]
     pub fn upgrade_account_app_store(
         &self, original_transaction_id: String, app_account_token: String,
@@ -600,7 +602,9 @@ impl<Client: Requester> CoreLib<Client> {
     pub fn admin_rebuild_index(
         &self, index: ServerIndex,
     ) -> Result<(), Error<AdminRebuildIndexError>> {
-        let val = self.db.transaction(|tx| self.context(tx)?.rebuild_index(index))?;
+        let val = self
+            .db
+            .transaction(|tx| self.context(tx)?.rebuild_index(index))?;
         Ok(val?)
     }
 }

--- a/libs/core/src/lib.rs
+++ b/libs/core/src/lib.rs
@@ -34,6 +34,7 @@ pub use lockbook_shared::tree_like::TreeLike;
 pub use lockbook_shared::tree_like::TreeLikeMut;
 pub use lockbook_shared::usage::bytes_to_human;
 pub use lockbook_shared::work_unit::{ClientWorkUnit, WorkUnit};
+pub use lockbook_shared::api::ServerIndex;
 
 pub use crate::model::drawing::SupportedImageFormats;
 pub use crate::model::errors::*;
@@ -48,9 +49,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use hmdb::transaction::Transaction as _;
 use itertools::Itertools;
 use lockbook_shared::account::Username;
-use lockbook_shared::api::{
-    AccountInfo, AdminFileInfoResponse, AdminValidateAccount, AdminValidateServer,
-};
+use lockbook_shared::api::{AccountInfo, AdminFileInfoResponse, AdminValidateAccount, AdminValidateServer};
 use lockbook_shared::clock;
 use lockbook_shared::crypto::AESKey;
 use serde_json::{json, value::Value};
@@ -76,7 +75,8 @@ pub struct DataCache {
 pub struct CoreLib<Client: Requester> {
     // TODO not pub?
     pub config: Config,
-    pub data_cache: Arc<Mutex<DataCache>>, // Or Rc<RefCell>>
+    pub data_cache: Arc<Mutex<DataCache>>,
+    // Or Rc<RefCell>>
     pub db: CoreDb,
     pub client: Client,
 }
@@ -490,9 +490,9 @@ impl<Client: Requester> CoreLib<Client> {
     }
 
     #[instrument(
-        level = "debug",
-        skip(self, original_transaction_id, app_account_token),
-        err(Debug)
+    level = "debug",
+    skip(self, original_transaction_id, app_account_token),
+    err(Debug)
     )]
     pub fn upgrade_account_app_store(
         &self, original_transaction_id: String, app_account_token: String,
@@ -593,6 +593,14 @@ impl<Client: Requester> CoreLib<Client> {
         &self, id: Uuid,
     ) -> Result<AdminFileInfoResponse, Error<AdminFileInfoError>> {
         let val = self.db.transaction(|tx| self.context(tx)?.file_info(id))?;
+        Ok(val?)
+    }
+
+    #[instrument(level = "debug", skip(self), err(Debug))]
+    pub fn admin_rebuild_index(
+        &self, index: ServerIndex,
+    ) -> Result<(), Error<AdminRebuildIndexError>> {
+        let val = self.db.transaction(|tx| self.context(tx)?.rebuild_index(index))?;
         Ok(val?)
     }
 }

--- a/libs/core/src/model/errors.rs
+++ b/libs/core/src/model/errors.rs
@@ -63,8 +63,8 @@ impl<T> From<crossbeam::channel::SendError<T>> for UnexpectedError {
 
 impl Serialize for UnexpectedError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         let mut state = serializer.serialize_struct("UnexpectedError", 2)?;
         state.serialize_field("tag", "Unexpected")?;
@@ -1175,7 +1175,9 @@ impl From<CoreError> for Error<AdminRebuildIndexError> {
                 UiError(AdminRebuildIndexError::InsufficientPermission)
             }
             CoreError::ServerUnreachable => UiError(AdminRebuildIndexError::CouldNotReachServer),
-            CoreError::ClientUpdateRequired => UiError(AdminRebuildIndexError::ClientUpdateRequired),
+            CoreError::ClientUpdateRequired => {
+                UiError(AdminRebuildIndexError::ClientUpdateRequired)
+            }
             _ => unexpected!("{:#?}", e),
         }
     }

--- a/libs/core/src/model/errors.rs
+++ b/libs/core/src/model/errors.rs
@@ -63,8 +63,8 @@ impl<T> From<crossbeam::channel::SendError<T>> for UnexpectedError {
 
 impl Serialize for UnexpectedError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         let mut state = serializer.serialize_struct("UnexpectedError", 2)?;
         state.serialize_field("tag", "Unexpected")?;
@@ -1156,6 +1156,26 @@ impl From<CoreError> for Error<AdminListUsersError> {
             }
             CoreError::ServerUnreachable => UiError(AdminListUsersError::CouldNotReachServer),
             CoreError::ClientUpdateRequired => UiError(AdminListUsersError::ClientUpdateRequired),
+            _ => unexpected!("{:#?}", e),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, EnumIter)]
+pub enum AdminRebuildIndexError {
+    InsufficientPermission,
+    CouldNotReachServer,
+    ClientUpdateRequired,
+}
+
+impl From<CoreError> for Error<AdminRebuildIndexError> {
+    fn from(e: CoreError) -> Self {
+        match e {
+            CoreError::InsufficientPermission => {
+                UiError(AdminRebuildIndexError::InsufficientPermission)
+            }
+            CoreError::ServerUnreachable => UiError(AdminRebuildIndexError::CouldNotReachServer),
+            CoreError::ClientUpdateRequired => UiError(AdminRebuildIndexError::ClientUpdateRequired),
             _ => unexpected!("{:#?}", e),
         }
     }

--- a/libs/core/src/service/admin_service.rs
+++ b/libs/core/src/service/admin_service.rs
@@ -124,4 +124,18 @@ impl<Client: Requester> RequestContext<'_, '_, Client> {
                 _ => core_err_unexpected(err),
             })
     }
+
+    pub fn rebuild_index(&self, index: ServerIndex) -> CoreResult<()> {
+        let account = self.get_account()?;
+        self.client
+            .request(account, AdminRebuildIndexRequest { index })
+            .map_err(|err| match err {
+                ApiError::Endpoint(AdminRebuildIndexError::NotPermissioned) => {
+                    CoreError::InsufficientPermission
+                }
+                ApiError::SendFailed(_) => CoreError::ServerUnreachable,
+                ApiError::ClientUpdateRequired => CoreError::ClientUpdateRequired,
+                _ => core_err_unexpected(err),
+            })
+    }
 }

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -35,7 +35,7 @@ pub async fn upsert_file_metadata(
                 &mut tx.file_children,
                 &mut tx.metas,
             )?
-                .to_lazy();
+            .to_lazy();
 
             for id in tree.owned_ids() {
                 if tree.find(&id)?.is_document() && tree.calculate_deleted(&id)? {
@@ -173,7 +173,7 @@ pub async fn change_doc(
             &mut tx.file_children,
             &mut tx.metas,
         )?
-            .to_lazy();
+        .to_lazy();
 
         if tree.maybe_find(request.diff.new.id()).is_none() {
             return Err(ClientError(NotPermissioned));
@@ -232,7 +232,7 @@ pub async fn change_doc(
         request.diff.new.document_hmac().unwrap(),
         &request.new_content,
     )
-        .await?;
+    .await?;
     debug!(?id, ?hmac, "Inserted document contents");
 
     let result = server_state.index_db.transaction(|tx| {
@@ -243,7 +243,7 @@ pub async fn change_doc(
             &mut tx.file_children,
             &mut tx.metas,
         )?
-            .to_lazy();
+        .to_lazy();
         let new_size = request.new_content.value.len() as u64;
 
         if tree.calculate_deleted(request.diff.new.id())? {
@@ -275,7 +275,7 @@ pub async fn change_doc(
             request.diff.new.id(),
             request.diff.new.document_hmac().unwrap(),
         )
-            .await?;
+        .await?;
         debug!(?id, ?hmac, "Cleaned up new document contents after failed metadata update");
     }
 
@@ -306,7 +306,7 @@ pub async fn get_document(
             &mut tx.file_children,
             &mut tx.metas,
         )?
-            .to_lazy();
+        .to_lazy();
 
         let meta = match tree.maybe_find(&request.id) {
             Some(meta) => Ok(meta),
@@ -350,7 +350,7 @@ pub async fn get_file_ids(
                 &mut tx.file_children,
                 &mut tx.metas,
             )?
-                .owned_ids(),
+            .owned_ids(),
         })
     })?
 }
@@ -368,7 +368,7 @@ pub async fn get_updates(
             &mut tx.file_children,
             &mut tx.metas,
         )?
-            .to_lazy();
+        .to_lazy();
 
         let mut result_ids = HashSet::new();
         for id in tree.owned_ids() {
@@ -377,9 +377,9 @@ pub async fn get_updates(
                 result_ids.insert(id);
                 if file.owner() != owner
                     && file
-                    .user_access_keys()
-                    .iter()
-                    .any(|k| !k.deleted && k.encrypted_for == context.public_key)
+                        .user_access_keys()
+                        .iter()
+                        .any(|k| !k.deleted && k.encrypted_for == context.public_key)
                 {
                     result_ids.insert(id);
                     result_ids.extend(tree.descendants(&id)?);
@@ -516,7 +516,7 @@ pub fn validate_account_helper(
         &mut tx.file_children,
         &mut tx.metas,
     )?
-        .to_lazy();
+    .to_lazy();
 
     for id in tree.owned_ids() {
         if !tree.calculate_deleted(&id)? {
@@ -574,7 +574,7 @@ pub async fn admin_validate_server(
                     &mut tx.file_children,
                     &mut tx.metas,
                 )?
-                    .to_lazy();
+                .to_lazy();
                 if tree.calculate_deleted(&id)? {
                     deleted_ids.insert(id);
                 }
@@ -777,7 +777,7 @@ pub async fn admin_file_info(
                 &mut tx.file_children,
                 &mut tx.metas,
             )?
-                .to_lazy();
+            .to_lazy();
 
             let ancestors = tree
                 .ancestors(&request.id)?
@@ -799,17 +799,22 @@ pub async fn admin_file_info(
 pub async fn admin_rebuild_index(
     context: RequestContext<'_, AdminRebuildIndexRequest>,
 ) -> Result<(), ServerError<AdminRebuildIndexError>> {
-    context.server_state.index_db.transaction(|tx| {
-        match context.request.index {
+    context
+        .server_state
+        .index_db
+        .transaction(|tx| match context.request.index {
             ServerIndex::OwnedFiles => {
                 tx.owned_files.clear();
                 for (id, file) in tx.metas.get_all() {
-                    let mut set = tx.owned_files.get(&file.owner()).cloned().unwrap_or_default();
+                    let mut set = tx
+                        .owned_files
+                        .get(&file.owner())
+                        .cloned()
+                        .unwrap_or_default();
                     set.insert(*id);
                     tx.owned_files.insert(file.owner(), set);
                 }
                 Ok(())
             }
-        }
-    })?
+        })?
 }

--- a/server/server/src/router_service.rs
+++ b/server/server/src/router_service.rs
@@ -150,6 +150,7 @@ pub fn core_routes(
         .or(core_req!(AdminValidateAccountRequest, admin_validate_account, server_state))
         .or(core_req!(AdminValidateServerRequest, admin_validate_server, server_state))
         .or(core_req!(AdminFileInfoRequest, admin_file_info, server_state))
+        .or(core_req!(AdminRebuildIndexRequest, admin_rebuild_index, server_state))
 }
 
 pub fn build_info() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {


### PR DESCRIPTION
+ delete account logic is incomplete #1521 
+ smail created an account and then shared some stuff to his main account and then deleted that account
+ that account's deletion eliminated files that smail owned and were shared to that account
+ smail now had files in his owned_files that no longer exist
+ this allows us to, on demand rebuild various indexes after admin action has been taken
+ wrote a lil test 