### PR TITLE
Revert "editor: fix unrendered heading rule (#2043)"

### DIFF
--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -145,9 +145,8 @@ pub fn calc(
                 let mut is_annotation = false;
                 if text_range.range_type == AstTextRangeType::Head
                     && text_range.range.0 == text_range_portion.range.0
-                    && (captured
-                    || text_range_portion.annotation(ast) == Some(Annotation::HeadingRule)) // heading rules drawn reglardless of capture
-                        && annotation.is_none()
+                    && captured
+                    && annotation.is_none()
                 {
                     annotation = text_range_portion.annotation(ast);
                     annotation_text_format = text_format.clone();


### PR DESCRIPTION
This reverts commit 4ae109ecee8df7cd3d4637e228c278dbd4be9312.