### PR TITLE
core,shared,server: upgrade uuid from 0.8.1 to 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
  "smol_str",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3020,7 +3020,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.2.2",
  "variant_count",
 ]
 
@@ -3101,7 +3101,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.2.2",
  "warp",
  "x509-parser",
 ]
@@ -3125,7 +3125,7 @@ dependencies = [
  "sha2 0.9.9",
  "test_utils",
  "tracing",
- "uuid",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -5187,7 +5187,7 @@ dependencies = [
  "itertools",
  "lockbook-core",
  "lockbook-shared",
- "uuid",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -5724,6 +5724,15 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.7",
+]
+
+[[package]]
+name = "uuid"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom 0.2.7",
  "serde",

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 strum = "0.19.5"
 strum_macros = "0.19.4"
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
+uuid = { version = "1.2.2", features = ["v4", "serde"] }
 itertools = "0.10.1"
 backtrace = "0.3"
 libsecp256k1 = "0.7.1"

--- a/libs/core/libs/shared/Cargo.toml
+++ b/libs/core/libs/shared/Cargo.toml
@@ -10,7 +10,7 @@ http = "0.2.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 libsecp256k1 = "0.7.1"
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
+uuid = { version = "1.2.2", features = ["v4", "serde"] }
 aead = "0.4.2"
 aes-gcm = "0.9.3"
 bincode = "1.2.1"

--- a/libs/core/libs/test_utils/Cargo.toml
+++ b/libs/core/libs/test_utils/Cargo.toml
@@ -10,4 +10,4 @@ hmdb = "0.2.2"
 bincode = "1.3.3"
 itertools = "0.10.1"
 chrono = "0.4.15"
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
+uuid = { version = "1.2.2", features = ["v4", "serde"] }

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 shadow-rs = "0.6.2"
 tokio = { version = "1.5.0", features = ["full"] }
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
+uuid = { version = "1.2.2", features = ["v4", "serde"] }
 libsecp256k1 = "0.7.1"
 prometheus = "0.13.0"
 prometheus-static-metric = "0.5.1"


### PR DESCRIPTION
`async-stripe` I believe is the one locked into `0.8.1` which is the reason why the lock file is adding the new version.

The impetus for upgrading is that this version gives us the `Uuid::into_bytes` method.