### PR TITLE
apple: remove navigation link file tree

### DIFF
--- a/clients/apple/Shared/Stateful Logic/FileService.swift
+++ b/clients/apple/Shared/Stateful Logic/FileService.swift
@@ -7,6 +7,9 @@ class FileService: ObservableObject {
     @Published var root: File? = nil
     @Published var files: [File] = []
     var successfulAction: FileAction? = nil
+    
+    @Published var parent: File? = nil
+    @Published var children: [File] = []
         
 
     func childrenOf(_ meta: File?) -> [File] {
@@ -19,6 +22,7 @@ class FileService: ObservableObject {
         } else {
             file = meta!
         }
+        
 
         var toBeSorted = files.filter {
             $0.parent == file.id && $0.parent != $0.id
@@ -27,6 +31,32 @@ class FileService: ObservableObject {
         toBeSorted.sort()
 
         return toBeSorted
+    }
+    
+    func refreshChildrenAtParent(_ maybeId: UUID?) {
+        var id: UUID
+        
+        if let realId = maybeId {
+            id = realId
+        } else {
+            guard let theRoot = root else {
+                return;
+            }
+            id = theRoot.id
+        }
+
+        var toBeSorted = files.filter {
+            $0.parent == id && $0.parent != $0.id
+        }
+        
+        var parentFile = files.filter {
+            $0.id == id
+        }[0]
+
+        toBeSorted.sort()
+        
+        parent = parentFile
+        children = toBeSorted
     }
 
     func childrenOfRoot() -> [File] {

--- a/clients/apple/Shared/Stateful Logic/FileService.swift
+++ b/clients/apple/Shared/Stateful Logic/FileService.swift
@@ -9,7 +9,7 @@ class FileService: ObservableObject {
     @Published var root: File? = nil
     @Published var files: [File] = []
     
-    // File Service takes
+    // File Service keeps track of the children and parent being displayed on iOS. Since this functionality is not used for macOS, it is conditionally compiled.
 #if os(iOS)
     @Published var parent: File? = nil
     @Published var children: [File] = []
@@ -98,7 +98,6 @@ class FileService: ObservableObject {
             refresh()
         }
     }
-
     // TODO in the future we should pop one of these bad boys up during this operation
     // https://github.com/elai950/AlertToast
     func moveFile(id: UUID, newParent: UUID) {

--- a/clients/apple/Shared/Stateful Logic/FileService.swift
+++ b/clients/apple/Shared/Stateful Logic/FileService.swift
@@ -75,7 +75,7 @@ class FileService: ObservableObject {
         } else {
             file = meta!
         }
-        
+
         var toBeSorted = files.filter {
             $0.parent == file.id && $0.parent != $0.id
         }
@@ -89,6 +89,7 @@ class FileService: ObservableObject {
         let root = root!
         return childrenOf(root)
     }
+
     init(_ core: LockbookApi) {
         self.core = core
 
@@ -96,7 +97,7 @@ class FileService: ObservableObject {
             refresh()
         }
     }
-    
+
     // TODO in the future we should pop one of these bad boys up during this operation
     // https://github.com/elai950/AlertToast
     func moveFile(id: UUID, newParent: UUID) {

--- a/clients/apple/Shared/Stateful Logic/FileService.swift
+++ b/clients/apple/Shared/Stateful Logic/FileService.swift
@@ -76,7 +76,6 @@ class FileService: ObservableObject {
             file = meta!
         }
         
-
         var toBeSorted = files.filter {
             $0.parent == file.id && $0.parent != $0.id
         }
@@ -90,7 +89,6 @@ class FileService: ObservableObject {
         let root = root!
         return childrenOf(root)
     }
-    
     init(_ core: LockbookApi) {
         self.core = core
 
@@ -98,6 +96,7 @@ class FileService: ObservableObject {
             refresh()
         }
     }
+    
     // TODO in the future we should pop one of these bad boys up during this operation
     // https://github.com/elai950/AlertToast
     func moveFile(id: UUID, newParent: UUID) {

--- a/clients/apple/Shared/Stateful Logic/FileService.swift
+++ b/clients/apple/Shared/Stateful Logic/FileService.swift
@@ -9,9 +9,10 @@ class FileService: ObservableObject {
     @Published var root: File? = nil
     @Published var files: [File] = []
     
-    // File Service keeps track of the children and parent being displayed on iOS. Since this functionality is not used for macOS, it is conditionally compiled.
+    // File Service keeps track of the parent being displayed on iOS. Since this functionality is not used for macOS, it is conditionally compiled.
 #if os(iOS)
     @Published var path: [File] = []
+    
     var parent: File? {
         get {
             path.last
@@ -201,7 +202,6 @@ class FileService: ObservableObject {
                             self.root = $0
                         }
                     }
-                    self.childrenOfParent()
                     self.closeOpenFileIfDeleted()
                 case .failure(let error):
                     DI.errors.handleError(error)

--- a/clients/apple/Shared/Views/BookView.swift
+++ b/clients/apple/Shared/Views/BookView.swift
@@ -54,8 +54,7 @@ struct BookView: View {
     
     #if os(iOS)
     var iOS: some View {
-        NavigationView {
-            FileListView(currentFolder: currentFolder, account: account)
+            FileListView()
                     .toolbar {
                         ToolbarItemGroup {
                             NavigationLink(
@@ -69,9 +68,7 @@ struct BookView: View {
                                         .padding(.horizontal, 10)
                                     }
                         }
-                    }
-        }
-                .navigationViewStyle(.stack)
+                    }                
     }
 
     @ViewBuilder

--- a/clients/apple/Shared/Views/BookView.swift
+++ b/clients/apple/Shared/Views/BookView.swift
@@ -71,7 +71,7 @@ struct BookView: View {
                     }
                 }
         }
-        .navigationViewStyle(.stack)
+            .navigationViewStyle(.stack)
     }
 
     @ViewBuilder

--- a/clients/apple/Shared/Views/BookView.swift
+++ b/clients/apple/Shared/Views/BookView.swift
@@ -54,21 +54,24 @@ struct BookView: View {
     
     #if os(iOS)
     var iOS: some View {
+        NavigationView {
             FileListView()
-                    .toolbar {
-                        ToolbarItemGroup {
-                            NavigationLink(
-                                destination: PendingSharesView()) {
-                                    Image(systemName: "shared.with.you").foregroundColor(.blue)
-                                }
-                            
-                            NavigationLink(
-                                destination: SettingsView().equatable(), isActive: $onboarding.theyChoseToBackup) {
-                                    Image(systemName: "gearshape.fill").foregroundColor(.blue)
-                                        .padding(.horizontal, 10)
-                                    }
-                        }
-                    }                
+                .toolbar {
+                    ToolbarItemGroup {
+                        NavigationLink(
+                            destination: PendingSharesView()) {
+                                Image(systemName: "shared.with.you").foregroundColor(.blue)
+                            }
+                        
+                        NavigationLink(
+                            destination: SettingsView().equatable(), isActive: $onboarding.theyChoseToBackup) {
+                                Image(systemName: "gearshape.fill").foregroundColor(.blue)
+                                    .padding(.horizontal, 10)
+                            }
+                    }
+                }
+        }
+        .navigationViewStyle(.stack)
     }
 
     @ViewBuilder

--- a/clients/apple/Shared/Views/DocumentView.swift
+++ b/clients/apple/Shared/Views/DocumentView.swift
@@ -9,6 +9,7 @@ struct DocumentView: View {
     @EnvironmentObject var model: DocumentLoader
 #if os(iOS)
     @EnvironmentObject var toolbar: ToolbarModel
+    @EnvironmentObject var current: CurrentDocument
 #endif
     
     var body: some View {
@@ -65,6 +66,7 @@ struct DocumentView: View {
                 }
             }
         }
+        
     }
 }
 

--- a/clients/apple/Shared/Views/ListFileCell.swift
+++ b/clients/apple/Shared/Views/ListFileCell.swift
@@ -66,7 +66,7 @@ struct RealFileCell: View {
             Text(meta.name)
                     .font(.title3)
             HStack {
-                Image(systemName: meta.fileType == .Folder ? "folder" : "doc")
+                Image(systemName: meta.fileType == .Folder ? "folder.fill" : "doc.fill")
                         .foregroundColor(meta.fileType == .Folder ? .blue : .secondary)
                 Text(intEpochToString(epoch: max(meta.lastModified, meta.lastModified)))
                         .foregroundColor(.secondary)

--- a/clients/apple/Shared/Views/ListFileCell.swift
+++ b/clients/apple/Shared/Views/ListFileCell.swift
@@ -38,11 +38,11 @@ struct FileCell: View {
     @ViewBuilder
     var cell: some View {
         if meta.fileType == .Folder {
-            NavigationLink(
-                    destination: FileListView(currentFolder: meta, account: account.account!)) {
+            Button(action: {
+                fileService.refreshChildrenAtParent(meta.parent)
+            }) {
                 RealFileCell(meta: meta)
             }
-                    .isDetailLink(false)
         } else {
             NavigationLink(destination: DocumentView(meta: meta), tag: meta, selection: $current.selectedDocument) {
                 RealFileCell(meta: meta)

--- a/clients/apple/Shared/Views/ListFileCell.swift
+++ b/clients/apple/Shared/Views/ListFileCell.swift
@@ -39,13 +39,10 @@ struct FileCell: View {
     var cell: some View {
         if meta.fileType == .Folder {
             Button(action: {
-                withAnimation {
-                    fileService.intoChildDirectory(meta)
-                }
+                fileService.intoChildDirectory(meta)
             }) {
                 RealFileCell(meta: meta)
             }
-            
         } else {
             NavigationLink(destination: DocumentView(meta: meta)) {
                 RealFileCell(meta: meta)

--- a/clients/apple/Shared/Views/ListFileCell.swift
+++ b/clients/apple/Shared/Views/ListFileCell.swift
@@ -72,7 +72,6 @@ struct RealFileCell: View {
                         .foregroundColor(.secondary)
                 
                 Spacer()
-                
             }
                     .font(.footnote)
         }

--- a/clients/apple/Shared/Views/ListFileCell.swift
+++ b/clients/apple/Shared/Views/ListFileCell.swift
@@ -39,12 +39,15 @@ struct FileCell: View {
     var cell: some View {
         if meta.fileType == .Folder {
             Button(action: {
-                fileService.refreshChildrenAtParent(meta.parent)
+                withAnimation {
+                    fileService.intoChildDirectory(meta)
+                }
             }) {
                 RealFileCell(meta: meta)
             }
+            
         } else {
-            NavigationLink(destination: DocumentView(meta: meta), tag: meta, selection: $current.selectedDocument) {
+            NavigationLink(destination: DocumentView(meta: meta)) {
                 RealFileCell(meta: meta)
             }
         }
@@ -67,11 +70,13 @@ struct RealFileCell: View {
                         .foregroundColor(meta.fileType == .Folder ? .blue : .secondary)
                 Text(intEpochToString(epoch: max(meta.lastModified, meta.lastModified)))
                         .foregroundColor(.secondary)
-
+                
+                Spacer()
+                
             }
                     .font(.footnote)
         }
-                .padding(.vertical, 5)
-                .contentShape(Rectangle()) /// https://stackoverflow.com/questions/57258371/swiftui-increase-tap-drag-area-for-user-interaction
+            .padding(.vertical, 5)
+            .contentShape(Rectangle()) /// https://stackoverflow.com/questions/57258371/swiftui-increase-tap-drag-area-for-user-interaction
     }
 }

--- a/clients/apple/Shared/Views/NewFileSheet.swift
+++ b/clients/apple/Shared/Views/NewFileSheet.swift
@@ -111,13 +111,14 @@ struct NewFileSheet: View {
         case .success(let newMeta):
             if newMeta.fileType == .Folder {
                 files.successfulAction = .createFolder
-                sheets.created = newMeta
             } else {
                 selection.selectedDocument = newMeta
             }
             files.refresh()
             status.checkForLocalWork()
             presentationMode.wrappedValue.dismiss()
+            
+            sheets.created = newMeta
         case .failure(let err):
             switch err.kind {
             case .UiError(let uiError):

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/File.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Models/File.swift
@@ -15,6 +15,7 @@ public struct File: Codable, Identifiable, Equatable, Hashable, Comparable {
             lhs.id == rhs.id &&
 //            lhs.metadataVersion == rhs.metadataVersion && // TODO don't do this here, do this at the view instead
 //            lhs.contentVersion == rhs.contentVersion &&
+            lhs.shares == rhs.shares &&
             lhs.parent == rhs.parent &&
             lhs.lastModifiedBy == rhs.lastModifiedBy &&
             lhs.name == rhs.name
@@ -75,7 +76,7 @@ public enum ShareMode: String, Codable {
     case Read
 }
 
-public struct Share: Codable {
+public struct Share: Codable, Equatable {
     public var mode: ShareMode
     public var sharedBy: String
     public var sharedWith: String

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -1,64 +1,57 @@
 import SwiftUI
-import SwiftLockbookCore
-import PencilKit
+import Foundation
 
 struct FileListView: View {
-
-    let currentFolder: File
-    let account: Account
-
+    
     @EnvironmentObject var current: CurrentDocument
     @EnvironmentObject var sheets: SheetState
     @EnvironmentObject var fileService: FileService
-    @EnvironmentObject var errors: UnexpectedErrorService
-    var files: [File] {
-        fileService.childrenOf(currentFolder)
-    }
-
-    // There are too many workarounds here, we want to learn how to properly animate a list and then do this ourselves
-    // So we can nicely navigate to new folders that have been created and manage the idea of a breadcrumb trail
+    
     var body: some View {
-        ZStack {
-            // The whole active selection concept doesn't handle links that don't exist yet properly
-            // This is a workaround for that scenario.
-            if let newDoc = sheets.created, newDoc.fileType == .Document {
-                NavigationLink(destination: DocumentView(meta: newDoc), isActive: Binding.constant(true)) {
-                    EmptyView()
+        NavigationView {
+            ZStack {
+                // The whole active selection concept doesn't handle links that don't exist yet properly
+                // This is a workaround for that scenario.
+                if let newDoc = sheets.created, newDoc.fileType == .Document {
+                    NavigationLink(destination: DocumentView(meta: newDoc), isActive: Binding.constant(true)) {
+                        EmptyView()
+                    }
+                    .hidden()
                 }
-                        .hidden()
-            }
-
-
-            VStack {
-                List(files) { meta in
-                    FileCell(meta: meta)
-                }
-                HStack {
-                    BottomBar(onCreating: {
-                        sheets.creatingInfo = CreatingInfo(parent: currentFolder, child_type: .Document)
-                    })
-                }
-                        .navigationBarTitle(currentFolder.name)
-                        .padding(.horizontal, 10)
-                        .onReceive(current.$selectedDocument) { _ in
-                            print("cleared")
-                            // When we return back to this screen, we have to change newFile back to nil regardless
-                            // of it's present value, otherwise we won't be able to navigate to new, new files
-                            if current.selectedDocument == nil {
-                                sheets.created = nil
+                
+                VStack {
+                    List(fileService.children) { meta in
+                        FileCell(meta: meta)
+                            .id(UUID())
+                    }
+                    HStack {
+                        BottomBar(onCreating: {
+                            if let parent = fileService.parent {
+                                sheets.creatingInfo = CreatingInfo(parent: parent, child_type: .Document)
                             }
+                        })
+                    }
+                    .navigationBarTitle(fileService.parent.map{($0.name)} ?? "")
+                    .padding(.horizontal, 10)
+                    .onReceive(current.$selectedDocument) { _ in
+                        print("cleared")
+                        // When we return back to this screen, we have to change newFile back to nil regardless
+                        // of it's present value, otherwise we won't be able to navigate to new, new files
+                        if current.selectedDocument == nil {
+                            sheets.created = nil
                         }
+                    }
+                }
             }
-        }
-
+        }.navigationViewStyle(.stack)
     }
 }
 
 struct FileListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            FileListView(currentFolder: Mock.files.root!, account: Mock.accounts.account!)
-                    .mockDI()
+            FileListView()
+                .mockDI()
         }
     }
 }

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -13,7 +13,6 @@ struct FileListView: View {
                 // This is a workaround for that scenario.
                 
                 VStack {
-                    FilePathBreadcrumb()
                     
                     if let newDoc = sheets.created, newDoc.fileType == .Document {
                         NavigationLink(destination: DocumentView(meta: newDoc), isActive: Binding(get: { current.selectedDocument != nil }, set: { _ in current.selectedDocument = nil }) ) {
@@ -27,6 +26,8 @@ struct FileListView: View {
                             .id(UUID())
                     }
                     .navigationBarTitle(fileService.parent.map{($0.name)} ?? "")
+                    
+                    FilePathBreadcrumb()
                     
                     HStack {
                         BottomBar(onCreating: {

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -19,7 +19,6 @@ struct FileListView: View {
                     
                     List(fileService.childrenOfParent()) { meta in
                         FileCell(meta: meta)
-                            .id(UUID())
                     }
                     .navigationBarTitle(fileService.parent.map{($0.name)} ?? "")
                     
@@ -46,9 +45,7 @@ struct FileListView: View {
             .gesture(
                 DragGesture().onEnded({ (value) in
                     if value.translation.width > 50 && fileService.parent?.isRoot == false {
-                        withAnimation {
-                            fileService.upADirectory()
-                        }
+                        fileService.upADirectory()
                     }
                 }))
     }

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -21,7 +21,7 @@ struct FileListView: View {
                          .hidden()
                     }
                     
-                    List(fileService.children) { meta in
+                    List(fileService.childrenOfParent()) { meta in
                         FileCell(meta: meta)
                             .id(UUID())
                     }
@@ -45,11 +45,6 @@ struct FileListView: View {
                             sheets.created = nil
                         }
                     }
-                }
-            }
-            .onAppear {
-                if fileService.parent == nil {
-                    fileService.refreshChildrenAtParent(nil)
                 }
             }
             .gesture(

--- a/clients/apple/iOS/FileListView.swift
+++ b/clients/apple/iOS/FileListView.swift
@@ -9,11 +9,7 @@ struct FileListView: View {
     
     var body: some View {
             ZStack {
-                // The whole active selection concept doesn't handle links that don't exist yet properly
-                // This is a workaround for that scenario.
-                
                 VStack {
-                    
                     if let newDoc = sheets.created, newDoc.fileType == .Document {
                         NavigationLink(destination: DocumentView(meta: newDoc), isActive: Binding(get: { current.selectedDocument != nil }, set: { _ in current.selectedDocument = nil }) ) {
                              EmptyView()

--- a/clients/apple/iOS/FilePathBreadcrumb.swift
+++ b/clients/apple/iOS/FilePathBreadcrumb.swift
@@ -33,9 +33,7 @@ struct FilePathBreadcrumb: View {
 
             if(index == lastFileIndex) {
                 Button(action: {
-                    withAnimation {
-                        fileService.pathBreadcrumbClicked(file)
-                    }
+                    fileService.pathBreadcrumbClicked(file)
                 }, label: {
                     Image(systemName: "folder.fill")
                         .foregroundColor(.blue)
@@ -45,9 +43,7 @@ struct FilePathBreadcrumb: View {
                 .id(index)
             } else {
                 Button(action: {
-                    withAnimation {
-                        fileService.pathBreadcrumbClicked(file)
-                    }
+                    fileService.pathBreadcrumbClicked(file)
                 }, label: {
                     Image(systemName: "folder.fill")
                         .foregroundColor(.blue)

--- a/clients/apple/iOS/FilePathBreadcrumb.swift
+++ b/clients/apple/iOS/FilePathBreadcrumb.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftUI
+
+struct FilePathBreadcrumb: View {
+    
+    @EnvironmentObject var fileService: FileService
+    
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack {
+                ForEach(fileService.path) { file in
+                    Button(action: {
+                        withAnimation {
+                            fileService.pathBreadcrumbClicked(file)
+                        }
+                    }, label: {
+                        Text(file.name)
+                    })
+                    Image(systemName: "arrow.right")
+                }
+            }
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct FilePathBreadcrumb_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            FileListView()
+                .mockDI()
+        }
+    }
+}

--- a/clients/apple/iOS/FilePathBreadcrumb.swift
+++ b/clients/apple/iOS/FilePathBreadcrumb.swift
@@ -6,17 +6,44 @@ struct FilePathBreadcrumb: View {
     @EnvironmentObject var fileService: FileService
     
     var body: some View {
-        ScrollView(.horizontal) {
-            HStack {
-                ForEach(fileService.path) { file in
-                    Button(action: {
-                        withAnimation {
-                            fileService.pathBreadcrumbClicked(file)
+        ScrollViewReader { scrollHelper in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(fileService.path, id: \.self) { file in                        
+                        if(fileService.path.last == file) {
+                            Button(action: {
+                                withAnimation {
+                                    fileService.pathBreadcrumbClicked(file)
+                                }
+                            }, label: {
+                                Text(file.name)
+                            })
+                            .padding(.trailing)
+                            .id(file)
+                        } else {
+                            Button(action: {
+                                withAnimation {
+                                    fileService.pathBreadcrumbClicked(file)
+                                }
+                            }, label: {
+                                Text(file.name)
+                            })
+                            .id(file)
                         }
-                    }, label: {
-                        Text(file.name)
-                    })
-                    Image(systemName: "arrow.right")
+                        
+                        if(fileService.path.last != file) {
+                            Image(systemName: "arrow.forward")
+                                .foregroundColor(.accentColor)
+                        }
+                        
+                    }
+                }
+                .onChange(of: fileService.path.count) { count in
+                    if count > 0 {
+                        withAnimation {
+                            scrollHelper.scrollTo(fileService.path.last, anchor: .trailing)
+                        }
+                    }
                 }
             }
         }

--- a/clients/apple/iOS/FilePathBreadcrumb.swift
+++ b/clients/apple/iOS/FilePathBreadcrumb.swift
@@ -9,13 +9,15 @@ struct FilePathBreadcrumb: View {
         ScrollViewReader { scrollHelper in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
-                    ForEach(fileService.path, id: \.self) { file in                        
+                    ForEach(fileService.path, id: \.self) { file in
                         if(fileService.path.last == file) {
                             Button(action: {
                                 withAnimation {
                                     fileService.pathBreadcrumbClicked(file)
                                 }
                             }, label: {
+                                Image(systemName: "folder.fill")
+                                    .foregroundColor(.blue)
                                 Text(file.name)
                             })
                             .padding(.trailing)
@@ -26,14 +28,16 @@ struct FilePathBreadcrumb: View {
                                     fileService.pathBreadcrumbClicked(file)
                                 }
                             }, label: {
+                                Image(systemName: "folder.fill")
+                                    .foregroundColor(.blue)
                                 Text(file.name)
                             })
                             .id(file)
                         }
                         
                         if(fileService.path.last != file) {
-                            Image(systemName: "arrow.forward")
-                                .foregroundColor(.accentColor)
+                            Image(systemName: "chevron.right")
+                                .foregroundColor(.gray)
                         }
                         
                     }

--- a/clients/apple/iOS/FilePathBreadcrumb.swift
+++ b/clients/apple/iOS/FilePathBreadcrumb.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import SwiftLockbookCore
 
 struct FilePathBreadcrumb: View {
     
@@ -9,49 +10,57 @@ struct FilePathBreadcrumb: View {
         ScrollViewReader { scrollHelper in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
-                    ForEach(fileService.path, id: \.self) { file in
-                        if(fileService.path.last == file) {
-                            Button(action: {
-                                withAnimation {
-                                    fileService.pathBreadcrumbClicked(file)
-                                }
-                            }, label: {
-                                Image(systemName: "folder.fill")
-                                    .foregroundColor(.blue)
-                                Text(file.name)
-                            })
-                            .padding(.trailing)
-                            .id(file)
-                        } else {
-                            Button(action: {
-                                withAnimation {
-                                    fileService.pathBreadcrumbClicked(file)
-                                }
-                            }, label: {
-                                Image(systemName: "folder.fill")
-                                    .foregroundColor(.blue)
-                                Text(file.name)
-                            })
-                            .id(file)
-                        }
-                        
-                        if(fileService.path.last != file) {
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.gray)
-                        }
-                        
+                    if(fileService.path.count - 2 >= 0) {
+                        breadcrumb
                     }
                 }
                 .onChange(of: fileService.path.count) { count in
                     if count > 0 {
                         withAnimation {
-                            scrollHelper.scrollTo(fileService.path.last, anchor: .trailing)
+                            scrollHelper.scrollTo(fileService.path.count - 2, anchor: .trailing)
                         }
                     }
                 }
             }
         }
         .padding(.horizontal)
+    }
+    
+    var breadcrumb: some View {
+        ForEach(0...fileService.path.count - 2, id: \.self) { index in
+            let lastFileIndex = fileService.path.count - 2
+            let file = fileService.path[index];
+
+            if(index == lastFileIndex) {
+                Button(action: {
+                    withAnimation {
+                        fileService.pathBreadcrumbClicked(file)
+                    }
+                }, label: {
+                    Image(systemName: "folder.fill")
+                        .foregroundColor(.blue)
+                    Text(file.name)
+                })
+                .padding(.trailing)
+                .id(index)
+            } else {
+                Button(action: {
+                    withAnimation {
+                        fileService.pathBreadcrumbClicked(file)
+                    }
+                }, label: {
+                    Image(systemName: "folder.fill")
+                        .foregroundColor(.blue)
+                    Text(file.name)
+                })
+                .id(index)
+            }
+            
+            if(lastFileIndex != index) {
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.gray)
+            }
+        }
     }
 }
 

--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4709DC39296609F100426106 /* PendingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC37296609F100426106 /* PendingSharesView.swift */; };
 		4709DC3E2966260500426106 /* AcceptShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC3D2966260500426106 /* AcceptShareSheet.swift */; };
 		4709DC3F2966260500426106 /* AcceptShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC3D2966260500426106 /* AcceptShareSheet.swift */; };
+		473A3DCE29AC354B0017BC6A /* FilePathBreadcrumb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A3DCD29AC354B0017BC6A /* FilePathBreadcrumb.swift */; };
 		477CC4902967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
 		477CC4912967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
 		47A45FBB2969047B00573044 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A45FBA2969047B00573044 /* ShareService.swift */; };
@@ -137,6 +138,7 @@
 		1F7E4FBE2521297D0045F606 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		4709DC37296609F100426106 /* PendingSharesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSharesView.swift; sourceTree = "<group>"; };
 		4709DC3D2966260500426106 /* AcceptShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptShareSheet.swift; sourceTree = "<group>"; };
+		473A3DCD29AC354B0017BC6A /* FilePathBreadcrumb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePathBreadcrumb.swift; sourceTree = "<group>"; };
 		4741C7902939C9220073F24F /* Products.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Products.storekit; sourceTree = "<group>"; };
 		477CC48F2967A53C00714456 /* ShareFileSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFileSheet.swift; sourceTree = "<group>"; };
 		47A45FBA2969047B00573044 /* ShareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
@@ -432,6 +434,7 @@
 				8715F92B271641CF0051689E /* Scanner.swift */,
 				B249B9E4282AC03A004F5300 /* MoveSheet.swift */,
 				B249B9E6282AF4F4004F5300 /* FileTreeView.swift */,
+				473A3DCD29AC354B0017BC6A /* FilePathBreadcrumb.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -663,6 +666,7 @@
 				8741E8E425AAA524005B7B01 /* BottomBar.swift in Sources */,
 				8737B2BE25D83EE600C93E09 /* DrawingView.swift in Sources */,
 				B249B9E8282AF6B1004F5300 /* OutlineBranch.swift in Sources */,
+				473A3DCE29AC354B0017BC6A /* FilePathBreadcrumb.swift in Sources */,
 				EA4559BE25169F7D003AD80A /* CodeScannerView.swift in Sources */,
 				EAEDCD0B2516FC1C00EBE313 /* BookView.swift in Sources */,
 				B227B6B327C156CC004CDF87 /* Parser.swift in Sources */,


### PR DESCRIPTION
Traditionally, we used `NavigationView` to keep track of the file tree structure on iOS. The problem with this implementation was that `NavigationView` was not supposed to be used dynamically in this way. This caused a myriad of bugs (which are resolved now by the new implementation). This PR removes `NavigationView` in place of just mutating a list. Gestures and animation were manually added back, although are not the exact same. 

In addition, I added a file path breadcrumb. Every time a user opens a new folder, the old folder appears in the breadcrumb. If the path becomes larger than the width of the iOS device, the breadcrumb will automatically scroll to the latest folder.

**Screenshot**:
<details>

![simulator_screenshot_BE615BBA-9325-468B-B55E-2E8E231D8BE1](https://user-images.githubusercontent.com/20663038/222545036-5be544ef-9655-41a2-99c1-cdddd709aef7.png)
</details>

fixes #1533
fixes #1529