### PR TITLE
infra: macos bump bundle version (releaser), detect lockfile changes (dev-tool)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,8 +43,8 @@ jobs:
     - name: Server Logs
       if: always()
       run: cargo run -p lockbook-dev -- print-server-logs
-    - name: Check Lock File 
-      run: cargo run -p lockbook-dev -- check-lock-file
+    - name: Check Lock File
+      run: cargo run -p lockbook-dev -- assert-git-clean
     - name: Cleanup
       if: always()
       run: cargo run -p lockbook-dev -- kill-server

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.21"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2638,12 +2638,12 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.41"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1779539f58004e5dba1c1f093d44325ebeb244bfc04b791acdc0aaeca9c04570"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
 dependencies = [
  "android_system_properties",
- "core-foundation",
+ "core-foundation-sys",
  "js-sys",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -4371,6 +4371,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 name = "releaser"
 version = "0.7.2"
 dependencies = [
+ "chrono",
  "fs_extra",
  "gh_release",
  "google-androidpublisher3",

--- a/utils/dev-tool/src/main.rs
+++ b/utils/dev-tool/src/main.rs
@@ -44,7 +44,7 @@ enum Commands {
     PrintServerLogs,
 
     // Check if cargo.lock is in sync with cargo.toml
-    CheckLockFile,
+    AssertGitClean,
 
     /// Kill the server for commit hash
     KillServer,
@@ -92,7 +92,7 @@ fn main() {
         RunKotlinTests => android::run_kotlin_tests(&tool_env),
         RunSwiftTests => apple::run_swift_tests(&tool_env),
         PrintServerLogs => server::print_server_logs(&tool_env),
-        CheckLockFile => workspace::check_lockfile(&tool_env),
+        AssertGitClean => workspace::assert_git_clean(&tool_env),
         KillServer => server::kill_server(&tool_env),
     }
 }

--- a/utils/dev-tool/src/workspace.rs
+++ b/utils/dev-tool/src/workspace.rs
@@ -23,9 +23,9 @@ pub fn udeps_workspace(tool_env: &ToolEnvironment) {
         .assert_success();
 }
 
-pub fn check_lockfile(tool_env: &ToolEnvironment) {
-    Command::new("cargo")
-        .args(["check", "--locked"])
+pub fn assert_git_clean(tool_env: &ToolEnvironment) {
+    Command::new("git")
+        .args(["diff", "--exit-code"])
         .current_dir(&tool_env.root_dir)
         .assert_success();
 }

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -16,3 +16,4 @@ tokio = "1.20.1"
 tempfile = { version = "3.1.0" }
 fs_extra = "1.2.0"
 regex = "1.7.1"
+chrono = "0.4.24"

--- a/utils/releaser/src/utils.rs
+++ b/utils/releaser/src/utils.rs
@@ -4,6 +4,7 @@ use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
+use chrono::Datelike;
 use toml::Value;
 use toml_edit::{value, Document};
 
@@ -170,11 +171,19 @@ pub fn bump_versions(bump_type: Option<String>) {
         edit_cargo_version(cargo_path, new_version);
     }
 
-    //apple
+    // apple
     let plists = ["clients/apple/iOS/info.plist", "clients/apple/macOS/info.plist"];
     for plist in plists {
         Command::new("/usr/libexec/Plistbuddy")
-            .args(["-c", &format!("Set CFBundleShortVersionString {}", new_version), plist])
+            .args(["-c", &format!("Set CFBundleShortVersionString {new_version}"), plist])
+            .spawn()
+            .unwrap();
+        let now = chrono::Utc::now();
+        let month = now.month();
+        let day = now.day();
+        let year = now.year();
+        Command::new("/usr/libexec/Plistbuddy")
+            .args(["-c", &format!("Set CFBundleVersion {year}{month}{day}"), plist])
             .spawn()
             .unwrap();
     }

--- a/utils/releaser/src/utils.rs
+++ b/utils/releaser/src/utils.rs
@@ -1,10 +1,10 @@
+use chrono::Datelike;
 use gh_release::RepoInfo;
 use regex::{Captures, Regex};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
-use chrono::Datelike;
 use toml::Value;
 use toml_edit::{value, Document};
 


### PR DESCRIPTION
# ci lockfiles

We were detecting lock file changes by doing a `cargo check --locked`. If you run this locally with/without a `.lock` it will behave as expected. However we invoke this at the end of our CI, at which file, if a lockfile change had not been pushed, the lockfile would have been updated by any of the commands that we run prior to it. My first thought was to just check this first. But the way we check -- inside a rust program that's a part of the workspace -- makes this infeasible.

So then I thought about just extracting out the `cargo check --locked` into the yml file for the CI job, but this needlessly overlaps with the `clippy` call we'll do later.

So I ultimately ended up asserting that after CI is done `git diff` must be empty.