### PR TITLE
egui: remove 'Plain Text' option from new file dialog and use clearer ui

### DIFF
--- a/clients/egui/src/account/modals/new_file.rs
+++ b/clients/egui/src/account/modals/new_file.rs
@@ -1,7 +1,5 @@
 use eframe::egui;
 
-use crate::widgets::ButtonGroup;
-
 pub struct NewFileParams {
     pub ftype: lb::FileType,
     pub parent_path: String,
@@ -42,13 +40,17 @@ impl super::Modal for NewDocModal {
 
         // File type selection.
         ui.horizontal(|ui| {
-            if let Some(_type_selected) = ButtonGroup::toggle_mut(&mut self.ftype)
-                .btn(NewDocType::Markdown, "Markdown")
-                .btn(NewDocType::Drawing, "Drawing")
-                .btn(NewDocType::PlainText, "Plain Text")
-                .show(ui)
+            if ui
+                .selectable_label(self.ftype == NewDocType::Markdown, "Markdown")
+                .clicked()
             {
-                self.name_field_needs_focus = true;
+                self.ftype = NewDocType::Markdown;
+            }
+            if ui
+                .selectable_label(self.ftype == NewDocType::Drawing, "Drawing")
+                .clicked()
+            {
+                self.ftype = NewDocType::Drawing;
             }
         });
 
@@ -121,7 +123,6 @@ impl super::Modal for NewDocModal {
 enum NewDocType {
     Markdown,
     Drawing,
-    PlainText,
 }
 
 impl NewDocType {
@@ -129,7 +130,6 @@ impl NewDocType {
         match self {
             Self::Markdown => ".md",
             Self::Drawing => ".draw",
-            Self::PlainText => "",
         }
     }
 }

--- a/clients/egui/src/widgets/button_group.rs
+++ b/clients/egui/src/widgets/button_group.rs
@@ -1,26 +1,20 @@
 use eframe::{egui, epaint};
 
-pub struct ButtonGroup<'a, T: Copy + PartialEq> {
-    value: Option<ToggleValue<'a, T>>,
+pub struct ButtonGroup<T: Copy + PartialEq> {
+    value: Option<ToggleValue<T>>,
     buttons: Vec<(T, ButtonContent)>,
     center: bool,
 }
 
-impl<'a, T: Copy + PartialEq> Default for ButtonGroup<'a, T> {
+impl<T: Copy + PartialEq> Default for ButtonGroup<T> {
     fn default() -> Self {
         Self { value: None, buttons: Vec::new(), center: false }
     }
 }
 
-impl<'a, T: Copy + PartialEq> ButtonGroup<'a, T> {
+impl<T: Copy + PartialEq> ButtonGroup<T> {
     pub fn toggle(value_copy: T) -> Self {
         let value = Some(ToggleValue::Copied(value_copy));
-
-        Self { value, ..Self::default() }
-    }
-
-    pub fn toggle_mut(value_mut: &'a mut T) -> Self {
-        let value = Some(ToggleValue::RefMut(value_mut));
 
         Self { value, ..Self::default() }
     }
@@ -155,9 +149,6 @@ impl<'a, T: Copy + PartialEq> ButtonGroup<'a, T> {
 
         if resp.clicked() {
             clicked = Some(btn.0);
-            if let Some(ToggleValue::RefMut(value)) = &mut self.value {
-                **value = btn.0;
-            }
         }
 
         if index != self.buttons.len() - 1 {
@@ -189,7 +180,6 @@ impl<'a, T: Copy + PartialEq> ButtonGroup<'a, T> {
         if let Some(value) = &self.value {
             match value {
                 ToggleValue::Copied(value) => *value == v,
-                ToggleValue::RefMut(value) => **value == v,
             }
         } else {
             false
@@ -197,9 +187,8 @@ impl<'a, T: Copy + PartialEq> ButtonGroup<'a, T> {
     }
 }
 
-enum ToggleValue<'a, T> {
+enum ToggleValue<T> {
     Copied(T),
-    RefMut(&'a mut T),
 }
 
 enum ButtonContent {


### PR DESCRIPTION
This resulted in an unused lifetime param in the button group widget.

The builtin egui `SelectableLabel` widget is used instead of our custom button group. Still needs to be polished, but it's clearer about which option is selected.