### PR TITLE
apple: macOS and iPadOS search shortcuts

### DIFF
--- a/clients/apple/Shared/LockbookApp.swift
+++ b/clients/apple/Shared/LockbookApp.swift
@@ -40,7 +40,14 @@ import AppKit
             }
             CommandMenu("Lockbook") {
                 Button("Sync", action: { DI.sync.sync() }).keyboardShortcut("S", modifiers: .command)
-                Button("Search", action: { DI.search.startPathSearch() }).keyboardShortcut("O", modifiers: .command)
+                Button("Search Paths", action: { DI.search.startPathSearch() }).keyboardShortcut("O", modifiers: .command)
+                #if os(macOS)
+                Button("Search Paths And Content") {
+                    if let toolbar = NSApp.keyWindow?.toolbar, let search = toolbar.items.first(where: { $0.itemIdentifier.rawValue == "com.apple.SwiftUI.search" }) as? NSSearchToolbarItem {
+                            search.beginSearchInteraction()
+                        }
+                }.keyboardShortcut("f", modifiers: [.command, .shift])
+                #endif
             }
             SidebarCommands()
         }

--- a/clients/apple/iOS/FileTreeView.swift
+++ b/clients/apple/iOS/FileTreeView.swift
@@ -16,6 +16,7 @@ struct FileTreeView: View {
     
     @State var searchInput: String = ""
     @State private var hideOutOfSpaceAlert = UserDefaults.standard.bool(forKey: "hideOutOfSpaceAlert")
+    @State private var searchBar: UISearchBar?
 
     let currentFolder: File
     let account: Account
@@ -27,6 +28,18 @@ struct FileTreeView: View {
                 mainView: mainView,
                 isiOS: false)
             .searchable(text: $searchInput, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search")
+            .background(
+                Button("Search Paths And Content") {
+                    focusSearchBar()
+                }
+                .keyboardShortcut("f", modifiers: [.command, .shift])
+                .hidden()
+            )
+            .introspectNavigationController { nav in
+                searchBar = nav.navigationBar.subviews.first { view in
+                    view is UISearchBar
+                } as? UISearchBar
+            }
             
             BottomBar(onCreating: {
                 sheets.creatingInfo = CreatingInfo(parent: currentFolder, child_type: .Document)
@@ -152,5 +165,9 @@ struct FileTreeView: View {
                 Spacer()
             }
         }
+    }
+    
+    func focusSearchBar() {
+        searchBar?.becomeFirstResponder()
     }
 }

--- a/clients/apple/macOS/FileListView.swift
+++ b/clients/apple/macOS/FileListView.swift
@@ -16,7 +16,6 @@ struct FileListView: View {
                 mainView: mainView,
                 isiOS: false)
             .searchable(text: $searchInput, prompt: "Search")
-            .keyboardShortcut(.escape)
                 
             BottomBar()
         }


### PR DESCRIPTION
Pressing `Cmd+Shift+F` will now allow you to initiate your document and content search.

fixes #1794 