### PR TITLE
editor: input tests

### DIFF
--- a/libs/editor/egui_editor/src/input/canonical.rs
+++ b/libs/editor/egui_editor/src/input/canonical.rs
@@ -212,6 +212,7 @@ mod test {
     use egui::{Event, Key, Modifiers, Pos2};
     use std::time::Instant;
 
+    #[derive(Default)]
     struct TestClickChecker {
         ui: bool,
         checkbox: Option<usize>,
@@ -242,7 +243,7 @@ mod test {
                     repeat: false,
                     modifiers: Default::default()
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
@@ -266,7 +267,7 @@ mod test {
                     repeat: false,
                     modifiers: Modifiers { command: true, ..Default::default() },
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
@@ -290,7 +291,7 @@ mod test {
                     repeat: false,
                     modifiers: Modifiers { shift: true, ..Default::default() },
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
@@ -314,7 +315,7 @@ mod test {
                     repeat: false,
                     modifiers: Modifiers { command: true, shift: true, ..Default::default() },
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
@@ -338,7 +339,7 @@ mod test {
                     repeat: false,
                     modifiers: Default::default()
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
@@ -362,7 +363,7 @@ mod test {
                     repeat: false,
                     modifiers: Modifiers { command: true, ..Default::default() },
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
@@ -386,7 +387,7 @@ mod test {
                     repeat: false,
                     modifiers: Modifiers { shift: true, ..Default::default() },
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
@@ -410,13 +411,397 @@ mod test {
                     repeat: false,
                     modifiers: Modifiers { command: true, shift: true, ..Default::default() },
                 },
-                TestClickChecker { ui: true, checkbox: None, link: None },
+                TestClickChecker::default(),
                 &mut Default::default(),
                 Instant::now()
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
                     offset: Offset::To(Bound::Doc),
+                    backwards: true,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_right() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowRight,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Char),
+                    backwards: false,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_alt_right() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowRight,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { alt: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Word),
+                    backwards: false,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_right() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowRight,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
+                    backwards: false,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_shift_right() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowRight,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Char),
+                    backwards: false,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_alt_shift_right() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowRight,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { alt: true, shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Word),
+                    backwards: false,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_shift_right() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowRight,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
+                    backwards: false,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_end() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::End,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
+                    backwards: false,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_shift_end() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::End,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
+                    backwards: false,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_left() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowLeft,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Char),
+                    backwards: true,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_alt_left() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowLeft,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { alt: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Word),
+                    backwards: true,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_left() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowLeft,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
+                    backwards: true,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_shift_left() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowLeft,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Char),
+                    backwards: true,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_alt_shift_left() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowLeft,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { alt: true, shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Word),
+                    backwards: true,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_shift_left() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowLeft,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
+                    backwards: true,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_home() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::Home,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
+                    backwards: true,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_shift_home() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::Home,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { shift: true, ..Default::default() },
+                },
+                TestClickChecker::default(),
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Line),
                     backwards: true,
                     extend_selection: true,
                 },

--- a/libs/editor/egui_editor/src/input/canonical.rs
+++ b/libs/editor/egui_editor/src/input/canonical.rs
@@ -1,11 +1,11 @@
 use crate::input::click_checker::ClickChecker;
 use crate::input::cursor::{ClickType, PointerState};
 use crate::offset_types::DocCharOffset;
-use egui::{Event, Key, PointerButton, Pos2};
+use egui::{Event, Key, Modifiers, PointerButton, Pos2};
 use std::time::Instant;
 
 /// text location
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Location {
     CurrentCursor, // start or end of current selection depending on context
     DocCharOffset(DocCharOffset),
@@ -13,7 +13,7 @@ pub enum Location {
 }
 
 /// text unit that has a start and end location
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Bound {
     Word,
     Line,
@@ -21,21 +21,21 @@ pub enum Bound {
 }
 
 /// text unit you can increment or decrement a location by
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Increment {
     Char,
     Line,
 }
 
 /// text location relative to some absolute text location
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Offset {
     To(Bound),
     By(Increment),
 }
 
 /// text region specified in some manner
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Region {
     /// 0-length region starting and ending at location
     Location(Location),
@@ -62,7 +62,7 @@ pub enum Region {
 
 /// Standardized edits to any editor state e.g. buffer, clipboard, debug state.
 /// May depend on render state e.g. galley positions, line wrap.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Modification {
     Select { region: Region },
     Mark { start: DocCharOffset, end: DocCharOffset },
@@ -78,8 +78,8 @@ pub enum Modification {
     OpenUrl(String),
 }
 
-impl From<&egui::Modifiers> for Offset {
-    fn from(modifiers: &egui::Modifiers) -> Self {
+impl From<&Modifiers> for Offset {
+    fn from(modifiers: &Modifiers) -> Self {
         if modifiers.command {
             Offset::To(Bound::Line)
         } else if modifiers.alt {
@@ -133,7 +133,7 @@ pub fn calc(
             Modification::Replace {
                 region: Region::SelectionOrOffset {
                     offset: Offset::from(modifiers),
-                    backwards: *key == Key::Backspace,
+                    backwards: key == &Key::Backspace,
                 },
                 text: "".to_string(),
             }
@@ -202,4 +202,225 @@ pub fn calc(
             return None;
         }
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::calc;
+    use crate::input::canonical::{Bound, Increment, Modification, Offset, Region};
+    use crate::input::click_checker::ClickChecker;
+    use egui::{Event, Key, Modifiers, Pos2};
+    use std::time::Instant;
+
+    struct TestClickChecker {
+        ui: bool,
+        checkbox: Option<usize>,
+        link: Option<String>,
+    }
+
+    impl ClickChecker for TestClickChecker {
+        fn ui(&self, _pos: Pos2) -> bool {
+            self.ui
+        }
+
+        fn checkbox(&self, _pos: Pos2) -> Option<usize> {
+            self.checkbox
+        }
+
+        fn link(&self, _pos: Pos2) -> Option<String> {
+            self.link.clone()
+        }
+    }
+
+    #[test]
+    fn calc_down() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowDown,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Default::default()
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Line),
+                    backwards: false,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_down() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowDown,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, ..Default::default() },
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Doc),
+                    backwards: false,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_shift_down() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowDown,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { shift: true, ..Default::default() },
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Line),
+                    backwards: false,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_shift_down() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowDown,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, shift: true, ..Default::default() },
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Doc),
+                    backwards: false,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_up() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowUp,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Default::default()
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Line),
+                    backwards: true,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_up() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowUp,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, ..Default::default() },
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Doc),
+                    backwards: true,
+                    extend_selection: false,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_shift_up() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowUp,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { shift: true, ..Default::default() },
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::By(Increment::Line),
+                    backwards: true,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
+
+    #[test]
+    fn calc_cmd_shift_up() {
+        assert!(matches!(
+            calc(
+                &Event::Key {
+                    key: Key::ArrowUp,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: Modifiers { command: true, shift: true, ..Default::default() },
+                },
+                TestClickChecker { ui: true, checkbox: None, link: None },
+                &mut Default::default(),
+                Instant::now()
+            ),
+            Some(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Doc),
+                    backwards: true,
+                    extend_selection: true,
+                },
+            })
+        ));
+    }
 }


### PR DESCRIPTION
Adds input parsing tests for {none or cmd} x {none or shift} x {up or down} + {none or alt or cmd} x {none or shift} x {left or right} + {none or shift} x {home or end} as a proof of concept for input parsing tests.

Testing remaining intended input combinations (e.g. text, enter, backspace, tab, clicks) as well as conflict resolution for current cases (e.g. cmd+alt+left should resolve the same as cmd+left) is left as future work.