### PR TITLE
editor: bounds refactor

### DIFF
--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -355,7 +355,7 @@ pub unsafe extern "C" fn position_offset_in_direction(
 
     let offset_type =
         if matches!(direction, CTextLayoutDirection::Right | CTextLayoutDirection::Left) {
-            Offset::By(Increment::Char)
+            Offset::Next(Bound::Char)
         } else {
             Offset::By(Increment::Line)
         };
@@ -363,7 +363,7 @@ pub unsafe extern "C" fn position_offset_in_direction(
 
     let mut cursor: Cursor = start.pos.into();
     for _ in 0..offset {
-        cursor.advance(offset_type, backwards, buffer, galleys, &obj.editor.paragraphs);
+        cursor.advance(offset_type, backwards, buffer, galleys, &obj.editor.bounds);
     }
     CTextPosition { none: start.none, pos: cursor.selection.1 .0 }
 }
@@ -390,8 +390,8 @@ pub unsafe extern "C" fn is_position_at_bound(
         CTextGranularity::Line => Bound::Line,
         CTextGranularity::Document => Bound::Doc,
     };
-    cursor.advance(Offset::To(bound), !backwards, buffer, galleys, &obj.editor.paragraphs);
-    cursor.advance(Offset::To(bound), backwards, buffer, galleys, &obj.editor.paragraphs);
+    cursor.advance(Offset::To(bound), !backwards, buffer, galleys, &obj.editor.bounds);
+    cursor.advance(Offset::To(bound), backwards, buffer, galleys, &obj.editor.bounds);
 
     cursor.selection.1 == pos.pos
 }
@@ -428,7 +428,7 @@ pub unsafe extern "C" fn bound_from_position(
         CTextGranularity::Line => Bound::Line,
         CTextGranularity::Document => Bound::Doc,
     };
-    cursor.advance(Offset::To(bound), backwards, buffer, galleys, &obj.editor.paragraphs);
+    cursor.advance(Offset::To(bound), backwards, buffer, galleys, &obj.editor.bounds);
 
     CTextPosition { none: false, pos: cursor.selection.1 .0 }
 }
@@ -458,7 +458,7 @@ pub unsafe extern "C" fn bound_at_position(
         buffer.cursor,
         buffer,
         galleys,
-        &obj.editor.paragraphs,
+        &obj.editor.bounds,
     );
 
     CTextRange {
@@ -483,7 +483,7 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
         let selection_start = range.start();
         let selection_end = range.end();
         let mut cursor: Cursor = selection_start.into();
-        cursor.advance(Offset::To(Bound::Line), false, buffer, galleys, &obj.editor.paragraphs);
+        cursor.advance(Offset::To(Bound::Line), false, buffer, galleys, &obj.editor.bounds);
         let end_of_selection_start_line = cursor.selection.1;
         let end_of_rect = cmp::min(selection_end, end_of_selection_start_line);
         (selection_start, end_of_rect).into()

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -416,6 +416,7 @@ pub unsafe extern "C" fn is_position_within_bound(
         CTextGranularity::Document => Bound::Doc,
     };
     if let Some(range) = pos.range_bound(bound, backwards, false, &obj.editor.bounds) {
+        // this implementation doesn't meet the specification in apple's docs, but the implementation that does creates word jumping bugs
         if range.contains(pos) {
             return true;
         }

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -377,12 +377,8 @@ pub unsafe extern "C" fn is_position_at_bound(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> bool {
     let obj = &mut *(obj as *mut WgpuEditor);
-    let buffer = &obj.editor.buffer.current;
-    let galleys = &obj.editor.galleys;
 
-    // if advancing the cursor then advancing it back leaves it in the original position, it's at a bound
-    let mut cursor: Cursor = pos.pos.into();
-    let bound = match granularity {
+    let bound: Bound = match granularity {
         CTextGranularity::Character => Bound::Char,
         CTextGranularity::Word => Bound::Word,
         CTextGranularity::Sentence => Bound::Paragraph, // note: sentence handled as paragraph
@@ -390,10 +386,14 @@ pub unsafe extern "C" fn is_position_at_bound(
         CTextGranularity::Line => Bound::Line,
         CTextGranularity::Document => Bound::Doc,
     };
-    cursor.advance(Offset::To(bound), !backwards, buffer, galleys, &obj.editor.bounds);
-    cursor.advance(Offset::To(bound), backwards, buffer, galleys, &obj.editor.bounds);
-
-    cursor.selection.1 == pos.pos
+    if let Some(range) =
+        DocCharOffset(pos.pos).range_bound(bound, backwards, false, &obj.editor.bounds)
+    {
+        if !backwards && pos.pos == range.0 || backwards && pos.pos == range.1 {
+            return true;
+        }
+    }
+    false
 }
 
 /// # Safety
@@ -402,15 +402,31 @@ pub unsafe extern "C" fn is_position_at_bound(
 /// https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614491-isposition
 #[no_mangle]
 pub unsafe extern "C" fn is_position_within_bound(
-    _obj: *mut c_void, _pos: CTextPosition, _granularity: CTextGranularity, _backwards: bool,
+    obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> bool {
-    true // aren't we always within a bound of each type?
+    let obj = &mut *(obj as *mut WgpuEditor);
+    let pos: DocCharOffset = pos.pos.into();
+
+    let bound = match granularity {
+        CTextGranularity::Character => Bound::Char,
+        CTextGranularity::Word => Bound::Word,
+        CTextGranularity::Sentence => Bound::Paragraph, // note: sentence handled as paragraph
+        CTextGranularity::Paragraph => Bound::Paragraph,
+        CTextGranularity::Line => Bound::Line,
+        CTextGranularity::Document => Bound::Doc,
+    };
+    if let Some(range) = pos.range_bound(bound, backwards, false, &obj.editor.bounds) {
+        if range.contains(pos) {
+            return true;
+        }
+    }
+    false
 }
 
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 ///
-/// https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614491-isposition
+/// https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614513-position
 #[no_mangle]
 pub unsafe extern "C" fn bound_from_position(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
@@ -428,7 +444,7 @@ pub unsafe extern "C" fn bound_from_position(
         CTextGranularity::Line => Bound::Line,
         CTextGranularity::Document => Bound::Doc,
     };
-    cursor.advance(Offset::To(bound), backwards, buffer, galleys, &obj.editor.bounds);
+    cursor.advance(Offset::Next(bound), backwards, buffer, galleys, &obj.editor.bounds);
 
     CTextPosition { none: false, pos: cursor.selection.1 .0 }
 }

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -1,13 +1,28 @@
 use crate::ast::{Ast, AstTextRangeType};
 use crate::buffer::SubBuffer;
-use crate::offset_types::{DocByteOffset, DocCharOffset, RelByteOffset};
+use crate::galleys::Galleys;
+use crate::input::canonical::Bound;
+use crate::offset_types::{DocByteOffset, DocCharOffset, RangeExt, RelByteOffset};
 use crate::Editor;
+use egui::epaint::text::cursor::RCursor;
 use std::collections::HashSet;
 use unicode_segmentation::UnicodeSegmentation;
 
-#[derive(Default)]
-pub struct Words {
-    pub words: Vec<(DocCharOffset, DocCharOffset)>,
+type Words = Vec<(DocCharOffset, DocCharOffset)>;
+type Lines = Vec<(DocCharOffset, DocCharOffset)>;
+type Paragraphs = Vec<(DocCharOffset, DocCharOffset)>;
+
+/// Represents bounds of various text regions in the buffer. Region bounds are inclusive on both sides. Regions do not
+/// overlap, have region.0 <= region.1, and are sorted. Character and doc regions are not stored explicitly but can be
+/// inferred from the other regions.
+#[derive(Debug, Default)]
+pub struct Bounds {
+    pub words: Words,
+    pub lines: Lines,
+
+    /// Paragraphs consist of all rendered text, excluding the newlines that usually delimit them. Every valid cursor
+    /// position is in some possibly-empty paragraph (inclusive of start/end).
+    pub paragraphs: Paragraphs,
 }
 
 pub fn calc_words(buffer: &SubBuffer, ast: &Ast) -> Words {
@@ -38,25 +53,24 @@ pub fn calc_words(buffer: &SubBuffer, ast: &Ast) -> Words {
         }
     }
 
-    Words { words: result }
+    result
 }
 
-impl Editor {
-    pub fn print_words(&self) {
-        println!(
-            "words: {:?}",
-            self.words
-                .words
-                .iter()
-                .map(|&range| self.buffer.current[range].to_string())
-                .collect::<Vec<_>>()
-        );
+pub fn calc_lines(galleys: &Galleys) -> Lines {
+    let mut result = vec![];
+    let galleys = galleys;
+    for (galley_idx, galley) in galleys.galleys.iter().enumerate() {
+        let galley = &galley.galley;
+        for (row_idx, _) in galley.rows.iter().enumerate() {
+            let start_cursor = galley.from_rcursor(RCursor { row: row_idx, column: 0 });
+            let row_start = galleys.char_offset_by_galley_and_cursor(galley_idx, &start_cursor);
+            let end_cursor = galley.cursor_end_of_row(&start_cursor);
+            let row_end = galleys.char_offset_by_galley_and_cursor(galley_idx, &end_cursor);
+            result.push((row_start, row_end))
+        }
     }
-}
 
-#[derive(Default)]
-pub struct Paragraphs {
-    pub paragraphs: Vec<(DocCharOffset, DocCharOffset)>,
+    result
 }
 
 pub fn calc_paragraphs(buffer: &SubBuffer, ast: &Ast) -> Paragraphs {
@@ -96,18 +110,1633 @@ pub fn calc_paragraphs(buffer: &SubBuffer, ast: &Ast) -> Paragraphs {
         prev_char_offset = char_offset + 1 // skip the matched newline;
     }
 
-    Paragraphs { paragraphs: result }
+    result
+}
+
+impl Bounds {
+    /// Returns the range with start < char_offset <= end, or None if there's no such range.
+    fn range_before(
+        ranges: &[(DocCharOffset, DocCharOffset)], char_offset: DocCharOffset,
+    ) -> Option<usize> {
+        ranges
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, &range)| range.start() < char_offset)
+            .map(|(idx, _)| idx)
+    }
+
+    /// Returns the range with start <= char_offset < end, or None if there's no such range.
+    fn range_after(
+        ranges: &[(DocCharOffset, DocCharOffset)], char_offset: DocCharOffset,
+    ) -> Option<usize> {
+        ranges
+            .iter()
+            .enumerate()
+            .find(|(_, &range)| char_offset < range.end())
+            .map(|(idx, _)| idx)
+    }
+}
+
+impl DocCharOffset {
+    /// Returns the start or end of the range in the direction of `backwards` from offset `self`. If `jump` is true,
+    /// `self` will not be at the boundary of the result in the direction of `backwards` (e.g. alt+left/right),
+    /// otherwise it will be (e.g. cmd+left/right). For instance, if `jump` is true, advancing beyond the first or last
+    /// range in the doc will return None, otherwise it will return the first or last range in the doc.
+    fn range_bound(
+        self, bound: Bound, backwards: bool, jump: bool, bounds: &Bounds,
+    ) -> Option<(Self, Self)> {
+        let ranges = match bound {
+            Bound::Char => {
+                return self.range_bound_char(backwards, jump, bounds);
+            }
+            Bound::Word => &bounds.words,
+            Bound::Line => &bounds.lines,
+            Bound::Paragraph => &bounds.paragraphs,
+            Bound::Doc => {
+                return Some((
+                    bounds
+                        .paragraphs
+                        .first()
+                        .map(|(start, _)| *start)
+                        .unwrap_or(DocCharOffset(0)),
+                    bounds
+                        .paragraphs
+                        .last()
+                        .map(|(_, end)| *end)
+                        .unwrap_or(DocCharOffset(0)),
+                ));
+            }
+        };
+
+        let range_before = Bounds::range_before(ranges, self);
+        let range_after = Bounds::range_after(ranges, self);
+
+        if jump {
+            if backwards {
+                range_before.map(|range_before| ranges[range_before])
+            } else {
+                range_after.map(|range_after| ranges[range_after])
+            }
+        } else {
+            match (range_before, range_after) {
+                // there are no ranges
+                (None, None) => None,
+                // before or at the start of the first range
+                (None, Some(_)) => {
+                    let first_range = ranges[0];
+                    if self < first_range.start() {
+                        // a cursor before the first range is considered at the start of the first range
+                        first_range
+                            .start()
+                            .range_bound(bound, backwards, jump, bounds)
+                    } else {
+                        // self == first_range.start() because otherwise we'd have a range before
+                        if backwards && jump {
+                            // jump backwards off the edge from the start of the first range
+                            None
+                        } else {
+                            // first range
+                            Some(first_range)
+                        }
+                    }
+                }
+                // after or at the end of the last range
+                (Some(_), None) => {
+                    let last_range = ranges[ranges.len() - 1];
+                    if self > last_range.end() {
+                        // a cursor after the last range is considered at the end of the last range
+                        last_range.end().range_bound(bound, backwards, jump, bounds)
+                    } else {
+                        // self == last_range.end() because otherwise we'd have a range after
+                        if !backwards && jump {
+                            // jump forwards off the edge from the end of the last range
+                            None
+                        } else {
+                            // last range
+                            Some(last_range)
+                        }
+                    }
+                }
+                // inside a range (not at bounds)
+                (Some(range_before), Some(range_after)) if range_before == range_after => {
+                    Some(ranges[range_before])
+                }
+                // at range bounds or between ranges
+                (Some(range_before_idx), Some(range_after_idx)) => {
+                    let range_before = ranges[range_before_idx];
+                    let range_after = ranges[range_after_idx];
+                    if range_before_idx + 1 != range_after_idx {
+                        // in an empty range
+                        Some((self, self))
+                    } else if range_before.end() == range_after.start() {
+                        // at bounds of two nonempty ranges
+                        // range is nonempty because ranges cannot both be empty and touch a range before/after
+                        if backwards {
+                            Some(range_before)
+                        } else {
+                            Some(range_after)
+                        }
+                    } else if self == range_before.end() {
+                        // at end of range before
+                        // range before is nonempty because Bounds::range_before does not consider the range (offset, offset) to be before offset
+                        Some(range_before)
+                    } else if self == range_after.start() {
+                        // at start of range after
+                        // range after is nonempty because Bounds::range_after does not consider the range (offset, offset) to be after offset
+                        Some(range_after)
+                    } else {
+                        // between ranges
+                        if backwards {
+                            Some(range_before)
+                        } else {
+                            Some(range_after)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns the range in the direction of `backwards` from offset `self` representing a single character. If a
+    /// range is returned, it's either a single character in a paragraph or a nonempty range between paragraphs. If
+    /// `jump` is true, advancing beyond the first or last character in the doc will return None, otherwise it will
+    /// return the first or last character in the doc.
+    fn range_bound_char(
+        self, backwards: bool, jump: bool, bounds: &Bounds,
+    ) -> Option<(Self, Self)> {
+        let paragraph_before = Bounds::range_before(&bounds.paragraphs, self);
+        let paragraph_after = Bounds::range_after(&bounds.paragraphs, self);
+
+        match (paragraph_before, paragraph_after) {
+            // there are no paragraphs
+            (None, None) => None,
+            // before or at start of the first paragraph
+            (None, Some(paragraph_after)) => {
+                let first_paragraph = bounds.paragraphs[0];
+                let paragraph_after = bounds.paragraphs[paragraph_after];
+                if self < first_paragraph.start() {
+                    // a cursor before the first paragraph is considered at the start of the first paragraph
+                    first_paragraph
+                        .start()
+                        .range_bound_char(backwards, jump, bounds)
+                } else {
+                    // self == first_paragraph.start() because otherwise we'd have a paragraph before
+                    if backwards && jump {
+                        // jump backwards off the edge from the start of the first paragraph
+                        None
+                    } else if first_paragraph.is_empty() {
+                        // nonempty range between paragraphs
+                        // paragraph after is not first_paragraph because Bounds::range_after does not consider the range (offset, offset) to be after offset
+                        // range is nonempty because paragraphs cannot both be empty and touch a paragraph before/after
+                        Some((first_paragraph.start(), paragraph_after.start()))
+                    } else {
+                        // first character of the first paragraph
+                        Some((first_paragraph.start(), first_paragraph.start() + 1))
+                    }
+                }
+            }
+            // after or at end of the last paragraph
+            (Some(paragraph_before), None) => {
+                let last_paragraph = bounds.paragraphs[bounds.paragraphs.len() - 1];
+                let paragraph_before = bounds.paragraphs[paragraph_before];
+                if self > last_paragraph.end() {
+                    // a cursor after the last paragraph is considered at the end of the last paragraph
+                    last_paragraph
+                        .end()
+                        .range_bound_char(backwards, jump, bounds)
+                } else {
+                    // self == last_paragraph.end() because otherwise we'd have a paragraph after
+                    if !backwards && jump {
+                        // jump forwards off the edge from the end of the last paragraph
+                        None
+                    } else if last_paragraph.is_empty() {
+                        // nonempty range between paragraphs
+                        // paragraph before is not last_paragraph because Bounds::range_before does not consider the range (offset, offset) to be before offset
+                        // range is nonempty because paragraphs cannot both be empty and touch a paragraph before/after
+                        Some((paragraph_before.end(), last_paragraph.end()))
+                    } else {
+                        // last character of the last paragraph
+                        Some((last_paragraph.end() - 1, last_paragraph.end()))
+                    }
+                }
+            }
+            // inside a paragraph (not at bounds)
+            (Some(paragraph_before), Some(paragraph_after))
+                if paragraph_before == paragraph_after =>
+            {
+                if backwards {
+                    Some((self - 1, self))
+                } else {
+                    Some((self, self + 1))
+                }
+            }
+            // at paragraph bounds or between paragraphs
+            (Some(paragraph_before_idx), Some(paragraph_after_idx)) => {
+                let paragraph_before = bounds.paragraphs[paragraph_before_idx];
+                let paragraph_after = bounds.paragraphs[paragraph_after_idx];
+                if paragraph_before_idx + 1 != paragraph_after_idx {
+                    // in an empty paragraph
+                    if backwards {
+                        Some((paragraph_before.end(), self))
+                    } else {
+                        Some((self, paragraph_after.start()))
+                    }
+                } else if paragraph_before.end() == paragraph_after.start() {
+                    // at bounds of two nonempty paragraphs
+                    // paragraph is nonempty because paragraphs cannot both be empty and touch a paragraph before/after
+                    if backwards {
+                        Some((self - 1, self))
+                    } else {
+                        Some((self, self + 1))
+                    }
+                } else if self == paragraph_before.end() {
+                    // at end of paragraph before
+                    // paragraph before is nonempty because Bounds::range_before does not consider the range (offset, offset) to be before offset
+                    if backwards {
+                        Some((self - 1, self))
+                    } else {
+                        Some((self, paragraph_after.start()))
+                    }
+                } else if self == paragraph_after.start() {
+                    // at start of paragraph after
+                    // paragraph after is nonempty because Bounds::range_after does not consider the range (offset, offset) to be after offset
+                    if backwards {
+                        Some((paragraph_before.end(), self))
+                    } else {
+                        Some((self, self + 1))
+                    }
+                } else {
+                    // between paragraphs
+                    Some((paragraph_before.end(), paragraph_after.start()))
+                }
+            }
+        }
+    }
+
+    fn advance_bound(self, bound: Bound, backwards: bool, jump: bool, bounds: &Bounds) -> Self {
+        if let Some(range) = self.range_bound(bound, backwards, jump, bounds) {
+            if backwards {
+                range.start()
+            } else {
+                range.end()
+            }
+        } else if bounds.paragraphs.len() > 0 {
+            if backwards {
+                bounds.paragraphs[0].start()
+            } else {
+                bounds.paragraphs[bounds.paragraphs.len() - 1].end()
+            }
+        } else {
+            self
+        }
+    }
+
+    /// Advances to a bound in a direction, stopping at the bound (e.g. cmd+left/right). If you're beyond the furthest
+    /// bound, this snaps you into it, even if that moves you in the opposite direction.
+    pub fn advance_to_bound(self, bound: Bound, backwards: bool, bounds: &Bounds) -> Self {
+        self.advance_bound(bound, backwards, false, bounds)
+    }
+
+    /// Advances to a bound in a direction, jumping to the next bound if already at one (e.g. alt+left/right). If
+    /// you're beyond the furthest bound, this snaps you into it, even if that moves you in the opposite direction.
+    pub fn advance_to_next_bound(self, bound: Bound, backwards: bool, bounds: &Bounds) -> Self {
+        self.advance_bound(bound, backwards, true, bounds)
+    }
 }
 
 impl Editor {
-    pub fn print_paragraphs(&self) {
-        println!(
-            "paragraphs: {:?}",
-            self.paragraphs
-                .paragraphs
-                .iter()
-                .map(|&range| self.buffer.current[range].to_string())
-                .collect::<Vec<_>>()
+    pub fn print_bounds(&self) {
+        println!("words: {:?}", self.ranges_text(&self.bounds.words));
+        println!("lines: {:?}", self.ranges_text(&self.bounds.lines));
+        println!("paragraphs: {:?}", self.ranges_text(&self.bounds.paragraphs));
+    }
+
+    fn ranges_text(&self, ranges: &[(DocCharOffset, DocCharOffset)]) -> Vec<String> {
+        ranges
+            .iter()
+            .map(|&range| self.buffer.current[range].to_string())
+            .collect::<Vec<_>>()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{input::canonical::Bound, offset_types::DocCharOffset};
+
+    use super::Bounds;
+
+    #[test]
+    fn range_before_after_no_ranges() {
+        let ranges = [];
+
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(0)), None);
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(0)), None);
+    }
+
+    #[test]
+    fn range_before_after_disjoint() {
+        let ranges = [(1, 3), (5, 7), (9, 11)]
+            .into_iter()
+            .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+            .collect::<Vec<_>>();
+
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(0)), None);
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(1)), None);
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(2)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(3)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(4)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(5)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(6)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(7)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(8)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(9)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(10)), Some(2));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(11)), Some(2));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(12)), Some(2));
+
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(0)), Some(0));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(1)), Some(0));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(2)), Some(0));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(3)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(4)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(5)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(6)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(7)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(8)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(9)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(10)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(11)), None);
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(12)), None);
+    }
+
+    #[test]
+    fn range_before_after_contiguous() {
+        let ranges = [(1, 3), (3, 5), (5, 7)]
+            .into_iter()
+            .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+            .collect::<Vec<_>>();
+
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(0)), None);
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(1)), None);
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(2)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(3)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(4)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(5)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(6)), Some(2));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(7)), Some(2));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(8)), Some(2));
+
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(0)), Some(0));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(1)), Some(0));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(2)), Some(0));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(3)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(4)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(5)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(6)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(7)), None);
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(8)), None);
+    }
+
+    #[test]
+    fn range_before_after_empty_ranges() {
+        let ranges = [(1, 1), (3, 3), (5, 5)]
+            .into_iter()
+            .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+            .collect::<Vec<_>>();
+
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(0)), None);
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(1)), None);
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(2)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(3)), Some(0));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(4)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(5)), Some(1));
+        assert_eq!(Bounds::range_before(&ranges, DocCharOffset(6)), Some(2));
+
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(0)), Some(0));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(1)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(2)), Some(1));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(3)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(4)), Some(2));
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(5)), None);
+        assert_eq!(Bounds::range_after(&ranges, DocCharOffset(6)), None);
+    }
+
+    #[test]
+    fn range_bound_no_ranges() {
+        let bounds = Bounds::default();
+        assert_eq!(DocCharOffset(0).range_bound(Bound::Word, false, false, &bounds), None);
+        assert_eq!(DocCharOffset(0).range_bound(Bound::Word, true, false, &bounds), None);
+        assert_eq!(DocCharOffset(0).range_bound(Bound::Word, false, true, &bounds), None);
+        assert_eq!(DocCharOffset(0).range_bound(Bound::Word, true, true, &bounds), None);
+    }
+
+    #[test]
+    fn range_bound_disjoint() {
+        let words: Vec<(DocCharOffset, DocCharOffset)> = vec![(1, 3), (5, 7), (9, 11)]
+            .into_iter()
+            .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+            .collect();
+        let bounds = Bounds { words, ..Default::default() };
+
+        assert_eq!(
+            DocCharOffset(0).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(11).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(12).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+
+        assert_eq!(
+            DocCharOffset(0).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(11).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(12).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+
+        assert_eq!(
+            DocCharOffset(0).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(DocCharOffset(11).range_bound(Bound::Word, false, true, &bounds), None);
+        assert_eq!(DocCharOffset(12).range_bound(Bound::Word, false, true, &bounds), None);
+
+        assert_eq!(DocCharOffset(0).range_bound(Bound::Word, true, true, &bounds), None);
+        assert_eq!(DocCharOffset(1).range_bound(Bound::Word, true, true, &bounds), None);
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(11).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(12).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(11)))
+        );
+    }
+
+    #[test]
+    fn range_bound_contiguous() {
+        let words: Vec<(DocCharOffset, DocCharOffset)> = vec![(1, 3), (3, 5), (5, 7)]
+            .into_iter()
+            .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+            .collect();
+        let bounds = Bounds { words, ..Default::default() };
+
+        assert_eq!(
+            DocCharOffset(0).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound(Bound::Word, false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+
+        assert_eq!(
+            DocCharOffset(0).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound(Bound::Word, true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+
+        assert_eq!(
+            DocCharOffset(0).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, false, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(DocCharOffset(7).range_bound(Bound::Word, false, true, &bounds), None);
+        assert_eq!(DocCharOffset(8).range_bound(Bound::Word, false, true, &bounds), None);
+
+        assert_eq!(DocCharOffset(0).range_bound(Bound::Word, true, true, &bounds), None);
+        assert_eq!(DocCharOffset(1).range_bound(Bound::Word, true, true, &bounds), None);
+        assert_eq!(
+            DocCharOffset(2).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound(Bound::Word, true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(7)))
+        );
+    }
+
+    #[test]
+    fn advance_to_bound_no_ranges() {
+        let bounds = Bounds { words: vec![], ..Default::default() };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(0)
+        );
+        assert_eq!(DocCharOffset(0).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(0));
+    }
+
+    #[test]
+    fn advance_to_bound_disjoint() {
+        let words: Vec<(DocCharOffset, DocCharOffset)> = vec![(1, 3), (5, 7), (9, 11)]
+            .into_iter()
+            .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+            .collect();
+        let bounds = Bounds { words, ..Default::default() };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(9).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(10).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(11).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(12).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+
+        assert_eq!(DocCharOffset(0).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(1).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(2).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(3).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(4).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(5).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(5));
+        assert_eq!(DocCharOffset(6).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(5));
+        assert_eq!(DocCharOffset(7).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(5));
+        assert_eq!(DocCharOffset(8).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(5));
+        assert_eq!(DocCharOffset(9).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(9));
+        assert_eq!(
+            DocCharOffset(10).advance_to_bound(Bound::Word, true, &bounds),
+            DocCharOffset(9)
+        );
+        assert_eq!(
+            DocCharOffset(11).advance_to_bound(Bound::Word, true, &bounds),
+            DocCharOffset(9)
+        );
+        assert_eq!(
+            DocCharOffset(12).advance_to_bound(Bound::Word, true, &bounds),
+            DocCharOffset(9)
+        );
+    }
+
+    #[test]
+    fn advance_to_bound_contiguous() {
+        let words: Vec<(DocCharOffset, DocCharOffset)> = vec![(1, 3), (3, 5), (5, 7)]
+            .into_iter()
+            .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+            .collect();
+        let bounds = Bounds { words, ..Default::default() };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+
+        assert_eq!(DocCharOffset(0).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(1).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(2).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(3).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(1));
+        assert_eq!(DocCharOffset(4).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(3));
+        assert_eq!(DocCharOffset(5).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(3));
+        assert_eq!(DocCharOffset(6).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(5));
+        assert_eq!(DocCharOffset(7).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(5));
+        assert_eq!(DocCharOffset(8).advance_to_bound(Bound::Word, true, &bounds), DocCharOffset(5));
+    }
+
+    #[test]
+    fn advance_to_bound_empty_ranges() {
+        let bounds = Bounds {
+            words: vec![(1, 3), (5, 5), (7, 7), (9, 11)]
+                .into_iter()
+                .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(9).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(10).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(11).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(12).advance_to_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+    }
+
+    #[test]
+    fn advance_to_next_bound_no_ranges() {
+        let bounds = Bounds::default();
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(0)
+        );
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(0)
+        );
+    }
+
+    #[test]
+    fn advance_to_next_bound_disjoint() {
+        let bounds = Bounds {
+            words: vec![(1, 3), (5, 7), (9, 11)]
+                .into_iter()
+                .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(9).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(10).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(11).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(12).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(12)
+        );
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(0)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(9).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(10).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(9)
+        );
+        assert_eq!(
+            DocCharOffset(11).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(9)
+        );
+        assert_eq!(
+            DocCharOffset(12).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(9)
+        );
+    }
+
+    #[test]
+    fn advance_to_next_bound_contiguous() {
+        let bounds = Bounds {
+            words: vec![(1, 3), (3, 5), (5, 7)]
+                .into_iter()
+                .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Word, false, &bounds),
+            DocCharOffset(8)
+        );
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(0)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Word, true, &bounds),
+            DocCharOffset(5)
+        );
+    }
+
+    #[test]
+    fn range_bound_char_no_ranges() {
+        let bounds = Bounds::default();
+
+        assert_eq!(DocCharOffset(0).range_bound_char(false, false, &bounds), None);
+        assert_eq!(DocCharOffset(0).range_bound_char(true, false, &bounds), None);
+        assert_eq!(DocCharOffset(0).range_bound_char(false, true, &bounds), None);
+        assert_eq!(DocCharOffset(0).range_bound_char(true, true, &bounds), None);
+    }
+
+    #[test]
+    fn range_bound_char_disjoint() {
+        let bounds = Bounds {
+            paragraphs: vec![(1, 3), (5, 7), (9, 11)]
+                .into_iter()
+                .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DocCharOffset(0).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(2), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(6)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(6), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(10)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(11).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(12).range_bound_char(false, false, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+
+        assert_eq!(
+            DocCharOffset(0).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(2), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(6)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(6), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(10)))
+        );
+        assert_eq!(
+            DocCharOffset(11).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(12).range_bound_char(true, false, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+
+        assert_eq!(
+            DocCharOffset(0).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(1).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(2).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(2), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(6)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(6), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(10)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound_char(false, true, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+        assert_eq!(DocCharOffset(11).range_bound_char(false, true, &bounds), None);
+        assert_eq!(DocCharOffset(12).range_bound_char(false, true, &bounds), None);
+
+        assert_eq!(DocCharOffset(0).range_bound_char(true, true, &bounds), None);
+        assert_eq!(DocCharOffset(1).range_bound_char(true, true, &bounds), None);
+        assert_eq!(
+            DocCharOffset(2).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(1), DocCharOffset(2)))
+        );
+        assert_eq!(
+            DocCharOffset(3).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(2), DocCharOffset(3)))
+        );
+        assert_eq!(
+            DocCharOffset(4).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(5).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(3), DocCharOffset(5)))
+        );
+        assert_eq!(
+            DocCharOffset(6).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(5), DocCharOffset(6)))
+        );
+        assert_eq!(
+            DocCharOffset(7).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(6), DocCharOffset(7)))
+        );
+        assert_eq!(
+            DocCharOffset(8).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(9).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(7), DocCharOffset(9)))
+        );
+        assert_eq!(
+            DocCharOffset(10).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(9), DocCharOffset(10)))
+        );
+        assert_eq!(
+            DocCharOffset(11).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+        assert_eq!(
+            DocCharOffset(12).range_bound_char(true, true, &bounds),
+            Some((DocCharOffset(10), DocCharOffset(11)))
+        );
+    }
+
+    #[test]
+    fn advance_to_next_bound_disjoint_char() {
+        let bounds = Bounds {
+            paragraphs: vec![(1, 3), (5, 7), (9, 11)]
+                .into_iter()
+                .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(2)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(2)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(6)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(9)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(9)
+        );
+        assert_eq!(
+            DocCharOffset(9).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(10)
+        );
+        assert_eq!(
+            DocCharOffset(10).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(11).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(11)
+        );
+        assert_eq!(
+            DocCharOffset(12).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(11)
+        );
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(2)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(6)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(9).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(10).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(9)
+        );
+        assert_eq!(
+            DocCharOffset(11).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(10)
+        );
+        assert_eq!(
+            DocCharOffset(12).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(10)
+        );
+    }
+
+    #[test]
+    fn advance_to_next_bound_contiguous_char() {
+        let bounds = Bounds {
+            paragraphs: vec![(1, 3), (3, 5), (5, 7)]
+                .into_iter()
+                .map(|(start, end)| (DocCharOffset(start), DocCharOffset(end)))
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(2)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(2)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(4)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(6)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(7)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Char, false, &bounds),
+            DocCharOffset(7)
+        );
+
+        assert_eq!(
+            DocCharOffset(0).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(1).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(2).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(1)
+        );
+        assert_eq!(
+            DocCharOffset(3).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(2)
+        );
+        assert_eq!(
+            DocCharOffset(4).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(3)
+        );
+        assert_eq!(
+            DocCharOffset(5).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(4)
+        );
+        assert_eq!(
+            DocCharOffset(6).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(5)
+        );
+        assert_eq!(
+            DocCharOffset(7).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(6)
+        );
+        assert_eq!(
+            DocCharOffset(8).advance_to_next_bound(Bound::Char, true, &bounds),
+            DocCharOffset(6)
         );
     }
 }

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -21,7 +21,7 @@ pub struct Bounds {
     pub lines: Lines,
 
     /// Paragraphs consist of all rendered text, excluding the newlines that usually delimit them. Every valid cursor
-    /// position is in some possibly-empty paragraph (inclusive of start/end).
+    /// position is in some possibly-empty paragraph.
     pub paragraphs: Paragraphs,
 }
 

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -141,7 +141,7 @@ impl Bounds {
     }
 }
 
-enum BoundCase {
+pub enum BoundCase {
     // |
     NoRanges,
     // |xx yy
@@ -194,10 +194,10 @@ enum BoundCase {
 }
 
 impl DocCharOffset {
-    /// Returns the start or end of the range in the direction of `backwards` from offset `self`. If `jump` is true,
-    /// `self` will not be at the boundary of the result in the direction of `backwards` (e.g. alt+left/right),
-    /// otherwise it will be (e.g. cmd+left/right). For instance, if `jump` is true, advancing beyond the first or last
-    /// range in the doc will return None, otherwise it will return the first or last range in the doc.
+    /// Returns the range in the direction of `backwards` from offset `self`. If `jump` is true, `self` will not be at
+    /// the boundary of the result in the direction of `backwards` (e.g. alt+left/right), otherwise it will be (e.g.
+    /// cmd+left/right). For instance, if `jump` is true, advancing beyond the first or last range in the doc will
+    /// return None, otherwise it will return the first or last range in the doc.
     pub fn range_bound(
         self, bound: Bound, backwards: bool, jump: bool, bounds: &Bounds,
     ) -> Option<(Self, Self)> {

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -418,7 +418,7 @@ impl DocCharOffset {
             } else {
                 range.end()
             }
-        } else if bounds.paragraphs.len() > 0 {
+        } else if !bounds.paragraphs.is_empty() {
             if backwards {
                 bounds.paragraphs[0].start()
             } else {

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -234,7 +234,7 @@ impl DocCharOffset {
                 range_after.map(|range_after| ranges[range_after])
             }
         } else {
-            match self.bound_case(ranges, backwards, jump) {
+            match self.bound_case(ranges) {
                 BoundCase::NoRanges => None,
                 BoundCase::AtFirstRangeStart { first_range, .. } => {
                     if backwards && jump {
@@ -279,7 +279,7 @@ impl DocCharOffset {
     /// `jump` is true, advancing beyond the first or last character in the doc will return None, otherwise it will
     /// return the first or last character in the doc.
     fn char_bound(self, backwards: bool, jump: bool, bounds: &Bounds) -> Option<(Self, Self)> {
-        match self.bound_case(&bounds.paragraphs, backwards, jump) {
+        match self.bound_case(&bounds.paragraphs) {
             BoundCase::NoRanges => None,
             BoundCase::AtFirstRangeStart {
                 first_range: first_paragraph,
@@ -361,9 +361,7 @@ impl DocCharOffset {
         }
     }
 
-    fn bound_case(
-        self, ranges: &[(DocCharOffset, DocCharOffset)], backwards: bool, jump: bool,
-    ) -> BoundCase {
+    fn bound_case(self, ranges: &[(DocCharOffset, DocCharOffset)]) -> BoundCase {
         let range_before = Bounds::range_before(ranges, self);
         let range_after = Bounds::range_after(ranges, self);
         match (range_before, range_after) {
@@ -374,7 +372,7 @@ impl DocCharOffset {
                 let range_after = ranges[range_after];
                 if self < first_range.start() {
                     // a cursor before the first range is considered at the start of the first range
-                    first_range.start().bound_case(ranges, backwards, jump)
+                    first_range.start().bound_case(ranges)
                 } else {
                     // self == first_range.start() because otherwise we'd have a range before
                     BoundCase::AtFirstRangeStart { first_range, range_after }
@@ -386,7 +384,7 @@ impl DocCharOffset {
                 let range_before = ranges[range_before];
                 if self > last_range.end() {
                     // a cursor after the last range is considered at the end of the last range
-                    last_range.end().bound_case(ranges, backwards, jump)
+                    last_range.end().bound_case(ranges)
                 } else {
                     // self == last_range.end() because otherwise we'd have a range after
                     BoundCase::AtLastRangeEnd { last_range, range_before }

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -30,7 +30,10 @@ pub fn calc_words(buffer: &SubBuffer, ast: &Ast) -> Words {
 
     for text_range in ast.iter_text_ranges() {
         match text_range.range_type {
-            AstTextRangeType::Head | AstTextRangeType::Tail => {} // syntax sequences don't count as words
+            AstTextRangeType::Head | AstTextRangeType::Tail => {
+                // syntax sequences count as words
+                result.push(text_range.range)
+            }
             AstTextRangeType::Text => {
                 let mut prev_char_offset = text_range.range.0;
                 let mut prev_word = "";
@@ -195,7 +198,7 @@ impl DocCharOffset {
     /// `self` will not be at the boundary of the result in the direction of `backwards` (e.g. alt+left/right),
     /// otherwise it will be (e.g. cmd+left/right). For instance, if `jump` is true, advancing beyond the first or last
     /// range in the doc will return None, otherwise it will return the first or last range in the doc.
-    fn range_bound(
+    pub fn range_bound(
         self, bound: Bound, backwards: bool, jump: bool, bounds: &Bounds,
     ) -> Option<(Self, Self)> {
         let ranges = match bound {

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -325,24 +325,9 @@ impl Editor {
 
         // scroll
         let all_selection = {
-            let mut select_all_cursor = Cursor::from(0);
-            select_all_cursor.advance(
-                Offset::To(Bound::Doc),
-                true,
-                &self.buffer.current,
-                &self.galleys,
-                &self.bounds,
-            );
-            let start = select_all_cursor.selection.1;
-            select_all_cursor.advance(
-                Offset::To(Bound::Doc),
-                false,
-                &self.buffer.current,
-                &self.galleys,
-                &self.bounds,
-            );
-            let end = select_all_cursor.selection.1;
-            (start, end)
+            DocCharOffset(0)
+                .range_bound(Bound::Doc, false, false, &self.bounds)
+                .unwrap() // there's always a document
         };
         if selection_updated && self.buffer.current.cursor.selection != all_selection {
             let cursor_end_line = self.buffer.current.cursor.end_line(&self.galleys);

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -1,6 +1,6 @@
 use crate::appearance::Appearance;
 use crate::ast::{Ast, AstTextRangeType};
-use crate::bounds::Paragraphs;
+use crate::bounds::Bounds;
 use crate::buffer::SubBuffer;
 use crate::images::ImageCache;
 use crate::layouts::{Annotation, LayoutJobInfo};
@@ -42,8 +42,8 @@ pub struct ImageInfo {
 }
 
 pub fn calc(
-    ast: &Ast, buffer: &SubBuffer, paragraphs: &Paragraphs, images: &ImageCache,
-    appearance: &Appearance, ui: &mut Ui,
+    ast: &Ast, buffer: &SubBuffer, bounds: &Bounds, images: &ImageCache, appearance: &Appearance,
+    ui: &mut Ui,
 ) -> Galleys {
     let mut result: Galleys = Default::default();
 
@@ -64,7 +64,7 @@ pub fn calc(
     // combine ast text ranges, paragraphs, and selection
     // each paragraph gets a galley; ast text ranges and selection determine styles and captured characters
     loop {
-        let paragraph = paragraphs.paragraphs[paragraph_idx];
+        let paragraph = bounds.paragraphs[paragraph_idx];
         if let Some(text_range) = maybe_text_range.clone() {
             if paragraph.1 < text_range.range.0 {
                 // paragraph ends before text_range starts -> emit galley
@@ -191,7 +191,7 @@ pub fn calc(
                 layout.append("", 0.0, text_format);
             }
             let layout_info = LayoutJobInfo {
-                range: paragraphs.paragraphs[paragraph_idx],
+                range: bounds.paragraphs[paragraph_idx],
                 job: mem::take(&mut layout),
                 annotation: mem::take(&mut annotation),
                 head_size: mem::take(&mut head_size),
@@ -206,7 +206,7 @@ pub fn calc(
             emit_galley = false;
         }
 
-        if paragraph_idx == paragraphs.paragraphs.len() || maybe_text_range.is_none() {
+        if paragraph_idx == bounds.paragraphs.len() || maybe_text_range.is_none() {
             break;
         }
     }

--- a/libs/editor/egui_editor/src/input/advance.rs
+++ b/libs/editor/egui_editor/src/input/advance.rs
@@ -1,28 +1,23 @@
-use crate::bounds::Paragraphs;
+use std::mem;
+
+use crate::bounds::Bounds;
 use crate::buffer::SubBuffer;
 use crate::galleys::{GalleyInfo, Galleys};
-use crate::input::canonical::{Bound, Increment, Offset};
-use crate::offset_types::{DocCharOffset, RangeExt, RelByteOffset};
-use crate::unicode_segs::UnicodeSegs;
+use crate::input::canonical::{Increment, Offset};
+use crate::offset_types::{DocCharOffset, RangeExt};
 use egui::epaint::text::cursor::Cursor as EguiCursor;
 use egui::{Pos2, Vec2};
-use std::{iter, mem};
-use unicode_segmentation::UnicodeSegmentation;
 
 impl DocCharOffset {
     #[allow(clippy::too_many_arguments)]
     pub fn advance(
         self, maybe_x_target: &mut Option<f32>, offset: Offset, backwards: bool, fix: bool,
-        buffer: &SubBuffer, galleys: &Galleys, paragraphs: &Paragraphs,
+        buffer: &SubBuffer, galleys: &Galleys, bounds: &Bounds,
     ) -> Self {
         let maybe_x_target_value = mem::take(maybe_x_target);
         match offset {
-            Offset::To(Bound::Char) => self,
-            Offset::To(Bound::Word) => self.advance_to_word_bound(backwards, buffer, galleys),
-            Offset::To(Bound::Line) => self.advance_to_line_bound(backwards, galleys),
-            Offset::To(Bound::Paragraph) => self.advance_to_paragraph_bound(backwards, paragraphs),
-            Offset::To(Bound::Doc) => self.advance_to_doc_bound(backwards, &buffer.segs),
-            Offset::By(Increment::Char) => self.advance_by_char(backwards, &buffer.segs),
+            Offset::To(bound) => self.advance_to_bound(bound, backwards, bounds),
+            Offset::Next(bound) => self.advance_to_next_bound(bound, backwards, bounds),
             Offset::By(Increment::Line) => {
                 let x_target = maybe_x_target_value.unwrap_or(self.x(galleys));
                 let result = self.advance_by_line(x_target, backwards, galleys);
@@ -33,17 +28,6 @@ impl DocCharOffset {
             }
         }
         .fix(backwards, fix, galleys)
-    }
-
-    fn advance_by_char(mut self, backwards: bool, segs: &UnicodeSegs) -> Self {
-        if !backwards && self < segs.last_cursor_position() {
-            self += 1;
-        }
-        if backwards && self > DocCharOffset(0) {
-            self -= 1;
-        }
-
-        self
     }
 
     fn advance_by_line(self, x_target: f32, backwards: bool, galleys: &Galleys) -> Self {
@@ -98,124 +82,6 @@ impl DocCharOffset {
             }
 
             galleys.char_offset_by_galley_and_cursor(new_galley_idx, &new_ecursor)
-        }
-    }
-
-    fn advance_to_word_bound(
-        mut self, backwards: bool, buffer: &SubBuffer, galleys: &Galleys,
-    ) -> Self {
-        let segs = &buffer.segs;
-        let galley_idx = galleys.galley_at_char(self);
-        let galley = &galleys[galley_idx];
-        let galley_text_range = galley.text_range();
-        let galley_text = &buffer[galley_text_range];
-        let galley_byte_range = buffer.segs.range_to_byte(galley_text_range);
-
-        let word_bound_indices_with_words = galley_text.split_word_bound_indices();
-        let word_bound_indices = word_bound_indices_with_words
-            .clone()
-            .map(|(idx, _)| segs.offset_to_char(galley_byte_range.start() + RelByteOffset(idx)))
-            .chain(iter::once(galley_text_range.end())) // add last word boundary (note: no corresponding word)
-            .collect::<Vec<_>>();
-        let words = word_bound_indices_with_words
-            .map(|(_, word)| word)
-            .collect::<Vec<_>>();
-        let i = match (word_bound_indices.binary_search(&self), backwards) {
-            (Ok(i), _) | (Err(i), true) => i,
-            (Err(i), false) => i.saturating_sub(1), // when moving forward from middle of word, behave as if from start of word
-        };
-
-        if !backwards {
-            // advance to the end of the next non-whitespace word if there is one...
-            let mut found = false;
-            for i in i..words.len() {
-                if !words[i].trim().is_empty() {
-                    found = true;
-                    self = word_bound_indices[i + 1];
-                    break;
-                }
-            }
-
-            // ...otherwise...
-            if !found {
-                // ...advance to the start of the next galley if there is one...
-                if galley_idx + 1 < galleys.len() {
-                    self = galleys[galley_idx + 1].text_range().start();
-                }
-                // ...or advance to the end of this galley
-                else {
-                    self = galley_text_range.end();
-                }
-            }
-        } else {
-            // advance to the start of the previous non-whitespace word if there is one...
-            let mut found = false;
-            for i in (0..i).rev() {
-                if !words[i].trim().is_empty() {
-                    found = true;
-                    self = word_bound_indices[i];
-                    break;
-                }
-            }
-
-            // ...otherwise...
-            if !found {
-                // ...advance to the end of the previous galley if there is one...
-                if galley_idx > 0 {
-                    self = galleys[galley_idx - 1].text_range().end();
-                }
-                // ...or advance to the start of this galley
-                else {
-                    self = galley_text_range.start();
-                }
-            }
-        }
-
-        self
-    }
-
-    pub fn advance_to_line_bound(self, backwards: bool, galleys: &Galleys) -> Self {
-        let (galley_idx, ecursor) = galleys.galley_and_cursor_by_char_offset(self);
-        let galley = &galleys[galley_idx];
-        let ecursor = if backwards {
-            galley.galley.cursor_begin_of_row(&ecursor)
-        } else {
-            galley.galley.cursor_end_of_row(&ecursor)
-        };
-        galleys.char_offset_by_galley_and_cursor(galley_idx, &ecursor)
-    }
-
-    fn advance_to_paragraph_bound(self, backwards: bool, paragraphs: &Paragraphs) -> Self {
-        // in a paragraph -> go to start or end
-        for &paragraph in &paragraphs.paragraphs {
-            if paragraph.contains(self) {
-                return if backwards { paragraph.start() } else { paragraph.end() };
-            }
-        }
-
-        // not in a paragraph -> go to end or start of previous or next paragraph
-        if backwards {
-            for &paragraph in paragraphs.paragraphs.iter().rev() {
-                if paragraph.end() < self {
-                    return paragraph.end();
-                }
-            }
-        } else {
-            for &paragraph in &paragraphs.paragraphs {
-                if paragraph.start() > self {
-                    return paragraph.start();
-                }
-            }
-        }
-
-        self
-    }
-
-    fn advance_to_doc_bound(self, backwards: bool, segs: &UnicodeSegs) -> Self {
-        if backwards {
-            0.into()
-        } else {
-            segs.last_cursor_position()
         }
     }
 

--- a/libs/editor/egui_editor/src/input/canonical.rs
+++ b/libs/editor/egui_editor/src/input/canonical.rs
@@ -27,14 +27,19 @@ pub enum Bound {
 /// text unit you can increment or decrement a location by
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Increment {
-    Char,
     Line,
 }
 
 /// text location relative to some absolute text location
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Offset {
+    /// text location at a bound; if you're already there, this leaves you there (e.g. cmd+left/right)
     To(Bound),
+
+    /// text location at the next bound; if you're already there, this goes to the next one (e.g. option+left/right)
+    Next(Bound),
+
+    /// text location some increment away
     By(Increment),
 }
 
@@ -105,9 +110,9 @@ impl From<&Modifiers> for Offset {
         if should_jump_line {
             Offset::To(Bound::Line)
         } else if should_jump_word {
-            Offset::To(Bound::Word)
+            Offset::Next(Bound::Word)
         } else {
-            Offset::By(Increment::Char)
+            Offset::Next(Bound::Char)
         }
     }
 }
@@ -594,7 +599,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::By(Increment::Char),
+                    offset: Offset::Next(Bound::Char),
                     backwards: false,
                     extend_selection: false,
                 },
@@ -620,7 +625,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::To(Bound::Word),
+                    offset: Offset::Next(Bound::Word),
                     backwards: false,
                     extend_selection: false,
                 },
@@ -670,7 +675,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::By(Increment::Char),
+                    offset: Offset::Next(Bound::Char),
                     backwards: false,
                     extend_selection: true,
                 },
@@ -696,7 +701,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::To(Bound::Word),
+                    offset: Offset::Next(Bound::Word),
                     backwards: false,
                     extend_selection: true,
                 },
@@ -796,7 +801,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::By(Increment::Char),
+                    offset: Offset::Next(Bound::Char),
                     backwards: true,
                     extend_selection: false,
                 },
@@ -822,7 +827,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::To(Bound::Word),
+                    offset: Offset::Next(Bound::Word),
                     backwards: true,
                     extend_selection: false,
                 },
@@ -872,7 +877,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::By(Increment::Char),
+                    offset: Offset::Next(Bound::Char),
                     backwards: true,
                     extend_selection: true,
                 },
@@ -898,7 +903,7 @@ mod test {
             ),
             Some(Modification::Select {
                 region: Region::ToOffset {
-                    offset: Offset::To(Bound::Word),
+                    offset: Offset::Next(Bound::Word),
                     backwards: true,
                     extend_selection: true,
                 },

--- a/libs/editor/egui_editor/src/input/click_checker.rs
+++ b/libs/editor/egui_editor/src/input/click_checker.rs
@@ -1,5 +1,6 @@
 use crate::appearance::Appearance;
 use crate::ast::Ast;
+use crate::bounds::Bounds;
 use crate::buffer::Buffer;
 use crate::galleys::Galleys;
 use crate::input::mutation;
@@ -7,6 +8,8 @@ use crate::layouts::Annotation;
 use crate::offset_types::RangeExt;
 use crate::style::{InlineNode, ItemType, MarkdownNode};
 use egui::{Pos2, Rect};
+
+use super::canonical::Bound;
 
 pub trait ClickChecker {
     fn ui(&self, pos: Pos2) -> bool; // was the click even in the ui?
@@ -18,6 +21,7 @@ pub trait ClickChecker {
 pub struct EditorClickChecker<'a> {
     pub ui_rect: Rect,
     pub galleys: &'a Galleys,
+    pub bounds: &'a Bounds,
     pub buffer: &'a Buffer,
     pub ast: &'a Ast,
     pub appearance: &'a Appearance,
@@ -34,7 +38,7 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
                 // galleys stretch across the screen, so we need to check if we're to the right of the text
                 let offset =
                     mutation::pos_to_char_offset(pos, self.galleys, &self.buffer.current.segs);
-                let line_end_offset = offset.advance_to_line_bound(false, self.galleys);
+                let line_end_offset = offset.advance_to_bound(Bound::Line, false, &self.bounds);
                 let (_, egui_cursor) = self
                     .galleys
                     .galley_and_cursor_by_char_offset(line_end_offset);

--- a/libs/editor/egui_editor/src/input/click_checker.rs
+++ b/libs/editor/egui_editor/src/input/click_checker.rs
@@ -38,7 +38,7 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
                 // galleys stretch across the screen, so we need to check if we're to the right of the text
                 let offset =
                     mutation::pos_to_char_offset(pos, self.galleys, &self.buffer.current.segs);
-                let line_end_offset = offset.advance_to_bound(Bound::Line, false, &self.bounds);
+                let line_end_offset = offset.advance_to_bound(Bound::Line, false, self.bounds);
                 let (_, egui_cursor) = self
                     .galleys
                     .galley_and_cursor_by_char_offset(line_end_offset);

--- a/libs/editor/egui_editor/src/input/cursor.rs
+++ b/libs/editor/egui_editor/src/input/cursor.rs
@@ -1,7 +1,7 @@
-use crate::bounds::Paragraphs;
+use crate::bounds::Bounds;
 use crate::buffer::SubBuffer;
 use crate::galleys::Galleys;
-use crate::input::canonical::{Bound, Offset};
+use crate::input::canonical::Offset;
 use crate::offset_types::*;
 use crate::unicode_segs::UnicodeSegs;
 use egui::{Modifiers, Pos2, Vec2};
@@ -100,7 +100,7 @@ impl Cursor {
 
     pub fn advance(
         &mut self, offset: Offset, backwards: bool, buffer: &SubBuffer, galleys: &Galleys,
-        paragraphs: &Paragraphs,
+        bounds: &Bounds,
     ) {
         self.selection.1 = self.selection.1.advance(
             &mut self.x_target,
@@ -109,7 +109,7 @@ impl Cursor {
             true,
             buffer,
             galleys,
-            paragraphs,
+            bounds,
         );
     }
 
@@ -117,7 +117,7 @@ impl Cursor {
     /// use only if you're sure your modifications will leave the cursor in a valid place at the end of the frame
     pub fn advance_for_edit(
         &mut self, offset: Offset, backwards: bool, buffer: &SubBuffer, galleys: &Galleys,
-        paragraphs: &Paragraphs,
+        bounds: &Bounds,
     ) {
         self.selection.1 = self.selection.1.advance(
             &mut self.x_target,
@@ -126,7 +126,7 @@ impl Cursor {
             false,
             buffer,
             galleys,
-            paragraphs,
+            bounds,
         );
     }
 
@@ -150,16 +150,6 @@ impl Cursor {
 
     fn empty(&self) -> bool {
         self.selection.0 == self.selection.1
-    }
-
-    pub fn at_line_bound(
-        &self, buffer: &SubBuffer, galleys: &Galleys, paragraphs: &Paragraphs,
-    ) -> bool {
-        let mut line_start = *self;
-        let mut line_end = *self;
-        line_start.advance(Offset::To(Bound::Line), true, buffer, galleys, paragraphs);
-        line_end.advance(Offset::To(Bound::Line), false, buffer, galleys, paragraphs);
-        self.selection.1 == line_start.selection.1 || self.selection.1 == line_end.selection.1
     }
 }
 

--- a/libs/editor/egui_editor/src/input/events.rs
+++ b/libs/editor/egui_editor/src/input/events.rs
@@ -1,5 +1,5 @@
 use crate::ast::Ast;
-use crate::bounds::Paragraphs;
+use crate::bounds::Bounds;
 use crate::buffer::{Buffer, EditorMutation};
 use crate::debug::DebugInfo;
 use crate::galleys::Galleys;
@@ -28,13 +28,13 @@ pub fn combine(
 /// processes `combined_events` and returns a boolean representing whether text was updated, new contents for clipboard
 /// (optional), and a link that was opened (optional)
 pub fn process(
-    combined_events: &[Modification], galleys: &Galleys, paragraphs: &Paragraphs, ast: &Ast,
+    combined_events: &[Modification], galleys: &Galleys, bounds: &Bounds, ast: &Ast,
     buffer: &mut Buffer, debug: &mut DebugInfo,
 ) -> (bool, Option<String>, Option<String>) {
     combined_events
         .iter()
         .cloned()
-        .map(|m| match input::mutation::calc(m, &buffer.current, galleys, paragraphs, ast) {
+        .map(|m| match input::mutation::calc(m, &buffer.current, galleys, bounds, ast) {
             EditorMutation::Buffer(mutations) if mutations.is_empty() => (false, None, None),
             EditorMutation::Buffer(mutations) => buffer.apply(mutations, debug),
             EditorMutation::Undo => {

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Ast, AstTextRangeType};
-use crate::bounds::Paragraphs;
+use crate::bounds::Bounds;
 use crate::buffer::{EditorMutation, Mutation, SubBuffer, SubMutation};
 use crate::galleys::Galleys;
 use crate::input::canonical::{Bound, Location, Modification, Offset, Region};
@@ -13,14 +13,13 @@ use std::cmp::Ordering;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub fn calc(
-    modification: Modification, buffer: &SubBuffer, galleys: &Galleys, paragraphs: &Paragraphs,
-    ast: &Ast,
+    modification: Modification, buffer: &SubBuffer, galleys: &Galleys, bounds: &Bounds, ast: &Ast,
 ) -> EditorMutation {
     let current_cursor = buffer.cursor;
     let mut mutation = Vec::new();
     match modification {
         Modification::Select { region } => mutation.push(SubMutation::Cursor {
-            cursor: region_to_cursor(region, current_cursor, buffer, galleys, paragraphs),
+            cursor: region_to_cursor(region, current_cursor, buffer, galleys, bounds),
         }),
         Modification::StageMarked { highlighted, text } => {
             let mut cursor = current_cursor;
@@ -51,13 +50,13 @@ pub fn calc(
         }
         Modification::Replace { region, text } => {
             mutation.push(SubMutation::Cursor {
-                cursor: region_to_cursor(region, current_cursor, buffer, galleys, paragraphs),
+                cursor: region_to_cursor(region, current_cursor, buffer, galleys, bounds),
             });
             mutation.push(SubMutation::Insert { text, advance_cursor: true });
             mutation.push(SubMutation::Cursor { cursor: current_cursor });
         }
         Modification::ToggleStyle { region, style } => {
-            let cursor = region_to_cursor(region, current_cursor, buffer, galleys, paragraphs);
+            let cursor = region_to_cursor(region, current_cursor, buffer, galleys, bounds);
             apply_style(
                 cursor,
                 style.clone(),
@@ -385,7 +384,7 @@ pub fn calc(
                 current_cursor,
                 buffer,
                 galleys,
-                paragraphs,
+                bounds,
             );
 
             mutation.push(SubMutation::Cursor {
@@ -427,7 +426,7 @@ pub fn calc(
                             current_cursor,
                             buffer,
                             galleys,
-                            paragraphs,
+                            bounds,
                         ),
                     });
                     mutation.push(SubMutation::Insert {
@@ -466,7 +465,7 @@ pub fn calc(
                             current_cursor,
                             buffer,
                             galleys,
-                            paragraphs,
+                            bounds,
                         ),
                     });
                     mutation.push(SubMutation::Insert {
@@ -505,7 +504,7 @@ pub fn calc(
                             current_cursor,
                             buffer,
                             galleys,
-                            paragraphs,
+                            bounds,
                         ),
                     });
                     mutation.push(SubMutation::Insert {
@@ -753,8 +752,7 @@ fn list_mutation_replacement(
 }
 
 pub fn region_to_cursor(
-    region: Region, current_cursor: Cursor, buffer: &SubBuffer, galleys: &Galleys,
-    paragraphs: &Paragraphs,
+    region: Region, current_cursor: Cursor, buffer: &SubBuffer, galleys: &Galleys, bounds: &Bounds,
 ) -> Cursor {
     match region {
         Region::Location(location) => {
@@ -776,7 +774,7 @@ pub fn region_to_cursor(
                 let mut cursor = current_cursor;
                 // note: this is only used for backspace
                 // advance_for_edit won't leave the cursor in captured characters if we delete the selected characters
-                cursor.advance_for_edit(offset, backwards, buffer, galleys, paragraphs);
+                cursor.advance_for_edit(offset, backwards, buffer, galleys, bounds);
                 cursor.selection.0 = current_cursor.selection.1;
                 cursor
             } else {
@@ -789,7 +787,7 @@ pub fn region_to_cursor(
                 || matches!(offset, Offset::To(..))
             {
                 let mut cursor = current_cursor;
-                cursor.advance(offset, backwards, buffer, galleys, paragraphs);
+                cursor.advance(offset, backwards, buffer, galleys, bounds);
                 if extend_selection {
                     cursor.selection.0 = current_cursor.selection.0;
                 } else {
@@ -804,17 +802,17 @@ pub fn region_to_cursor(
         }
         Region::Bound { bound, backwards } => {
             let mut cursor = current_cursor;
-            cursor.advance(Offset::To(bound), backwards, buffer, galleys, paragraphs);
+            cursor.advance(Offset::To(bound), backwards, buffer, galleys, bounds);
             cursor.selection.0 = cursor.selection.1;
-            cursor.advance(Offset::To(bound), !backwards, buffer, galleys, paragraphs);
+            cursor.advance(Offset::To(bound), !backwards, buffer, galleys, bounds);
             cursor
         }
         Region::BoundAt { bound, location, backwards } => {
             let mut cursor: Cursor =
                 location_to_char_offset(location, current_cursor, galleys, &buffer.segs).into();
-            cursor.advance(Offset::To(bound), backwards, buffer, galleys, paragraphs);
+            cursor.advance(Offset::To(bound), backwards, buffer, galleys, bounds);
             cursor.selection.0 = cursor.selection.1;
-            cursor.advance(Offset::To(bound), !backwards, buffer, galleys, paragraphs);
+            cursor.advance(Offset::To(bound), !backwards, buffer, galleys, bounds);
             cursor
         }
     }

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -801,19 +801,18 @@ pub fn region_to_cursor(
             }
         }
         Region::Bound { bound, backwards } => {
-            let mut cursor = current_cursor;
-            cursor.advance(Offset::To(bound), backwards, buffer, galleys, bounds);
-            cursor.selection.0 = cursor.selection.1;
-            cursor.advance(Offset::To(bound), !backwards, buffer, galleys, bounds);
-            cursor
+            let offset = current_cursor.selection.1;
+            let range = offset
+                .range_bound(bound, backwards, false, bounds)
+                .unwrap_or((offset, offset));
+            range.into()
         }
         Region::BoundAt { bound, location, backwards } => {
-            let mut cursor: Cursor =
-                location_to_char_offset(location, current_cursor, galleys, &buffer.segs).into();
-            cursor.advance(Offset::To(bound), backwards, buffer, galleys, bounds);
-            cursor.selection.0 = cursor.selection.1;
-            cursor.advance(Offset::To(bound), !backwards, buffer, galleys, bounds);
-            cursor
+            let offset = location_to_char_offset(location, current_cursor, galleys, &buffer.segs);
+            let range = offset
+                .range_bound(bound, backwards, false, bounds)
+                .unwrap_or((offset, offset));
+            range.into()
         }
     }
 }

--- a/libs/editor/egui_editor/src/test_input.rs
+++ b/libs/editor/egui_editor/src/test_input.rs
@@ -1,4 +1,4 @@
-pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_52;
+pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_50;
 
 pub static TEST_MARKDOWN_ALL: [&str; 54] = [
     TEST_MARKDOWN_0,


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1847
also fixes an issue where alt+left on iOS doesn't jump over bullets etc in one go

- [x] use new implementation for advancing chars
- [x] use new implementation for jumping words
- [x] use new implementation for word bounds
  - [x] double click
  - [x] iOS tokenizer