### PR TITLE
shared: force capture backtrace when converting kind to shared error

### DIFF
--- a/libs/core/libs/shared/src/lib.rs
+++ b/libs/core/libs/shared/src/lib.rs
@@ -47,7 +47,7 @@ pub struct SharedError {
 
 impl From<SharedErrorKind> for SharedError {
     fn from(kind: SharedErrorKind) -> Self {
-        Self { kind, backtrace: Some(Backtrace::capture()) }
+        Self { kind, backtrace: Some(Backtrace::force_capture()) }
     }
 }
 


### PR DESCRIPTION
I missed one when changing capture to force capture for backtracing on errors.