### PR TITLE
editor: reduce text highlight background intensity on dark mode

### DIFF
--- a/libs/editor/egui_editor/src/appearance.rs
+++ b/libs/editor/egui_editor/src/appearance.rs
@@ -89,10 +89,14 @@ impl Appearance {
     pub fn selection_bg(&self) -> Color32 {
         let mut color = BLUE;
 
-        // light mode: use half saturation
         color.light = {
             let mut color_hsva = Hsva::from(color.light);
             color_hsva.s /= 2.0;
+            Color32::from(color_hsva)
+        };
+        color.dark = {
+            let mut color_hsva = Hsva::from(color.dark);
+            color_hsva.a /= 10.0;
             Color32::from(color_hsva)
         };
 


### PR DESCRIPTION
Fixes #1700 

<img width="912" alt="Screenshot 2023-04-23 at 11 24 25 AM" src="https://user-images.githubusercontent.com/6198756/233848807-5598aa90-d2b9-43b6-be03-946e97509ce3.png">
<img width="868" alt="Screenshot 2023-04-23 at 11 24 46 AM" src="https://user-images.githubusercontent.com/6198756/233848809-2f3dd012-38fe-4c66-8711-f6f4b6c41628.png">
