### PR TITLE
core: remove ignored release profile config

### DIFF
--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -42,9 +42,6 @@ db-rs-derive = "0.1.18"
 lockbook-server = { path = "../../server/server", optional = true }
 tokio = { version = "1.5.0", optional = true }
 
-[profile.release]
-debug = true
-
 [dev-dependencies]
 criterion = "0.4.0"
 indicatif = "=0.17.0-rc.11"


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/profiles.html
> Cargo only looks at the profile settings in the Cargo.toml manifest at the root of the workspace. Profile settings defined in dependencies will be ignored.

Removing this causes no change in the final core lib. Adding it to the workspace Cargo.toml file causes an increase from 66M to 352M.