### PR TITLE
apple: toolbar hide keyboard

### DIFF
--- a/clients/apple/Shared/Stateful Logic/DocumentService.swift
+++ b/clients/apple/Shared/Stateful Logic/DocumentService.swift
@@ -67,7 +67,7 @@ class DocumentService: ObservableObject {
         selectedDoc = maybeId
         
         if let id = maybeId {
-            openDocuments[id]?.textDocument?.focused = true
+            openDocuments[id]?.textDocument?.shouldFocus = true
         }
     }
     

--- a/clients/apple/Shared/Views/DocumentTabView.swift
+++ b/clients/apple/Shared/Views/DocumentTabView.swift
@@ -18,7 +18,7 @@ struct DocumentTabView: View {
                         ForEach(current.openDocumentsKeyArr, id: \.hashValue) { id in
                             Button(action: {
                                 current.selectedDoc = id
-                                current.openDocuments[id]?.textDocument?.focused = true
+                                current.openDocuments[id]?.textDocument?.shouldFocus = true
                                 docTabKillOpacity[id] = 1
                             }, label: {
                                 HStack {

--- a/clients/apple/Shared/Views/DocumentView.swift
+++ b/clients/apple/Shared/Views/DocumentView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 import SwiftLockbookCore
 import PencilKit
 import SwiftEditor
-import Combine
-
 
 struct iOSDocumentViewWrapper: View {
     let id: UUID
@@ -172,8 +170,8 @@ struct MarkdownCompleteEditor: View, Equatable {
 }
 
 struct MarkdownToolbar: View {
-    @StateObject var toolbarState: ToolbarState
-        
+    @ObservedObject var toolbarState: ToolbarState
+    
     var body: some View {
         HStack(spacing: 20) {
             #if os(iOS)
@@ -465,4 +463,3 @@ extension String {
         self.lowercased().replacingOccurrences(of: " ", with: "-")
     }
 }
-

--- a/clients/apple/Shared/Views/DocumentView.swift
+++ b/clients/apple/Shared/Views/DocumentView.swift
@@ -163,7 +163,7 @@ struct MarkdownCompleteEditor: View, Equatable {
     }
     
     var markdownToolbar: MarkdownToolbar {
-        MarkdownToolbar(toolbarState: toolbarState, id: fileId)
+        MarkdownToolbar(toolbarState: toolbarState)
     }
     
     static func == (lhs: MarkdownCompleteEditor, rhs: MarkdownCompleteEditor) -> Bool {
@@ -171,44 +171,20 @@ struct MarkdownCompleteEditor: View, Equatable {
     }
 }
 
-struct MarkdownToolbar: View, KeyboardReadable {
+struct MarkdownToolbar: View {
     @StateObject var toolbarState: ToolbarState
-    
-    #if os(iOS)
-    
-    @State var isKeyboardVisible: Bool = false
-    
-    #endif
-    
-    let id: UUID
-    
-    
-    var docInfo: DocumentLoadingInfo? {
-        get {
-            DI.currentDoc.openDocuments[id]
-        }
-    }
-    
+        
     var body: some View {
         HStack(spacing: 20) {
             #if os(iOS)
             
             HStack(spacing: 15) {
                 Button(action: {
-                    if isKeyboardVisible {
-                        print("unfocusing")
-                        docInfo?.textDocument?.shouldUnfocus = true
-                    } else {
-                        print("focusing")
-                        docInfo?.textDocument?.shouldFocus = true
-                    }
+                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                 }) {
-                    MarkdownEditorImage(systemImageName: "keyboard.badge.eye", isSelected: false)
+                    MarkdownEditorImage(systemImageName: "keyboard.chevron.compact.down", isSelected: false)
                 }
                 .buttonStyle(.borderless)
-                .onReceive(keyboardPublisher) { newValue in
-                    isKeyboardVisible = newValue
-                }
             }
             
             Divider()
@@ -487,25 +463,6 @@ struct MarkdownEditorImage: View {
 extension String {
     func toKebabCase() -> String {
         self.lowercased().replacingOccurrences(of: " ", with: "-")
-    }
-}
-
-protocol KeyboardReadable {
-    var keyboardPublisher: AnyPublisher<Bool, Never> { get }
-}
-
-extension KeyboardReadable {
-    var keyboardPublisher: AnyPublisher<Bool, Never> {
-        Publishers.Merge(
-            NotificationCenter.default
-                .publisher(for: UIResponder.keyboardWillShowNotification)
-                .map { _ in true },
-            
-            NotificationCenter.default
-                .publisher(for: UIResponder.keyboardWillHideNotification)
-                .map { _ in false }
-        )
-        .eraseToAnyPublisher()
     }
 }
 

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
@@ -5,7 +5,10 @@ public class EditorState: ObservableObject {
     
     @Published public var text: String
     @Published public var reload: Bool = false
-    @Published public var focused: Bool = true
+    @Published public var shouldFocus: Bool = true
+    @Published public var shouldUnfocus: Bool = true
+    
+    var stoppedInitialiPhoneFocus = false
     
     public var isiPhone: Bool
     

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
@@ -6,9 +6,6 @@ public class EditorState: ObservableObject {
     @Published public var text: String
     @Published public var reload: Bool = false
     @Published public var shouldFocus: Bool = true
-    @Published public var shouldUnfocus: Bool = true
-    
-    var stoppedInitialiPhoneFocus = false
     
     public var isiPhone: Bool
     

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
@@ -25,7 +25,7 @@ public struct EditorView: UIViewRepresentable {
         if editorState.isiPhone {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: {
                 mtkView.becomeFirstResponder()
-                editorState.focused = false
+                editorState.shouldFocus = false
             })
         }
         
@@ -38,9 +38,20 @@ public struct EditorView: UIViewRepresentable {
             editorState.reload = false
         }
         
-        if editorState.focused && !editorState.isiPhone {
+        if editorState.shouldFocus && editorState.isiPhone && !editorState.stoppedInitialiPhoneFocus {
+            editorState.stoppedInitialiPhoneFocus = true
+            editorState.shouldFocus = false
+            return
+        }
+        
+        if editorState.shouldFocus {
             mtkView.becomeFirstResponder()
-            editorState.focused = false
+            editorState.shouldFocus = false
+        }
+        
+        if editorState.shouldUnfocus {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+            editorState.shouldUnfocus = false
         }
     }
 }
@@ -62,7 +73,7 @@ public struct EditorView: View {
             .onAppear {
                 focused = true
             }
-            .onChange(of: editorState.focused, perform: { newValue in
+            .onChange(of: editorState.shouldFocus, perform: { newValue in
                 if newValue {
                     focused = true
                 }
@@ -100,8 +111,8 @@ public struct NSEditorView: NSViewRepresentable {
             editorState.reload = false
         }
         
-        if editorState.focused {
-            editorState.focused = false
+        if editorState.shouldFocus {
+            editorState.shouldFocus = false
         }
     }
 }

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
@@ -38,20 +38,9 @@ public struct EditorView: UIViewRepresentable {
             editorState.reload = false
         }
         
-        if editorState.shouldFocus && editorState.isiPhone && !editorState.stoppedInitialiPhoneFocus {
-            editorState.stoppedInitialiPhoneFocus = true
-            editorState.shouldFocus = false
-            return
-        }
-        
-        if editorState.shouldFocus {
+        if editorState.shouldFocus && !editorState.isiPhone {
             mtkView.becomeFirstResponder()
             editorState.shouldFocus = false
-        }
-        
-        if editorState.shouldUnfocus {
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-            editorState.shouldUnfocus = false
         }
     }
 }

--- a/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -136,6 +136,10 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
             nameState?.potentialTitle = nil
         }
         
+        if output.editor_response.selection_updated {
+            becomeFirstResponder()
+        }
+        
         if output.editor_response.show_edit_menu {
             self.hasSelection = output.editor_response.has_selection
             let location = CGPoint(
@@ -375,8 +379,6 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
         let value = UInt64(UInt(bitPattern: point))
         let location = touches.first!.location(in: self)
         touches_began(editorHandle, value, Float(location.x), Float(location.y), Float(touches.first?.force ?? 0))
-        
-        becomeFirstResponder()
 
         self.setNeedsDisplay(self.frame)
     }

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -133,9 +133,6 @@ pub unsafe extern "C" fn set_selected(obj: *mut c_void, range: CTextRange) {
         obj.editor
             .custom_events
             .push(Modification::Select { region: range.into() });
-    } else {
-        obj.editor.buffer.current.cursor.selection
-        obj.editor.custom_events.push(Modification::Select { region: Region:: })
     }
 }
 
@@ -571,14 +568,3 @@ pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
         .custom_events
         .push(Modification::Indent { deindent });
 }
-
-/// # Safety
-/// obj must be a valid pointer to WgpuEditor
-#[no_mangle]
-pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
-    let obj = &mut *(obj as *mut WgpuEditor);
-    obj.editor
-        .custom_events
-        .push(Modification::Indent { deindent });
-}
-

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -133,6 +133,9 @@ pub unsafe extern "C" fn set_selected(obj: *mut c_void, range: CTextRange) {
         obj.editor
             .custom_events
             .push(Modification::Select { region: range.into() });
+    } else {
+        obj.editor.buffer.current.cursor.selection
+        obj.editor.custom_events.push(Modification::Select { region: Region:: })
     }
 }
 
@@ -568,3 +571,14 @@ pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
         .custom_events
         .push(Modification::Indent { deindent });
 }
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
+pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
+    let obj = &mut *(obj as *mut WgpuEditor);
+    obj.editor
+        .custom_events
+        .push(Modification::Indent { deindent });
+}
+

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -33,6 +33,7 @@ pub struct EditorResponse {
 
     pub show_edit_menu: bool,
     pub has_selection: bool,
+    pub selection_updated: bool,
     pub edit_menu_x: f32,
     pub edit_menu_y: f32,
 
@@ -74,6 +75,7 @@ impl Default for EditorResponse {
 
             show_edit_menu: false,
             has_selection: false,
+            selection_updated: false,
             edit_menu_x: 0.0,
             edit_menu_y: 0.0,
 
@@ -363,6 +365,7 @@ impl Editor {
 
             show_edit_menu: self.maybe_menu_location.is_some(),
             has_selection: self.buffer.current.cursor.selection().is_some(),
+            selection_updated,
             edit_menu_x: self.maybe_menu_location.map(|p| p.x).unwrap_or_default(),
             edit_menu_y: self.maybe_menu_location.map(|p| p.y).unwrap_or_default(),
             ..Default::default()

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -56,6 +56,7 @@ pub struct EditorResponse {
 
     pub show_edit_menu: bool,
     pub has_selection: bool,
+    pub selection_updated: bool,
     pub edit_menu_x: f32,
     pub edit_menu_y: f32,
 


### PR DESCRIPTION
fixes #1935

On iOS and iPadOS, users can lose keyboard focus using the hide keyboard button located on the toolbar.

## iOS screenshot

<details>
<img src="https://github.com/lockbook/lockbook/assets/20663038/aa48c5ca-06a9-4088-aa45-6f8a67f4a8a1" width="350" />
</details>


