### PR TITLE
editor: enhance background color and refine margins

### DIFF
--- a/libs/editor/egui_editor/src/appearance.rs
+++ b/libs/editor/egui_editor/src/appearance.rs
@@ -28,7 +28,8 @@ pub const BROWN: ThemedColor =
     ThemedColor { light: Color32::from_rgb(162, 132, 94), dark: Color32::from_rgb(172, 142, 104) };
 
 // light theme semantics; `GRAY` is closest to `BLACK` and `GRAY_6` is closest to `WHITE`
-pub const BLACK: ThemedColor = ThemedColor { light: Color32::BLACK, dark: Color32::WHITE };
+pub const BLACK: ThemedColor =
+    ThemedColor { light: Color32::from_rgb(18, 18, 18), dark: Color32::from_rgb(240, 240, 240) };
 pub const GRAY: ThemedColor =
     ThemedColor { light: Color32::from_rgb(142, 142, 147), dark: Color32::from_rgb(142, 142, 147) };
 pub const GRAY_2: ThemedColor =
@@ -41,7 +42,8 @@ pub const GRAY_5: ThemedColor =
     ThemedColor { light: Color32::from_rgb(229, 229, 234), dark: Color32::from_rgb(44, 44, 46) };
 pub const GRAY_6: ThemedColor =
     ThemedColor { light: Color32::from_rgb(242, 242, 247), dark: Color32::from_rgb(28, 28, 30) };
-pub const WHITE: ThemedColor = ThemedColor { light: Color32::WHITE, dark: Color32::BLACK };
+pub const WHITE: ThemedColor =
+    ThemedColor { light: Color32::from_rgb(240, 240, 240), dark: Color32::from_rgb(18, 18, 18) };
 
 /// provides a mechanism for the application developer to override colors for dark mode and light
 /// mode and for us to provide defaults

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -116,9 +116,7 @@ impl Default for Editor {
 
 impl Editor {
     pub fn draw(&mut self, ctx: &Context) -> EditorResponse {
-        let fill = if ctx.style().visuals.dark_mode { Color32::BLACK } else { Color32::WHITE };
         egui::CentralPanel::default()
-            .frame(Frame::default().fill(fill))
             .show(ctx, |ui| self.scroll_ui(ui))
             .inner
     }
@@ -169,12 +167,17 @@ impl Editor {
                     }
                 });
 
+                let fill = if ui.style().visuals.dark_mode {
+                    Color32::from_rgb(18, 18, 18)
+                } else {
+                    Color32::WHITE
+                };
+
                 Frame::default()
-                    .inner_margin(Margin::symmetric(
-                        clamp(0.04, 0.1, 0.25, ui.max_rect().width()),
-                        0.0,
-                    ))
-                    .show(ui, |ui| self.ui(ui, id, touch_mode, &events))
+                    .fill(fill)
+                    .outer_margin(egui::Margin::symmetric(7.0, 0.0))
+                    .inner_margin(egui::Margin::symmetric(0.0, 15.0))
+                    .show(ui, |ui| ui.vertical_centered(|ui| self.ui(ui, id, touch_mode, &events)))
             });
         self.ui_rect = sao.inner_rect;
 
@@ -190,7 +193,7 @@ impl Editor {
         self.scroll_area_rect = sao.inner_rect;
         self.scroll_area_offset = sao.state.offset;
 
-        sao.inner.inner
+        sao.inner.inner.inner
     }
 
     fn ui(
@@ -200,6 +203,12 @@ impl Editor {
 
         // update theme
         let theme_updated = self.appearance.set_theme(ui.visuals());
+
+        // clip elements width
+        let max_width = 800.0;
+        if ui.max_rect().width() > max_width {
+            ui.set_max_width(max_width);
+        }
 
         // process events
         let (text_updated, selection_updated) = if self.initialized {

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 use std::mem;
 
 use egui::os::OperatingSystem;
-use egui::{Color32, Context, Event, FontDefinitions, Frame, Margin, Pos2, Rect, Sense, Ui, Vec2};
+use egui::{Color32, Context, Event, FontDefinitions, Frame, Pos2, Rect, Sense, Ui, Vec2};
 
 use crate::appearance::Appearance;
 use crate::ast::Ast;
@@ -451,13 +451,4 @@ impl Editor {
         register_fonts(&mut fonts);
         ctx.set_fonts(fonts);
     }
-}
-
-fn clamp(min: f32, mid: f32, max: f32, viewport_width: f32) -> f32 {
-    if viewport_width > 800.0 {
-        return viewport_width * max;
-    } else if viewport_width < 400.0 {
-        return viewport_width * min;
-    }
-    viewport_width * mid
 }


### PR DESCRIPTION
fixes #1878 
added margin on the top, and decreased margin on medium size screens. 
for colors: i made the editor's background true white and true black. it looks crispier. 
# Screenshots

after
<details>

![image](https://github.com/lockbook/lockbook/assets/66345861/29a98b7f-6cd7-4904-bdad-76144c795cd7)
![image](https://github.com/lockbook/lockbook/assets/66345861/e099164f-bb68-4a28-9e58-ac9ccdca8b8a)
![image](https://github.com/lockbook/lockbook/assets/66345861/b8fe3c56-ae35-466a-987c-1a2f91531f19)

</details>

before
<details>

![image](https://github.com/lockbook/lockbook/assets/66345861/0a92383a-7772-4e76-88fa-d3f4f2cfc01e)
![image](https://github.com/lockbook/lockbook/assets/66345861/54eb2223-d68b-41c1-9004-f9f3eb7c879d)

<details>

