### PR TITLE
editor: plaintext links, bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,7 @@ dependencies = [
  "egui_wgpu_backend",
  "image",
  "libc",
+ "linkify",
  "pollster",
  "pulldown-cmark",
  "rand 0.8.5",
@@ -3261,6 +3262,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/libs/editor/egui_editor/Cargo.toml
+++ b/libs/editor/egui_editor/Cargo.toml
@@ -24,6 +24,7 @@ pulldown-cmark = { version = "0.9.2", default-features = false }
 reqwest = { version = "0.11", features = ["blocking"] }
 unicode-segmentation = "1.10.0"
 rand = "0.8.5"
+linkify = "0.10.0"
 
 #eframe = { version = "0.19.0", optional = true, default-features = false, features = ['wgpu', 'dark-light'] }
 eframe = { version = "0.22.0", optional = true }

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -427,7 +427,7 @@ pub unsafe extern "C" fn is_position_within_bound(
     };
     if let Some(range) = pos.range_bound(bound, backwards, false, &obj.editor.bounds) {
         // this implementation doesn't meet the specification in apple's docs, but the implementation that does creates word jumping bugs
-        if range.contains(pos) {
+        if range.contains_inclusive(pos) {
             return true;
         }
     }

--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -35,15 +35,6 @@ pub unsafe extern "C" fn insert_text(obj: *mut c_void, content: *const c_char) {
 pub unsafe extern "C" fn backspace(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuEditor);
 
-    // iOS selects the previous character before deleting it, but we prefer the behavior when the selection is empty
-    // because it e.g. deletes annotations in one keystroke (consistent with other platforms)
-    obj.raw_input.events.push(Event::Key {
-        key: Key::ArrowRight,
-        pressed: true,
-        repeat: false,
-        modifiers: Default::default(),
-    });
-
     obj.raw_input.events.push(Event::Key {
         key: Key::Backspace,
         pressed: true,

--- a/libs/editor/egui_editor/src/ast.rs
+++ b/libs/editor/egui_editor/src/ast.rs
@@ -1,7 +1,7 @@
 use crate::buffer::SubBuffer;
 use crate::input::cursor::Cursor;
 use crate::layouts::Annotation;
-use crate::offset_types::{DocCharOffset, RangeExt};
+use crate::offset_types::{DocCharOffset, RangeExt, RelCharOffset};
 use crate::style::{
     BlockNode, BlockNodeType, InlineNode, ListItem, MarkdownNode, MarkdownNodeType,
 };
@@ -61,7 +61,7 @@ impl Ast {
         let mut smallest_chosen_ast_range = usize::MAX;
 
         for i in 0..self.nodes.len() {
-            if self.nodes[i].range.contains(offset)
+            if self.nodes[i].range.contains_inclusive(offset)
                 && self.nodes[i].range.len().0 < smallest_chosen_ast_range
             {
                 chosen = i;
@@ -412,7 +412,7 @@ impl Ast {
     pub fn text_range_at_offset(&self, offset: DocCharOffset) -> Option<AstTextRange> {
         let mut end_range = None;
         for text_range in self.iter_text_ranges() {
-            if text_range.range.contains(offset) {
+            if text_range.range.contains_inclusive(offset) {
                 end_range = Some(text_range);
             }
         }
@@ -426,7 +426,7 @@ impl Ast {
             for ancestor_node_idx in text_range.ancestors {
                 let ancestor_node = &self.nodes[ancestor_node_idx];
                 // offset must be in text range (not head/tail syntax chars) to apply
-                if ancestor_node.text_range.contains(offset) {
+                if ancestor_node.text_range.contains_inclusive(offset) {
                     result.push(ancestor_node.node_type.clone());
                 }
             }
@@ -514,10 +514,42 @@ impl AstTextRange {
 
     pub fn intersects_selection(&self, ast: &Ast, cursor: Cursor) -> bool {
         if let Some(&ast_node_idx) = self.ancestors.last() {
-            ast.nodes[ast_node_idx].range.intersects(&cursor.selection)
+            ast.nodes[ast_node_idx]
+                .range
+                .intersects_allow_empty(&cursor.selection)
         } else {
             false
         }
+    }
+}
+
+impl RangeExt<DocCharOffset> for AstTextRange {
+    /// returns whether the range includes the value
+    fn contains(&self, value: DocCharOffset, start_inclusive: bool, end_inclusive: bool) -> bool {
+        self.range.contains(value, start_inclusive, end_inclusive)
+    }
+
+    /// returns whether the range intersects another range
+    fn intersects(
+        &self, other: &(DocCharOffset, DocCharOffset), allow_empty_intersection: bool,
+    ) -> bool {
+        self.range.intersects(other, allow_empty_intersection)
+    }
+
+    fn start(&self) -> DocCharOffset {
+        self.range.start()
+    }
+
+    fn end(&self) -> DocCharOffset {
+        self.range.end()
+    }
+
+    fn len(&self) -> RelCharOffset {
+        self.range.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.range.is_empty()
     }
 }
 

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -42,7 +42,9 @@ pub fn calc_ast(ast: &Ast) -> AstTextRanges {
     ast.iter_text_ranges().collect()
 }
 
-pub fn calc_words(buffer: &SubBuffer, ast: &Ast, appearance: &Appearance) -> Words {
+pub fn calc_words(
+    buffer: &SubBuffer, ast: &Ast, ast_ranges: &AstTextRanges, appearance: &Appearance,
+) -> Words {
     let mut result = vec![];
 
     for text_range in ast.iter_text_ranges() {
@@ -82,10 +84,10 @@ pub fn calc_words(buffer: &SubBuffer, ast: &Ast, appearance: &Appearance) -> Wor
     result
 }
 
-pub fn calc_lines(galleys: &Galleys, ast: &Ast, text: &Text) -> Lines {
+pub fn calc_lines(galleys: &Galleys, ast: &AstTextRanges, text: &Text) -> Lines {
     let mut result = vec![];
     let galleys = galleys;
-    let mut text_range_iter = ast.iter_text_ranges();
+    let mut text_range_iter = ast.iter();
     for (galley_idx, galley) in galleys.galleys.iter().enumerate() {
         for (row_idx, _) in galley.galley.rows.iter().enumerate() {
             let start_cursor = galley
@@ -136,12 +138,12 @@ pub fn calc_lines(galleys: &Galleys, ast: &Ast, text: &Text) -> Lines {
     result
 }
 
-pub fn calc_paragraphs(buffer: &SubBuffer, ast: &Ast) -> Paragraphs {
+pub fn calc_paragraphs(buffer: &SubBuffer, ast: &AstTextRanges) -> Paragraphs {
     let mut result = vec![];
 
     let captured_newlines = {
         let mut captured_newlines = HashSet::new();
-        for text_range in ast.iter_text_ranges() {
+        for text_range in ast {
             match text_range.range_type {
                 AstTextRangeType::Head | AstTextRangeType::Tail => {
                     // newlines in syntax sequences don't break paragraphs
@@ -176,10 +178,13 @@ pub fn calc_paragraphs(buffer: &SubBuffer, ast: &Ast) -> Paragraphs {
     result
 }
 
-pub fn calc_text(ast: &Ast, appearance: &Appearance, segs: &UnicodeSegs, cursor: Cursor) -> Text {
+pub fn calc_text(
+    ast: &Ast, ast_ranges: &AstTextRanges, appearance: &Appearance, segs: &UnicodeSegs,
+    cursor: Cursor,
+) -> Text {
     let mut result = vec![];
     let mut last_range_pushed = false;
-    for text_range in ast.iter_text_ranges() {
+    for text_range in ast_ranges {
         let captured = match appearance.markdown_capture(text_range.node(ast).node_type()) {
             CaptureCondition::Always => true,
             CaptureCondition::NoCursor => !text_range.intersects_selection(ast, cursor),

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -578,7 +578,7 @@ impl<Range: RangeExt<DocCharOffset>> RangesExt for Vec<Range> {
                 } else {
                     Ordering::Less
                 }
-            } else if offset > range.start() && offset > range.end() {
+            } else if offset > range.start() && offset < range.end() {
                 Ordering::Equal
             } else if offset == range.end() {
                 if end_inclusive {

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -47,7 +47,7 @@ pub fn calc_words(
 ) -> Words {
     let mut result = vec![];
 
-    for text_range in ast.iter_text_ranges() {
+    for text_range in ast_ranges {
         if text_range.range_type != AstTextRangeType::Text
             && appearance.markdown_capture(text_range.node(ast).node_type())
                 == CaptureCondition::Always

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -620,9 +620,7 @@ impl<Range: RangeExt<DocCharOffset>> RangesExt for Vec<Range> {
     }
 }
 
-pub fn join<'r, const N: usize>(
-    ranges: [&'r [(DocCharOffset, DocCharOffset)]; N],
-) -> RangeJoinIter<'r, N> {
+pub fn join<const N: usize>(ranges: [&[(DocCharOffset, DocCharOffset)]; N]) -> RangeJoinIter<N> {
     let mut result = RangeJoinIter {
         ranges,
         in_range: [false; N],
@@ -683,7 +681,7 @@ impl<'r, const N: usize> Iterator for RangeJoinIter<'r, N> {
 
             // exclude between-ranges ranges from result
             let idx_result = {
-                let mut this = self.current.clone();
+                let mut this = self.current;
                 for (idx, &in_range) in self.in_range.iter().enumerate() {
                     if !in_range {
                         this[idx] = None;

--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -2081,7 +2081,7 @@ mod test {
     #[test]
     fn range_join_iter() {
         let a = vec![(0.into(), 10.into())];
-        let b = vec![(0.into(), 5.into()), (5.into(), 10.into())];
+        let b = vec![(0.into(), 5.into()), (5.into(), 5.into()), (5.into(), 10.into())];
         let c = vec![(3.into(), 7.into())];
 
         let result = join([&a, &b, &c]).collect::<Vec<_>>();
@@ -2091,8 +2091,9 @@ mod test {
             &[
                 ([Some(0), Some(0), None], (0.into(), 3.into())),
                 ([Some(0), Some(0), Some(0)], (3.into(), 5.into())),
-                ([Some(0), Some(1), Some(0)], (5.into(), 7.into())),
-                ([Some(0), Some(1), None], (7.into(), 10.into())),
+                ([Some(0), Some(1), Some(0)], (5.into(), 5.into())),
+                ([Some(0), Some(2), Some(0)], (5.into(), 7.into())),
+                ([Some(0), Some(2), None], (7.into(), 10.into())),
             ]
         )
     }

--- a/libs/editor/egui_editor/src/draw.rs
+++ b/libs/editor/egui_editor/src/draw.rs
@@ -123,7 +123,10 @@ impl Editor {
             let mut selection_end_line = selection_end_line;
             let mut stroke = stroke;
 
-            for style in self.ast.styles_at_offset(cursor.selection.1) {
+            for style in self
+                .ast
+                .styles_at_offset(cursor.selection.1, &self.bounds.ast)
+            {
                 match style {
                     MarkdownNode::Inline(InlineNode::Bold)
                     | MarkdownNode::Block(BlockNode::Heading(HeadingLevel::H1)) => {

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -305,6 +305,7 @@ impl Editor {
         // recalculate dependent state
         if text_updated {
             self.ast = ast::calc(&self.buffer.current);
+            self.bounds.ast = bounds::calc_ast(&self.ast);
             self.bounds.words =
                 bounds::calc_words(&self.buffer.current, &self.ast, &self.appearance);
             self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer.current, &self.ast);
@@ -511,7 +512,7 @@ impl Editor {
                     .any(|e| matches!(e, Modification::Select { region: Region::Location(..) }));
 
             let touched_selection = current_selection.is_empty()
-                && prior_selection.contains(current_selection.1)
+                && prior_selection.contains_inclusive(current_selection.1)
                 && touched_a_galley
                 && combined_events
                     .iter()

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -398,7 +398,7 @@ impl Editor {
         if self.buffer.current.cursor.selection.is_empty() {
             for style in self
                 .ast
-                .styles_at_offset(self.buffer.current.cursor.selection.start())
+                .styles_at_offset(self.buffer.current.cursor.selection.start(), &self.bounds.ast)
             {
                 match style {
                     MarkdownNode::Inline(InlineNode::Bold) => result.cursor_in_bold = true,

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -306,13 +306,19 @@ impl Editor {
         if text_updated {
             self.ast = ast::calc(&self.buffer.current);
             self.bounds.ast = bounds::calc_ast(&self.ast);
-            self.bounds.words =
-                bounds::calc_words(&self.buffer.current, &self.ast, &self.appearance);
-            self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer.current, &self.ast);
+            self.bounds.words = bounds::calc_words(
+                &self.buffer.current,
+                &self.ast,
+                &self.bounds.ast,
+                &self.appearance,
+            );
+            self.bounds.paragraphs =
+                bounds::calc_paragraphs(&self.buffer.current, &self.bounds.ast);
         }
         if text_updated || selection_updated {
             self.bounds.text = bounds::calc_text(
                 &self.ast,
+                &self.bounds.ast,
                 &self.appearance,
                 &self.buffer.current.segs,
                 self.buffer.current.cursor,
@@ -330,7 +336,7 @@ impl Editor {
             &self.appearance,
             ui,
         );
-        self.bounds.lines = bounds::calc_lines(&self.galleys, &self.ast, &self.bounds.text);
+        self.bounds.lines = bounds::calc_lines(&self.galleys, &self.bounds.ast, &self.bounds.text);
         self.initialized = true;
 
         // draw

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -316,6 +316,7 @@ impl Editor {
                 &self.buffer.current.segs,
                 self.buffer.current.cursor,
             );
+            self.bounds.links = bounds::calc_links(&self.buffer.current, &self.bounds.text);
         }
         if text_updated || selection_updated || theme_updated {
             self.images = images::calc(&self.ast, &self.images, &self.client, ui);

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -177,7 +177,7 @@ pub fn calc(
                             layout.append(&text, 0.0, text_format);
                         }
 
-                        if is_annotation {
+                        if captured && is_annotation {
                             head_size = text_range_portion.range.len();
                         }
                     }

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -250,7 +250,7 @@ impl Galleys {
     pub fn galley_at_char(&self, offset: DocCharOffset) -> usize {
         for i in 0..self.galleys.len() {
             let galley = &self.galleys[i];
-            if galley.range.contains(offset) {
+            if galley.range.contains_inclusive(offset) {
                 return i;
             }
         }

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -104,7 +104,8 @@ pub fn calc(
             let mut is_annotation = false;
             if text_range.range_type == AstTextRangeType::Head
                 && text_range.range.start() == text_range_portion.start()
-                && captured
+                && (captured
+                    || text_range.annotation(ast) == Some(Annotation::HeadingRule)) // heading rules drawn reglardless of capture
                 && annotation.is_none()
             {
                 annotation = text_range.annotation(ast);
@@ -134,7 +135,7 @@ pub fn calc(
                         layout.append(&text, 0.0, text_format);
                     }
 
-                    if is_annotation {
+                    if captured && is_annotation {
                         head_size = text_range.range.len();
                     }
                 }

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -80,7 +80,7 @@ pub fn calc(
 
         if let Some(ast_idx) = ast_idx {
             let text_range = &bounds.ast[ast_idx];
-            let maybe_link_range = link_idx.map(|link_idx| bounds.links[link_idx].clone());
+            let maybe_link_range = link_idx.map(|link_idx| bounds.links[link_idx]);
             let in_selection = selection_idx.is_some();
 
             let captured = match appearance.markdown_capture(text_range.node(ast).node_type()) {

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -99,6 +99,9 @@ pub fn calc(
             if in_selection {
                 RenderStyle::Selection.apply_style(&mut text_format, appearance);
             }
+            if maybe_link_range.is_some() {
+                RenderStyle::PlaintextLink.apply_style(&mut text_format, appearance);
+            }
 
             // only the first portion of a head text range gets that range's annotation
             let mut is_annotation = false;

--- a/libs/editor/egui_editor/src/input/click_checker.rs
+++ b/libs/editor/egui_editor/src/input/click_checker.rs
@@ -79,7 +79,7 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
         );
         for ast_node in &self.ast.nodes {
             if let MarkdownNode::Inline(InlineNode::Link(_, url, _)) = &ast_node.node_type {
-                if ast_node.range.contains(offset) {
+                if ast_node.range.contains_inclusive(offset) {
                     return Some(url.to_string());
                 }
             }

--- a/libs/editor/egui_editor/src/input/click_checker.rs
+++ b/libs/editor/egui_editor/src/input/click_checker.rs
@@ -77,6 +77,8 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
             &self.buffer.current.segs,
             &self.bounds.text,
         );
+
+        // todo: binary search
         for ast_node in &self.ast.nodes {
             if let MarkdownNode::Inline(InlineNode::Link(_, url, _)) = &ast_node.node_type {
                 if ast_node.range.contains_inclusive(offset) {
@@ -84,6 +86,12 @@ impl<'a> ClickChecker for &'a EditorClickChecker<'a> {
                 }
             }
         }
+        for plaintext_link in &self.bounds.links {
+            if plaintext_link.contains_inclusive(offset) {
+                return Some(self.buffer.current[*plaintext_link].to_string());
+            }
+        }
+
         None
     }
 

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -733,8 +733,8 @@ pub fn pos_to_char_offset(
         let mut result = 0.into();
         for galley_idx in 0..galleys.len() {
             let galley = &galleys[galley_idx];
-            if galley.galley_location.min.y <= pos.y {
-                if pos.y <= galley.galley_location.max.y {
+            if pos.y <= galley.galley_location.max.y {
+                if galley.galley_location.min.y <= pos.y {
                     // click position is in a galley
                 } else {
                     // click position is between galleys
@@ -743,6 +743,7 @@ pub fn pos_to_char_offset(
                 let relative_pos = pos - galley.text_location;
                 let new_cursor = galley.galley.cursor_from_pos(relative_pos);
                 result = galleys.char_offset_by_galley_and_cursor(galley_idx, &new_cursor, text);
+                break;
             }
         }
         result

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Ast, AstTextRangeType};
-use crate::bounds::{Bounds, Text};
+use crate::bounds::{AstTextRanges, Bounds, Text};
 use crate::buffer::{EditorMutation, Mutation, SubBuffer, SubMutation};
 use crate::galleys::Galleys;
 use crate::input::canonical::{Location, Modification, Offset, Region};
@@ -463,7 +463,7 @@ fn conflicting_styles(cursor: Cursor, style: &MarkdownNode, ast: &Ast) -> HashSe
 /// Applies or unapplies `style` to `cursor`, splitting or joining surrounding styles as necessary.
 fn apply_style(
     cursor: Cursor, style: MarkdownNode, unapply: bool, buffer: &SubBuffer, ast: &Ast,
-    mutation: &mut Vec<SubMutation>,
+    ast_ranges: &AstTextRanges, mutation: &mut Vec<SubMutation>,
 ) {
     if buffer.is_empty() {
         insert_head(cursor.selection.start(), style.clone(), mutation);

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -476,12 +476,15 @@ fn apply_style(
     let mut end_range = None;
     for text_range in ast.iter_text_ranges() {
         // when at bound, start prefers next
-        if text_range.range.contains(cursor.selection.start()) {
+        if text_range
+            .range
+            .contains_inclusive(cursor.selection.start())
+        {
             start_range = Some(text_range.clone());
         }
         // when at bound, end prefers previous unless selection is empty
         if (cursor.selection.is_empty() || end_range.is_none())
-            && text_range.range.contains(cursor.selection.end())
+            && text_range.range.contains_inclusive(cursor.selection.end())
         {
             end_range = Some(text_range);
         }

--- a/libs/editor/egui_editor/src/offset_types.rs
+++ b/libs/editor/egui_editor/src/offset_types.rs
@@ -489,3 +489,47 @@ where
         (self.into(), self.into())
     }
 }
+
+pub trait RangeIterExt {
+    type Item;
+    type Iter: DoubleEndedIterator<Item = Self::Item>;
+    fn iter(self) -> Self::Iter;
+}
+
+impl RangeIterExt for (usize, usize) {
+    type Item = usize;
+    type Iter = RangeIter;
+    fn iter(self) -> Self::Iter {
+        RangeIter { start_inclusive: self.0, end_exclusive: self.1 }
+    }
+}
+
+pub struct RangeIter {
+    start_inclusive: usize,
+    end_exclusive: usize,
+}
+
+impl Iterator for RangeIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start_inclusive < self.end_exclusive {
+            let result = self.start_inclusive;
+            self.start_inclusive += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+}
+
+impl DoubleEndedIterator for RangeIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start_inclusive < self.end_exclusive {
+            self.end_exclusive -= 1;
+            Some(self.end_exclusive)
+        } else {
+            None
+        }
+    }
+}

--- a/libs/editor/egui_editor/src/style.rs
+++ b/libs/editor/egui_editor/src/style.rs
@@ -111,6 +111,7 @@ impl ListItemType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RenderStyle {
     Selection,
+    PlaintextLink,
     Syntax,
     Markdown(MarkdownNode),
 }
@@ -238,6 +239,9 @@ impl RenderStyle {
         match self {
             RenderStyle::Selection => {
                 text_format.background = vis.selection_bg();
+            }
+            RenderStyle::PlaintextLink => {
+                text_format.color = vis.link();
             }
             RenderStyle::Syntax => {
                 text_format.color = vis.syntax();


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2009

- fixes an issue where galley head sizes were calculated incorrectly in the presence of heading rules
- fixes an issue where the galley of a click was calculated incorrectly
- reduces ast traversals and replaces some linear searches with binary searches (gains not measured, but we should check the use case in https://github.com/lockbook/lockbook/issues/2030 after merging)

https://github.com/lockbook/lockbook/assets/6198756/04928b2e-f226-4cc1-a3fb-08338a56647d