### PR TITLE
editor: fix small image stretch

### DIFF
--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -303,7 +303,7 @@ impl GalleyInfo {
                     f32::min(ui.available_width() - appearance.image_padding() * 2.0, image_width);
                 let height = image_height * width / image_width + appearance.image_padding() * 2.0;
                 let (location, _) =
-                    ui.allocate_exact_size(Vec2::new(ui.available_width(), height), Sense::hover());
+                    ui.allocate_exact_size(Vec2::new(width, height), Sense::hover());
                 Some(ImageInfo { location, texture })
             } else {
                 None


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2064

This works for cases I tried but I might be missing something - try opening an image-heavy document to confirm everything's good here.

<img width="912" alt="Screenshot 2023-09-17 at 12 00 34 PM" src="https://github.com/lockbook/lockbook/assets/6198756/2f1f7f0a-8d97-463c-9d8f-3b07a4772892">
