### PR TITLE
core: use sublime_fuzzy for path search and drop fuzzy-matcher dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,7 +3077,6 @@ dependencies = [
  "db-rs",
  "db-rs-derive",
  "diffy",
- "fuzzy-matcher",
  "hmdb",
  "image",
  "indicatif",

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -22,7 +22,6 @@ basic-human-duration = "0.1.2"
 bincode = "1.3.3"
 chrono = "0.4.15"
 diffy = "0.2.0"
-fuzzy-matcher = "0.3.7"
 image = "0.24.3"
 raqote = { version = "0.8.0", default-features = false }
 reqwest = { version = "0.11.1", default-features = false, features = ["blocking", "json"] }

--- a/libs/core/tests/search_service_tests.rs
+++ b/libs/core/tests/search_service_tests.rs
@@ -53,7 +53,7 @@ fn test_matches() {
     assert_result_paths(&search_results, &["/dir/doc3"]);
 
     let search_results = core.search_file_paths("ad").unwrap();
-    assert_result_paths(&search_results, &["/abcd.md", "/abcde.md", "/abc.md"]);
+    assert_result_paths(&search_results, &["/abc.md", "/abcd.md", "/abcde.md"]);
 }
 
 fn assert_result_paths(results: &[SearchResultItem], paths: &[&str]) {


### PR DESCRIPTION
The results and their order seem identical to fuzzy-matcher.