### PR TITLE
egui: use a separate menu item and modal for creating new folder

### DIFF
--- a/clients/egui/src/account/modals/mod.rs
+++ b/clients/egui/src/account/modals/mod.rs
@@ -8,7 +8,7 @@ mod settings;
 pub use confirm_delete::ConfirmDeleteModal;
 pub use error::ErrorModal;
 pub use help::HelpModal;
-pub use new_file::{NewFileModal, NewFileParams};
+pub use new_file::{NewDocModal, NewFileParams, NewFolderModal};
 pub use search::SearchModal;
 pub use settings::{SettingsModal, SettingsResponse};
 
@@ -18,7 +18,8 @@ use eframe::egui;
 pub struct Modals {
     pub error: Option<Box<ErrorModal>>,
     pub settings: Option<Box<SettingsModal>>,
-    pub new_file: Option<Box<NewFileModal>>,
+    pub new_doc: Option<Box<NewDocModal>>,
+    pub new_folder: Option<Box<NewFolderModal>>,
     pub search: Option<Box<SearchModal>>,
     pub help: Option<Box<HelpModal>>,
     pub confirm_delete: Option<Box<ConfirmDeleteModal>>,
@@ -50,7 +51,13 @@ impl super::AccountScreen {
             }
         }
 
-        if let Some(response) = show(ctx, x_offset, &mut self.modals.new_file) {
+        if let Some(response) = show(ctx, x_offset, &mut self.modals.new_doc) {
+            if let Some(submission) = response.inner {
+                self.create_file(submission);
+            }
+        }
+
+        if let Some(response) = show(ctx, x_offset, &mut self.modals.new_folder) {
             if let Some(submission) = response.inner {
                 self.create_file(submission);
             }
@@ -70,7 +77,8 @@ impl super::AccountScreen {
     pub fn is_any_modal_open(&self) -> bool {
         let m = &self.modals;
         m.settings.is_some()
-            || m.new_file.is_some()
+            || m.new_doc.is_some()
+            || m.new_folder.is_some()
             || m.search.is_some()
             || m.help.is_some()
             || m.confirm_delete.is_some()
@@ -83,8 +91,12 @@ impl super::AccountScreen {
             self.save_settings();
             return true;
         }
-        if m.new_file.is_some() {
-            m.new_file = None;
+        if m.new_doc.is_some() {
+            m.new_doc = None;
+            return true;
+        }
+        if m.new_folder.is_some() {
+            m.new_folder = None;
             return true;
         }
         if m.search.is_some() {

--- a/clients/egui/src/account/modals/new_file.rs
+++ b/clients/egui/src/account/modals/new_file.rs
@@ -2,18 +2,24 @@ use eframe::egui;
 
 use crate::widgets::ButtonGroup;
 
-pub struct NewFileModal {
-    ftype: NewFileType,
+pub struct NewFileParams {
+    pub ftype: lb::FileType,
+    pub parent_path: String,
+    pub name: String,
+}
+
+pub struct NewDocModal {
+    ftype: NewDocType,
     parent_path: String,
     new_name: String,
     name_field_needs_focus: bool,
     pub err_msg: Option<String>,
 }
 
-impl NewFileModal {
+impl NewDocModal {
     pub fn new(parent_path: String) -> Self {
         Self {
-            ftype: NewFileType::Markdown,
+            ftype: NewDocType::Markdown,
             parent_path,
             new_name: "".to_string(),
             name_field_needs_focus: true,
@@ -22,11 +28,11 @@ impl NewFileModal {
     }
 }
 
-impl super::Modal for NewFileModal {
+impl super::Modal for NewDocModal {
     type Response = Option<NewFileParams>;
 
     fn title(&self) -> &str {
-        "New File"
+        "New Document"
     }
 
     fn show(&mut self, ui: &mut egui::Ui) -> Self::Response {
@@ -37,10 +43,9 @@ impl super::Modal for NewFileModal {
         // File type selection.
         ui.horizontal(|ui| {
             if let Some(_type_selected) = ButtonGroup::toggle_mut(&mut self.ftype)
-                .btn(NewFileType::Markdown, "Markdown")
-                .btn(NewFileType::Drawing, "Drawing")
-                .btn(NewFileType::PlainText, "Plain Text")
-                .btn(NewFileType::Folder, "Folder")
+                .btn(NewDocType::Markdown, "Markdown")
+                .btn(NewDocType::Drawing, "Drawing")
+                .btn(NewDocType::PlainText, "Plain Text")
                 .show(ui)
             {
                 self.name_field_needs_focus = true;
@@ -49,7 +54,7 @@ impl super::Modal for NewFileModal {
 
         ui.add_space(10.0);
 
-        egui::Grid::new("new_file_modal_content")
+        egui::Grid::new("new_doc_modal_content")
             .spacing(egui::vec2(10.0, 10.0))
             .show(ui, |ui| {
                 ui.label("Parent:");
@@ -80,13 +85,9 @@ impl super::Modal for NewFileModal {
                         if self.new_name.is_empty() {
                             self.err_msg = Some("File names cannot be empty!".to_string());
                         } else {
-                            let name = format!(
-                                "{}{}",
-                                self.new_name,
-                                self.ftype.ext().unwrap_or_default()
-                            );
+                            let name = format!("{}{}", self.new_name, self.ftype.ext());
                             maybe_submission = Some(NewFileParams {
-                                ftype: self.ftype.as_lb_type(),
+                                ftype: lb::FileType::Document,
                                 parent_path: self.parent_path.clone(),
                                 name,
                             });
@@ -99,9 +100,7 @@ impl super::Modal for NewFileModal {
                         out.response.request_focus();
                     }
 
-                    if let Some(ext) = self.ftype.ext() {
-                        ui.label(ext);
-                    }
+                    ui.label(self.ftype.ext());
                 });
 
                 ui.end_row();
@@ -119,33 +118,103 @@ impl super::Modal for NewFileModal {
 }
 
 #[derive(Clone, Copy, PartialEq)]
-enum NewFileType {
+enum NewDocType {
     Markdown,
     Drawing,
     PlainText,
-    Folder,
 }
 
-impl NewFileType {
-    fn ext(&self) -> Option<&'static str> {
+impl NewDocType {
+    fn ext(&self) -> &'static str {
         match self {
-            Self::Markdown => Some(".md"),
-            Self::Drawing => Some(".draw"),
-            Self::PlainText => Some(".txt"),
-            Self::Folder => None,
-        }
-    }
-
-    fn as_lb_type(&self) -> lb::FileType {
-        match self {
-            Self::Folder => lb::FileType::Folder,
-            _ => lb::FileType::Document,
+            Self::Markdown => ".md",
+            Self::Drawing => ".draw",
+            Self::PlainText => "",
         }
     }
 }
 
-pub struct NewFileParams {
-    pub ftype: lb::FileType,
-    pub parent_path: String,
-    pub name: String,
+pub struct NewFolderModal {
+    parent_path: String,
+    new_name: String,
+    name_field_needs_focus: bool,
+    pub err_msg: Option<String>,
+}
+
+impl NewFolderModal {
+    pub fn new(parent_path: String) -> Self {
+        Self { parent_path, new_name: "".to_string(), name_field_needs_focus: true, err_msg: None }
+    }
+}
+
+impl super::Modal for NewFolderModal {
+    type Response = Option<NewFileParams>;
+
+    fn title(&self) -> &str {
+        "New Folder"
+    }
+
+    fn show(&mut self, ui: &mut egui::Ui) -> Self::Response {
+        let mut maybe_submission = None;
+
+        ui.add_space(10.0);
+
+        egui::Grid::new("new_folder_modal_content")
+            .spacing(egui::vec2(10.0, 10.0))
+            .show(ui, |ui| {
+                ui.label("Parent:");
+
+                // The path of the parent folder.
+                ui.add_sized(
+                    ui.available_size_before_wrap(),
+                    egui::TextEdit::singleline(&mut self.parent_path)
+                        .margin(egui::vec2(8.0, 8.0))
+                        .hint_text("Parent...")
+                        .interactive(false),
+                );
+
+                ui.end_row();
+
+                ui.label("Name:");
+
+                // The new file's name and extension.
+                ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                    ui.set_max_width(300.0);
+
+                    let out = egui::TextEdit::singleline(&mut self.new_name)
+                        .margin(egui::vec2(8.0, 8.0))
+                        .hint_text("Name...")
+                        .show(ui);
+
+                    if out.response.lost_focus() && ui.input().key_pressed(egui::Key::Enter) {
+                        if self.new_name.is_empty() {
+                            self.err_msg = Some("File names cannot be empty!".to_string());
+                        } else {
+                            maybe_submission = Some(NewFileParams {
+                                ftype: lb::FileType::Folder,
+                                parent_path: self.parent_path.clone(),
+                                name: self.new_name.clone(),
+                            });
+                        }
+                    }
+
+                    // If this is the first frame for the modal, or if a file type was
+                    // selected, focus the name input field.
+                    if self.name_field_needs_focus {
+                        out.response.request_focus();
+                    }
+                });
+
+                ui.end_row();
+            });
+
+        ui.add_space(10.0);
+
+        if let Some(msg) = &self.err_msg {
+            ui.label(egui::RichText::new(msg).color(egui::Color32::RED));
+            ui.add_space(10.0);
+        }
+
+        maybe_submission
+    }
 }

--- a/clients/egui/src/account/tree/node.rs
+++ b/clients/egui/src/account/tree/node.rs
@@ -254,8 +254,12 @@ impl TreeNode {
             ui.close_menu();
         }
 
-        if ui.button("New...").clicked() {
-            node_resp.new_file_modal = Some(self.file.clone());
+        if ui.button("New Document").clicked() {
+            node_resp.new_doc_modal = Some(self.file.clone());
+            ui.close_menu();
+        }
+        if ui.button("New Folder").clicked() {
+            node_resp.new_folder_modal = Some(self.file.clone());
             ui.close_menu();
         }
         if ui.button("Rename").clicked() {

--- a/clients/egui/src/account/tree/response.rs
+++ b/clients/egui/src/account/tree/response.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 #[derive(Default)]
 pub struct NodeResponse {
     pub open_requests: HashSet<lb::Uuid>,
-    pub new_file_modal: Option<lb::File>,
+    pub new_doc_modal: Option<lb::File>,
+    pub new_folder_modal: Option<lb::File>,
     pub rename_request: Option<(lb::Uuid, String)>,
     pub delete_request: bool,
     pub dropped_on: Option<lb::Uuid>,
@@ -12,7 +13,8 @@ pub struct NodeResponse {
 impl NodeResponse {
     pub fn union(self, other: Self) -> Self {
         let mut this = self;
-        this.new_file_modal = this.new_file_modal.or(other.new_file_modal);
+        this.new_doc_modal = this.new_doc_modal.or(other.new_doc_modal);
+        this.new_folder_modal = this.new_folder_modal.or(other.new_folder_modal);
         this.open_requests.extend(other.open_requests);
         this.rename_request = this.rename_request.or(other.rename_request);
         this.delete_request = this.delete_request || other.delete_request;


### PR DESCRIPTION
This also allows for creating files with no extensions by having the "plain text" option be empty instead of `.txt`.

Closes #1384.