### PR TITLE
shared: remove unused Filter derives and parse fn in path_ops

### DIFF
--- a/libs/core/libs/shared/src/path_ops.rs
+++ b/libs/core/libs/shared/src/path_ops.rs
@@ -209,21 +209,11 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum Filter {
     DocumentsOnly,
     FoldersOnly,
     LeafNodesOnly,
-}
-
-pub fn filter_from_str(input: &str) -> SharedResult<Option<Filter>> {
-    match input {
-        "DocumentsOnly" => Ok(Some(Filter::DocumentsOnly)),
-        "FoldersOnly" => Ok(Some(Filter::FoldersOnly)),
-        "LeafNodesOnly" => Ok(Some(Filter::LeafNodesOnly)),
-        "Unfiltered" => Ok(None),
-        _ => Err(SharedErrorKind::Unexpected("unknown filter").into()),
-    }
 }
 
 fn split_path(path: &str) -> Vec<&str> {


### PR DESCRIPTION
I forgot to clean this up after the cli redesign, which eliminated the only time we were parsing a `Filter` from strings.