### PR TITLE
core: drop unused error variant from import status

### DIFF
--- a/clients/cli/src/imex.rs
+++ b/clients/cli/src/imex.rs
@@ -42,12 +42,6 @@ pub fn copy(core: &lb::Core, disk_files: &[PathBuf], dest: &str) -> Result<(), C
     let nth_file = Cell::new(0);
     let update_status = move |status: ImportStatus| match status {
         ImportStatus::CalculatedTotal(n_files) => total.set(n_files),
-        ImportStatus::Error(disk_path, err) => match err {
-            lb::CoreError::DiskPathInvalid => {
-                eprintln!("invalid disk path '{}'", disk_path.display())
-            }
-            _ => eprintln!("unexpected error: {:#?}", err),
-        },
         ImportStatus::StartingItem(disk_path) => {
             nth_file.set(nth_file.get() + 1);
             print!("({}/{}) importing: {}... ", nth_file.get(), total.get(), disk_path);

--- a/libs/core/src/lib.rs
+++ b/libs/core/src/lib.rs
@@ -39,7 +39,7 @@ pub use crate::model::drawing::SupportedImageFormats;
 pub use crate::model::errors::{
     CoreError, LbError, LbResult, TestRepoError, UnexpectedError, Warning,
 };
-pub use crate::service::import_export_service::{ImportExportFileInfo, ImportStatus};
+pub use crate::service::import_export_service::{ExportFileInfo, ImportStatus};
 pub use crate::service::search_service::{SearchResultItem, StartSearchInfo};
 pub use crate::service::sync_service::{SyncProgress, WorkCalculated};
 pub use crate::service::usage_service::{UsageItemMetric, UsageMetrics};
@@ -467,7 +467,7 @@ impl<Client: Requester> CoreLib<Client> {
     #[instrument(level = "debug", skip(self, export_progress), err(Debug))]
     pub fn export_file(
         &self, id: Uuid, destination: PathBuf, edit: bool,
-        export_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
+        export_progress: Option<Box<dyn Fn(ExportFileInfo)>>,
     ) -> Result<(), LbError> {
         self.in_tx(|s| s.export_file(id, destination, edit, export_progress))
             .expected_errs(&[

--- a/libs/core/src/service/import_export_service.rs
+++ b/libs/core/src/service/import_export_service.rs
@@ -43,7 +43,7 @@ impl<Client: Requester> CoreState<Client> {
 
     pub(crate) fn export_file(
         &mut self, id: Uuid, destination: PathBuf, edit: bool,
-        export_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
+        export_progress: Option<Box<dyn Fn(ExportFileInfo)>>,
     ) -> LbResult<()> {
         if destination.is_file() {
             return Err(CoreError::DiskPathInvalid.into());
@@ -77,7 +77,7 @@ impl<Client: Requester> CoreState<Client> {
     fn export_file_recursively<Base, Local>(
         config: &Config, account: &Account, tree: &mut LazyStaged1<Base, Local>,
         this_file: &Base::F, disk_path: &Path, edit: bool,
-        export_progress: &Option<Box<dyn Fn(ImportExportFileInfo)>>,
+        export_progress: &Option<Box<dyn Fn(ExportFileInfo)>>,
     ) -> LbResult<()>
     where
         Base: TreeLike<F = SignedFile>,
@@ -86,7 +86,7 @@ impl<Client: Requester> CoreState<Client> {
         let dest_with_new = disk_path.join(tree.name_using_links(this_file.id(), account)?);
 
         if let Some(ref func) = export_progress {
-            func(ImportExportFileInfo {
+            func(ExportFileInfo {
                 disk_path: disk_path.to_path_buf(),
                 lockbook_path: tree.id_to_path(this_file.id(), account)?,
             })
@@ -281,7 +281,7 @@ fn get_child_count(path: &Path) -> LbResult<usize> {
     Ok(count)
 }
 
-pub struct ImportExportFileInfo {
+pub struct ExportFileInfo {
     pub disk_path: PathBuf,
     pub lockbook_path: String,
 }

--- a/libs/core/src/service/import_export_service.rs
+++ b/libs/core/src/service/import_export_service.rs
@@ -18,7 +18,6 @@ use uuid::Uuid;
 
 pub enum ImportStatus {
     CalculatedTotal(usize),
-    Error(PathBuf, CoreError),
     StartingItem(String),
     FinishedItem(File),
 }

--- a/libs/core/tests/import_export_file_tests.rs
+++ b/libs/core/tests/import_export_file_tests.rs
@@ -1,4 +1,4 @@
-use lockbook_core::service::import_export_service::{ImportExportFileInfo, ImportStatus};
+use lockbook_core::service::import_export_service::{ExportFileInfo, ImportStatus};
 use lockbook_shared::file_metadata::FileType;
 use rand::Rng;
 
@@ -71,10 +71,10 @@ fn export_file_successfully() {
     core.write_document(file.id, &rand::thread_rng().gen::<[u8; 32]>())
         .unwrap();
 
-    let paths: Arc<Mutex<Vec<ImportExportFileInfo>>> = Arc::new(Mutex::new(Vec::new()));
+    let paths: Arc<Mutex<Vec<ExportFileInfo>>> = Arc::new(Mutex::new(Vec::new()));
     let path_copy = paths.clone();
 
-    let export_progress = move |info: ImportExportFileInfo| {
+    let export_progress = move |info: ExportFileInfo| {
         path_copy.lock().unwrap().push(info);
     };
     core.export_file(file.id, tmp_path.clone(), false, Some(Box::new(export_progress.clone())))

--- a/libs/core/tests/import_export_file_tests.rs
+++ b/libs/core/tests/import_export_file_tests.rs
@@ -22,12 +22,10 @@ fn import_file_successfully() {
     let root = core.get_root().unwrap();
 
     let f = move |status: ImportStatus| {
-        // only checking if the disk path exists since a lockbook folder that has children won't be created until its first child is
+        // only checking if the disk path exists since a lockbook folder that has children won't
+        // be created until its first child is
         match status {
             ImportStatus::CalculatedTotal(_) => {}
-            ImportStatus::Error(path, err) => {
-                panic!("error importing '{}': {:#?}", path.display(), err)
-            }
             ImportStatus::StartingItem(path_str) => {
                 let disk_path = PathBuf::from(path_str);
                 assert!(disk_path.exists());

--- a/libs/core_external_interface/src/lib.rs
+++ b/libs/core_external_interface/src/lib.rs
@@ -246,7 +246,7 @@ impl FfiCore {
 
     pub fn export_file(
         &self, id: Uuid, destination: PathBuf, edit: bool,
-        export_progress: Option<Box<dyn Fn(ImportExportFileInfo)>>,
+        export_progress: Option<Box<dyn Fn(ExportFileInfo)>>,
     ) -> Result<(), Error<ExportFileError>> {
         Ok(self
             .core


### PR DESCRIPTION
Import still returns on any error, so the error variant of the status is unused.