### PR TITLE
editor: fix arrow key behavior when there's a selection

### DIFF
--- a/libs/editor/egui_editor/src/input/canonical.rs
+++ b/libs/editor/egui_editor/src/input/canonical.rs
@@ -41,26 +41,28 @@ pub enum Region {
     /// 0-length region starting and ending at location
     Location(Location),
 
-    /// text from secondary cursor to location. preserves selection.
+    /// Text from secondary cursor to location. preserves selection.
     ToLocation(Location),
 
-    /// text from one location to another
+    /// Text from one location to another
     BetweenLocations { start: Location, end: Location },
 
-    /// currently selected text
+    /// Currently selected text
     Selection,
 
-    /// currently selected text, or if the selection is empty, text from the primary cursor
-    /// to one char/line before/after or to start/end of word/line/doc
+    /// Currently selected text, or if the selection is empty, text from the primary cursor to one char/line
+    /// before/after or to start/end of word/line/doc
     SelectionOrOffset { offset: Offset, backwards: bool },
 
-    /// text from primary cursor to one char/line before/after or to start/end of word/line/doc.
+    /// Text from primary cursor to one char/line before/after or to start/end of word/line/paragraph/doc. In some
+    /// situations this instead represents the start of selection (if `backwards`) or end of selection, based on what
+    /// feels intuitive when using arrow keys to navigate a document.
     ToOffset { offset: Offset, backwards: bool, extend_selection: bool },
 
-    /// current word/line/doc
+    /// Current word/line/paragraph/doc
     Bound { bound: Bound },
 
-    /// word/line/doc at a location
+    /// Word/line/paragraph/doc at a location
     BoundAt { bound: Bound, location: Location },
 }
 

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -382,14 +382,23 @@ pub fn region_to_cursor(
             }
         }
         Region::ToOffset { offset, backwards, extend_selection } => {
-            let mut cursor = current_cursor;
-            cursor.advance(offset, backwards, buffer, galleys);
-            if extend_selection {
-                cursor.selection.0 = current_cursor.selection.0;
+            if extend_selection
+                || current_cursor.selection.is_empty()
+                || matches!(offset, Offset::To(..))
+            {
+                let mut cursor = current_cursor;
+                cursor.advance(offset, backwards, buffer, galleys);
+                if extend_selection {
+                    cursor.selection.0 = current_cursor.selection.0;
+                } else {
+                    cursor.selection.0 = cursor.selection.1;
+                }
+                cursor
+            } else if backwards {
+                current_cursor.selection.start().into()
             } else {
-                cursor.selection.0 = cursor.selection.1;
+                current_cursor.selection.end().into()
             }
-            cursor
         }
         Region::Bound { bound } => {
             let mut cursor = current_cursor;


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1789

Previous behavior was to move cursor regardless of if there's a selection. New behavior is to do that under the following conditions, otherwise snap the cursor to the start or end of the selection instead:
1. `extend_selection`: if we're extending the selection (e.g. shift+right), we naturally shouldn't snap the cursor (which would clear the selection) when an arrowkey is pressed
2. `current_cursor.selection.is_empty()`: if there's no selection and we're just arrowkey'ing around the doc, we should move the cursor as usual
3. `matches!(offset, Offset::To(..))`: if we're moving the selection to a word/line/paragraph/doc boundary, go ahead and move it to that boundary, so that e.g. cmd+right and end keys still move the cursor to the end of the line

Basically, the new behavior only happens when there's a selection and you hit an arrow key with no modifiers.