### PR TITLE
core: eliminate two unecessary uses of itertools and it make dev dep

### DIFF
--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -29,7 +29,6 @@ reqwest = { version = "0.11.1", default-features = false, features = ["blocking"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 uuid = { version = "1.2.2", features = ["v4", "serde"] }
-itertools = "0.10.1"
 backtrace = "0.3"
 libsecp256k1 = "0.7.1"
 tracing = "0.1.5"
@@ -52,6 +51,7 @@ debug = true
 [dev-dependencies]
 criterion = "0.3.5"
 indicatif = "=0.17.0-rc.11"
+itertools = "0.10.1"
 variant_count = "1.1.0"
 num_cpus = "1.13.0"
 rand = "0.8.4"

--- a/libs/core/src/lib.rs
+++ b/libs/core/src/lib.rs
@@ -49,7 +49,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use db_rs::Db;
-use itertools::Itertools;
 use lockbook_shared::account::Username;
 use lockbook_shared::api::{
     AccountInfo, AdminFileInfoResponse, AdminValidateAccount, AdminValidateServer,
@@ -353,7 +352,7 @@ impl<Client: Requester> CoreLib<Client> {
                 .keys()
                 .into_iter()
                 .copied()
-                .collect_vec())
+                .collect::<Vec<Uuid>>())
         })?)
     }
 

--- a/libs/core/src/service/sync_service.rs
+++ b/libs/core/src/service/sync_service.rs
@@ -18,7 +18,6 @@ use lockbook_shared::work_unit::{ClientWorkUnit, WorkUnit};
 use lockbook_shared::{document_repo, symkey, SharedErrorKind, ValidationFailure};
 
 use db_rs::LookupTable;
-use itertools::Itertools;
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -735,7 +734,7 @@ where
                                 // pick one local id and generate a non-conflicting filename
                                 let mut progress = false;
                                 for &id in ids {
-                                    if duplicate_file_ids.values().contains(&id) {
+                                    if duplicate_file_ids.values().any(|&dup| dup == id) {
                                         *rename_increments.entry(id).or_insert(0) += 1;
                                         progress = true;
                                         break;


### PR DESCRIPTION
this change uses standard iter functionality for the last two instances of itertools trait funcs in core and makes itertools a dev dep since we still use it in tests. no impact on static lib size but one less dep for core.