### PR TITLE
editor: toggle off current style with empty selection

### DIFF
--- a/libs/editor/egui_editor/src/ast.rs
+++ b/libs/editor/egui_editor/src/ast.rs
@@ -407,7 +407,7 @@ impl Ast {
         }
     }
 
-    /// Returns the AstTextRange at the given offset. Prefers the previous range when at a boundary.
+    /// Returns the AstTextRange at the given offset. Prefers the next range when at a boundary.
     pub fn text_range_at_offset(&self, offset: DocCharOffset) -> Option<AstTextRange> {
         let mut end_range = None;
         for text_range in self.iter_text_ranges() {

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -187,6 +187,19 @@ pub fn calc_text(ast: &Ast, appearance: &Appearance, segs: &UnicodeSegs) -> Text
         // empty range at end of doc
         result.push((segs.last_cursor_position(), segs.last_cursor_position()));
     }
+
+    // if let Some(first) = result.first() {
+    //     if first.start() != 0 {
+    //         // prepend empty range so that doc start is always a valid cursor location
+    //         result.splice(0..0, iter::once((0.into(), 0.into())));
+    //     }
+    // }
+    // if let Some(last) = result.last() {
+    //     if last.end() != segs.last_cursor_position() {
+    //         // append empty range so that doc end is always a valid cursor location
+    //         result.push((segs.last_cursor_position(), segs.last_cursor_position()));
+    //     }
+    // }
     if result.is_empty() {
         result = vec![(0.into(), 0.into())];
     }

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -187,19 +187,6 @@ pub fn calc_text(ast: &Ast, appearance: &Appearance, segs: &UnicodeSegs) -> Text
         // empty range at end of doc
         result.push((segs.last_cursor_position(), segs.last_cursor_position()));
     }
-
-    // if let Some(first) = result.first() {
-    //     if first.start() != 0 {
-    //         // prepend empty range so that doc start is always a valid cursor location
-    //         result.splice(0..0, iter::once((0.into(), 0.into())));
-    //     }
-    // }
-    // if let Some(last) = result.last() {
-    //     if last.end() != segs.last_cursor_position() {
-    //         // append empty range so that doc end is always a valid cursor location
-    //         result.push((segs.last_cursor_position(), segs.last_cursor_position()));
-    //     }
-    // }
     if result.is_empty() {
         result = vec![(0.into(), 0.into())];
     }

--- a/libs/editor/egui_editor/src/style.rs
+++ b/libs/editor/egui_editor/src/style.rs
@@ -21,8 +21,8 @@ impl MarkdownNodeType {
             Self::Document => "",
             Self::Paragraph => "",
             Self::Inline(InlineNodeType::Code) => "`",
-            Self::Inline(InlineNodeType::Bold) => "__",
-            Self::Inline(InlineNodeType::Italic) => "_",
+            Self::Inline(InlineNodeType::Bold) => "**",
+            Self::Inline(InlineNodeType::Italic) => "*",
             Self::Inline(InlineNodeType::Strikethrough) => "~~",
             Self::Inline(InlineNodeType::Link) => "[",
             Self::Inline(InlineNodeType::Image) => {
@@ -47,8 +47,8 @@ impl MarkdownNodeType {
             Self::Document => "",
             Self::Paragraph => "",
             Self::Inline(InlineNodeType::Code) => "`",
-            Self::Inline(InlineNodeType::Bold) => "__",
-            Self::Inline(InlineNodeType::Italic) => "_",
+            Self::Inline(InlineNodeType::Bold) => "**",
+            Self::Inline(InlineNodeType::Italic) => "*",
             Self::Inline(InlineNodeType::Strikethrough) => "~~",
             Self::Inline(InlineNodeType::Link) => "]()",
             Self::Inline(InlineNodeType::Image) => {
@@ -62,10 +62,6 @@ impl MarkdownNodeType {
             Self::Block(BlockNodeType::ListItem(..)) => "",
             Self::Block(BlockNodeType::Rule) => "",
         }
-    }
-
-    pub fn needs_whitespace(&self) -> bool {
-        matches!(self, Self::Inline(InlineNodeType::Bold | InlineNodeType::Italic))
     }
 }
 

--- a/libs/editor/egui_editor/src/test_input.rs
+++ b/libs/editor/egui_editor/src/test_input.rs
@@ -267,8 +267,8 @@ code block
 fin"#;
 pub static TEST_MARKDOWN_50: &str = r#"# Editor Demo
 Featuring:
-1. a __bold__ list item,
-    * an _italic_ list item,
+1. a **bold** list item,
+    * an *italic* list item,
     - [ ] a `code` list item,
 
 ```


### PR DESCRIPTION
based on https://github.com/lockbook/lockbook/pull/2011

fixes https://github.com/lockbook/lockbook/issues/2007
Also changes default bold and italic characters from underscores to asterisks because they don't need whitespace around them whereas underscores do.

https://github.com/lockbook/lockbook/assets/6198756/45f54724-ee73-45ea-803d-e0c30e27875d