### PR TITLE
editor: support floating cursor on iOS

### DIFF
--- a/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -290,14 +290,13 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
     public func firstRect(for range: UITextRange) -> CGRect {
         let range = (range as! LBTextRange).c
         let result = first_rect(editorHandle, range)
-        let result2 = CGRect(x: result.min_x, y: result.min_y, width: result.max_x-result.min_x, height: result.max_y-result.min_y)
-        print("\(#function)(\(range)) -> \(result2)")
-        return result2
+        return CGRect(x: result.min_x, y: result.min_y, width: result.max_x-result.min_x, height: result.max_y-result.min_y)
     }
     
     public func caretRect(for position: UITextPosition) -> CGRect {
-        print("\(#function)")
-        return CGRect(origin: CGPoint(x: 10, y: 10), size: CGSize(width: 10, height: 100))
+        let position = (position as! LBTextPos).c
+        let result = cursor_rect_at_position(editorHandle, position)
+        return CGRect(x: result.min_x, y: result.min_y, width: result.max_x-result.min_x, height: result.max_y-result.min_y)
     }
     
     public func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {
@@ -307,9 +306,9 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
     }
     
     public func closestPosition(to point: CGPoint) -> UITextPosition? {
-        print("\(#function)")
-        unimplemented()
-        return nil
+        let point = CPoint(x: point.x, y: point.y)
+        let result = position_at_point(editorHandle, point)
+        return LBTextPos(c: result)
     }
     
     public func closestPosition(to point: CGPoint, within range: UITextRange) -> UITextPosition? {

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -425,14 +425,14 @@ pub unsafe extern "C" fn clipboard_paste(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> CTextPosition {
     let obj = &mut *(obj as *mut WgpuEditor);
-    let buffer = &obj.editor.buffer.current;
+    let segs = &obj.editor.buffer.current.segs;
     let galleys = &obj.editor.galleys;
 
-    // todo: does this account for scrolling?
+    let scroll = obj.editor.scroll_area_offset;
     let offset = mutation::pos_to_char_offset(
-        Pos2 { x: point.x as f32, y: point.y as f32 },
-        &galleys,
-        &buffer.segs,
+        Pos2 { x: point.x as f32 + scroll.x, y: point.y as f32 + scroll.y },
+        galleys,
+        segs,
     );
     CTextPosition { none: false, pos: offset.0 }
 }
@@ -446,10 +446,11 @@ pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPos
 
     let cursor: Cursor = pos.pos.into();
     let rect = cursor.start_rect(galleys);
+    let scroll = obj.editor.scroll_area_offset;
     CRect {
-        min_x: rect.min.x as f64,
-        min_y: rect.min.y as f64,
-        max_x: rect.max.x as f64,
-        max_y: rect.max.y as f64,
+        min_x: (rect.min.x - scroll.x) as f64,
+        min_y: (rect.min.y - scroll.y) as f64,
+        max_x: (rect.max.x - scroll.x) as f64,
+        max_y: (rect.max.y - scroll.y) as f64,
     }
 }

--- a/libs/editor/egui_editor/src/lib.rs
+++ b/libs/editor/egui_editor/src/lib.rs
@@ -54,6 +54,13 @@ pub enum CTextLayoutDirection {
 
 #[repr(C)]
 #[derive(Debug)]
+pub struct CPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub struct CRect {
     pub min_x: f64,
     pub min_y: f64,


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1773

demo: https://discord.com/channels/1014184997751619664/1026208854280777789/1116403913969643621

Note that this supports floating cursor via holding the spacebar. Long pressing the cursor and dragging is not supported and will just scroll.