### PR TITLE
egui: don't box modals and change their `open` funcs to idiomatic `new`

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -103,10 +103,10 @@ impl AccountScreen {
                     OpenModal::NewDoc(maybe_parent) => self.open_new_doc_modal(maybe_parent),
                     OpenModal::NewFolder(maybe_parent) => self.open_new_folder_modal(maybe_parent),
                     OpenModal::Settings => {
-                        self.modals.settings = SettingsModal::open(&self.core, &self.settings);
+                        self.modals.settings = Some(SettingsModal::new(&self.core, &self.settings));
                     }
                     OpenModal::ConfirmDelete(files) => {
-                        self.modals.confirm_delete = ConfirmDeleteModal::open(files);
+                        self.modals.confirm_delete = Some(ConfirmDeleteModal::new(files));
                     }
                 },
                 AccountUpdate::FileCreated(result) => match result {
@@ -234,13 +234,13 @@ impl AccountScreen {
             if let Some(search) = &mut self.modals.search {
                 search.focus_select_all();
             } else {
-                self.modals.search = SearchModal::open(&self.core, ctx);
+                self.modals.search = Some(SearchModal::new(&self.core, ctx));
             }
         }
 
         // Ctrl-, to open settings modal.
         if self.modals.settings.is_none() && consume_key(ctx, ',') {
-            self.modals.settings = SettingsModal::open(&self.core, &self.settings);
+            self.modals.settings = Some(SettingsModal::new(&self.core, &self.settings));
         }
 
         // Alt-H pressed to toggle the help modal.
@@ -248,7 +248,7 @@ impl AccountScreen {
             let d = &mut self.modals.help;
             *d = match d {
                 Some(_) => None,
-                None => Some(Box::default()),
+                None => Some(HelpModal),
             };
         }
 
@@ -317,7 +317,7 @@ impl AccountScreen {
 
     fn save_settings(&mut self) {
         if let Err(err) = self.settings.read().unwrap().to_file() {
-            self.modals.error = ErrorModal::open(err);
+            self.modals.error = Some(ErrorModal::new(err));
         }
     }
 
@@ -409,9 +409,9 @@ impl AccountScreen {
         let parent_path = self.core.get_path_by_id(parent_id).unwrap();
 
         if typ == lb::FileType::Folder {
-            self.modals.new_folder = Some(Box::new(NewFolderModal::new(parent_path)));
+            self.modals.new_folder = Some(NewFolderModal::new(parent_path));
         } else {
-            self.modals.new_doc = Some(Box::new(NewDocModal::new(parent_path)));
+            self.modals.new_doc = Some(NewDocModal::new(parent_path));
         }
     }
 

--- a/clients/egui/src/account/modals/confirm_delete.rs
+++ b/clients/egui/src/account/modals/confirm_delete.rs
@@ -12,8 +12,8 @@ pub struct ConfirmDeleteModal {
 }
 
 impl ConfirmDeleteModal {
-    pub fn open(file_ids: Vec<lb::File>) -> Option<Box<Self>> {
-        Some(Box::new(Self { state: State::WaitingForAnswer, file_ids }))
+    pub fn new(file_ids: Vec<lb::File>) -> Self {
+        Self { state: State::WaitingForAnswer, file_ids }
     }
 }
 

--- a/clients/egui/src/account/modals/error.rs
+++ b/clients/egui/src/account/modals/error.rs
@@ -5,8 +5,8 @@ pub struct ErrorModal {
 }
 
 impl ErrorModal {
-    pub fn open(err: impl ToString) -> Option<Box<Self>> {
-        Some(Box::new(Self { err: err.to_string() }))
+    pub fn new(err: impl ToString) -> Self {
+        Self { err: err.to_string() }
     }
 }
 

--- a/clients/egui/src/account/modals/mod.rs
+++ b/clients/egui/src/account/modals/mod.rs
@@ -16,13 +16,13 @@ use eframe::egui;
 
 #[derive(Default)]
 pub struct Modals {
-    pub error: Option<Box<ErrorModal>>,
-    pub settings: Option<Box<SettingsModal>>,
-    pub new_doc: Option<Box<NewDocModal>>,
-    pub new_folder: Option<Box<NewFolderModal>>,
-    pub search: Option<Box<SearchModal>>,
-    pub help: Option<Box<HelpModal>>,
-    pub confirm_delete: Option<Box<ConfirmDeleteModal>>,
+    pub error: Option<ErrorModal>,
+    pub settings: Option<SettingsModal>,
+    pub new_doc: Option<NewDocModal>,
+    pub new_folder: Option<NewFolderModal>,
+    pub search: Option<SearchModal>,
+    pub help: Option<HelpModal>,
+    pub confirm_delete: Option<ConfirmDeleteModal>,
 }
 
 impl super::AccountScreen {
@@ -126,7 +126,7 @@ pub trait Modal {
 }
 
 pub fn show<M: Modal>(
-    ctx: &egui::Context, x_offset: f32, maybe_modal: &mut Option<Box<M>>,
+    ctx: &egui::Context, x_offset: f32, maybe_modal: &mut Option<M>,
 ) -> Option<ModalResponse<M::Response>> {
     if let Some(d) = maybe_modal {
         let dr = show_modal(ctx, x_offset, d);
@@ -145,7 +145,7 @@ pub struct ModalResponse<R> {
 }
 
 fn show_modal<M: Modal>(
-    ctx: &egui::Context, x_offset: f32, d: &mut Box<M>,
+    ctx: &egui::Context, x_offset: f32, d: &mut M,
 ) -> ModalResponse<M::Response> {
     let mut is_open = true;
 

--- a/clients/egui/src/account/modals/search.rs
+++ b/clients/egui/src/account/modals/search.rs
@@ -18,7 +18,7 @@ pub struct SearchModal {
 }
 
 impl SearchModal {
-    pub fn open(core: &Arc<lb::Core>, etx: &egui::Context) -> Option<Box<Self>> {
+    pub fn new(core: &Arc<lb::Core>, etx: &egui::Context) -> Self {
         let (request_tx, request_rx) = mpsc::channel::<String>();
         let (response_tx, response_rx) = mpsc::channel();
 
@@ -45,7 +45,7 @@ impl SearchModal {
             }
         });
 
-        Some(Box::new(Self {
+        Self {
             requests: request_tx,
             responses: response_rx,
             input: String::new(),
@@ -55,7 +55,7 @@ impl SearchModal {
             errors: Vec::new(),
             arrow_index: None,
             arrowed_path: String::new(),
-        }))
+        }
     }
 
     pub fn focus_select_all(&mut self) {

--- a/clients/egui/src/account/modals/settings/mod.rs
+++ b/clients/egui/src/account/modals/settings/mod.rs
@@ -36,7 +36,7 @@ pub enum SettingsResponse {
 }
 
 impl SettingsModal {
-    pub fn open(core: &Arc<lb::Core>, s: &Arc<RwLock<Settings>>) -> Option<Box<Self>> {
+    pub fn new(core: &Arc<lb::Core>, s: &Arc<RwLock<Settings>>) -> Self {
         let export_result = core.export_account().map_err(|err| format!("{:?}", err)); // TODO
 
         let sub_info_result = core
@@ -48,7 +48,7 @@ impl SettingsModal {
             .get_uncompressed_usage()
             .map_err(|err| format!("{:?}", err)); // TODO
 
-        Some(Box::new(Self {
+        Self {
             core: core.clone(),
             settings: s.clone(),
             account: AccountSettings::new(export_result),
@@ -59,7 +59,7 @@ impl SettingsModal {
                 upgrading: None,
             },
             active_tab: SettingsTab::Account,
-        }))
+        }
     }
 
     fn show_tab_labels(&mut self, ui: &mut egui::Ui) {
@@ -94,8 +94,8 @@ impl SettingsModal {
                 ui.set_height(height);
 
                 StripBuilder::new(ui)
-                    .size(Size::remainder())
-                    .size(Size::exact(4.0))
+                    .size(Size::remainder()) // Main tab content.
+                    .size(Size::exact(4.0)) // Active bar indicator.
                     .horizontal(|mut strip| {
                         strip.cell(|ui| {
                             ui.vertical_centered(|ui| {


### PR DESCRIPTION
this results in ~2mb more mem usage, which is not worth the slightly more obscure code (imo).