### PR TITLE
releaser: fix snap release for lockbook cli

### DIFF
--- a/utils/releaser/src/linux/cli.rs
+++ b/utils/releaser/src/linux/cli.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use crate::utils::{core_version, lb_repo, CommandRunner};
 use crate::Github;
 use gh_release::ReleaseClient;
@@ -50,6 +51,8 @@ apps:
       - home
     "#
     );
+
+    fs::create_dir_all("utils/dev/snap-packages/lockbook/snap").unwrap();
 
     let mut file = OpenOptions::new()
         .write(true)

--- a/utils/releaser/src/linux/cli.rs
+++ b/utils/releaser/src/linux/cli.rs
@@ -1,7 +1,7 @@
-use std::fs;
 use crate::utils::{core_version, lb_repo, CommandRunner};
 use crate::Github;
 use gh_release::ReleaseClient;
+use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::process::Command;


### PR DESCRIPTION
Since the snapcraft package files were removed and instead created only when we needed it, the directory it was located under for `lockbook cli` became empty. This meant `git` untracked it, and was removed. This directory is still needed as a part of the correct directory structure when building a snapcraft package, and cause releaser to error if it is not found.

I now create the directory if it does not already exist, and since it is always untracked, I do not need to clean it up.