### PR TITLE
editor: rewrite list item replacement using ast

### DIFF
--- a/libs/editor/egui_editor/src/ast.rs
+++ b/libs/editor/egui_editor/src/ast.rs
@@ -26,6 +26,16 @@ pub struct AstNode {
     pub children: Vec<usize>,
 }
 
+impl AstNode {
+    pub fn head_range(&self) -> (DocCharOffset, DocCharOffset) {
+        (self.range.0, self.text_range.0)
+    }
+
+    pub fn tail_range(&self) -> (DocCharOffset, DocCharOffset) {
+        (self.text_range.1, self.range.1)
+    }
+}
+
 pub fn calc(buffer: &SubBuffer) -> Ast {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
@@ -57,6 +67,14 @@ impl Ast {
         }
 
         chosen
+    }
+
+    pub fn parent(&self, node_idx: usize) -> Option<usize> {
+        self.nodes
+            .iter()
+            .enumerate()
+            .find(|(_, n)| n.children.contains(&node_idx))
+            .map(|(idx, _)| idx)
     }
 
     fn push_children(&mut self, current_idx: usize, iter: &mut OffsetIter, buffer: &SubBuffer) {

--- a/libs/editor/egui_editor/src/input/canonical.rs
+++ b/libs/editor/egui_editor/src/input/canonical.rs
@@ -217,6 +217,21 @@ pub fn calc(
                 style: MarkdownNode::Inline(InlineNode::Strikethrough),
             })
         }
+        Event::Key { key: Key::Num7 , pressed: true, modifiers, .. }
+            if modifiers.command && modifiers.shift =>
+        {
+            Some(Modification::NumberListItem)
+        }
+        Event::Key { key: Key::Num8 , pressed: true, modifiers, .. }
+            if modifiers.command && modifiers.shift =>
+        {
+            Some(Modification::BulletListItem)
+        }
+        Event::Key { key: Key::Num9 , pressed: true, modifiers, .. }
+            if modifiers.command && modifiers.shift =>
+        {
+            Some(Modification::TodoListItem)
+        }
         Event::PointerButton { pos, button: PointerButton::Primary, pressed: true, modifiers }
             if click_checker.ui(*pos) =>
         {

--- a/libs/editor/egui_editor/src/input/canonical.rs
+++ b/libs/editor/egui_editor/src/input/canonical.rs
@@ -217,17 +217,17 @@ pub fn calc(
                 style: MarkdownNode::Inline(InlineNode::Strikethrough),
             })
         }
-        Event::Key { key: Key::Num7 , pressed: true, modifiers, .. }
+        Event::Key { key: Key::Num7, pressed: true, modifiers, .. }
             if modifiers.command && modifiers.shift =>
         {
             Some(Modification::NumberListItem)
         }
-        Event::Key { key: Key::Num8 , pressed: true, modifiers, .. }
+        Event::Key { key: Key::Num8, pressed: true, modifiers, .. }
             if modifiers.command && modifiers.shift =>
         {
             Some(Modification::BulletListItem)
         }
-        Event::Key { key: Key::Num9 , pressed: true, modifiers, .. }
+        Event::Key { key: Key::Num9, pressed: true, modifiers, .. }
             if modifiers.command && modifiers.shift =>
         {
             Some(Modification::TodoListItem)

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -6,7 +6,7 @@ use crate::input::canonical::{Bound, Location, Modification, Offset, Region};
 use crate::input::cursor::Cursor;
 use crate::layouts::Annotation;
 use crate::offset_types::{DocCharOffset, RangeExt};
-use crate::style::{ItemType, MarkdownNode, RenderStyle};
+use crate::style::{ItemType, MarkdownNode, RenderStyle, BlockNode};
 use crate::unicode_segs::UnicodeSegs;
 use egui::Pos2;
 use std::cmp::Ordering;
@@ -405,25 +405,19 @@ pub fn calc(
             let galley = &galleys.galleys[galley_idx];
 
             match &galley.annotation {
-                Some(Annotation::Item(ItemType::Bulleted, _)) => {
+                Some(Annotation::Item(ItemType::Bulleted, ..)) => {
                     list_mutation_replacement(
                         &mut mutation,
-                        buffer,
-                        galleys,
-                        paragraphs,
+                        ast,
                         current_cursor,
-                        ItemType::Bulleted,
                         None,
                     );
                 }
-                Some(Annotation::Item(item_type, _)) => {
+                Some(Annotation::Item(..)) => {
                     list_mutation_replacement(
                         &mut mutation,
-                        buffer,
-                        galleys,
-                        paragraphs,
+                        ast,
                         current_cursor,
-                        *item_type,
                         Some(ItemType::Bulleted),
                     );
                 }
@@ -442,7 +436,7 @@ pub fn calc(
                         ),
                     });
                     mutation
-                        .push(SubMutation::Insert { text: "+ ".to_string(), advance_cursor: true });
+                        .push(SubMutation::Insert { text: ItemType::Bulleted.head().to_string(), advance_cursor: true });
 
                     mutation.push(SubMutation::Cursor { cursor: current_cursor });
                 }
@@ -453,25 +447,19 @@ pub fn calc(
             let galley = &galleys.galleys[galley_idx];
 
             match &galley.annotation {
-                Some(Annotation::Item(ItemType::Numbered(num), _)) => {
+                Some(Annotation::Item(ItemType::Numbered(..), ..)) => {
                     list_mutation_replacement(
                         &mut mutation,
-                        buffer,
-                        galleys,
-                        paragraphs,
+                        ast,
                         current_cursor,
-                        ItemType::Numbered(*num),
                         None,
                     );
                 }
-                Some(Annotation::Item(item_type, _)) => {
+                Some(Annotation::Item(..)) => {
                     list_mutation_replacement(
                         &mut mutation,
-                        buffer,
-                        galleys,
-                        paragraphs,
+                        ast,
                         current_cursor,
-                        *item_type,
                         Some(ItemType::Numbered(1)),
                     );
                 }
@@ -490,7 +478,7 @@ pub fn calc(
                         ),
                     });
                     mutation.push(SubMutation::Insert {
-                        text: "1. ".to_string(),
+                        text: ItemType::Numbered(1).head().to_string(),
                         advance_cursor: true,
                     });
 
@@ -503,25 +491,19 @@ pub fn calc(
             let galley = &galleys.galleys[galley_idx];
 
             match &galley.annotation {
-                Some(Annotation::Item(ItemType::Todo(checked), _)) => {
+                Some(Annotation::Item(ItemType::Todo(..), ..)) => {
                     list_mutation_replacement(
                         &mut mutation,
-                        buffer,
-                        galleys,
-                        paragraphs,
+                        ast,
                         current_cursor,
-                        ItemType::Todo(*checked),
                         None,
                     );
                 }
-                Some(Annotation::Item(item_type, _)) => {
+                Some(Annotation::Item(..)) => {
                     list_mutation_replacement(
                         &mut mutation,
-                        buffer,
-                        galleys,
-                        paragraphs,
+                        ast,
                         current_cursor,
-                        *item_type,
                         Some(ItemType::Todo(false)),
                     );
                 }
@@ -540,7 +522,7 @@ pub fn calc(
                         ),
                     });
                     mutation.push(SubMutation::Insert {
-                        text: "- [ ] ".to_string(),
+                        text: ItemType::Todo(false).head().to_string(),
                         advance_cursor: true,
                     });
 
@@ -758,40 +740,28 @@ fn insert_tail(
 }
 
 fn list_mutation_replacement(
-    mutation: &mut Vec<SubMutation>, buffer: &SubBuffer, galleys: &Galleys,
-    paragraphs: &Paragraphs, current_cursor: Cursor, from: ItemType, to: Option<ItemType>,
+    mutation: &mut Vec<SubMutation>,  ast: &Ast, 
+    current_cursor: Cursor, to: Option<ItemType>,
 ) {
-    let from_size = match from {
-        ItemType::Bulleted => 2,
-        ItemType::Numbered(num) => num.to_string().len() + 2,
-        ItemType::Todo(_) => 6,
-    };
-
-    let to_text = match to {
-        Some(ItemType::Bulleted) => "+ ".to_string(),
-        Some(ItemType::Numbered(num)) => format!("{}. ", num),
-        Some(ItemType::Todo(checked)) => if checked { "- [x] " } else { "- [ ] " }.to_string(),
-        None => "".to_string(),
-    };
-
-    let line_cursor = region_to_cursor(
-        Region::ToOffset {
-            offset: Offset::To(Bound::Line),
-            backwards: true,
-            extend_selection: false,
-        },
-        current_cursor,
-        buffer,
-        galleys,
-        paragraphs,
-    );
-
-    mutation.push(SubMutation::Cursor {
-        cursor: (line_cursor.selection.start() - from_size, line_cursor.selection.start()).into(),
-    });
-
-    mutation.push(SubMutation::Insert { text: to_text, advance_cursor: false });
-    mutation.push(SubMutation::Cursor { cursor: current_cursor });
+    let mut ast_node_idx = ast.ast_node_at_char(current_cursor.selection.1);
+    loop {
+        let ast_node = &ast.nodes[ast_node_idx];
+        if let MarkdownNode::Block(BlockNode::ListItem(..)) = ast_node.node_type {
+            // found a list item
+            let text = to.map(|t| t.head().to_string()).unwrap_or_else(|| "".to_string());
+            mutation.push(SubMutation::Cursor { cursor: ast_node.head_range().into() });
+            mutation.push(SubMutation::Insert { text, advance_cursor: true });
+            mutation.push(SubMutation::Cursor { cursor: current_cursor });
+            
+            break;
+        } else if let Some(parent_node_idx) = ast.parent(ast_node_idx) {
+            // check other ast nodes we're in
+            ast_node_idx = parent_node_idx;
+        } else {
+            // not in a list item
+            break;
+        }
+    }
 }
 
 pub fn region_to_cursor(

--- a/libs/editor/egui_editor/src/style.rs
+++ b/libs/editor/egui_editor/src/style.rs
@@ -81,6 +81,17 @@ pub enum ItemType {
     Todo(bool),
 }
 
+impl ItemType {
+    pub fn head(&self) -> &'static str {
+        match self {
+            ItemType::Bulleted => "- ",
+            ItemType::Numbered(_) => "1. ", // todo: support other numbers
+            ItemType::Todo(true) => "- [x] ",
+            ItemType::Todo(false) => "- [ ] ",
+        }
+    }
+}
+
 // Ignore inner values in enum variant comparison
 // Note: you need to remember to incorporate new variants here!
 impl PartialEq for ItemType {
@@ -178,9 +189,7 @@ impl MarkdownNode {
             Self::Block(BlockNode::Code) => {
                 unimplemented!()
             }
-            Self::Block(BlockNode::ListItem(..)) => {
-                unimplemented!()
-            }
+            Self::Block(BlockNode::ListItem(item_type, ..)) => item_type.head(), // todo: support indentation
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1872

also fixes an issue where cursor is in wrong place after replacing a list item of one type with that of another

also adds hotkeys for list items