### PR TITLE
dev-tool: use --all-targets to also cover benches

### DIFF
--- a/utils/dev-tool/src/workspace.rs
+++ b/utils/dev-tool/src/workspace.rs
@@ -11,7 +11,7 @@ pub fn fmt_workspace(tool_env: &ToolEnvironment) {
 
 pub fn clippy_workspace(tool_env: &ToolEnvironment) {
     Command::new("cargo")
-        .args(["clippy", "--tests", "--all-features", "--", "-D", "warnings"])
+        .args(["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"])
         .current_dir(&tool_env.root_dir)
         .assert_success();
 }


### PR DESCRIPTION
This would have caught the errors that were fixed in https://github.com/lockbook/lockbook/pull/1599