### PR TITLE
editor: handle tab input as indent

### DIFF
--- a/libs/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/ios_ffi.rs
@@ -22,6 +22,10 @@ pub unsafe extern "C" fn insert_text(obj: *mut c_void, content: *const c_char) {
         obj.editor
             .custom_events
             .push(Modification::Newline { advance_cursor: true });
+    } else if content == "\t" {
+        obj.editor
+            .custom_events
+            .push(Modification::Indent { deindent: false });
     } else {
         obj.raw_input.events.push(Event::Text(content))
     }

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -121,7 +121,8 @@ pub fn calc(
             // see https://github.com/lockbook/lockbook/issues/1983, https://github.com/emilk/egui/issues/3203
             let text = {
                 let mut this = buffer[text_range_portion].to_string();
-                if buffer[paragraph] == "\t".repeat(buffer[paragraph].len()) {
+                let paragraph_body = &buffer[(paragraph.0 + head_size, paragraph.1)];
+                if paragraph_body == "\t".repeat(paragraph_body.len()) {
                     this = " ".repeat(this.len()).to_string();
                 }
                 this


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2049 (graphical glitch and non-indenting-behavior)