### PR TITLE
editor: pass font definitions into register instead of starting a new one

### DIFF
--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -9,7 +9,7 @@ use crate::styles::StyleInfo;
 use crate::test_input::TEST_MARKDOWN;
 use crate::unicode_segs::UnicodeSegs;
 use crate::{ast, events, galleys, layouts, register_fonts, styles, unicode_segs};
-use egui::{Context, Ui, Vec2};
+use egui::{FontDefinitions, Context, Ui, Vec2};
 
 pub struct Editor {
     pub initialized: bool,
@@ -125,6 +125,8 @@ impl Editor {
     }
 
     pub fn set_font(&self, ctx: &Context) {
-        register_fonts(ctx);
+        let mut fonts = FontDefinitions::default();
+        register_fonts(&mut fonts);
+        ctx.set_fonts(fonts);
     }
 }

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -9,7 +9,7 @@ use crate::styles::StyleInfo;
 use crate::test_input::TEST_MARKDOWN;
 use crate::unicode_segs::UnicodeSegs;
 use crate::{ast, events, galleys, layouts, register_fonts, styles, unicode_segs};
-use egui::{FontDefinitions, Context, Ui, Vec2};
+use egui::{Context, FontDefinitions, Ui, Vec2};
 
 pub struct Editor {
     pub initialized: bool,

--- a/libs/editor/egui_editor/src/lib.rs
+++ b/libs/editor/egui_editor/src/lib.rs
@@ -1,5 +1,5 @@
 pub use crate::editor::Editor;
-use egui::{Context, FontData, FontDefinitions, FontFamily, Pos2, Rect};
+use egui::{FontData, FontDefinitions, FontFamily, Pos2, Rect};
 use egui_wgpu_backend::wgpu;
 use std::iter;
 use std::sync::Arc;
@@ -128,9 +128,7 @@ impl WgpuEditor {
     }
 }
 
-pub fn register_fonts(ctx: &Context) {
-    let mut fonts = FontDefinitions::default();
-
+pub fn register_fonts(fonts: &mut FontDefinitions) {
     fonts.font_data.insert(
         "pt_sans".to_string(),
         FontData::from_static(include_bytes!("../fonts/PTSans-Regular.ttf")),
@@ -159,6 +157,4 @@ pub fn register_fonts(ctx: &Context) {
         .get_mut(&FontFamily::Monospace)
         .unwrap()
         .insert(0, "pt_mono".to_string());
-
-    ctx.set_fonts(fonts);
 }


### PR DESCRIPTION
A little oversight on my part: the font registry starts out with a new `FontDefinitions` when the editor registers fonts. This means either its fonts are getting registered, or the clients are getting registered.

This change makes it so that registering modifies a provided `FontDefinitions`.