### PR TITLE
editor: capture more syntax characters

### DIFF
--- a/libs/editor/egui_editor/src/appearance.rs
+++ b/libs/editor/egui_editor/src/appearance.rs
@@ -1,5 +1,10 @@
+use std::collections::HashSet;
+
 use egui::ecolor::Hsva;
 use egui::{Color32, Visuals};
+use pulldown_cmark::HeadingLevel;
+
+use crate::style::{BlockNodeType, InlineNodeType, ListItemType, MarkdownNodeType};
 
 // Apple colors: https://developer.apple.com/design/human-interface-guidelines/foundations/color/
 pub const RED: ThemedColor =
@@ -45,6 +50,43 @@ pub const GRAY_6: ThemedColor =
 pub const WHITE: ThemedColor =
     ThemedColor { light: Color32::from_rgb(240, 240, 240), dark: Color32::from_rgb(18, 18, 18) };
 
+// presets for markdown syntax char capture
+pub fn plain_text() -> HashSet<MarkdownNodeType> {
+    HashSet::new()
+}
+pub fn blocks() -> HashSet<MarkdownNodeType> {
+    vec![
+        MarkdownNodeType::Block(BlockNodeType::Heading(HeadingLevel::H1)),
+        MarkdownNodeType::Block(BlockNodeType::Heading(HeadingLevel::H2)),
+        MarkdownNodeType::Block(BlockNodeType::Heading(HeadingLevel::H3)),
+        MarkdownNodeType::Block(BlockNodeType::Heading(HeadingLevel::H4)),
+        MarkdownNodeType::Block(BlockNodeType::Heading(HeadingLevel::H5)),
+        MarkdownNodeType::Block(BlockNodeType::Heading(HeadingLevel::H6)),
+        MarkdownNodeType::Block(BlockNodeType::Quote),
+        MarkdownNodeType::Block(BlockNodeType::Code),
+        MarkdownNodeType::Block(BlockNodeType::ListItem(ListItemType::Bulleted)),
+        MarkdownNodeType::Block(BlockNodeType::ListItem(ListItemType::Numbered)),
+        MarkdownNodeType::Block(BlockNodeType::ListItem(ListItemType::Todo)),
+    ]
+    .into_iter()
+    .collect()
+}
+pub fn rich_text() -> HashSet<MarkdownNodeType> {
+    let mut result = blocks();
+    result.extend(
+        vec![
+            MarkdownNodeType::Inline(InlineNodeType::Code),
+            MarkdownNodeType::Inline(InlineNodeType::Bold),
+            MarkdownNodeType::Inline(InlineNodeType::Italic),
+            MarkdownNodeType::Inline(InlineNodeType::Strikethrough),
+            MarkdownNodeType::Inline(InlineNodeType::Link),
+            MarkdownNodeType::Inline(InlineNodeType::Image),
+        ]
+        .into_iter(),
+    );
+    result
+}
+
 /// provides a mechanism for the application developer to override colors for dark mode and light
 /// mode and for us to provide defaults
 #[derive(Default)]
@@ -72,6 +114,9 @@ pub struct Appearance {
     pub checkbox_slash_width: Option<f32>,
     pub rule_height: Option<f32>,
     pub image_padding: Option<f32>,
+
+    // capture of markdown syntax characters
+    pub markdown_capture: Option<HashSet<MarkdownNodeType>>,
 }
 
 impl Appearance {
@@ -169,6 +214,10 @@ impl Appearance {
 
     pub fn image_padding(&self) -> f32 {
         self.image_padding.unwrap_or(12.0)
+    }
+
+    pub fn markdown_capture(&self) -> HashSet<MarkdownNodeType> {
+        self.markdown_capture.clone().unwrap_or_else(rich_text)
     }
 }
 

--- a/libs/editor/egui_editor/src/appearance.rs
+++ b/libs/editor/egui_editor/src/appearance.rs
@@ -217,7 +217,7 @@ impl Appearance {
     }
 
     pub fn markdown_capture(&self) -> HashSet<MarkdownNodeType> {
-        self.markdown_capture.clone().unwrap_or_else(plain_text)
+        self.markdown_capture.clone().unwrap_or_else(rich_text)
     }
 }
 

--- a/libs/editor/egui_editor/src/appearance.rs
+++ b/libs/editor/egui_editor/src/appearance.rs
@@ -217,7 +217,7 @@ impl Appearance {
     }
 
     pub fn markdown_capture(&self) -> HashSet<MarkdownNodeType> {
-        self.markdown_capture.clone().unwrap_or_else(rich_text)
+        self.markdown_capture.clone().unwrap_or_else(plain_text)
     }
 }
 

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -494,6 +494,7 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
     let obj = &mut *(obj as *mut WgpuEditor);
     let buffer = &obj.editor.buffer.current;
     let galleys = &obj.editor.galleys;
+    let text = &obj.editor.bounds.text;
 
     let cursor_representing_rect: Cursor = {
         let range: (DocCharOffset, DocCharOffset) = range.into();
@@ -506,8 +507,8 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
         (selection_start, end_of_rect).into()
     };
 
-    let start_line = cursor_representing_rect.start_line(galleys);
-    let end_line = cursor_representing_rect.end_line(galleys);
+    let start_line = cursor_representing_rect.start_line(galleys, text);
+    let end_line = cursor_representing_rect.end_line(galleys, text);
     CRect {
         min_x: (start_line[1].x + 1.0) as f64,
         min_y: start_line[0].y as f64,
@@ -548,12 +549,14 @@ pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> C
     let obj = &mut *(obj as *mut WgpuEditor);
     let segs = &obj.editor.buffer.current.segs;
     let galleys = &obj.editor.galleys;
+    let text = &obj.editor.bounds.text;
 
     let scroll = obj.editor.scroll_area_offset;
     let offset = mutation::pos_to_char_offset(
         Pos2 { x: point.x as f32 + scroll.x, y: point.y as f32 + scroll.y },
         galleys,
         segs,
+        text,
     );
     CTextPosition { none: false, pos: offset.0 }
 }
@@ -564,9 +567,10 @@ pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> C
 pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPosition) -> CRect {
     let obj = &mut *(obj as *mut WgpuEditor);
     let galleys = &obj.editor.galleys;
+    let text = &obj.editor.bounds.text;
 
     let cursor: Cursor = pos.pos.into();
-    let line = cursor.start_line(galleys);
+    let line = cursor.start_line(galleys, text);
     let scroll = obj.editor.scroll_area_offset;
     CRect {
         min_x: (line[0].x - scroll.x) as f64,

--- a/libs/editor/egui_editor/src/ast.rs
+++ b/libs/editor/egui_editor/src/ast.rs
@@ -1,7 +1,7 @@
 use crate::buffer::SubBuffer;
 use crate::layouts::Annotation;
 use crate::offset_types::{DocCharOffset, RangeExt};
-use crate::style::{BlockNode, InlineNode, ItemType, MarkdownNode};
+use crate::style::{BlockNode, InlineNode, ListItem, MarkdownNode};
 use crate::Editor;
 use pulldown_cmark::{Event, HeadingLevel, LinkType, OffsetIter, Options, Parser, Tag};
 
@@ -153,23 +153,23 @@ impl Ast {
         }
     }
 
-    fn item_type(text: &str) -> ItemType {
+    fn item_type(text: &str) -> ListItem {
         let text = text.trim_start();
         if text.starts_with("+ [ ]") || text.starts_with("* [ ]") || text.starts_with("- [ ]") {
-            ItemType::Todo(false)
+            ListItem::Todo(false)
         } else if text.starts_with("+ [x]")
             || text.starts_with("* [x]")
             || text.starts_with("- [x]")
         {
-            ItemType::Todo(true)
+            ListItem::Todo(true)
         } else if let Some(prefix) = text.split('.').next() {
             if let Ok(num) = prefix.parse::<usize>() {
-                ItemType::Numbered(num)
+                ListItem::Numbered(num)
             } else {
-                ItemType::Bulleted // default to bullet
+                ListItem::Bulleted // default to bullet
             }
         } else {
-            ItemType::Bulleted // default to bullet
+            ListItem::Bulleted // default to bullet
         }
     }
 
@@ -296,9 +296,9 @@ impl Ast {
 
                     text_range.0 += buffer[range].len() - buffer[range].trim_start().len();
                     text_range.0 += match item_type {
-                        ItemType::Bulleted => 1,
-                        ItemType::Numbered(n) => 1 + n.to_string().len(),
-                        ItemType::Todo(_) => 5,
+                        ListItem::Bulleted => 1,
+                        ListItem::Numbered(n) => 1 + n.to_string().len(),
+                        ListItem::Todo(_) => 5,
                     };
 
                     // correct cmark behavior with no space in syntax chars

--- a/libs/editor/egui_editor/src/ast.rs
+++ b/libs/editor/egui_editor/src/ast.rs
@@ -216,8 +216,8 @@ impl Ast {
             // clamp range to text range of parent
             let parent_text_range = self.nodes[parent_idx].text_range;
             let (min, max) = parent_text_range;
-            range.0 = std::cmp::max(std::cmp::min(range.0, max), min);
-            range.1 = std::cmp::max(std::cmp::min(range.1, max), min);
+            range.0 = range.0.max(min).min(max);
+            range.1 = range.1.max(min).min(max);
 
             if range.is_empty() {
                 return None;

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -11,6 +11,7 @@ use unicode_segmentation::UnicodeSegmentation;
 type Words = Vec<(DocCharOffset, DocCharOffset)>;
 type Lines = Vec<(DocCharOffset, DocCharOffset)>;
 type Paragraphs = Vec<(DocCharOffset, DocCharOffset)>;
+type RenderedText = Vec<(DocCharOffset, DocCharOffset)>;
 
 /// Represents bounds of various text regions in the buffer. Region bounds are inclusive on both sides. Regions do not
 /// overlap, have region.0 <= region.1, and are sorted. Character and doc regions are not stored explicitly but can be
@@ -23,6 +24,8 @@ pub struct Bounds {
     /// Paragraphs consist of all rendered text, excluding the newlines that usually delimit them. Every valid cursor
     /// position is in some possibly-empty paragraph.
     pub paragraphs: Paragraphs,
+
+    pub rendered_text: RenderedText,
 }
 
 pub fn calc_words(buffer: &SubBuffer, ast: &Ast) -> Words {
@@ -114,6 +117,10 @@ pub fn calc_paragraphs(buffer: &SubBuffer, ast: &Ast) -> Paragraphs {
     }
 
     result
+}
+
+pub fn calc_rendered_text() -> RenderedText {
+    todo!()
 }
 
 impl Bounds {

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -12,7 +12,6 @@ use unicode_segmentation::UnicodeSegmentation;
 type Words = Vec<(DocCharOffset, DocCharOffset)>;
 type Lines = Vec<(DocCharOffset, DocCharOffset)>;
 type Paragraphs = Vec<(DocCharOffset, DocCharOffset)>;
-type RenderedText = Vec<(DocCharOffset, DocCharOffset)>;
 
 /// Represents bounds of various text regions in the buffer. Region bounds are inclusive on both sides. Regions do not
 /// overlap, have region.0 <= region.1, and are sorted. Character and doc regions are not stored explicitly but can be
@@ -25,8 +24,6 @@ pub struct Bounds {
     /// Paragraphs consist of all rendered text, excluding the newlines that usually delimit them. Every valid cursor
     /// position is in some possibly-empty paragraph.
     pub paragraphs: Paragraphs,
-
-    pub rendered_text: RenderedText,
 }
 
 pub fn calc_words(buffer: &SubBuffer, ast: &Ast, appearance: &Appearance) -> Words {
@@ -140,10 +137,6 @@ pub fn calc_paragraphs(buffer: &SubBuffer, ast: &Ast) -> Paragraphs {
     }
 
     result
-}
-
-pub fn calc_rendered_text() -> RenderedText {
-    todo!()
 }
 
 impl Bounds {

--- a/libs/editor/egui_editor/src/draw.rs
+++ b/libs/editor/egui_editor/src/draw.rs
@@ -2,7 +2,7 @@ use crate::appearance::YELLOW;
 use crate::input::canonical::{Location, Modification, Region};
 use crate::layouts::Annotation;
 use crate::offset_types::RangeExt;
-use crate::style::{BlockNode, InlineNode, ItemType, MarkdownNode, RenderStyle};
+use crate::style::{BlockNode, InlineNode, ListItem, MarkdownNode, RenderStyle};
 use crate::Editor;
 use egui::text::LayoutJob;
 use egui::{Align2, Color32, FontId, Pos2, Rect, Rounding, Sense, Stroke, Ui, Vec2};
@@ -16,7 +16,7 @@ impl Editor {
             if let Some(annotation) = &galley.annotation {
                 match annotation {
                     Annotation::Item(item_type, indent_level) => match item_type {
-                        ItemType::Bulleted => {
+                        ListItem::Bulleted => {
                             let bullet_point = galley.bullet_center();
                             match indent_level {
                                 0 => ui.painter().circle_filled(
@@ -31,7 +31,7 @@ impl Editor {
                                 ),
                             }
                         }
-                        ItemType::Numbered(num) => {
+                        ListItem::Numbered(num) => {
                             let mut job = LayoutJob::default();
 
                             let mut text_format = galley.annotation_text_format.clone();
@@ -47,7 +47,7 @@ impl Editor {
                                 .anchor_rect(Rect::from_min_size(pos.max, galley.size()));
                             ui.painter().galley(rect.min, galley);
                         }
-                        ItemType::Todo(checked) => {
+                        ListItem::Todo(checked) => {
                             ui.painter().rect_filled(
                                 galley.checkbox_bounds(&self.appearance),
                                 self.appearance.checkbox_rounding(),

--- a/libs/editor/egui_editor/src/draw.rs
+++ b/libs/editor/egui_editor/src/draw.rs
@@ -105,8 +105,8 @@ impl Editor {
     pub fn draw_cursor(&mut self, ui: &mut Ui, touch_mode: bool) {
         // determine cursor style
         let cursor = self.buffer.current.cursor;
-        let selection_start_line = cursor.start_line(&self.galleys);
-        let selection_end_line = cursor.end_line(&self.galleys);
+        let selection_start_line = cursor.start_line(&self.galleys, &self.bounds.text);
+        let selection_end_line = cursor.end_line(&self.galleys, &self.bounds.text);
 
         let color = if touch_mode { self.appearance.cursor() } else { self.appearance.text() };
         let stroke = Stroke { width: 1.0, color };

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -164,13 +164,7 @@ impl Default for Editor {
             selection_updated: Default::default(),
             maybe_menu_location: Default::default(),
 
-            custom_events: vec![Modification::Select {
-                region: Region::ToOffset {
-                    offset: Offset::To(Bound::Doc),
-                    backwards: true,
-                    extend_selection: false,
-                },
-            }],
+            custom_events: Default::default(),
 
             scroll_area_rect: Rect { min: Default::default(), max: Default::default() },
             scroll_area_offset: Default::default(),
@@ -310,7 +304,8 @@ impl Editor {
             self.bounds.words =
                 bounds::calc_words(&self.buffer.current, &self.ast, &self.appearance);
             self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer.current, &self.ast);
-            self.bounds.text = bounds::calc_text(&self.ast, &self.appearance);
+            self.bounds.text =
+                bounds::calc_text(&self.ast, &self.appearance, &self.buffer.current.segs);
         }
         if text_updated || selection_updated || theme_updated {
             self.images = images::calc(&self.ast, &self.images, &self.client, ui);

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -324,7 +324,6 @@ impl Editor {
             ui,
         );
         self.bounds.lines = bounds::calc_lines(&self.galleys, &self.bounds.text);
-        self.print_bounds();
         self.initialized = true;
 
         // draw

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -304,7 +304,6 @@ impl Editor {
             self.bounds.words =
                 bounds::calc_words(&self.buffer.current, &self.ast, &self.appearance);
             self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer.current, &self.ast);
-            // self.bounds.rendered_text = bounds::calc_rendered_text();
         }
         if text_updated || selection_updated || theme_updated {
             self.images = images::calc(&self.ast, &self.images, &self.client, ui);

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -19,7 +19,7 @@ use crate::input::click_checker::{ClickChecker, EditorClickChecker};
 use crate::input::cursor::{Cursor, PointerState};
 use crate::input::events;
 use crate::offset_types::{DocCharOffset, RangeExt};
-use crate::style::{BlockNode, InlineNode, ItemType, MarkdownNode};
+use crate::style::{BlockNode, InlineNode, ListItem, MarkdownNode};
 use crate::test_input::TEST_MARKDOWN;
 use crate::{ast, bounds, galleys, images, register_fonts};
 
@@ -303,6 +303,7 @@ impl Editor {
             self.ast = ast::calc(&self.buffer.current);
             self.bounds.words = bounds::calc_words(&self.buffer.current, &self.ast);
             self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer.current, &self.ast);
+            // self.bounds.rendered_text = bounds::calc_rendered_text();
         }
         if text_updated || selection_updated || theme_updated {
             self.images = images::calc(&self.ast, &self.images, &self.client, ui);
@@ -380,13 +381,13 @@ impl Editor {
                     MarkdownNode::Inline(InlineNode::Italic) => result.cursor_in_italic = true,
                     MarkdownNode::Inline(InlineNode::Code) => result.cursor_in_inline_code = true,
                     MarkdownNode::Block(BlockNode::Heading(..)) => result.cursor_in_heading = true,
-                    MarkdownNode::Block(BlockNode::ListItem(ItemType::Bulleted, ..)) => {
+                    MarkdownNode::Block(BlockNode::ListItem(ListItem::Bulleted, ..)) => {
                         result.cursor_in_bullet_list = true
                     }
-                    MarkdownNode::Block(BlockNode::ListItem(ItemType::Numbered(..), ..)) => {
+                    MarkdownNode::Block(BlockNode::ListItem(ListItem::Numbered(..), ..)) => {
                         result.cursor_in_number_list = true
                     }
-                    MarkdownNode::Block(BlockNode::ListItem(ItemType::Todo(..), ..)) => {
+                    MarkdownNode::Block(BlockNode::ListItem(ListItem::Todo(..), ..)) => {
                         result.cursor_in_todo_list = true
                     }
                     _ => {}

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -301,7 +301,8 @@ impl Editor {
         // recalculate dependent state
         if text_updated {
             self.ast = ast::calc(&self.buffer.current);
-            self.bounds.words = bounds::calc_words(&self.buffer.current, &self.ast);
+            self.bounds.words =
+                bounds::calc_words(&self.buffer.current, &self.ast, &self.appearance);
             self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer.current, &self.ast);
             // self.bounds.rendered_text = bounds::calc_rendered_text();
         }

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -143,8 +143,10 @@ pub fn calc(
                         .markdown_capture()
                         .contains(&text_range_portion.node(ast).node_type())
                 {
+                    if annotation.is_none() {
+                        annotation_text_format = text_format.clone();
+                    }
                     annotation = text_range_portion.annotation(ast).or(annotation);
-                    annotation_text_format = text_format.clone();
                 }
 
                 RenderStyle::Markdown(text_range_portion.node(ast))

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -165,8 +165,13 @@ pub fn calc(
                             // uncaptured syntax characters have syntax style applied on top of node style
                             RenderStyle::Syntax.apply_style(&mut text_format, appearance);
                             layout.append(&buffer[text_range_portion.range], 0.0, text_format);
+
+                            head_size_locked = true;
                         }
-                        tail_size = 0.into();
+
+                        if !text_range_portion.range.is_empty() {
+                            tail_size = 0.into();
+                        }
                     }
                     AstTextRangeType::Tail => {
                         if appearance
@@ -180,14 +185,19 @@ pub fn calc(
                             RenderStyle::Syntax.apply_style(&mut text_format, appearance);
                             layout.append(&buffer[text_range_portion.range], 0.0, text_format);
                         }
-                        head_size_locked = true;
-                        tail_size += text_range_portion.range.len();
+
+                        if !text_range_portion.range.is_empty() {
+                            head_size_locked = true;
+                            tail_size += text_range_portion.range.len();
+                        }
                     }
                     AstTextRangeType::Text => {
                         layout.append(&buffer[text_range_portion.range], 0.0, text_format);
 
-                        head_size_locked = true;
-                        tail_size = 0.into();
+                        if !text_range_portion.range.is_empty() {
+                            head_size_locked = true;
+                            tail_size = 0.into();
+                        }
                     }
                 }
             }
@@ -414,7 +424,7 @@ impl GalleyInfo {
 
 impl Editor {
     pub fn print_galleys(&self) {
-        println!("layouts:");
+        println!("galleys:");
         for galley in &self.galleys.galleys {
             println!(
                 "galley: range: {:?}, annotation: {:?}, head: {:?}, tail: {:?}",

--- a/libs/editor/egui_editor/src/input/click_checker.rs
+++ b/libs/editor/egui_editor/src/input/click_checker.rs
@@ -6,7 +6,7 @@ use crate::galleys::Galleys;
 use crate::input::mutation;
 use crate::layouts::Annotation;
 use crate::offset_types::RangeExt;
-use crate::style::{InlineNode, ItemType, MarkdownNode};
+use crate::style::{InlineNode, ListItem, MarkdownNode};
 use egui::{Pos2, Rect};
 
 use super::canonical::Bound;
@@ -53,7 +53,7 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
 
     fn checkbox(&self, pos: Pos2) -> Option<usize> {
         for (galley_idx, galley) in self.galleys.galleys.iter().enumerate() {
-            if let Some(Annotation::Item(ItemType::Todo(_), ..)) = galley.annotation {
+            if let Some(Annotation::Item(ListItem::Todo(_), ..)) = galley.annotation {
                 if galley.checkbox_bounds(self.appearance).contains(pos) {
                     return Some(galley_idx);
                 }

--- a/libs/editor/egui_editor/src/input/click_checker.rs
+++ b/libs/editor/egui_editor/src/input/click_checker.rs
@@ -36,12 +36,16 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
         for (galley_idx, galley) in self.galleys.galleys.iter().enumerate() {
             if galley.galley_location.contains(pos) {
                 // galleys stretch across the screen, so we need to check if we're to the right of the text
-                let offset =
-                    mutation::pos_to_char_offset(pos, self.galleys, &self.buffer.current.segs);
+                let offset = mutation::pos_to_char_offset(
+                    pos,
+                    self.galleys,
+                    &self.buffer.current.segs,
+                    &self.bounds.text,
+                );
                 let line_end_offset = offset.advance_to_bound(Bound::Line, false, self.bounds);
                 let (_, egui_cursor) = self
                     .galleys
-                    .galley_and_cursor_by_char_offset(line_end_offset);
+                    .galley_and_cursor_by_char_offset(line_end_offset, &self.bounds.text);
                 let end_pos_x =
                     galley.galley.pos_from_cursor(&egui_cursor).max.x + galley.text_location.x;
                 let tolerance = 10.0;
@@ -64,7 +68,12 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
 
     fn link(&self, pos: Pos2) -> Option<String> {
         self.text(pos)?;
-        let offset = mutation::pos_to_char_offset(pos, self.galleys, &self.buffer.current.segs);
+        let offset = mutation::pos_to_char_offset(
+            pos,
+            self.galleys,
+            &self.buffer.current.segs,
+            &self.bounds.text,
+        );
         for ast_node in &self.ast.nodes {
             if let MarkdownNode::Inline(InlineNode::Link(_, url, _)) = &ast_node.node_type {
                 if ast_node.range.contains(offset) {

--- a/libs/editor/egui_editor/src/input/cursor.rs
+++ b/libs/editor/egui_editor/src/input/cursor.rs
@@ -1,4 +1,4 @@
-use crate::bounds::Bounds;
+use crate::bounds::{Bounds, Text};
 use crate::buffer::SubBuffer;
 use crate::galleys::Galleys;
 use crate::input::canonical::Offset;
@@ -130,16 +130,16 @@ impl Cursor {
         );
     }
 
-    pub fn start_line(&self, galleys: &Galleys) -> [Pos2; 2] {
-        self.line(galleys, self.selection.0)
+    pub fn start_line(&self, galleys: &Galleys, text: &Text) -> [Pos2; 2] {
+        self.line(galleys, self.selection.0, text)
     }
 
-    pub fn end_line(&self, galleys: &Galleys) -> [Pos2; 2] {
-        self.line(galleys, self.selection.1)
+    pub fn end_line(&self, galleys: &Galleys, text: &Text) -> [Pos2; 2] {
+        self.line(galleys, self.selection.1, text)
     }
 
-    fn line(&self, galleys: &Galleys, offset: DocCharOffset) -> [Pos2; 2] {
-        let (galley_idx, cursor) = galleys.galley_and_cursor_by_char_offset(offset);
+    fn line(&self, galleys: &Galleys, offset: DocCharOffset, text: &Text) -> [Pos2; 2] {
+        let (galley_idx, cursor) = galleys.galley_and_cursor_by_char_offset(offset, text);
         let galley = &galleys[galley_idx];
 
         let max = DocCharOffset::cursor_to_pos_abs(galley, cursor);

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -6,7 +6,7 @@ use crate::input::canonical::{Bound, Location, Modification, Offset, Region};
 use crate::input::cursor::Cursor;
 use crate::layouts::Annotation;
 use crate::offset_types::{DocCharOffset, RangeExt};
-use crate::style::{BlockNode, ItemType, MarkdownNode, RenderStyle};
+use crate::style::{BlockNode, ListItem, ListItemType, MarkdownNode, RenderStyle};
 use crate::unicode_segs::UnicodeSegs;
 use egui::Pos2;
 use std::cmp::Ordering;
@@ -87,13 +87,13 @@ pub fn calc(
                         .push(SubMutation::Insert { text: "\n".to_string(), advance_cursor: true });
 
                     match galley.annotation {
-                        Some(Annotation::Item(ItemType::Bulleted, _)) => {
+                        Some(Annotation::Item(ListItem::Bulleted, _)) => {
                             mutation.push(SubMutation::Insert {
                                 text: galley.head(buffer).to_string(),
                                 advance_cursor: true,
                             });
                         }
-                        Some(Annotation::Item(ItemType::Numbered(cur_number), indent_level)) => {
+                        Some(Annotation::Item(ListItem::Numbered(cur_number), indent_level)) => {
                             let head = galley.head(buffer);
                             let text = head[0..head.len() - (cur_number).to_string().len() - 2]
                                 .to_string()
@@ -111,7 +111,7 @@ pub fn calc(
                                 cursor,
                             ));
                         }
-                        Some(Annotation::Item(ItemType::Todo(_), _)) => {
+                        Some(Annotation::Item(ListItem::Todo(_), _)) => {
                             let head = galley.head(buffer);
                             let text = head[0..head.len() - 6].to_string() + "- [ ] ";
                             mutation.push(SubMutation::Insert { text, advance_cursor: true });
@@ -223,7 +223,7 @@ pub fn calc(
 
                         // re-number numbered lists
                         if new_indent_level != *indent_level {
-                            if let ItemType::Numbered(cur_number) = item_type {
+                            if let ListItem::Numbered(cur_number) = item_type {
                                 // assign a new_number to this item based on position in new nested list
                                 let new_number = {
                                     let mut new_number = 1;
@@ -232,7 +232,7 @@ pub fn calc(
                                         prior_galley_idx -= 1;
                                         let prior_galley = &galleys[prior_galley_idx];
                                         if let Some(Annotation::Item(
-                                            ItemType::Numbered(prior_number),
+                                            ListItem::Numbered(prior_number),
                                             prior_indent_level,
                                         )) = prior_galley.annotation
                                         {
@@ -351,7 +351,7 @@ pub fn calc(
         }
         Modification::ToggleCheckbox(galley_idx) => {
             let galley = &galleys[galley_idx];
-            if let Some(Annotation::Item(ItemType::Todo(checked), ..)) = galley.annotation {
+            if let Some(Annotation::Item(ListItem::Todo(checked), ..)) = galley.annotation {
                 mutation.push(SubMutation::Cursor {
                     cursor: (
                         galley.range.start() + galley.head_size - 6,
@@ -404,7 +404,7 @@ pub fn calc(
             let galley = &galleys.galleys[galley_idx];
 
             match &galley.annotation {
-                Some(Annotation::Item(ItemType::Bulleted, ..)) => {
+                Some(Annotation::Item(ListItem::Bulleted, ..)) => {
                     list_mutation_replacement(&mut mutation, ast, current_cursor, None);
                 }
                 Some(Annotation::Item(..)) => {
@@ -412,7 +412,7 @@ pub fn calc(
                         &mut mutation,
                         ast,
                         current_cursor,
-                        Some(ItemType::Bulleted),
+                        Some(ListItemType::Bulleted),
                     );
                 }
                 _ => {
@@ -430,7 +430,7 @@ pub fn calc(
                         ),
                     });
                     mutation.push(SubMutation::Insert {
-                        text: ItemType::Bulleted.head().to_string(),
+                        text: ListItemType::Bulleted.head().to_string(),
                         advance_cursor: true,
                     });
 
@@ -443,7 +443,7 @@ pub fn calc(
             let galley = &galleys.galleys[galley_idx];
 
             match &galley.annotation {
-                Some(Annotation::Item(ItemType::Numbered(..), ..)) => {
+                Some(Annotation::Item(ListItem::Numbered(..), ..)) => {
                     list_mutation_replacement(&mut mutation, ast, current_cursor, None);
                 }
                 Some(Annotation::Item(..)) => {
@@ -451,7 +451,7 @@ pub fn calc(
                         &mut mutation,
                         ast,
                         current_cursor,
-                        Some(ItemType::Numbered(1)),
+                        Some(ListItemType::Numbered),
                     );
                 }
                 _ => {
@@ -469,7 +469,7 @@ pub fn calc(
                         ),
                     });
                     mutation.push(SubMutation::Insert {
-                        text: ItemType::Numbered(1).head().to_string(),
+                        text: ListItemType::Numbered.head().to_string(),
                         advance_cursor: true,
                     });
 
@@ -482,7 +482,7 @@ pub fn calc(
             let galley = &galleys.galleys[galley_idx];
 
             match &galley.annotation {
-                Some(Annotation::Item(ItemType::Todo(..), ..)) => {
+                Some(Annotation::Item(ListItem::Todo(..), ..)) => {
                     list_mutation_replacement(&mut mutation, ast, current_cursor, None);
                 }
                 Some(Annotation::Item(..)) => {
@@ -490,7 +490,7 @@ pub fn calc(
                         &mut mutation,
                         ast,
                         current_cursor,
-                        Some(ItemType::Todo(false)),
+                        Some(ListItemType::Todo),
                     );
                 }
                 _ => {
@@ -508,7 +508,7 @@ pub fn calc(
                         ),
                     });
                     mutation.push(SubMutation::Insert {
-                        text: ItemType::Todo(false).head().to_string(),
+                        text: ListItemType::Todo.head().to_string(),
                         advance_cursor: true,
                     });
 
@@ -694,10 +694,10 @@ fn detail_ast_node(node_idx: usize, ast: &Ast, mutation: &mut Vec<SubMutation>) 
 fn insert_head(
     offset: DocCharOffset, style: MarkdownNode, buffer: &SubBuffer, mutation: &mut Vec<SubMutation>,
 ) {
-    let mut text = style.head().to_string();
+    let mut text = style.node_type().head().to_string();
 
     // add leading/trailing whitespace if needed
-    if style.needs_whitespace()
+    if style.node_type().needs_whitespace()
         && offset != 0
         && !buffer[(offset - 1, offset)].contains(|c: char| c.is_whitespace())
     {
@@ -711,10 +711,10 @@ fn insert_head(
 fn insert_tail(
     offset: DocCharOffset, style: MarkdownNode, buffer: &SubBuffer, mutation: &mut Vec<SubMutation>,
 ) {
-    let mut text = style.tail().to_string();
+    let mut text = style.node_type().tail().to_string();
 
     // add leading/trailing whitespace if needed
-    if style.needs_whitespace()
+    if style.node_type().needs_whitespace()
         && offset != buffer.segs.last_cursor_position()
         && !buffer[(offset, offset + 1)].contains(|c: char| c.is_whitespace())
     {
@@ -726,7 +726,7 @@ fn insert_tail(
 }
 
 fn list_mutation_replacement(
-    mutation: &mut Vec<SubMutation>, ast: &Ast, current_cursor: Cursor, to: Option<ItemType>,
+    mutation: &mut Vec<SubMutation>, ast: &Ast, current_cursor: Cursor, to: Option<ListItemType>,
 ) {
     let mut ast_node_idx = ast.ast_node_at_char(current_cursor.selection.1);
     loop {
@@ -872,7 +872,7 @@ pub fn increment_numbered_list_items(
                     break; // end of nested list
                 }
                 Ordering::Equal => {
-                    if let ItemType::Numbered(cur_number) = item_type {
+                    if let ListItem::Numbered(cur_number) = item_type {
                         // replace cur_number with next_number in head
                         modifications.push(SubMutation::Cursor {
                             cursor: (galley.range.start(), galley.range.start() + galley.head_size)

--- a/libs/editor/egui_editor/src/layouts.rs
+++ b/libs/editor/egui_editor/src/layouts.rs
@@ -1,5 +1,5 @@
 use crate::offset_types::{DocCharOffset, RelCharOffset};
-use crate::style::{IndentLevel, ItemType, Title, Url};
+use crate::style::{IndentLevel, ListItem, Title, Url};
 use egui::text::LayoutJob;
 use egui::TextFormat;
 use pulldown_cmark::LinkType;
@@ -19,7 +19,7 @@ pub struct LayoutJobInfo {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Annotation {
-    Item(ItemType, IndentLevel),
+    Item(ListItem, IndentLevel),
     Image(LinkType, Url, Title),
     Rule,
 }

--- a/libs/editor/egui_editor/src/style.rs
+++ b/libs/editor/egui_editor/src/style.rs
@@ -1,16 +1,121 @@
 use crate::appearance::Appearance;
 use egui::{FontFamily, Stroke, TextFormat};
 use pulldown_cmark::{HeadingLevel, LinkType};
+use std::hash::Hash;
 use std::sync::Arc;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// Represents a type of markdown node e.g. link, not a particular node e.g. link to google.com (see MarkdownNode)
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub enum MarkdownNodeType {
+    #[default]
+    Document,
+    Paragraph,
+
+    Inline(InlineNodeType),
+    Block(BlockNodeType),
+}
+
+impl MarkdownNodeType {
+    pub fn head(&self) -> &'static str {
+        match self {
+            Self::Document => "",
+            Self::Paragraph => "",
+            Self::Inline(InlineNodeType::Code) => "`",
+            Self::Inline(InlineNodeType::Bold) => "__",
+            Self::Inline(InlineNodeType::Italic) => "_",
+            Self::Inline(InlineNodeType::Strikethrough) => "~~",
+            Self::Inline(InlineNodeType::Link) => {
+                unimplemented!()
+            }
+            Self::Inline(InlineNodeType::Image) => {
+                unimplemented!()
+            }
+            Self::Block(BlockNodeType::Heading(..)) => {
+                unimplemented!()
+            }
+            Self::Block(BlockNodeType::Quote) => {
+                unimplemented!()
+            }
+            Self::Block(BlockNodeType::Code) => {
+                unimplemented!()
+            }
+            Self::Block(BlockNodeType::ListItem(item_type)) => item_type.head(), // todo: support indentation
+        }
+    }
+
+    pub fn tail(&self) -> &'static str {
+        match self {
+            Self::Document => "",
+            Self::Paragraph => "",
+            Self::Inline(InlineNodeType::Code) => "`",
+            Self::Inline(InlineNodeType::Bold) => "__",
+            Self::Inline(InlineNodeType::Italic) => "_",
+            Self::Inline(InlineNodeType::Strikethrough) => "~~",
+            Self::Inline(InlineNodeType::Link) => {
+                unimplemented!()
+            }
+            Self::Inline(InlineNodeType::Image) => {
+                unimplemented!()
+            }
+            Self::Block(BlockNodeType::Heading(..)) => "",
+            Self::Block(BlockNodeType::Quote) => "",
+            Self::Block(BlockNodeType::Code) => {
+                unimplemented!()
+            }
+            Self::Block(BlockNodeType::ListItem(..)) => "",
+        }
+    }
+
+    pub fn needs_whitespace(&self) -> bool {
+        matches!(self, Self::Inline(InlineNodeType::Bold | InlineNodeType::Italic))
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum InlineNodeType {
+    Code,
+    Bold,
+    Italic,
+    Strikethrough,
+    Link,
+    Image,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum BlockNodeType {
+    Heading(HeadingLevel),
+    Quote,
+    Code,
+    ListItem(ListItemType),
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ListItemType {
+    Bulleted,
+    Numbered,
+    Todo,
+}
+
+impl ListItemType {
+    pub fn head(&self) -> &'static str {
+        match self {
+            Self::Bulleted => "- ",
+            Self::Numbered => "1. ",
+            Self::Todo => "- [ ] ",
+        }
+    }
+}
+
+/// Represents a style that can be applied to rendered text
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RenderStyle {
     Selection,
     Syntax,
     Markdown(MarkdownNode),
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Represents a particular markdown node e.g. link to google.com, not a type of node e.g. link (see MarkdownNodeType)
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub enum MarkdownNode {
     #[default]
     Document,
@@ -30,78 +135,94 @@ pub enum InlineNode {
     Image(LinkType, Url, Title), // todo: swap strings for text ranges and impl Copy
 }
 
-// if you add a variant to InlineNode, you have to also add it here
-// two nodes should be considered equal if toggling the style for one should remove the other
-// todo: better pattern where you don't have to just remember to update this
+impl InlineNode {
+    fn node_type(&self) -> InlineNodeType {
+        match self {
+            Self::Code => InlineNodeType::Code,
+            Self::Bold => InlineNodeType::Bold,
+            Self::Italic => InlineNodeType::Italic,
+            Self::Strikethrough => InlineNodeType::Strikethrough,
+            Self::Link(..) => InlineNodeType::Link,
+            Self::Image(..) => InlineNodeType::Image,
+        }
+    }
+}
+
 impl PartialEq for InlineNode {
     fn eq(&self, other: &Self) -> bool {
-        matches!(
-            (self, other),
-            (Self::Code, Self::Code)
-                | (Self::Bold, Self::Bold)
-                | (Self::Italic, Self::Italic)
-                | (Self::Strikethrough, Self::Strikethrough)
-                | (Self::Link(..), Self::Link(..))
-                | (Self::Image(..), Self::Image(..))
-        )
+        self.node_type() == other.node_type()
     }
 }
 
 impl Eq for InlineNode {}
 
-#[derive(Clone, Copy, Debug, Eq)]
+impl Hash for InlineNode {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.node_type().hash(state);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 pub enum BlockNode {
     Heading(HeadingLevel),
     Quote,
     Code,
-    ListItem(ItemType, IndentLevel),
+    ListItem(ListItem, IndentLevel),
 }
 
-// if you add a variant to BlockNode, you have to also add it here
-// two nodes should be considered equal if toggling the style for one should remove the other
-// todo: better pattern where you don't have to just remember to update this
-impl PartialEq for BlockNode {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Quote, Self::Quote)
-            | (Self::Code, Self::Code)
-            | (Self::Heading(..), Self::Heading(..)) => true,
-            (Self::ListItem(item_type_a, ..), Self::ListItem(item_type_b, ..)) => {
-                item_type_a == item_type_b
-            }
-            _ => false,
+impl BlockNode {
+    fn node_type(&self) -> BlockNodeType {
+        match self {
+            Self::Heading(level) => BlockNodeType::Heading(*level),
+            Self::Quote => BlockNodeType::Quote,
+            Self::Code => BlockNodeType::Code,
+            Self::ListItem(item, ..) => BlockNodeType::ListItem(item.item_type()),
         }
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq)]
-pub enum ItemType {
+impl PartialEq for BlockNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.node_type() == other.node_type()
+    }
+}
+
+impl Eq for BlockNode {}
+
+impl Hash for BlockNode {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.node_type().hash(state);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ListItem {
     Bulleted,
     Numbered(usize),
     Todo(bool),
 }
 
-impl ItemType {
-    pub fn head(&self) -> &'static str {
+impl ListItem {
+    pub fn item_type(&self) -> ListItemType {
         match self {
-            ItemType::Bulleted => "- ",
-            ItemType::Numbered(_) => "1. ", // todo: support other numbers
-            ItemType::Todo(true) => "- [x] ",
-            ItemType::Todo(false) => "- [ ] ",
+            ListItem::Bulleted => ListItemType::Bulleted,
+            ListItem::Numbered(_) => ListItemType::Numbered,
+            ListItem::Todo(_) => ListItemType::Todo,
         }
     }
 }
 
-// Ignore inner values in enum variant comparison
-// Note: you need to remember to incorporate new variants here!
-impl PartialEq for ItemType {
+impl PartialEq for ListItem {
     fn eq(&self, other: &Self) -> bool {
-        matches!(
-            (self, other),
-            (ItemType::Bulleted, ItemType::Bulleted)
-                | (ItemType::Numbered(_), ItemType::Numbered(_))
-                | (ItemType::Todo(_), ItemType::Todo(_))
-        )
+        self.item_type() == other.item_type()
+    }
+}
+
+impl Eq for ListItem {}
+
+impl Hash for ListItem {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.item_type().hash(state);
     }
 }
 
@@ -166,58 +287,13 @@ impl RenderStyle {
 }
 
 impl MarkdownNode {
-    pub fn head(&self) -> &'static str {
+    pub fn node_type(&self) -> MarkdownNodeType {
         match self {
-            Self::Document => "",
-            Self::Paragraph => "",
-            Self::Inline(InlineNode::Code) => "`",
-            Self::Inline(InlineNode::Bold) => "__",
-            Self::Inline(InlineNode::Italic) => "_",
-            Self::Inline(InlineNode::Strikethrough) => "~~",
-            Self::Inline(InlineNode::Link(..)) => {
-                unimplemented!()
-            }
-            Self::Inline(InlineNode::Image(..)) => {
-                unimplemented!()
-            }
-            Self::Block(BlockNode::Heading(..)) => {
-                unimplemented!()
-            }
-            Self::Block(BlockNode::Quote) => {
-                unimplemented!()
-            }
-            Self::Block(BlockNode::Code) => {
-                unimplemented!()
-            }
-            Self::Block(BlockNode::ListItem(item_type, ..)) => item_type.head(), // todo: support indentation
+            Self::Document => MarkdownNodeType::Document,
+            Self::Paragraph => MarkdownNodeType::Paragraph,
+            Self::Inline(inline_node) => MarkdownNodeType::Inline(inline_node.node_type()),
+            Self::Block(block_node) => MarkdownNodeType::Block(block_node.node_type()),
         }
-    }
-
-    pub fn tail(&self) -> &'static str {
-        match self {
-            Self::Document => "",
-            Self::Paragraph => "",
-            Self::Inline(InlineNode::Code) => "`",
-            Self::Inline(InlineNode::Bold) => "__",
-            Self::Inline(InlineNode::Italic) => "_",
-            Self::Inline(InlineNode::Strikethrough) => "~~",
-            Self::Inline(InlineNode::Link(..)) => {
-                unimplemented!()
-            }
-            Self::Inline(InlineNode::Image(..)) => {
-                unimplemented!()
-            }
-            Self::Block(BlockNode::Heading(..)) => "",
-            Self::Block(BlockNode::Quote) => "",
-            Self::Block(BlockNode::Code) => {
-                unimplemented!()
-            }
-            Self::Block(BlockNode::ListItem(..)) => "",
-        }
-    }
-
-    pub fn needs_whitespace(&self) -> bool {
-        matches!(self, Self::Inline(InlineNode::Bold | InlineNode::Italic))
     }
 }
 

--- a/libs/editor/egui_editor/src/test_input.rs
+++ b/libs/editor/egui_editor/src/test_input.rs
@@ -1,4 +1,4 @@
-pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_0;
+pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_43;
 
 pub static TEST_MARKDOWN_ALL: [&str; 54] = [
     TEST_MARKDOWN_0,

--- a/libs/editor/egui_editor/src/test_input.rs
+++ b/libs/editor/egui_editor/src/test_input.rs
@@ -1,4 +1,4 @@
-pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_43;
+pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_50;
 
 pub static TEST_MARKDOWN_ALL: [&str; 54] = [
     TEST_MARKDOWN_0,
@@ -269,7 +269,7 @@ Featuring:
 1. a __bold__ list item,
     * an _italic_ list item,
     - [ ] a `code` list item,
-    
+
 ```
 a code block
 ```

--- a/libs/editor/egui_editor/src/test_input.rs
+++ b/libs/editor/egui_editor/src/test_input.rs
@@ -1,4 +1,4 @@
-pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_50;
+pub static TEST_MARKDOWN: &str = TEST_MARKDOWN_0;
 
 pub static TEST_MARKDOWN_ALL: [&str; 54] = [
     TEST_MARKDOWN_0,


### PR DESCRIPTION
based on https://github.com/lockbook/lockbook/pull/1924

fixes https://github.com/lockbook/lockbook/issues/1838
fixes https://github.com/lockbook/lockbook/issues/1900
fixes https://github.com/lockbook/lockbook/issues/1902

Which markdown elements have syntax characters captured is configurable, but right now only at compile time.

This will require a more formal demo for the next release after UX feedback from the team. For now, here's some screencaps showing the new behavior:

Plain text mode:
<img width="912" alt="Screenshot 2023-07-27 at 5 05 32 PM" src="https://github.com/lockbook/lockbook/assets/6198756/c55dfd40-1686-48de-9154-9986eeceb3ed">
Block mode:
<img width="912" alt="Screenshot 2023-07-27 at 5 05 58 PM" src="https://github.com/lockbook/lockbook/assets/6198756/a0c14ee8-ac95-48af-9b42-379f08d82150">
Rich text mode:
<img width="912" alt="Screenshot 2023-07-27 at 5 06 11 PM" src="https://github.com/lockbook/lockbook/assets/6198756/c82399ee-2742-49ea-8d21-0417d790f1c0">

https://github.com/lockbook/lockbook/assets/6198756/ab837abc-2148-4880-ad1e-995e757a1ba7

