### PR TITLE
editor: iOS tokenizer

### DIFF
--- a/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -309,7 +309,7 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
     
     public var inputDelegate: UITextInputDelegate?
     
-    public lazy var tokenizer: UITextInputTokenizer = UITextInputStringTokenizer(textInput: self)
+    public lazy var tokenizer: UITextInputTokenizer = LBTokenizer(editorHandle: self.editorHandle)
     
     public func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? {
         print("\(#function)")
@@ -561,6 +561,44 @@ class LBTextPos: UITextPosition {
     
     init(c: CTextPosition) {
         self.c = c
+    }
+}
+
+class LBTokenizer: NSObject, UITextInputTokenizer {
+    let editorHandle: UnsafeMutableRawPointer?
+    
+    init(editorHandle: UnsafeMutableRawPointer?) {
+        self.editorHandle = editorHandle
+    }
+    
+    func isPosition(_ position: UITextPosition, atBoundary granularity: UITextGranularity, inDirection direction: UITextDirection) -> Bool {
+        let position = (position as! LBTextPos).c
+        let granularity = CTextGranularity(rawValue: UInt32(granularity.rawValue))
+        let backwards = direction.rawValue == 1
+        return is_position_at_bound(editorHandle, position, granularity, backwards)
+    }
+    
+    func isPosition(_ position: UITextPosition, withinTextUnit granularity: UITextGranularity, inDirection direction: UITextDirection) -> Bool {
+        let position = (position as! LBTextPos).c
+        let granularity = CTextGranularity(rawValue: UInt32(granularity.rawValue))
+        let backwards = direction.rawValue == 1
+        return is_position_within_bound(editorHandle, position, granularity, backwards)
+    }
+    
+    func position(from position: UITextPosition, toBoundary granularity: UITextGranularity, inDirection direction: UITextDirection) -> UITextPosition? {
+        let position = (position as! LBTextPos).c
+        let granularity = CTextGranularity(rawValue: UInt32(granularity.rawValue))
+        let backwards = direction.rawValue == 1
+        let result = bound_from_position(editorHandle, position, granularity, backwards)
+        return LBTextPos(c: result)
+    }
+    
+    func rangeEnclosingPosition(_ position: UITextPosition, with granularity: UITextGranularity, inDirection direction: UITextDirection) -> UITextRange? {
+        let position = (position as! LBTextPos).c
+        let granularity = CTextGranularity(rawValue: UInt32(granularity.rawValue))
+        let backwards = direction.rawValue == 1
+        let result = bound_at_position(editorHandle, position, granularity, backwards)
+        return LBTextRange(c: result)
     }
 }
 #endif

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -1,8 +1,10 @@
-use crate::input::canonical::{Bound, Increment, Modification, Offset, Region};
+use crate::input::canonical::{Bound, Increment, Location, Modification, Offset, Region};
 use crate::input::cursor::Cursor;
 use crate::input::mutation;
 use crate::offset_types::{DocCharOffset, RangeExt};
-use crate::{CPoint, CRect, CTextLayoutDirection, CTextPosition, CTextRange, WgpuEditor};
+use crate::{
+    CPoint, CRect, CTextGranularity, CTextLayoutDirection, CTextPosition, CTextRange, WgpuEditor,
+};
 use egui::{Event, Key, PointerButton, Pos2, TouchDeviceId, TouchId, TouchPhase};
 use std::cmp;
 use std::ffi::{c_char, c_void, CStr, CString};
@@ -140,9 +142,9 @@ pub unsafe extern "C" fn set_selected(obj: *mut c_void, range: CTextRange) {
 pub unsafe extern "C" fn select_current_word(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuEditor);
 
-    obj.editor
-        .custom_events
-        .push(Modification::Select { region: Region::Bound { bound: Bound::Word } });
+    obj.editor.custom_events.push(Modification::Select {
+        region: Region::Bound { bound: Bound::Word, backwards: true },
+    });
 }
 
 /// # Safety
@@ -151,9 +153,9 @@ pub unsafe extern "C" fn select_current_word(obj: *mut c_void) {
 pub unsafe extern "C" fn select_all(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuEditor);
 
-    obj.editor
-        .custom_events
-        .push(Modification::Select { region: Region::Bound { bound: Bound::Doc } });
+    obj.editor.custom_events.push(Modification::Select {
+        region: Region::Bound { bound: Bound::Doc, backwards: true },
+    });
 }
 
 /// # Safety
@@ -364,6 +366,105 @@ pub unsafe extern "C" fn position_offset_in_direction(
         cursor.advance(offset_type, backwards, buffer, galleys);
     }
     CTextPosition { none: start.none, pos: cursor.selection.1 .0 }
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+///
+/// https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614553-isposition
+#[no_mangle]
+pub unsafe extern "C" fn is_position_at_bound(
+    obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
+) -> bool {
+    let obj = &mut *(obj as *mut WgpuEditor);
+    let buffer = &obj.editor.buffer.current;
+    let galleys = &obj.editor.galleys;
+
+    // if advancing the cursor then advancing it back leaves it in the original position, it's at a bound
+    let mut cursor: Cursor = pos.pos.into();
+    let bound = match granularity {
+        CTextGranularity::Character => Bound::Char,
+        CTextGranularity::Word => Bound::Word,
+        CTextGranularity::Sentence => Bound::Paragraph, // note: sentence handled as paragraph
+        CTextGranularity::Paragraph => Bound::Paragraph,
+        CTextGranularity::Line => Bound::Line,
+        CTextGranularity::Document => Bound::Doc,
+    };
+    cursor.advance(Offset::To(bound), !backwards, buffer, galleys);
+    cursor.advance(Offset::To(bound), backwards, buffer, galleys);
+
+    cursor.selection.1 == pos.pos
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+///
+/// https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614491-isposition
+#[no_mangle]
+pub unsafe extern "C" fn is_position_within_bound(
+    _obj: *mut c_void, _pos: CTextPosition, _granularity: CTextGranularity, _backwards: bool,
+) -> bool {
+    true // aren't we always within a bound of each type?
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+///
+/// https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614491-isposition
+#[no_mangle]
+pub unsafe extern "C" fn bound_from_position(
+    obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
+) -> CTextPosition {
+    let obj = &mut *(obj as *mut WgpuEditor);
+    let buffer = &obj.editor.buffer.current;
+    let galleys = &obj.editor.galleys;
+
+    let mut cursor: Cursor = pos.pos.into();
+    let bound = match granularity {
+        CTextGranularity::Character => Bound::Char,
+        CTextGranularity::Word => Bound::Word,
+        CTextGranularity::Sentence => Bound::Paragraph, // note: sentence handled as paragraph
+        CTextGranularity::Paragraph => Bound::Paragraph,
+        CTextGranularity::Line => Bound::Line,
+        CTextGranularity::Document => Bound::Doc,
+    };
+    cursor.advance(Offset::To(bound), backwards, buffer, galleys);
+
+    CTextPosition { none: false, pos: cursor.selection.1 .0 }
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+///
+/// https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614464-rangeenclosingposition
+#[no_mangle]
+pub unsafe extern "C" fn bound_at_position(
+    obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
+) -> CTextRange {
+    let obj = &mut *(obj as *mut WgpuEditor);
+    let buffer = &obj.editor.buffer.current;
+    let galleys = &obj.editor.galleys;
+
+    let bound = match granularity {
+        CTextGranularity::Character => Bound::Char,
+        CTextGranularity::Word => Bound::Word,
+        CTextGranularity::Sentence => Bound::Paragraph, // note: sentence handled as paragraph
+        CTextGranularity::Paragraph => Bound::Paragraph,
+        CTextGranularity::Line => Bound::Line,
+        CTextGranularity::Document => Bound::Doc,
+    };
+    let cursor = mutation::region_to_cursor(
+        Region::BoundAt { bound, location: Location::DocCharOffset(pos.pos.into()), backwards },
+        buffer.cursor,
+        buffer,
+        galleys,
+    );
+
+    CTextRange {
+        none: false,
+        start: CTextPosition { none: false, pos: cursor.selection.start().0 },
+        end: CTextPosition { none: false, pos: cursor.selection.end().0 },
+    }
 }
 
 /// # Safety

--- a/libs/editor/egui_editor/src/input/advance.rs
+++ b/libs/editor/egui_editor/src/input/advance.rs
@@ -14,6 +14,7 @@ impl DocCharOffset {
         buffer: &SubBuffer, galleys: &Galleys,
     ) -> Self {
         match offset {
+            Offset::To(Bound::Char) => self,
             Offset::To(Bound::Word) => self
                 .advance_to_word_bound(backwards, buffer, galleys)
                 .fix(backwards, galleys),
@@ -190,6 +191,16 @@ impl DocCharOffset {
         let galley_idx = galleys.galley_at_char(self);
         let galley_text_range = &galleys[galley_idx].text_range();
         if backwards {
+            if self == galley_text_range.start() && galley_idx != 0 {
+                // backwards from start of galley -> end of previous galley
+                let galley_text_range = &galleys[galley_idx - 1].text_range();
+                galley_text_range.end()
+            } else {
+                galley_text_range.start()
+            }
+        } else if self == galley_text_range.end() && galley_idx != galleys.len() - 1 {
+            // forwards from end of galley -> start of next galley
+            let galley_text_range = &galleys[galley_idx + 1].text_range();
             galley_text_range.start()
         } else {
             galley_text_range.end()

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -638,19 +638,19 @@ pub fn region_to_cursor(
                 current_cursor.selection.end().into()
             }
         }
-        Region::Bound { bound } => {
+        Region::Bound { bound, backwards } => {
             let mut cursor = current_cursor;
-            cursor.advance(Offset::To(bound), true, buffer, galleys);
+            cursor.advance(Offset::To(bound), backwards, buffer, galleys);
             cursor.selection.0 = cursor.selection.1;
-            cursor.advance(Offset::To(bound), false, buffer, galleys);
+            cursor.advance(Offset::To(bound), !backwards, buffer, galleys);
             cursor
         }
-        Region::BoundAt { bound, location } => {
+        Region::BoundAt { bound, location, backwards } => {
             let mut cursor: Cursor =
                 location_to_char_offset(location, current_cursor, galleys, &buffer.segs).into();
-            cursor.advance(Offset::To(bound), true, buffer, galleys);
+            cursor.advance(Offset::To(bound), backwards, buffer, galleys);
             cursor.selection.0 = cursor.selection.1;
-            cursor.advance(Offset::To(bound), false, buffer, galleys);
+            cursor.advance(Offset::To(bound), !backwards, buffer, galleys);
             cursor
         }
     }

--- a/libs/editor/egui_editor/src/lib.rs
+++ b/libs/editor/egui_editor/src/lib.rs
@@ -61,6 +61,17 @@ pub struct CPoint {
 
 #[repr(C)]
 #[derive(Debug)]
+pub enum CTextGranularity {
+    Character = 0,
+    Word = 1,
+    Sentence = 2,
+    Paragraph = 3,
+    Line = 4,
+    Document = 5,
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub struct CRect {
     pub min_x: f64,
     pub min_y: f64,


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1791 (pending QA)
based on #1778 (uses `Bound::Paragraph`)

also fixes an issue where option+arrowkey would treat annotations as multiple words