### PR TITLE
apple: paste images in editor

### DIFF
--- a/clients/apple/Shared/Stateful Logic/DocumentService.swift
+++ b/clients/apple/Shared/Stateful Logic/DocumentService.swift
@@ -289,7 +289,7 @@ class DocumentLoadingInfo: ObservableObject {
                         
                         if let parentPath = DI.files.getPathByIdOrParent(maybeId: self.meta.parent) {
                             if let file = DI.files.getFileByPath(path: parentPath + url.lastPathComponent) {
-                                return "![alt text](lb://\(file.id.uuidString.lowercased()))"
+                                return "![\((url.lastPathComponent as NSString).deletingPathExtension)](lb://\(file.id.uuidString.lowercased()))"
                             }
                         }
                         

--- a/clients/apple/Shared/Stateful Logic/DocumentService.swift
+++ b/clients/apple/Shared/Stateful Logic/DocumentService.swift
@@ -239,8 +239,11 @@ class DocumentLoadingInfo: ObservableObject {
                     switch operation {
                     case .success(let txt):
                         if let editor = self.textDocument {
-                            if editor.text != txt {
-                                editor.reload = true
+                            if self.textDocument?.pasted == true {
+                                editor.reloadView = true
+                                self.textDocument?.pasted = false
+                            } else if editor.text != txt {
+                                editor.reloadText = true
                                 editor.text = txt
                             }
                         }
@@ -260,7 +263,6 @@ class DocumentLoadingInfo: ObservableObject {
         case .Unknown:
             print("cannot reload unknown content type")
         }
-
     }
 
     private func drawingAutosaver() {
@@ -286,11 +288,12 @@ class DocumentLoadingInfo: ObservableObject {
                         DI.importExport.importFilesSync(sources:[url.path(percentEncoded: false)], destination: self.meta.parent)
                         
                         if let parentPath = DI.files.getPathByIdOrParent(maybeId: self.meta.parent) {
-                            
-                            return "lb:/\(parentPath)\(url.lastPathComponent)"
-                        } else {
-                            return nil
+                            if let file = DI.files.getFileByPath(path: parentPath + url.lastPathComponent) {
+                                return "![alt text](lb://\(file.id.uuidString.lowercased()))"
+                            }
                         }
+                        
+                        return nil
                     }
                     self.textDocumentToolbar = ToolbarState()
                     self

--- a/clients/apple/Shared/Stateful Logic/DocumentService.swift
+++ b/clients/apple/Shared/Stateful Logic/DocumentService.swift
@@ -282,7 +282,16 @@ class DocumentLoadingInfo: ObservableObject {
             DispatchQueue.main.async {
                 switch operation {
                 case .success(let txt):
-                    self.textDocument = EditorState(text: txt, isiPhone: self.isiPhone)
+                    self.textDocument = EditorState(text: txt, isiPhone: self.isiPhone) { url in
+                        DI.importExport.importFilesSync(sources:[url.path(percentEncoded: false)], destination: self.meta.parent)
+                        
+                        if let parentPath = DI.files.getPathByIdOrParent(maybeId: self.meta.parent) {
+                            
+                            return "lb:/\(parentPath)\(url.lastPathComponent)"
+                        } else {
+                            return nil
+                        }
+                    }
                     self.textDocumentToolbar = ToolbarState()
                     self
                         .textDocument!

--- a/clients/apple/Shared/Stateful Logic/FileService.swift
+++ b/clients/apple/Shared/Stateful Logic/FileService.swift
@@ -382,6 +382,16 @@ class FileService: ObservableObject {
         }
     }
     
+    public func getFileByPath(path: String) -> File? {
+        switch core.getFileByPath(path: path) {
+        case .success(let file):
+            return file
+        case .failure(let err):
+            DI.errors.handleError(err)
+            return nil
+        }
+    }
+    
     public func copyFileLink(id: UUID) {
         #if os(iOS)
         UIPasteboard.general.string = "lb://\(id.uuidString.lowercased())"

--- a/clients/apple/Shared/Stateful Logic/ImportExportService.swift
+++ b/clients/apple/Shared/Stateful Logic/ImportExportService.swift
@@ -38,7 +38,6 @@ class ImportExportService: ObservableObject {
             return nil
         }
         
-        
         if meta.fileType == .Document && meta.name.hasSuffix(".draw") {
             destination = destination.appendingPathComponent(meta.name + ".jpeg")
             let operation = DI.core.exportDrawingToDisk(id: meta.id, destination: destination.path())

--- a/clients/apple/Shared/Views/DocumentView.swift
+++ b/clients/apple/Shared/Views/DocumentView.swift
@@ -118,8 +118,14 @@ struct DocumentView: View, Equatable {
                         .title("")
                     }
                 case .Unknown:
-                    Text("\(model.meta.name) cannot be opened on this device.")
-                        .title(model.meta.name)
+                    VStack {
+                        Spacer()
+                        
+                        Text("\(model.meta.name) cannot be opened on this device.")
+                            .title(model.meta.name)
+                        
+                        Spacer()
+                    }
                 }
             }
         }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/CoreApi.swift
@@ -164,6 +164,10 @@ public struct CoreApi: LockbookApi {
         fromPrimitiveResult(result: get_file_by_id(id.uuidString))
     }
     
+    public func getFileByPath(path: String) -> FfiResult<File, GetFileByPathError> {
+        fromPrimitiveResult(result: get_by_path(path))
+    }
+    
     public func startSearch(context: UnsafeRawPointer?, updateStatus: @escaping @convention(c) (UnsafePointer<Int8>?, Int32, UnsafePointer<Int8>?) -> Void) -> FfiResult<Empty, GeneralSearchError> {
         fromPrimitiveResult(result: start_search(context, updateStatus))
     }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/FakeApi.swift
@@ -152,6 +152,10 @@ Vestibulum ante ipsum primis in vel.
         .failure(.init(unexpected: "LAZY"))
     }
     
+    public func getFileByPath(path: String) -> FfiResult<File, GetFileByPathError> {
+        .failure(.init(unexpected: "LAZY"))
+    }
+    
     public func searchFilePaths(input: String) ->FfiResult<[SearchResultItem], SearchFilePathsError> {
         .failure(.init(unexpected: "LAZY"))
     }

--- a/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
+++ b/clients/apple/SwiftLockbookCore/Sources/SwiftLockbookCore/Apis/LockbookApi.swift
@@ -43,6 +43,7 @@ public protocol LockbookApi {
     func exportDrawingToDisk(id: UUID, destination: String) ->FfiResult<Empty, ExportDrawingToDiskError>
     func importFiles(sources: [String], destination: UUID) ->FfiResult<Empty, ImportFilesError>
     func getFileById(id: UUID) -> FfiResult<File, GetFileByIdError>
+    func getFileByPath(path: String) -> FfiResult<File, GetFileByPathError>
     func suggestedDocs() -> FfiResult<[UUID], SuggestedDocsError>
     func getPathById(id: UUID) -> FfiResult<String, GetPathByIdError>
     

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
@@ -9,10 +9,18 @@ public class EditorState: ObservableObject {
     
     public var isiPhone: Bool
     
-    public init(text: String, isiPhone: Bool) {
+    public var importFile: (URL) -> String?
+    
+    public init(text: String, isiPhone: Bool, importFile: @escaping (URL) -> String?) {
         self.text = text
         self.isiPhone = isiPhone
+        self.importFile = importFile
     }
+}
+
+public enum SupportedImportImageFormats {
+    case png
+    case tiff
 }
 
 public class ToolbarState: ObservableObject {
@@ -44,3 +52,17 @@ public class NameState: ObservableObject {
     
     public init() {}
 }
+
+func createTempDir() -> URL? {
+    let fileManager = FileManager.default
+    let tempTempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("editor-tmp").appendingPathComponent(UUID().uuidString)
+    
+    do {
+        try fileManager.createDirectory(at: tempTempURL, withIntermediateDirectories: true, attributes: nil)
+    } catch {
+        return nil
+    }
+    
+    return tempTempURL
+}
+

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
@@ -4,8 +4,10 @@ import Combine
 public class EditorState: ObservableObject {
     
     @Published public var text: String
-    @Published public var reload: Bool = false
+    @Published public var reloadText: Bool = false
+    @Published public var reloadView: Bool = false
     @Published public var shouldFocus: Bool = true
+    @Published public var pasted: Bool = false
     
     public var isiPhone: Bool
     

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorState.swift
@@ -20,11 +20,6 @@ public class EditorState: ObservableObject {
     }
 }
 
-public enum SupportedImportImageFormats {
-    case png
-    case tiff
-}
-
 public class ToolbarState: ObservableObject {
     @Published public var isBulletListSelected: Bool = false
     @Published public var isNumberListSelected: Bool = false

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
@@ -33,9 +33,14 @@ public struct EditorView: UIViewRepresentable {
     }
     
     public func updateUIView(_ uiView: iOSMTK, context: Context) {
-        if editorState.reload {
+        if editorState.reloadText {
             mtkView.updateText(editorState.text)
-            editorState.reload = false
+            editorState.reloadText = false
+        }
+        
+        if editorState.reloadView {
+            mtkView.setNeedsDisplay(mtkView.frame)
+            editorState.reloadView = false
         }
         
         if editorState.shouldFocus && !editorState.isiPhone {
@@ -95,9 +100,14 @@ public struct NSEditorView: NSViewRepresentable {
     }
     
     public func updateNSView(_ nsView: MTKView, context: NSViewRepresentableContext<NSEditorView>) {
-        if editorState.reload {
+        if editorState.reloadText {
             mtkView.updateText(editorState.text)
-            editorState.reload = false
+            editorState.reloadText = false
+        }
+        
+        if editorState.reloadView {
+            mtkView.setNeedsDisplay(mtkView.frame)
+            editorState.reloadView = false
         }
         
         if editorState.shouldFocus {

--- a/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -66,7 +66,7 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
         if let image = UIPasteboard.general.image {
             if let url = createTempDir(),
                let data = image.pngData() ?? image.jpegData(compressionQuality: 1.0){
-                let imageUrl = url.appendingPathComponent(String(UUID().uuidString.prefix(10)), conformingTo: .tiff)
+                let imageUrl = url.appendingPathComponent(String(UUID().uuidString.prefix(10).lowercased()), conformingTo: .png)
                 
                 do {
                     try data.write(to: imageUrl)

--- a/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -62,6 +62,37 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
         
     }
     
+    func checkIfImagePasted() -> Bool {
+        if let image = UIPasteboard.general.image {
+            if let path = pasteImage(image: image) {
+                paste_text(editorHandle, path)
+                editorState?.pasted = true
+                
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    func pasteImage(image: UIImage) -> String? {
+        if let url = createTempDir() {
+            if let data = image.pngData() ?? image.jpegData(compressionQuality: 1.0) {
+                let imageUrl = url.appendingPathComponent(String(UUID().uuidString.prefix(10)), conformingTo: .tiff)
+                
+                do {
+                    try data.write(to: imageUrl)
+                } catch {
+                    return nil
+                }
+                
+                return editorState!.importFile(imageUrl)
+            }
+        }
+        
+        return nil
+    }
+    
     public func header(headingSize: UInt32) {
         apply_style_to_selection_header(editorHandle, headingSize)
         self.setNeedsDisplay(self.frame)
@@ -486,6 +517,11 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
     
     @objc func clipboardPaste() {
         self.setClipboard()
+        
+        if checkIfImagePasted() {
+            return
+        }
+        
         clipboard_paste(self.editorHandle)
         self.setNeedsDisplay()
     }

--- a/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -62,35 +62,28 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
         
     }
     
-    func checkIfImagePasted() -> Bool {
+    func pasteImageInClipboard() -> Bool {
         if let image = UIPasteboard.general.image {
-            if let path = pasteImage(image: image) {
-                paste_text(editorHandle, path)
-                editorState?.pasted = true
-                
-                return true
-            }
-        }
-        
-        return false
-    }
-    
-    func pasteImage(image: UIImage) -> String? {
-        if let url = createTempDir() {
-            if let data = image.pngData() ?? image.jpegData(compressionQuality: 1.0) {
+            if let url = createTempDir(),
+               let data = image.pngData() ?? image.jpegData(compressionQuality: 1.0){
                 let imageUrl = url.appendingPathComponent(String(UUID().uuidString.prefix(10)), conformingTo: .tiff)
                 
                 do {
                     try data.write(to: imageUrl)
                 } catch {
-                    return nil
+                    return false
                 }
                 
-                return editorState!.importFile(imageUrl)
+                if let lbImageURL = editorState!.importFile(imageUrl) {
+                    paste_text(editorHandle, lbImageURL)
+                    editorState?.pasted = true
+                    
+                    return true
+                }
             }
         }
         
-        return nil
+        return false
     }
     
     public func header(headingSize: UInt32) {
@@ -518,7 +511,7 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
     @objc func clipboardPaste() {
         self.setClipboard()
         
-        if checkIfImagePasted() {
+        if pasteImageInClipboard() {
             return
         }
         

--- a/libs/editor/SwiftEditor/Sources/Editor/macMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/macMTK.swift
@@ -176,7 +176,7 @@ public class MacMTK: MTKView, MTKViewDelegate {
             && event.modifierFlags.contains(.command) {
             if let data = NSPasteboard.general.data(forType: .png) ?? NSPasteboard.general.data(forType: .tiff),
                let url = createTempDir() {
-                let imageUrl = url.appendingPathComponent(String(UUID().uuidString.prefix(10)), conformingTo: .tiff)
+                let imageUrl = url.appendingPathComponent(String(UUID().uuidString.prefix(10).lowercased()), conformingTo: .png)
                 
                 do {
                     try data.write(to: imageUrl)

--- a/libs/editor/SwiftEditor/Sources/Editor/macMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/macMTK.swift
@@ -172,17 +172,15 @@ public class MacMTK: MTKView, MTKViewDelegate {
     }
     
     func checkIfImagePasted(_ event: NSEvent) -> Bool {
-        if #available(macOS 13.0, *) {
-            if event.keyCode == 9 // v key
-                && event.modifierFlags.contains(.command) {
-                if let data = NSPasteboard.general.data(forType: .png) ?? NSPasteboard.general.data(forType: .tiff) {
-                    if let path = pasteImage(data: data) {
-                        paste_text(editorHandle, path)
-                        setNeedsDisplay(self.frame)
-                    }
-                    
-                    return true
+        if event.keyCode == 9
+            && event.modifierFlags.contains(.command) {
+            if let data = NSPasteboard.general.data(forType: .png) ?? NSPasteboard.general.data(forType: .tiff) {
+                if let path = pasteImage(data: data) {
+                    paste_text(editorHandle, path)
+                    editorState?.pasted = true
                 }
+                
+                return true
             }
         }
         
@@ -192,11 +190,7 @@ public class MacMTK: MTKView, MTKViewDelegate {
     func pasteImage(data: Data) -> String? {
         if let url = createTempDir() {
             let imageUrl = url.appendingPathComponent(String(UUID().uuidString.prefix(10)), conformingTo: .tiff)
-            if #available(macOS 13.0, *) {
-                print("importing \(imageUrl.path(percentEncoded: true))")
-            } else {
-                // Fallback on earlier versions
-            }
+            
             do {
                 try data.write(to: imageUrl)
             } catch {

--- a/libs/editor/egui_editor/src/apple/common_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/common_ffi.rs
@@ -148,6 +148,8 @@ pub unsafe extern "C" fn free_text(s: *mut c_void) {
 
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
+///
+/// used solely for image pasting
 #[no_mangle]
 pub unsafe extern "C" fn paste_text(obj: *mut c_void, content: *const c_char) {
     let obj = &mut *(obj as *mut WgpuEditor);

--- a/libs/editor/egui_editor/src/apple/common_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/common_ffi.rs
@@ -147,6 +147,16 @@ pub unsafe extern "C" fn free_text(s: *mut c_void) {
 }
 
 /// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
+pub unsafe extern "C" fn paste_text(obj: *mut c_void, content: *const c_char) {
+    let obj = &mut *(obj as *mut WgpuEditor);
+    let content = CStr::from_ptr(content).to_str().unwrap().into();
+
+    obj.raw_input.events.push(Event::Paste(content));
+}
+
+/// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn deinit_editor(obj: *mut c_void) {
     let _ = Box::from_raw(obj as *mut WgpuEditor);

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -344,7 +344,7 @@ impl Editor {
         self.initialized = true;
 
         if self.images.any_loading() {
-            ui.ctx().request_repaint_after(Duration::from_millis(125));
+            ui.ctx().request_repaint_after(Duration::from_millis(50));
         }
 
         // draw

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -2,6 +2,7 @@
 use std::ffi::{c_char, CString};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use std::ptr;
+use std::time::Duration;
 use std::{cmp, mem};
 
 use egui::os::OperatingSystem;
@@ -341,6 +342,10 @@ impl Editor {
         );
         self.bounds.lines = bounds::calc_lines(&self.galleys, &self.bounds.ast, &self.bounds.text);
         self.initialized = true;
+
+        if self.images.any_loading() {
+            ui.ctx().request_repaint_after(Duration::from_millis(125));
+        }
 
         // draw
         self.draw_text(self.ui_rect.size(), ui, touch_mode);

--- a/libs/editor/egui_editor/src/images.rs
+++ b/libs/editor/egui_editor/src/images.rs
@@ -12,7 +12,7 @@ pub struct ImageCache {
     pub map: HashMap<Url, Arc<Mutex<ImageState>>>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum ImageState {
     #[default]
     Loading,
@@ -130,12 +130,8 @@ fn download_image(
 
 impl ImageCache {
     pub fn any_loading(&self) -> bool {
-        self.map.values().any(|state| {
-            if let ImageState::Loading = state.lock().unwrap().deref() {
-                true
-            } else {
-                false
-            }
-        })
+        self.map
+            .values()
+            .any(|state| &ImageState::Loading == state.lock().unwrap().deref())
     }
 }

--- a/libs/editor/egui_editor/src/images.rs
+++ b/libs/editor/egui_editor/src/images.rs
@@ -127,3 +127,15 @@ fn download_image(
     let response = client.get(url).send()?.bytes()?.to_vec();
     Ok(response)
 }
+
+impl ImageCache {
+    pub fn any_loading(&self) -> bool {
+        self.map.values().any(|state| {
+            if let ImageState::Loading = state.lock().unwrap().deref() {
+                true
+            } else {
+                false
+            }
+        })
+    }
+}


### PR DESCRIPTION
Images can now be pasted into the editor. Lockbook will automatically import the file and insert the appropriate markdown syntax for the image to appear.

Demonstration
<details>

https://github.com/lockbook/lockbook/assets/20663038/bbdce5d5-9600-45d0-92d8-ed0b8d33244d
</details>

fixes #2113
