### PR TITLE
editor: ignore alt tab

### DIFF
--- a/libs/editor/egui_editor/src/input/canonical.rs
+++ b/libs/editor/egui_editor/src/input/canonical.rs
@@ -164,7 +164,7 @@ pub fn calc(
         Event::Key { key: Key::Enter, pressed: true, modifiers, .. } => {
             Some(Modification::Newline { advance_cursor: !modifiers.shift })
         }
-        Event::Key { key: Key::Tab, pressed: true, modifiers, .. } => {
+        Event::Key { key: Key::Tab, pressed: true, modifiers, .. } if !modifiers.alt => {
             Some(Modification::Indent { deindent: modifiers.shift })
         }
         Event::Key { key: Key::A, pressed: true, modifiers, .. } if modifiers.command => {


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1910

QA note: Not QA'd because I'm on MacOS and I use command+tab which is working as expected