### PR TITLE
core: cleanup old logs after a successful migration

### DIFF
--- a/libs/core/src/lib.rs
+++ b/libs/core/src/lib.rs
@@ -83,6 +83,7 @@ impl Core {
         log_service::init(config)?;
         let db =
             CoreDb::init_with_migration(config).map_err(|err| unexpected_only!("{:#?}", err))?;
+
         let config = config.clone();
         let client = Network::default();
 

--- a/libs/core/src/repo/mod.rs
+++ b/libs/core/src/repo/mod.rs
@@ -64,10 +64,12 @@ impl CoreV3 {
 
             let mut path = PathBuf::from(&config.writeable_path);
             path.push("lockbook_core__repo__schema_v2__CoreV2");
+            // ignore if file is missing
             drop(remove_file(path));
 
             let mut path = PathBuf::from(&config.writeable_path);
             path.push("lockbook_core__repo__schema__CoreV1");
+            // ignore if file is missing
             drop(remove_file(path));
         }
 

--- a/libs/core/src/repo/mod.rs
+++ b/libs/core/src/repo/mod.rs
@@ -1,6 +1,8 @@
 use db_rs::{Db, LookupTable, Single};
 use db_rs_derive::Schema;
 use hmdb::log::Reader;
+use std::fs::remove_file;
+use std::path::PathBuf;
 
 use lockbook_shared::account::Account;
 use lockbook_shared::file_metadata::Owner;
@@ -57,6 +59,16 @@ impl CoreV3 {
 
                 tx.drop_safely()?;
             }
+
+            drop(source);
+
+            let mut path = PathBuf::from(&config.writeable_path);
+            path.push("lockbook_core__repo__schema_v2__CoreV2");
+            drop(remove_file(path));
+
+            let mut path = PathBuf::from(&config.writeable_path);
+            path.push("lockbook_core__repo__schema__CoreV1");
+            drop(remove_file(path));
         }
 
         Ok(dest)


### PR DESCRIPTION
if a migration occurs, cleanup any old log files that may exist, ignore any errors if a cleanup doesn't work.

Tested manually by me from 0.5.11 using cli