### PR TITLE
egui: fix color contrast on light mode

### DIFF
--- a/clients/egui/src/theme/palette.rs
+++ b/clients/egui/src/theme/palette.rs
@@ -29,7 +29,7 @@ impl ThemePalette {
         red: Color32::from_rgb(255, 59, 48),
         green: Color32::from_rgb(40, 205, 65),
         yellow: Color32::from_rgb(255, 204, 0),
-        blue: Color32::from_rgb(0, 122, 255),
+        blue: Color32::from_rgb(165, 208, 255),
         magenta: Color32::from_rgb(175, 82, 222),
         cyan: Color32::from_rgb(85, 190, 240),
         white: Color32::from_rgb(255, 255, 255),


### PR DESCRIPTION
fixes: #1893 
# Screenshots
before
![image](https://github.com/lockbook/lockbook/assets/66345861/3d27c9d6-2eac-4dcc-923d-49c10d266f3c)

after
![image](https://github.com/lockbook/lockbook/assets/66345861/0e8a6173-042f-447e-88c5-394a970d4e8e)
