### PR TITLE
editor: cursor serif

### DIFF
--- a/libs/editor/egui_editor/src/draw.rs
+++ b/libs/editor/egui_editor/src/draw.rs
@@ -157,6 +157,20 @@ impl Editor {
 
         // draw cursor for selection end
         ui.painter().line_segment(selection_end_line, stroke);
+        ui.painter().line_segment(
+            [
+                Pos2 { x: selection_end_line[0].x - 2.0, y: selection_end_line[0].y },
+                Pos2 { x: selection_end_line[0].x + 2.0, y: selection_end_line[0].y },
+            ],
+            stroke,
+        );
+        ui.painter().line_segment(
+            [
+                Pos2 { x: selection_end_line[1].x - 2.0, y: selection_end_line[1].y },
+                Pos2 { x: selection_end_line[1].x + 2.0, y: selection_end_line[1].y },
+            ],
+            stroke,
+        );
 
         if touch_mode {
             // draw cursor for selection start


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2026


https://github.com/lockbook/lockbook/assets/6198756/964e1829-a730-467c-a9bb-f6c9be9528bb



Draft because I don't think this looks better than what we have now, and slack/discord/github/google docs use a single line (which, notably, blinks when you have focus)