### PR TITLE
editor: fix delete annotation at beginning of doc

### DIFF
--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -12,7 +12,7 @@ use crate::debug::DebugInfo;
 use crate::element::{Element, ItemType};
 use crate::galleys::Galleys;
 use crate::images::ImageCache;
-use crate::input::canonical::{Bound, Modification, Offset, Region};
+use crate::input::canonical::{Bound, Increment, Modification, Offset, Region};
 use crate::input::cursor::{Cursor, PointerState};
 use crate::input::events;
 use crate::layouts::Annotation;
@@ -221,6 +221,16 @@ impl Editor {
             }
         } else {
             ui.memory_mut(|m| m.request_focus(id));
+
+            // put the cursor at the first valid cursor position
+            self.custom_events.push(Modification::Select {
+                region: Region::ToOffset {
+                    offset: Offset::To(Bound::Doc),
+                    backwards: false,
+                    extend_selection: false,
+                },
+            });
+
             (true, true)
         };
 

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -12,7 +12,7 @@ use crate::debug::DebugInfo;
 use crate::element::{Element, ItemType};
 use crate::galleys::Galleys;
 use crate::images::ImageCache;
-use crate::input::canonical::{Bound, Increment, Modification, Offset, Region};
+use crate::input::canonical::{Bound, Modification, Offset, Region};
 use crate::input::cursor::{Cursor, PointerState};
 use crate::input::events;
 use crate::layouts::Annotation;

--- a/libs/editor/egui_editor/src/input/advance.rs
+++ b/libs/editor/egui_editor/src/input/advance.rs
@@ -11,20 +11,16 @@ use unicode_segmentation::UnicodeSegmentation;
 
 impl DocCharOffset {
     pub fn advance(
-        self, maybe_x_target: &mut Option<f32>, offset: Offset, backwards: bool,
+        self, maybe_x_target: &mut Option<f32>, offset: Offset, backwards: bool, fix: bool,
         buffer: &SubBuffer, galleys: &Galleys, paragraphs: &Paragraphs,
     ) -> Self {
         match offset {
             Offset::To(Bound::Char) => self,
-            Offset::To(Bound::Word) => self
-                .advance_to_word_bound(backwards, buffer, galleys)
-                .fix(backwards, galleys),
+            Offset::To(Bound::Word) => self.advance_to_word_bound(backwards, buffer, galleys),
             Offset::To(Bound::Line) => self.advance_to_line_bound(backwards, galleys),
             Offset::To(Bound::Paragraph) => self.advance_to_paragraph_bound(backwards, paragraphs),
             Offset::To(Bound::Doc) => self.advance_to_doc_bound(backwards, &buffer.segs),
-            Offset::By(Increment::Char) => self
-                .advance_by_char(backwards, &buffer.segs)
-                .fix(backwards, galleys),
+            Offset::By(Increment::Char) => self.advance_by_char(backwards, &buffer.segs),
             Offset::By(Increment::Line) => {
                 let x_target = maybe_x_target.unwrap_or(self.x(galleys));
                 let result = self.advance_by_line(x_target, backwards, galleys);
@@ -33,8 +29,8 @@ impl DocCharOffset {
                 }
                 result
             }
-            .fix(backwards, galleys),
         }
+        .fix(backwards, fix, galleys)
     }
 
     fn advance_by_char(mut self, backwards: bool, segs: &UnicodeSegs) -> Self {
@@ -221,26 +217,40 @@ impl DocCharOffset {
         }
     }
 
-    fn fix(self, prefer_backwards: bool, galleys: &Galleys) -> Self {
+    fn fix(self, prefer_backwards: bool, fix: bool, galleys: &Galleys) -> Self {
         let galley_idx = galleys.galley_at_char(self);
         let galley = &galleys[galley_idx];
         let galley_text_range = galley.text_range();
 
         if self < galley_text_range.start() {
-            if !prefer_backwards || galley_idx == 0 {
+            if prefer_backwards {
+                if !fix && galley_idx == 0 {
+                    // move cursor to beginning of annotation text (invalid at end of frame)
+                    galley.range.start()
+                } else if galley_idx == 0 {
+                    self
+                } else {
+                    // move cursor backwards into text of preceding galley
+                    galleys[galley_idx - 1].text_range().end()
+                }
+            } else {
                 // move cursor forwards into galley text
                 galley_text_range.start()
-            } else {
-                // move cursor backwards into text of preceding galley
-                galleys[galley_idx - 1].text_range().end()
             }
         } else if self > galley_text_range.end() {
-            if prefer_backwards || galley_idx == galleys.len() - 1 {
+            if !prefer_backwards {
+                if !fix && galley_idx == galleys.len() - 1 {
+                    // move cursor to end of annotation text (invalid at end of frame)
+                    galley.range.end()
+                } else if galley_idx == galleys.len() - 1 {
+                    self
+                } else {
+                    // move cursor forwards into text of next galley
+                    galleys[galley_idx + 1].text_range().start()
+                }
+            } else {
                 // move cursor backwards into galley text
                 galley_text_range.end()
-            } else {
-                // move cursor forwards into text of next galley
-                galleys[galley_idx + 1].text_range().start()
             }
         } else {
             self

--- a/libs/editor/egui_editor/src/input/advance.rs
+++ b/libs/editor/egui_editor/src/input/advance.rs
@@ -10,6 +10,7 @@ use std::iter;
 use unicode_segmentation::UnicodeSegmentation;
 
 impl DocCharOffset {
+    #[allow(clippy::too_many_arguments)]
     pub fn advance(
         self, maybe_x_target: &mut Option<f32>, offset: Offset, backwards: bool, fix: bool,
         buffer: &SubBuffer, galleys: &Galleys, paragraphs: &Paragraphs,

--- a/libs/editor/egui_editor/src/input/cursor.rs
+++ b/libs/editor/egui_editor/src/input/cursor.rs
@@ -106,6 +106,24 @@ impl Cursor {
             &mut self.x_target,
             offset,
             backwards,
+            true,
+            buffer,
+            galleys,
+            paragraphs,
+        );
+    }
+
+    /// use to put the cursor in a place that's invalid for it to be at the end of the frame e.g. inside captured characters
+    /// use only if you're sure your modifications will leave the cursor in a valid place at the end of the frame
+    pub fn advance_for_edit(
+        &mut self, offset: Offset, backwards: bool, buffer: &SubBuffer, galleys: &Galleys,
+        paragraphs: &Paragraphs,
+    ) {
+        self.selection.1 = self.selection.1.advance(
+            &mut self.x_target,
+            offset,
+            backwards,
+            false,
             buffer,
             galleys,
             paragraphs,

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -624,7 +624,9 @@ pub fn region_to_cursor(
         Region::SelectionOrOffset { offset, backwards } => {
             if current_cursor.selection().is_none() {
                 let mut cursor = current_cursor;
-                cursor.advance(offset, backwards, buffer, galleys, paragraphs);
+                // note: this is only used for backspace
+                // advance_for_edit won't leave the cursor in captured characters if we delete the selected characters
+                cursor.advance_for_edit(offset, backwards, buffer, galleys, paragraphs);
                 cursor.selection.0 = current_cursor.selection.1;
                 cursor
             } else {


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1740

Solution is a bit hacky; I will consider this use case while working on cursor improvements (#1836)