### PR TITLE
editor: prefer asterisks for bullets

### DIFF
--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -113,7 +113,7 @@ pub fn calc(
                         }
                         Some(Annotation::Item(ListItem::Todo(_), _)) => {
                             let head = galley.head(buffer);
-                            let text = head[0..head.len() - 6].to_string() + "- [ ] ";
+                            let text = head[0..head.len() - 6].to_string() + "* [ ] ";
                             mutation.push(SubMutation::Insert { text, advance_cursor: true });
                         }
                         Some(Annotation::Image(_, _, _)) => {}
@@ -360,7 +360,7 @@ pub fn calc(
                         .into(),
                 });
                 mutation.push(SubMutation::Insert {
-                    text: if checked { "- [ ] " } else { "- [x] " }.to_string(),
+                    text: if checked { "* [ ] " } else { "* [x] " }.to_string(),
                     advance_cursor: true,
                 });
                 mutation.push(SubMutation::Cursor { cursor: current_cursor });

--- a/libs/editor/egui_editor/src/style.rs
+++ b/libs/editor/egui_editor/src/style.rs
@@ -99,9 +99,9 @@ pub enum ListItemType {
 impl ListItemType {
     pub fn head(&self) -> &'static str {
         match self {
-            Self::Bulleted => "- ",
+            Self::Bulleted => "*",
             Self::Numbered => "1. ",
-            Self::Todo => "- [ ] ",
+            Self::Todo => "* [ ] ",
         }
     }
 }


### PR DESCRIPTION
I hereby declare asterisks the top-tier bulleted list character 👑 

*'s most closely resemble •'s
+'s don't render as bullets in slack, where I commonly paste a copied bulleted list text
-'s can cause other text to become a header before you start typing, e.g. in
```
confusingly a header
  - 
```
confusingly a header
  - 