### PR TITLE
apple: fix ipad portrait dark mode icons

### DIFF
--- a/clients/apple/Shared/Views/BottomBar.swift
+++ b/clients/apple/Shared/Views/BottomBar.swift
@@ -18,7 +18,7 @@ struct BottomBar: View {
         }) {
             Image(systemName: "plus.circle.fill")
                 .imageScale(.large)
-                .foregroundColor(.blue)
+                .foregroundColor(.accentColor)
                 .frame(width: 40, height: 40, alignment: .center)
         }
     }
@@ -35,7 +35,7 @@ struct BottomBar: View {
             }) {
                 Image(systemName: "arrow.triangle.2.circlepath.circle.fill")
                     .imageScale(.large)
-                    .foregroundColor(.blue)
+                    .foregroundColor(.accentColor)
                     .frame(width: 40, height: 40, alignment: .center)
             }
         }

--- a/clients/apple/iOS/OutlineView/OutlineRow.swift
+++ b/clients/apple/iOS/OutlineView/OutlineRow.swift
@@ -27,7 +27,7 @@ struct OutlineRow: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 16, height: 16)
-                .foregroundColor(file.fileType == .Folder ? .blue : .secondary)
+                .foregroundColor(file.fileType == .Folder ? .accentColor : .secondary)
             
             Text(file.name)
                 .lineLimit(1) // If lineLimit is not specified, non-leaf names will wrap
@@ -42,7 +42,7 @@ struct OutlineRow: View {
                     .scaledToFit()
                     .frame(width: 10, height: 10)
                     .rotationEffect(Angle.degrees(open ? 90 : 0))
-                    .foregroundColor(Color.blue)
+                    .foregroundColor(.accentColor)
                     .onTapGesture {
                         open.toggle()
                     }


### PR DESCRIPTION
From:
<details>

![Simulator Screen Shot - iPad (10th generation) - 2023-05-22 at 20 34 06](https://github.com/lockbook/lockbook/assets/20663038/277b4578-5ffa-4039-b89f-ed3bf8a419b1)
</details>

To:
<details>

![Simulator Screen Shot - iPad (10th generation) - 2023-05-22 at 20 32 36](https://github.com/lockbook/lockbook/assets/20663038/033fc534-b4ce-416d-abf6-27beada1a662)
</details>

fixes #1641