### PR TITLE
cli: restore version flag

### DIFF
--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lockbook-cli"
 version = "0.7.2"
 edition = "2021"
+description = "The private, polished note-taking platform."
 
 [[bin]]
 name = "lockbook"

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -20,6 +20,7 @@ use self::error::CliError;
 const ID_PREFIX_LEN: usize = 8;
 
 #[derive(Parser, Debug)]
+#[command(version, about)]
 enum LbCli {
     /// account related commands
     #[command(subcommand)]


### PR DESCRIPTION
fixes #1691

```
[I] parth@Parths-MBP ~/D/l/l/c/cli (cli-version-about)> lockbook
The private, polished note-taking platform.

Usage: lockbook <COMMAND>

Commands:
  account  account related commands
  copy     import files from your file system into lockbook
  debug    investigative commands
  delete   delete a file
  edit     edit a document
  export   export a lockbook file to your file system
  list     list files and file information
  move     move a file to a new parent
  new      create a new file at the given path or do nothing if it exists
  print    print a document to stdout
  rename   rename a file
  share    sharing related commands
  sync     file sync
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
[I] parth@Parths-MBP ~/D/l/l/c/cli (cli-version-about) [2]> lockbook -V 
lockbook-cli 0.7.2
[I] parth@Parths-MBP ~/D/l/l/c/cli (cli-version-about)> 
```