### PR TITLE
editor: toggle style refinements

### DIFF
--- a/libs/editor/egui_editor/src/bounds.rs
+++ b/libs/editor/egui_editor/src/bounds.rs
@@ -571,12 +571,14 @@ impl<Range: RangeExt<DocCharOffset>> RangesExt for Vec<Range> {
     ) -> (usize, usize) {
         match self.binary_search_by(|range| {
             if offset < range.start() {
-                Ordering::Less
+                Ordering::Greater
             } else if offset == range.start() {
-                if start_inclusive {
+                if offset == range.end() && !end_inclusive {
+                    Ordering::Less
+                } else if start_inclusive {
                     Ordering::Equal
                 } else {
-                    Ordering::Less
+                    Ordering::Greater
                 }
             } else if offset > range.start() && offset < range.end() {
                 Ordering::Equal
@@ -584,23 +586,23 @@ impl<Range: RangeExt<DocCharOffset>> RangesExt for Vec<Range> {
                 if end_inclusive {
                     Ordering::Equal
                 } else {
-                    Ordering::Greater
+                    Ordering::Less
                 }
             } else if offset > range.end() {
-                Ordering::Greater
+                Ordering::Less
             } else {
                 unreachable!()
             }
         }) {
             Ok(idx) => {
                 let mut start = idx;
-                while start > 0 && self[idx - 1].contains(offset, start_inclusive, end_inclusive) {
+                while start > 0 && self[start - 1].contains(offset, start_inclusive, end_inclusive)
+                {
                     start -= 1;
                 }
 
                 let mut end = idx;
-                while end < self.len() - 1
-                    && self[end + 1].contains(offset, start_inclusive, end_inclusive)
+                while end < self.len() && self[end].contains(offset, start_inclusive, end_inclusive)
                 {
                     end += 1;
                 }
@@ -747,9 +749,8 @@ impl Editor {
 
 #[cfg(test)]
 mod test {
+    use super::{join, Bounds, RangesExt};
     use crate::{input::canonical::Bound, offset_types::DocCharOffset};
-
-    use super::{join, Bounds};
 
     #[test]
     fn range_before_after_no_ranges() {
@@ -2063,6 +2064,56 @@ mod test {
             DocCharOffset(8).advance_to_next_bound(Bound::Char, true, &bounds),
             DocCharOffset(6)
         );
+    }
+
+    #[test]
+    fn find_containing() {
+        let ranges: Vec<(DocCharOffset, DocCharOffset)> = vec![
+            (1.into(), 3.into()),
+            (5.into(), 6.into()),
+            (6.into(), 6.into()),
+            (6.into(), 7.into()),
+        ];
+
+        assert_eq!(ranges.find_containing(0.into(), false, false), (0, 0));
+        assert_eq!(ranges.find_containing(1.into(), false, false), (0, 0));
+        assert_eq!(ranges.find_containing(2.into(), false, false), (0, 1));
+        assert_eq!(ranges.find_containing(3.into(), false, false), (1, 1));
+        assert_eq!(ranges.find_containing(4.into(), false, false), (1, 1));
+        assert_eq!(ranges.find_containing(5.into(), false, false), (1, 1));
+        assert_eq!(ranges.find_containing(6.into(), false, false), (3, 3));
+        assert_eq!(ranges.find_containing(7.into(), false, false), (4, 4));
+        assert_eq!(ranges.find_containing(8.into(), false, false), (4, 4));
+
+        assert_eq!(ranges.find_containing(0.into(), true, false), (0, 0));
+        assert_eq!(ranges.find_containing(1.into(), true, false), (0, 1));
+        assert_eq!(ranges.find_containing(2.into(), true, false), (0, 1));
+        assert_eq!(ranges.find_containing(3.into(), true, false), (1, 1));
+        assert_eq!(ranges.find_containing(4.into(), true, false), (1, 1));
+        assert_eq!(ranges.find_containing(5.into(), true, false), (1, 2));
+        assert_eq!(ranges.find_containing(6.into(), true, false), (3, 4));
+        assert_eq!(ranges.find_containing(7.into(), true, false), (4, 4));
+        assert_eq!(ranges.find_containing(8.into(), true, false), (4, 4));
+
+        assert_eq!(ranges.find_containing(0.into(), false, true), (0, 0));
+        assert_eq!(ranges.find_containing(1.into(), false, true), (0, 0));
+        assert_eq!(ranges.find_containing(2.into(), false, true), (0, 1));
+        assert_eq!(ranges.find_containing(3.into(), false, true), (0, 1));
+        assert_eq!(ranges.find_containing(4.into(), false, true), (1, 1));
+        assert_eq!(ranges.find_containing(5.into(), false, true), (1, 1));
+        assert_eq!(ranges.find_containing(6.into(), false, true), (1, 2));
+        assert_eq!(ranges.find_containing(7.into(), false, true), (3, 4));
+        assert_eq!(ranges.find_containing(8.into(), false, true), (4, 4));
+
+        assert_eq!(ranges.find_containing(0.into(), true, true), (0, 0));
+        assert_eq!(ranges.find_containing(1.into(), true, true), (0, 1));
+        assert_eq!(ranges.find_containing(2.into(), true, true), (0, 1));
+        assert_eq!(ranges.find_containing(3.into(), true, true), (0, 1));
+        assert_eq!(ranges.find_containing(4.into(), true, true), (1, 1));
+        assert_eq!(ranges.find_containing(5.into(), true, true), (1, 2));
+        assert_eq!(ranges.find_containing(6.into(), true, true), (1, 4));
+        assert_eq!(ranges.find_containing(7.into(), true, true), (3, 4));
+        assert_eq!(ranges.find_containing(8.into(), true, true), (4, 4));
     }
 
     #[test]

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -512,29 +512,25 @@ fn apply_style(
 
     // modify head/tail for nodes containing cursor start and cursor end
     let mut last_start_ancestor: Option<usize> = None;
-    if start_range.range_type == AstTextRangeType::Text {
-        for &ancestor in &start_range.ancestors {
-            // dehead and detail all but the last ancestor applying the style
-            if let Some(prev_ancestor) = last_start_ancestor {
-                dehead_ast_node(prev_ancestor, ast, mutation);
-                detail_ast_node(prev_ancestor, ast, mutation);
-            }
-            if ast.nodes[ancestor].node_type == style {
-                last_start_ancestor = Some(ancestor);
-            }
+    for &ancestor in &start_range.ancestors {
+        // dehead and detail all but the last ancestor applying the style
+        if let Some(prev_ancestor) = last_start_ancestor {
+            dehead_ast_node(prev_ancestor, ast, mutation);
+            detail_ast_node(prev_ancestor, ast, mutation);
+        }
+        if ast.nodes[ancestor].node_type == style {
+            last_start_ancestor = Some(ancestor);
         }
     }
     let mut last_end_ancestor: Option<usize> = None;
-    if end_range.range_type == AstTextRangeType::Text {
-        for &ancestor in &end_range.ancestors {
-            // dehead and detail all but the last ancestor applying the style
-            if let Some(prev_ancestor) = last_end_ancestor {
-                dehead_ast_node(prev_ancestor, ast, mutation);
-                detail_ast_node(prev_ancestor, ast, mutation);
-            }
-            if ast.nodes[ancestor].node_type == style {
-                last_end_ancestor = Some(ancestor);
-            }
+    for &ancestor in &end_range.ancestors {
+        // dehead and detail all but the last ancestor applying the style
+        if let Some(prev_ancestor) = last_end_ancestor {
+            dehead_ast_node(prev_ancestor, ast, mutation);
+            detail_ast_node(prev_ancestor, ast, mutation);
+        }
+        if ast.nodes[ancestor].node_type == style {
+            last_end_ancestor = Some(ancestor);
         }
     }
     if last_start_ancestor != last_end_ancestor {
@@ -565,10 +561,10 @@ fn apply_style(
         }
     } else {
         // if applying, head start and/or tail end to extend styled region to selection
-        if last_start_ancestor.is_none() {
+        if last_start_ancestor.is_none() && !cursor.selection.is_empty() {
             insert_head(cursor.selection.start(), style.clone(), mutation)
         }
-        if last_end_ancestor.is_none() {
+        if last_end_ancestor.is_none() && !cursor.selection.is_empty() {
             insert_tail(cursor.selection.end(), style.clone(), mutation)
         }
     }

--- a/libs/editor/egui_editor/src/input/mutation.rs
+++ b/libs/editor/egui_editor/src/input/mutation.rs
@@ -546,7 +546,13 @@ fn apply_style(
         // if unapplying, tail or dehead node containing start to crop styled region to selection
         if let Some(last_start_ancestor) = last_start_ancestor {
             if ast.nodes[last_start_ancestor].text_range.start() < cursor.selection.start() {
-                insert_tail(cursor.selection.start(), style.clone(), mutation);
+                let offset = adjust_for_whitespace(
+                    buffer,
+                    cursor.selection.start(),
+                    style.node_type(),
+                    true,
+                );
+                insert_tail(offset, style.clone(), mutation);
             } else {
                 dehead_ast_node(last_start_ancestor, ast, mutation);
             }
@@ -554,7 +560,9 @@ fn apply_style(
         // if unapplying, head or detail node containing end to crop styled region to selection
         if let Some(last_end_ancestor) = last_end_ancestor {
             if ast.nodes[last_end_ancestor].text_range.end() > cursor.selection.end() {
-                insert_head(cursor.selection.end(), style.clone(), mutation);
+                let offset =
+                    adjust_for_whitespace(buffer, cursor.selection.end(), style.node_type(), false);
+                insert_head(offset, style.clone(), mutation);
             } else {
                 detail_ast_node(last_end_ancestor, ast, mutation);
             }
@@ -562,10 +570,14 @@ fn apply_style(
     } else {
         // if applying, head start and/or tail end to extend styled region to selection
         if last_start_ancestor.is_none() && !cursor.selection.is_empty() {
-            insert_head(cursor.selection.start(), style.clone(), mutation)
+            let offset =
+                adjust_for_whitespace(buffer, cursor.selection.start(), style.node_type(), false);
+            insert_head(offset, style.clone(), mutation)
         }
         if last_end_ancestor.is_none() && !cursor.selection.is_empty() {
-            insert_tail(cursor.selection.end(), style.clone(), mutation)
+            let offset =
+                adjust_for_whitespace(buffer, cursor.selection.end(), style.node_type(), true);
+            insert_tail(offset, style.clone(), mutation)
         }
     }
 
@@ -611,6 +623,32 @@ fn detail_ast_node(node_idx: usize, ast: &Ast, mutation: &mut Vec<SubMutation>) 
     let node = &ast.nodes[node_idx];
     mutation.push(SubMutation::Cursor { cursor: (node.text_range.end(), node.range.end()).into() });
     mutation.push(SubMutation::Insert { text: "".to_string(), advance_cursor: false });
+}
+
+fn adjust_for_whitespace(
+    buffer: &SubBuffer, mut offset: DocCharOffset, style: MarkdownNodeType, tail: bool,
+) -> DocCharOffset {
+    if matches!(style, MarkdownNodeType::Inline(..)) {
+        loop {
+            if (tail && offset == 0) || (!tail && offset == buffer.segs.last_cursor_position() - 1)
+            {
+                break;
+            }
+
+            let c =
+                if tail { &buffer[(offset - 1, offset)] } else { &buffer[(offset, offset + 1)] };
+            if c == " " {
+                if tail {
+                    offset -= 1
+                } else {
+                    offset += 1
+                }
+            } else {
+                break;
+            }
+        }
+    }
+    offset
 }
 
 fn insert_head(offset: DocCharOffset, style: MarkdownNode, mutation: &mut Vec<SubMutation>) {

--- a/libs/editor/egui_editor/src/offset_types.rs
+++ b/libs/editor/egui_editor/src/offset_types.rs
@@ -540,47 +540,47 @@ mod test {
 
     #[test]
     fn contains() {
-        assert_eq!((1, 3).contains(0, false, false), false);
-        assert_eq!((1, 3).contains(1, false, false), false);
-        assert_eq!((1, 3).contains(2, false, false), true);
-        assert_eq!((1, 3).contains(3, false, false), false);
-        assert_eq!((1, 3).contains(4, false, false), false);
+        assert!(!(1, 3).contains(0, false, false));
+        assert!(!(1, 3).contains(1, false, false));
+        assert!((1, 3).contains(2, false, false));
+        assert!(!(1, 3).contains(3, false, false));
+        assert!(!(1, 3).contains(4, false, false));
 
-        assert_eq!((1, 3).contains(0, true, false), false);
-        assert_eq!((1, 3).contains(1, true, false), true);
-        assert_eq!((1, 3).contains(2, true, false), true);
-        assert_eq!((1, 3).contains(3, true, false), false);
-        assert_eq!((1, 3).contains(4, true, false), false);
+        assert!(!(1, 3).contains(0, true, false));
+        assert!((1, 3).contains(1, true, false));
+        assert!((1, 3).contains(2, true, false));
+        assert!(!(1, 3).contains(3, true, false));
+        assert!(!(1, 3).contains(4, true, false));
 
-        assert_eq!((1, 3).contains(0, false, true), false);
-        assert_eq!((1, 3).contains(1, false, true), false);
-        assert_eq!((1, 3).contains(2, false, true), true);
-        assert_eq!((1, 3).contains(3, false, true), true);
-        assert_eq!((1, 3).contains(4, false, true), false);
+        assert!(!(1, 3).contains(0, false, true));
+        assert!(!(1, 3).contains(1, false, true));
+        assert!((1, 3).contains(2, false, true));
+        assert!((1, 3).contains(3, false, true));
+        assert!(!(1, 3).contains(4, false, true));
 
-        assert_eq!((1, 3).contains(0, true, true), false);
-        assert_eq!((1, 3).contains(1, true, true), true);
-        assert_eq!((1, 3).contains(2, true, true), true);
-        assert_eq!((1, 3).contains(3, true, true), true);
-        assert_eq!((1, 3).contains(4, true, true), false);
+        assert!(!(1, 3).contains(0, true, true));
+        assert!((1, 3).contains(1, true, true));
+        assert!((1, 3).contains(2, true, true));
+        assert!((1, 3).contains(3, true, true));
+        assert!(!(1, 3).contains(4, true, true));
     }
 
     #[test]
     fn contains_empty() {
-        assert_eq!((1, 1).contains(0, false, false), false);
-        assert_eq!((1, 1).contains(1, false, false), false);
-        assert_eq!((1, 1).contains(2, false, false), false);
+        assert!(!(1, 1).contains(0, false, false));
+        assert!(!(1, 1).contains(1, false, false));
+        assert!(!(1, 1).contains(2, false, false));
 
-        assert_eq!((1, 1).contains(0, true, false), false);
-        assert_eq!((1, 1).contains(1, true, false), false);
-        assert_eq!((1, 1).contains(2, true, false), false);
+        assert!(!(1, 1).contains(0, true, false));
+        assert!(!(1, 1).contains(1, true, false));
+        assert!(!(1, 1).contains(2, true, false));
 
-        assert_eq!((1, 1).contains(0, false, true), false);
-        assert_eq!((1, 1).contains(1, false, true), false);
-        assert_eq!((1, 1).contains(2, false, true), false);
+        assert!(!(1, 1).contains(0, false, true));
+        assert!(!(1, 1).contains(1, false, true));
+        assert!(!(1, 1).contains(2, false, true));
 
-        assert_eq!((1, 1).contains(0, true, true), false);
-        assert_eq!((1, 1).contains(1, true, true), true);
-        assert_eq!((1, 1).contains(2, true, true), false);
+        assert!(!(1, 1).contains(0, true, true));
+        assert!((1, 1).contains(1, true, true));
+        assert!(!(1, 1).contains(2, true, true));
     }
 }

--- a/libs/editor/egui_editor/src/offset_types.rs
+++ b/libs/editor/egui_editor/src/offset_types.rs
@@ -533,3 +533,54 @@ impl DoubleEndedIterator for RangeIter {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::offset_types::RangeExt;
+
+    #[test]
+    fn contains() {
+        assert_eq!((1, 3).contains(0, false, false), false);
+        assert_eq!((1, 3).contains(1, false, false), false);
+        assert_eq!((1, 3).contains(2, false, false), true);
+        assert_eq!((1, 3).contains(3, false, false), false);
+        assert_eq!((1, 3).contains(4, false, false), false);
+
+        assert_eq!((1, 3).contains(0, true, false), false);
+        assert_eq!((1, 3).contains(1, true, false), true);
+        assert_eq!((1, 3).contains(2, true, false), true);
+        assert_eq!((1, 3).contains(3, true, false), false);
+        assert_eq!((1, 3).contains(4, true, false), false);
+
+        assert_eq!((1, 3).contains(0, false, true), false);
+        assert_eq!((1, 3).contains(1, false, true), false);
+        assert_eq!((1, 3).contains(2, false, true), true);
+        assert_eq!((1, 3).contains(3, false, true), true);
+        assert_eq!((1, 3).contains(4, false, true), false);
+
+        assert_eq!((1, 3).contains(0, true, true), false);
+        assert_eq!((1, 3).contains(1, true, true), true);
+        assert_eq!((1, 3).contains(2, true, true), true);
+        assert_eq!((1, 3).contains(3, true, true), true);
+        assert_eq!((1, 3).contains(4, true, true), false);
+    }
+
+    #[test]
+    fn contains_empty() {
+        assert_eq!((1, 1).contains(0, false, false), false);
+        assert_eq!((1, 1).contains(1, false, false), false);
+        assert_eq!((1, 1).contains(2, false, false), false);
+
+        assert_eq!((1, 1).contains(0, true, false), false);
+        assert_eq!((1, 1).contains(1, true, false), false);
+        assert_eq!((1, 1).contains(2, true, false), false);
+
+        assert_eq!((1, 1).contains(0, false, true), false);
+        assert_eq!((1, 1).contains(1, false, true), false);
+        assert_eq!((1, 1).contains(2, false, true), false);
+
+        assert_eq!((1, 1).contains(0, true, true), false);
+        assert_eq!((1, 1).contains(1, true, true), true);
+        assert_eq!((1, 1).contains(2, true, true), false);
+    }
+}


### PR DESCRIPTION
- fixes https://github.com/lockbook/lockbook/issues/2079
- fixes an issue where toggling style with empty selection in a nonempty document would do nothing
- fixes an issue where toggling the current style at the end of the styled region would insert characters instead of advancing to after the region
- fixes anything else using range binary search (implemented since last release)
- improves toggle style when selection bounds are in syntax sequences