### PR TITLE
core,ffi,admin: drop backtrace crate in favor of standard backtrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,6 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 name = "admin"
 version = "0.6.0"
 dependencies = [
- "backtrace",
  "dialoguer",
  "lockbook-core",
  "structopt",
@@ -963,7 +962,6 @@ dependencies = [
 name = "core_external_interface"
 version = "0.1.0"
 dependencies = [
- "backtrace",
  "basic-human-duration",
  "chrono",
  "crossbeam",
@@ -3070,7 +3068,6 @@ dependencies = [
 name = "lockbook-core"
 version = "0.6.0"
 dependencies = [
- "backtrace",
  "base64",
  "basic-human-duration",
  "bincode",

--- a/clients/admin/Cargo.toml
+++ b/clients/admin/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 structopt = "0.3.13"
 lockbook-core = { path = "../../libs/core" }
 dialoguer = { version = "0.10.1", features = ["fuzzy-select"] }
-backtrace = "0.3"

--- a/clients/admin/src/error.rs
+++ b/clients/admin/src/error.rs
@@ -1,12 +1,12 @@
-use backtrace::Backtrace;
+use std::backtrace::Backtrace;
 use std::fmt::Debug;
 
 pub struct Error;
 
 impl<T: Debug> From<T> for Error {
     fn from(err: T) -> Self {
-        eprintln!("encountered error: {:?}", err);
-        eprintln!("{:?}", Backtrace::new());
+        eprintln!("error: {:?}", err);
+        eprintln!("{:?}", Backtrace::force_capture());
         Error
     }
 }

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -29,7 +29,6 @@ reqwest = { version = "0.11.1", default-features = false, features = ["blocking"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 uuid = { version = "1.2.2", features = ["v4", "serde"] }
-backtrace = "0.3"
 libsecp256k1 = "0.7.1"
 tracing = "0.1.5"
 tracing-subscriber = "0.3.9"

--- a/libs/core/src/model/errors.rs
+++ b/libs/core/src/model/errors.rs
@@ -22,7 +22,7 @@ pub struct LbError {
 
 impl From<CoreError> for LbError {
     fn from(kind: CoreError) -> Self {
-        Self { kind, backtrace: Some(Backtrace::capture()) }
+        Self { kind, backtrace: Some(Backtrace::force_capture()) }
     }
 }
 
@@ -68,7 +68,7 @@ pub struct UnexpectedError {
 
 impl UnexpectedError {
     pub fn new(s: impl ToString) -> Self {
-        Self { msg: s.to_string(), backtrace: Some(Backtrace::capture()) }
+        Self { msg: s.to_string(), backtrace: Some(Backtrace::force_capture()) }
     }
 }
 
@@ -124,7 +124,7 @@ impl Serialize for UnexpectedError {
 macro_rules! unexpected_only {
     ($base:literal $(, $args:tt )*) => {{
         debug!($base $(, $args )*);
-        debug!("{:?}", backtrace::Backtrace::new());
+        debug!("{:?}", std::backtrace::Backtrace::force_capture());
         debug!($base $(, $args )*);
         UnexpectedError::new(format!($base $(, $args )*))
     }};

--- a/libs/core_external_interface/Cargo.toml
+++ b/libs/core_external_interface/Cargo.toml
@@ -8,7 +8,6 @@ name = "lockbook_core_external_interface"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-backtrace = "0.3"
 basic-human-duration = "0.1.2"
 chrono = "0.4.15"
 crossbeam = "0.8.1"

--- a/libs/core_external_interface/src/errors.rs
+++ b/libs/core_external_interface/src/errors.rs
@@ -16,7 +16,7 @@ pub enum Error<U: Serialize> {
 macro_rules! unexpected {
     ($base:literal $(, $args:tt )*) => {{
         debug!($base $(, $args )*);
-        debug!("{:?}", backtrace::Backtrace::new());
+        debug!("{:?}", std::backtrace::Backtrace::force_capture());
         debug!($base $(, $args )*);
         Error::Unexpected(format!($base $(, $args )*))
     }};


### PR DESCRIPTION
the backtrace crate provides some cool additional functionality for inspecting and using backtraces, none of which we are using. so this change removes it as a dep and just uses std::backtrace instead.

this resulted in 8 less dependencies for core and ~2M reduction in the static lib size.