### PR TITLE
apple: change conflicting toolbar shortcut and fix toolbar sync bug

### DIFF
--- a/clients/apple/Shared/Stateful Logic/DocumentLoader.swift
+++ b/clients/apple/Shared/Stateful Logic/DocumentLoader.swift
@@ -18,7 +18,7 @@ class DocumentLoader: ObservableObject {
     
     let core: LockbookApi
     
-    @Published var meta: File?
+    var meta: File?
     @Published var type: ViewType?
     @Published var deleted: Bool = false
     @Published var loading: Bool = true

--- a/clients/apple/Shared/Views/DocumentView.swift
+++ b/clients/apple/Shared/Views/DocumentView.swift
@@ -89,7 +89,6 @@ struct MarkdownEditor: View {
 
         self.editor = EditorView(editorState)
     }
-
     
     @Environment(\.colorScheme) var colorScheme
     
@@ -121,32 +120,59 @@ struct MarkdownEditor: View {
         HStack(spacing: 20) {
             HStack(spacing: 0) {
                 
-                // hack for the heading 1 shortcut since the shortcut in the menu is not recognized
+                // hack for the heading 1-4 shortcut since the shortcuts in the menu won't work unless opened
                 Button(action: {
                     editor.header(headingSize: 1)
                 }) {
                     EmptyView()
                 }
                 .frame(width: 0, height: 0)
-                .keyboardShortcut("h", modifiers: [.command, .shift])
+                .keyboardShortcut("1", modifiers: [.command, .control])
+                
+                Button(action: {
+                    editor.header(headingSize: 2)
+                }) {
+                    EmptyView()
+                }
+                .frame(width: 0, height: 0)
+                .keyboardShortcut("2", modifiers: [.command, .control])
+                
+                Button(action: {
+                    editor.header(headingSize: 3)
+                }) {
+                    EmptyView()
+                }
+                .frame(width: 0, height: 0)
+                .keyboardShortcut("3", modifiers: [.command, .control])
+                
+                Button(action: {
+                    editor.header(headingSize: 4)
+                }) {
+                    EmptyView()
+                }
+                .frame(width: 0, height: 0)
+                .keyboardShortcut("4", modifiers: [.command, .control])
                 
                 Menu(content: {
                     Button("Heading 1") {
                         editor.header(headingSize: 1)
                     }
-                    .keyboardShortcut("h", modifiers: [.command, .shift])
+                    .keyboardShortcut("1", modifiers: [.command, .control])
 
                     Button("Heading 2") {
                         editor.header(headingSize: 2)
                     }
+                    .keyboardShortcut("2", modifiers: [.command, .control])
 
                     Button("Heading 3") {
                         editor.header(headingSize: 3)
                     }
+                    .keyboardShortcut("3", modifiers: [.command, .control])
 
                     Button("Heading 4") {
                         editor.header(headingSize: 4)
                     }
+                    .keyboardShortcut("4", modifiers: [.command, .control])
                 }, label: {
                     HStack {
                         Image(systemName: "h.square")
@@ -192,7 +218,7 @@ struct MarkdownEditor: View {
                     MarkdownEditorImage(systemImageName: "greaterthan.square", isSelected: editorState.isInlineCodeSelected)
                 }
                 .buttonStyle(.borderless)
-                .keyboardShortcut("c", modifiers: .command)
+                .keyboardShortcut("c", modifiers: [.command, .control])
 
             }
 

--- a/clients/apple/Shared/Views/DocumentView.swift
+++ b/clients/apple/Shared/Views/DocumentView.swift
@@ -218,7 +218,7 @@ struct MarkdownEditor: View {
                     MarkdownEditorImage(systemImageName: "greaterthan.square", isSelected: editorState.isInlineCodeSelected)
                 }
                 .buttonStyle(.borderless)
-                .keyboardShortcut("c", modifiers: [.command, .control])
+                .keyboardShortcut("c", modifiers: [.command, .shift])
 
             }
 
@@ -227,20 +227,20 @@ struct MarkdownEditor: View {
 
             HStack(spacing: 15) {
                 Button(action: {
-                    editor.bulletedList()
-                }) {
-                    MarkdownEditorImage(systemImageName: "list.bullet", isSelected: editorState.isBulletListSelected)
-                }
-                .buttonStyle(.borderless)
-                .keyboardShortcut("b", modifiers: [.command, .shift])
-
-                Button(action: {
                     editor.numberedList()
                 }) {
                     MarkdownEditorImage(systemImageName: "list.number", isSelected: editorState.isNumberListSelected)
                 }
                 .buttonStyle(.borderless)
-                .keyboardShortcut("n", modifiers: [.command, .shift])
+                .keyboardShortcut("7", modifiers: [.command, .shift])
+                
+                Button(action: {
+                    editor.bulletedList()
+                }) {
+                    MarkdownEditorImage(systemImageName: "list.bullet", isSelected: editorState.isBulletListSelected)
+                }
+                .buttonStyle(.borderless)
+                .keyboardShortcut("8", modifiers: [.command, .shift])
 
                 Button(action: {
                     editor.todoList()
@@ -248,7 +248,7 @@ struct MarkdownEditor: View {
                     MarkdownEditorImage(systemImageName: "checklist", isSelected: editorState.isTodoListSelected)
                 }
                 .buttonStyle(.borderless)
-                .keyboardShortcut("c", modifiers: [.command, .shift])
+                .keyboardShortcut("9", modifiers: [.command, .shift])
             }
 
             #if os(iOS)


### PR DESCRIPTION
The sync bug is caused by SwiftUI recreating the editor when the file's metadata has changed. Often times it is just the `lastModified` field. The change in metadata should not cause the editor to be recreated, since nothing has actually changed (and if there is a document content change, that is propagated to the editor directly through `EditorState`). To fix this, I changed `meta` in `DocumentLoader` into a regular variable, rather than one that is `Published`.

Also modified the shortcut for heading 1, and added shortcuts for headings 2-4.

fixes #1817
fixes #1819