### PR TITLE
egui: unbreak settings tab and fix usage bar

### DIFF
--- a/clients/egui/src/account/modals/settings/mod.rs
+++ b/clients/egui/src/account/modals/settings/mod.rs
@@ -128,7 +128,11 @@ impl SettingsModal {
             })
             .response;
 
-        let response = response.interact(egui::Sense::click());
+        let response = ui.interact(
+            response.rect,
+            egui::Id::from(format!("tab_label_{}", text)),
+            egui::Sense::click(),
+        );
         if response.clicked() {
             self.active_tab = tab;
         }

--- a/clients/egui/src/widgets/subscription.rs
+++ b/clients/egui/src/widgets/subscription.rs
@@ -70,11 +70,11 @@ fn usage_bar(
     let used = metrics.server_usage.exact as f32;
     let available = metrics.data_cap.exact as f32;
     let human_usage = lb::bytes_to_human(used as u64);
-    let percent = (used / available) * 100.0;
+    let percent = used / available;
 
     ui.horizontal(|ui| {
         ui.columns(2, |uis| {
-            uis[0].label(&format!("{}    ({:.2} %)", human_usage, percent));
+            uis[0].label(&format!("{}    ({:.2} %)", human_usage, percent * 100.0));
 
             uis[1].with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
                 ui.label(&lb::bytes_to_human(available as u64));


### PR DESCRIPTION
I don't know why `Response::interact` ceased to work after `0.20`, but good news is that `Ui::interact` still works!

Closes #1674.