### PR TITLE
releaser: better version bump & publish lockbook-server

### DIFF
--- a/libs/editor/egui_editor/src/apple/apple_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/apple_ffi.rs
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn key_event(
     if let Some(key) = key.egui_key() {
         obj.raw_input
             .events
-            .push(Event::Key { key, pressed, modifiers });
+            .push(Event::Key { key, pressed, repeat: false, modifiers });
     }
 }
 

--- a/utils/releaser/src/main.rs
+++ b/utils/releaser/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
 
 fn from_args(releaser: Releaser) {
     match releaser {
-        Releaser::DeployServer => server::deploy_server(),
+        Releaser::DeployServer => server::deploy_server(&Github::env()),
         Releaser::ReleaseApple => apple::release_apple(&Github::env(), &AppStore::env()),
         Releaser::ReleaseAndroid => android::release_android(&Github::env(), &PlayStore::env()),
         Releaser::ReleaseWindows => windows::release(&Github::env()),

--- a/utils/releaser/src/main.rs
+++ b/utils/releaser/src/main.rs
@@ -6,13 +6,13 @@ mod public_site;
 mod secrets;
 mod server;
 mod utils;
+mod version;
 mod windows;
 
 use crate::secrets::*;
 use crate::utils::root;
 
 use clap::Parser;
-use utils::bump_versions;
 
 #[derive(Parser, PartialEq)]
 #[structopt(name = "basic")]
@@ -26,8 +26,8 @@ enum Releaser {
     ReleaseLinux,
     CreateGithubRelease,
     BumpVersion {
-        #[arg(short, long, name = "bump type")]
-        increment: Option<String>,
+        #[arg(short, long, name = "bump type", default_value_t)]
+        increment: version::BumpType,
     },
 }
 
@@ -47,7 +47,7 @@ fn from_args(releaser: Releaser) {
         Releaser::ReleasePublicSite => public_site::release(),
         Releaser::ReleaseLinux => linux::release_linux(),
         Releaser::CreateGithubRelease => github::create_gh_release(&Github::env()),
-        Releaser::BumpVersion { increment } => bump_versions(increment),
+        Releaser::BumpVersion { increment } => version::bump(increment),
         Releaser::All => {
             let releases = if cfg!(target_os = "macos") {
                 vec![Releaser::ReleaseApple]

--- a/utils/releaser/src/secrets.rs
+++ b/utils/releaser/src/secrets.rs
@@ -12,24 +12,28 @@ pub struct PlayStore {
 
 impl Github {
     pub fn env() -> Self {
-        Self(env::var("GITHUB_TOKEN").unwrap())
+        Self(env_or_panic("GITHUB_TOKEN"))
     }
 }
 
 impl AppStore {
     pub fn env() -> Self {
-        Self(env::var("APPLE_ID_PASSWORD").unwrap())
+        Self(env_or_panic("APPLE_ID_PASSWORD"))
     }
 }
 
 impl PlayStore {
     pub fn env() -> Self {
         Self {
-            service_account_key: env::var("GOOGLE_CLOUD_SERVICE_ACCOUNT_KEY").unwrap(),
-            release_store_file: env::var("ANDROID_RELEASE_STORE_FILE").unwrap(),
-            release_store_password: env::var("ANDROID_RELEASE_STORE_PASSWORD").unwrap(),
-            release_key_alias: env::var("ANDROID_RELEASE_KEY_ALIAS").unwrap(),
-            release_key_password: env::var("ANDROID_RELEASE_KEY_PASSWORD").unwrap(),
+            service_account_key: env_or_panic("GOOGLE_CLOUD_SERVICE_ACCOUNT_KEY"),
+            release_store_file: env_or_panic("ANDROID_RELEASE_STORE_FILE"),
+            release_store_password: env_or_panic("ANDROID_RELEASE_STORE_PASSWORD"),
+            release_key_alias: env_or_panic("ANDROID_RELEASE_KEY_ALIAS"),
+            release_key_password: env_or_panic("ANDROID_RELEASE_KEY_PASSWORD"),
         }
     }
+}
+
+fn env_or_panic(key: &str) -> String {
+    env::var(key).unwrap_or_else(|_| panic!("env var: {key} missing"))
 }

--- a/utils/releaser/src/utils.rs
+++ b/utils/releaser/src/utils.rs
@@ -1,12 +1,9 @@
 use gh_release::RepoInfo;
-use regex::{Captures, Regex};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
-use time::OffsetDateTime;
 use toml::Value;
-use toml_edit::{value, Document};
 
 pub trait CommandRunner {
     fn assert_success(&mut self);
@@ -84,111 +81,4 @@ pub fn commit_hash() -> String {
     return String::from_utf8_lossy(hash_bytes.as_slice())
         .trim()
         .to_string();
-}
-
-pub fn determine_new_version(bump_type: Option<String>) -> Option<String> {
-    let mut current_version: Vec<i32> = core_version()
-        .split('.')
-        .map(|f| f.parse().unwrap())
-        .collect();
-
-    let bump_type = bump_type.unwrap_or_else(|| "patch".to_string());
-    match bump_type.as_ref() {
-        "major" => {
-            current_version[0] += 1;
-            current_version[1] = 0;
-            current_version[2] = 0;
-        }
-        "minor" => {
-            current_version[1] += 1;
-            current_version[2] = 0;
-        }
-        "patch" => current_version[2] += 1,
-        _ => panic!(
-            "{} is an undefined version bump. accepted values are: major, minor, patch",
-            bump_type
-        ),
-    }
-
-    let new_version = current_version
-        .iter()
-        .map(|f| f.to_string())
-        .collect::<Vec<String>>()
-        .join(".");
-
-    Some(new_version)
-}
-
-pub fn edit_cargo_version(cargo_path: &str, version: &str) {
-    let cargo_path = &[cargo_path, "/Cargo.toml"].join("");
-    let mut cargo_toml = fs::read_to_string(cargo_path)
-        .unwrap()
-        .parse::<Document>()
-        .unwrap();
-
-    cargo_toml["package"]["version"] = value(version);
-    fs::write(cargo_path, cargo_toml.to_string()).unwrap();
-}
-
-pub fn edit_android_version(version_name: &str) {
-    let path = "clients/android/app/build.gradle";
-    let mut gradle_build = fs::read_to_string(path).unwrap();
-
-    let version_name_re = Regex::new(r"(versionName) (.*)").unwrap();
-    let version_code_re = Regex::new(r"(versionCode) *(?P<version_code>\d+)").unwrap();
-    let mut version_code = 0;
-    for caps in version_code_re.captures_iter(&gradle_build) {
-        version_code = caps["version_code"].parse().unwrap();
-    }
-    gradle_build = version_code_re
-        .replace(&gradle_build, |caps: &Captures| format!("{} {}", &caps[1], version_code + 1))
-        .to_string();
-
-    gradle_build = version_name_re
-        .replace(&gradle_build, |caps: &Captures| format!("{} \"{}\"", &caps[1], version_name))
-        .to_string();
-
-    fs::write(path, gradle_build).unwrap();
-}
-
-pub fn bump_versions(bump_type: Option<String>) {
-    let new_version = determine_new_version(bump_type).unwrap_or_else(core_version);
-    let new_version = new_version.as_str();
-
-    let cargos_to_update = vec![
-        "clients/admin",
-        "clients/cli",
-        "clients/egui",
-        "server/server",
-        "libs/core",
-        "libs/core/libs/shared",
-        "libs/core/libs/test_utils",
-        "libs/c_interface_v2",
-        "libs/editor/egui_editor",
-        "utils/dev-tool",
-        "utils/releaser",
-        "utils/winstaller",
-    ];
-    for cargo_path in cargos_to_update {
-        edit_cargo_version(cargo_path, new_version);
-    }
-
-    // apple
-    let plists = ["clients/apple/iOS/info.plist", "clients/apple/macOS/info.plist"];
-    for plist in plists {
-        Command::new("/usr/libexec/Plistbuddy")
-            .args(["-c", &format!("Set CFBundleShortVersionString {new_version}"), plist])
-            .spawn()
-            .unwrap();
-        let now = OffsetDateTime::now_utc();
-        let month = now.month() as u8;
-        let day = now.day();
-        let year = now.year();
-        Command::new("/usr/libexec/Plistbuddy")
-            .args(["-c", &format!("Set CFBundleVersion {year}{month}{day}"), plist])
-            .spawn()
-            .unwrap();
-    }
-
-    edit_android_version(new_version)
 }

--- a/utils/releaser/src/version.rs
+++ b/utils/releaser/src/version.rs
@@ -1,0 +1,149 @@
+use crate::utils::{core_version, CommandRunner};
+use clap::ValueEnum;
+use regex::{Captures, Regex};
+use std::fmt::{Display, Formatter};
+use std::fs;
+use std::process::Command;
+use time::OffsetDateTime;
+use toml_edit::{value, Document};
+
+pub fn bump(bump_type: BumpType) {
+    let new_version = determine_new_version(bump_type);
+
+    ensure_clean_start_state();
+
+    handle_cargo_tomls(&new_version);
+    handle_apple(&new_version);
+    handle_android(&new_version);
+    generate_lockfile();
+
+    push_to_git(&new_version);
+}
+
+#[derive(Copy, Clone, ValueEnum, PartialEq, Default, Debug)]
+pub enum BumpType {
+    Major,
+    Minor,
+
+    #[default]
+    Patch,
+}
+
+impl Display for BumpType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{:?}", self).to_ascii_lowercase())
+    }
+}
+
+fn handle_cargo_tomls(version: &str) {
+    let cargos_to_update = vec![
+        "clients/admin",
+        "clients/cli",
+        "clients/egui",
+        "server/server",
+        "libs/core",
+        "libs/core/libs/shared",
+        "libs/core/libs/test_utils",
+        "libs/editor/egui_editor",
+        "libs/c_interface_v2",
+        "libs/core_external_interface",
+        "utils/dev-tool",
+        "utils/releaser",
+        "utils/winstaller",
+    ];
+
+    for cargo_path in cargos_to_update {
+        let cargo_path = &[cargo_path, "/Cargo.toml"].join("");
+        let mut cargo_toml = fs::read_to_string(cargo_path)
+            .unwrap()
+            .parse::<Document>()
+            .unwrap();
+
+        cargo_toml["package"]["version"] = value(version);
+        fs::write(cargo_path, cargo_toml.to_string()).unwrap();
+    }
+}
+
+fn handle_apple(version: &str) {
+    let plists = ["clients/apple/iOS/info.plist", "clients/apple/macOS/info.plist"];
+    for plist in plists {
+        Command::new("/usr/libexec/Plistbuddy")
+            .args(["-c", &format!("Set CFBundleShortVersionString {version}"), plist])
+            .spawn()
+            .unwrap();
+        let now = OffsetDateTime::now_utc();
+        let month = now.month() as u8;
+        let day = now.day();
+        let year = now.year();
+        Command::new("/usr/libexec/Plistbuddy")
+            .args(["-c", &format!("Set CFBundleVersion {year}{month}{day}"), plist])
+            .spawn()
+            .unwrap();
+    }
+}
+
+fn handle_android(version: &str) {
+    let path = "clients/android/app/build.gradle";
+    let mut gradle_build = fs::read_to_string(path).unwrap();
+
+    let version_name_re = Regex::new(r"(versionName) (.*)").unwrap();
+    let version_code_re = Regex::new(r"(versionCode) *(?P<version_code>\d+)").unwrap();
+    let mut version_code = 0;
+    for caps in version_code_re.captures_iter(&gradle_build) {
+        version_code = caps["version_code"].parse().unwrap();
+    }
+    gradle_build = version_code_re
+        .replace(&gradle_build, |caps: &Captures| format!("{} {}", &caps[1], version_code + 1))
+        .to_string();
+
+    gradle_build = version_name_re
+        .replace(&gradle_build, |caps: &Captures| format!("{} \"{}\"", &caps[1], version))
+        .to_string();
+
+    fs::write(path, gradle_build).unwrap();
+}
+
+fn determine_new_version(bump_type: BumpType) -> String {
+    let mut current_version: Vec<i32> = core_version()
+        .split('.')
+        .map(|f| f.parse().unwrap())
+        .collect();
+
+    match bump_type {
+        BumpType::Major => {
+            current_version[0] += 1;
+            current_version[1] = 0;
+            current_version[2] = 0;
+        }
+        BumpType::Minor => {
+            current_version[1] += 1;
+            current_version[2] = 0;
+        }
+        BumpType::Patch => current_version[2] += 1,
+    }
+
+    current_version
+        .iter()
+        .map(|f| f.to_string())
+        .collect::<Vec<String>>()
+        .join(".")
+}
+
+fn generate_lockfile() {
+    Command::new("cargo").arg("check").assert_success();
+}
+
+fn ensure_clean_start_state() {
+    Command::new("git")
+        .args(["diff", "--exit-code"])
+        .assert_success()
+}
+
+fn push_to_git(version: &str) {
+    Command::new("bash")
+        .args([
+            "-c",
+            &format!("git checkout -b bump-{version} && git add -A && git commit -m 'bump-{version}' && git push origin bump-{version}")
+        ])
+        .assert_success()
+}


### PR DESCRIPTION
+ cleanup code around version bumps and express version bump types to clap more ergonomically
+ fire away a `cargo check` to generate the lockfile
+ push it all to a branch
+ also publish `lockbook-server` along with every release
+ also better error messages for missing env vars

fixes #1562 

I was going to generate a 32 bit version of the windows egui binary, but it didn't compile, in exactly the same manner that the arm binary doesn't compile, so that's going to be something to look into later.