### PR TITLE
egui: file tree style improvments

### DIFF
--- a/clients/egui/src/account/tree/node.rs
+++ b/clients/egui/src/account/tree/node.rs
@@ -177,9 +177,14 @@ impl TreeNode {
         let depth_inset = self.depth_inset() + 5.0;
         let wrap_width = ui.available_width();
 
-        let icon = if self.file.is_folder() { Icon::FOLDER_OPEN } else { self.icon() };
+        let icon = if self.file.is_folder() {
+            let wt: egui::WidgetText = (&Icon::FOLDER_OPEN).into();
+            wt.color(ui.visuals().hyperlink_color)
+        } else {
+            let wt: egui::WidgetText = (&self.icon()).into();
+            wt.color(ui.visuals().text_color().gamma_multiply(0.6))
+        };
 
-        let icon: egui::WidgetText = (&icon).into();
         let icon = icon.into_galley(ui, Some(false), wrap_width, egui::TextStyle::Body);
 
         let text: egui::WidgetText = (&self.file.name).into();
@@ -197,9 +202,9 @@ impl TreeNode {
         let (rect, resp) = ui.allocate_exact_size(desired_size, egui::Sense::click_and_drag());
         if ui.is_rect_visible(rect) {
             let bg = if state.selected.contains(&self.file.id) {
-                ui.visuals().widgets.active.bg_fill
+                ui.visuals().code_bg_color.gamma_multiply(0.6)
             } else if resp.hovered() {
-                ui.visuals().widgets.hovered.bg_fill
+                ui.visuals().code_bg_color.gamma_multiply(0.3)
             } else {
                 ui.visuals().panel_fill
             };

--- a/clients/egui/src/account/workspace.rs
+++ b/clients/egui/src/account/workspace.rs
@@ -224,6 +224,13 @@ impl super::AccountScreen {
 
             ui.visuals_mut().widgets.inactive.bg_fill = ui.visuals().widgets.active.bg_fill;
             ui.visuals_mut().widgets.hovered.bg_fill = ui.visuals().widgets.active.bg_fill;
+
+            let text_stroke =
+                egui::Stroke { color: ui.visuals().extreme_bg_color, ..Default::default() };
+            ui.visuals_mut().widgets.inactive.fg_stroke = text_stroke;
+            ui.visuals_mut().widgets.active.fg_stroke = text_stroke;
+            ui.visuals_mut().widgets.hovered.fg_stroke = text_stroke;
+
             if Button::default()
                 .text("New document")
                 .frame(true)

--- a/clients/egui/src/theme/palette.rs
+++ b/clients/egui/src/theme/palette.rs
@@ -24,16 +24,16 @@ impl ThemePalette {
         white: Color32::from_rgb(255, 255, 255),
     };
 
-    pub const LIGHT: Self = Self {
-        black: Color32::from_rgb(0, 0, 0),
-        red: Color32::from_rgb(255, 59, 48),
-        green: Color32::from_rgb(40, 205, 65),
-        yellow: Color32::from_rgb(255, 204, 0),
-        blue: Color32::from_rgb(165, 208, 255),
-        magenta: Color32::from_rgb(175, 82, 222),
-        cyan: Color32::from_rgb(85, 190, 240),
-        white: Color32::from_rgb(255, 255, 255),
-    };
+    // pub const LIGHT: Self = Self {
+    //     black: Color32::from_rgb(0, 0, 0),
+    //     red: Color32::from_rgb(255, 59, 48),
+    //     green: Color32::from_rgb(40, 205, 65),
+    //     yellow: Color32::from_rgb(255, 204, 0),
+    //     blue: Color32::from_rgb(165, 208, 255),
+    //     magenta: Color32::from_rgb(175, 82, 222),
+    //     cyan: Color32::from_rgb(85, 190, 240),
+    //     white: Color32::from_rgb(255, 255, 255),
+    // };
 }
 
 impl std::ops::Index<lb::ColorAlias> for ThemePalette {

--- a/clients/egui/src/theme/palette.rs
+++ b/clients/egui/src/theme/palette.rs
@@ -24,16 +24,16 @@ impl ThemePalette {
         white: Color32::from_rgb(255, 255, 255),
     };
 
-    // pub const LIGHT: Self = Self {
-    //     black: Color32::from_rgb(0, 0, 0),
-    //     red: Color32::from_rgb(255, 59, 48),
-    //     green: Color32::from_rgb(40, 205, 65),
-    //     yellow: Color32::from_rgb(255, 204, 0),
-    //     blue: Color32::from_rgb(165, 208, 255),
-    //     magenta: Color32::from_rgb(175, 82, 222),
-    //     cyan: Color32::from_rgb(85, 190, 240),
-    //     white: Color32::from_rgb(255, 255, 255),
-    // };
+    pub const LIGHT: Self = Self {
+        black: Color32::from_rgb(0, 0, 0),
+        red: Color32::from_rgb(255, 59, 48),
+        green: Color32::from_rgb(40, 205, 65),
+        yellow: Color32::from_rgb(255, 204, 0),
+        blue: Color32::from_rgb(10, 132, 255),
+        magenta: Color32::from_rgb(175, 82, 222),
+        cyan: Color32::from_rgb(85, 190, 240),
+        white: Color32::from_rgb(255, 255, 255),
+    };
 }
 
 impl std::ops::Index<lb::ColorAlias> for ThemePalette {

--- a/clients/egui/src/theme/visuals.rs
+++ b/clients/egui/src/theme/visuals.rs
@@ -16,6 +16,6 @@ pub fn dark(primary: lb::ColorAlias) -> egui::Visuals {
 pub fn light(primary: lb::ColorAlias) -> egui::Visuals {
     let mut v = egui::Visuals::light();
     v.widgets.hovered.bg_fill = v.widgets.active.bg_fill;
-    v.widgets.active.bg_fill = ThemePalette::DARK[primary];
+    v.widgets.active.bg_fill = ThemePalette::LIGHT[primary];
     v
 }

--- a/clients/egui/src/theme/visuals.rs
+++ b/clients/egui/src/theme/visuals.rs
@@ -16,6 +16,6 @@ pub fn dark(primary: lb::ColorAlias) -> egui::Visuals {
 pub fn light(primary: lb::ColorAlias) -> egui::Visuals {
     let mut v = egui::Visuals::light();
     v.widgets.hovered.bg_fill = v.widgets.active.bg_fill;
-    v.widgets.active.bg_fill = ThemePalette::LIGHT[primary];
+    v.widgets.active.bg_fill = ThemePalette::DARK[primary];
     v
 }


### PR DESCRIPTION
slight visual changes in the aesthetics of the sidebar file tree to make the ui feel more modern and sleek. 

# Demo
after: 

https://github.com/lockbook/lockbook/assets/66345861/dedb21e5-0f41-44db-9080-fa2fe16c871e

before: 

<details>

![image](https://github.com/lockbook/lockbook/assets/66345861/9d621b64-a5b3-4ad1-b5c6-630328e72d20)
![image](https://github.com/lockbook/lockbook/assets/66345861/37dfa9de-d153-4d1a-b711-0c2ba150b6c4)

</details

