### PR TITLE
egui: save tabs when closing them

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -162,10 +162,9 @@ impl AccountScreen {
                 AccountUpdate::DoneDeleting => self.modals.confirm_delete = None,
                 AccountUpdate::ReloadTree(root) => self.tree.root = root,
                 AccountUpdate::ReloadTabs(mut new_tabs) => {
-                    let ws = &mut self.workspace;
-                    let active_id = ws.current_tab().map(|t| t.id);
-                    for i in (0..ws.tabs.len()).rev() {
-                        let t = &mut ws.tabs[i];
+                    let active_id = self.workspace.current_tab().map(|t| t.id);
+                    for i in (0..self.workspace.tabs.len()).rev() {
+                        let t = &mut self.workspace.tabs[i];
                         if let Some(new_tab_result) = new_tabs.remove(&t.id) {
                             match new_tab_result {
                                 Ok(new_tab) => {
@@ -181,7 +180,7 @@ impl AccountScreen {
                                 }
                             }
                         } else {
-                            ws.close_tab(i);
+                            self.close_tab(i);
                         }
                     }
                 }
@@ -216,7 +215,7 @@ impl AccountScreen {
         // Ctrl-W to close current tab.
         if ctx.input_mut().consume_key(CTRL, egui::Key::W) && !self.workspace.is_empty() {
             self.save_current_tab();
-            self.workspace.close_current_tab();
+            self.close_current_tab();
             frame.set_window_title(
                 self.workspace
                     .current_tab()

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -209,13 +209,12 @@ impl AccountScreen {
 
         // Ctrl-S to save current tab.
         if ctx.input_mut().consume_key(CTRL, egui::Key::S) {
-            self.save_current_tab();
+            self.save_tab(self.workspace.active_tab);
         }
 
         // Ctrl-W to close current tab.
         if ctx.input_mut().consume_key(CTRL, egui::Key::W) && !self.workspace.is_empty() {
-            self.save_current_tab();
-            self.close_current_tab();
+            self.close_tab(self.workspace.active_tab);
             frame.set_window_title(
                 self.workspace
                     .current_tab()

--- a/clients/egui/src/account/workspace.rs
+++ b/clients/egui/src/account/workspace.rs
@@ -46,18 +46,6 @@ impl Workspace {
         self.tabs.get(self.active_tab)
     }
 
-    pub fn close_tab(&mut self, i: usize) {
-        self.tabs.remove(i);
-        let n_tabs = self.tabs.len();
-        if self.active_tab >= n_tabs && n_tabs > 0 {
-            self.active_tab = n_tabs - 1;
-        }
-    }
-
-    pub fn close_current_tab(&mut self) {
-        self.close_tab(self.active_tab);
-    }
-
     pub fn goto_tab_id(&mut self, id: lb::Uuid) -> bool {
         for (i, tab) in self.tabs.iter().enumerate() {
             if tab.id == id {
@@ -204,13 +192,12 @@ impl super::AccountScreen {
         ui.vertical(|ui| {
             if self.workspace.tabs.len() > 1 {
                 ui.horizontal(|ui| {
-                    let ws = &mut self.workspace;
-
-                    for (i, maybe_resp) in ws
+                    for (i, maybe_resp) in self
+                        .workspace
                         .tabs
                         .iter()
                         .enumerate()
-                        .map(|(i, t)| tab_label(ui, t, ws.active_tab == i))
+                        .map(|(i, t)| tab_label(ui, t, self.workspace.active_tab == i))
                         .collect::<Vec<Option<TabLabelResponse>>>()
                         .iter()
                         .enumerate()
@@ -218,12 +205,12 @@ impl super::AccountScreen {
                         if let Some(resp) = maybe_resp {
                             match resp {
                                 TabLabelResponse::Clicked => {
-                                    ws.active_tab = i;
-                                    frame.set_window_title(&ws.tabs[i].name);
+                                    self.workspace.active_tab = i;
+                                    frame.set_window_title(&self.workspace.tabs[i].name);
                                 }
                                 TabLabelResponse::Closed => {
-                                    ws.close_tab(i);
-                                    frame.set_window_title(match ws.current_tab() {
+                                    self.close_tab(i);
+                                    frame.set_window_title(match self.workspace.current_tab() {
                                         Some(tab) => &tab.name,
                                         None => "Lockbook",
                                     });
@@ -298,6 +285,19 @@ impl super::AccountScreen {
                 }
             }
         }
+    }
+
+    pub fn close_tab(&mut self, i: usize) {
+        let ws = &mut self.workspace;
+        ws.tabs.remove(i);
+        let n_tabs = ws.tabs.len();
+        if ws.active_tab >= n_tabs && n_tabs > 0 {
+            ws.active_tab = n_tabs - 1;
+        }
+    }
+
+    pub fn close_current_tab(&mut self) {
+        self.close_tab(self.workspace.active_tab);
     }
 }
 

--- a/clients/egui/src/account/workspace.rs
+++ b/clients/egui/src/account/workspace.rs
@@ -267,8 +267,8 @@ impl super::AccountScreen {
         });
     }
 
-    pub fn save_current_tab(&self) {
-        if let Some(tab) = self.workspace.current_tab() {
+    pub fn save_tab(&self, i: usize) {
+        if let Some(tab) = self.workspace.tabs.get(i) {
             if let Some(content) = &tab.content {
                 if let TabContent::Drawing(d) = content {
                     self.core.save_drawing(tab.id, &d.drawing).unwrap(); // TODO
@@ -278,7 +278,6 @@ impl super::AccountScreen {
                         TabContent::PlainText(txt) => Some(txt.content.as_bytes()),
                         _ => None,
                     };
-
                     if let Some(bytes) = maybe_bytes {
                         self.core.write_document(tab.id, bytes).unwrap(); // TODO
                     }
@@ -288,16 +287,13 @@ impl super::AccountScreen {
     }
 
     pub fn close_tab(&mut self, i: usize) {
+        self.save_tab(i);
         let ws = &mut self.workspace;
         ws.tabs.remove(i);
         let n_tabs = ws.tabs.len();
         if ws.active_tab >= n_tabs && n_tabs > 0 {
             ws.active_tab = n_tabs - 1;
         }
-    }
-
-    pub fn close_current_tab(&mut self) {
-        self.close_tab(self.workspace.active_tab);
     }
 }
 


### PR DESCRIPTION
There is still room for improving the uiux around saving, for example:
* keep the tab open while saving and then report any error back there.
* still close the tab (currently the case) and then report any error via dialog.

But for now, this prevents one form of data loss.

Checks one box in https://github.com/lockbook/lockbook/issues/1676.

@parth UAT if you can.