### PR TITLE
editor: image refinements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "image",
  "libc",
  "linkify",
+ "lockbook-core",
  "pollster",
  "pulldown-cmark",
  "rand 0.8.5",

--- a/clients/apple/Shared/Views/DocumentView.swift
+++ b/clients/apple/Shared/Views/DocumentView.swift
@@ -1,3 +1,4 @@
+import CLockbookCore
 import SwiftUI
 import SwiftLockbookCore
 import PencilKit
@@ -504,8 +505,9 @@ struct MarkdownEditor: View {
     let editor: EditorView
     
     public init(_ editorState: EditorState, _ toolbarState: ToolbarState, _ nameState: NameState) {
+        let coreHandle = get_core_ptr()
         self.editorState = editorState
-        self.editor = EditorView(editorState, toolbarState, nameState)
+        self.editor = EditorView(editorState, coreHandle, toolbarState, nameState)
     }
         
     var body: some View {

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -644,6 +644,7 @@ impl AccountScreen {
                         .map(|bytes| {
                             if ext == "md" {
                                 TabContent::Markdown(Markdown::boxed(
+                                    core.clone(),
                                     &bytes,
                                     &toolbar_visibility,
                                     update_tx.clone(),
@@ -787,6 +788,7 @@ impl AccountScreen {
                     .map(|bytes| {
                         if ext == "md" {
                             TabContent::Markdown(Markdown::boxed(
+                                core.clone(),
                                 &bytes,
                                 &toolbar_visibility,
                                 update_tx.clone(),

--- a/clients/egui/src/account/tabs/markdown.rs
+++ b/clients/egui/src/account/tabs/markdown.rs
@@ -17,11 +17,11 @@ pub struct Markdown {
 
 impl Markdown {
     pub fn boxed(
-        bytes: &[u8], toolbar_visibility: &ToolBarVisibility, update_tx: Sender<AccountUpdate>,
-        new_file: bool,
+        core: lb::Core, bytes: &[u8], toolbar_visibility: &ToolBarVisibility,
+        update_tx: Sender<AccountUpdate>, new_file: bool,
     ) -> Box<Self> {
         let content = String::from_utf8_lossy(bytes).to_string();
-        let mut editor = Editor::default();
+        let mut editor = Editor::new(core);
         editor.set_text(content);
 
         let toolbar = ToolBar::new(toolbar_visibility);

--- a/libs/core_external_interface/src/c_interface.rs
+++ b/libs/core_external_interface/src/c_interface.rs
@@ -2,7 +2,7 @@ use basic_human_duration::ChronoHumanDuration;
 use crossbeam::channel::Sender;
 use lazy_static::lazy_static;
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
 use std::ptr;
 use std::sync::{Arc, Mutex};
@@ -703,6 +703,15 @@ pub unsafe extern "C" fn time_ago(time_stamp: i64) -> *const c_char {
     } else {
         "never".to_string()
     })
+}
+
+/// # Safety
+///
+/// Be sure to call `release_pointer` on the result of this function to free the data.
+#[no_mangle]
+pub unsafe extern "C" fn get_core_ptr() -> *mut c_void {
+    let obj = static_state::get().expect("Could not get core");
+    Box::into_raw(Box::new(obj)) as *mut c_void
 }
 
 // FOR INTEGRATION TESTS ONLY

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
@@ -12,13 +12,13 @@ public struct EditorView: UIViewRepresentable {
     @Environment(\.horizontalSizeClass) var horizontal
     @Environment(\.verticalSizeClass) var vertical
     
-    public init(_ editorState: EditorState, _ toolbarState: ToolbarState, _ nameState: NameState) {
+    public init(_ editorState: EditorState, _ coreHandle: UnsafeMutableRawPointer?, _ toolbarState: ToolbarState, _ nameState: NameState) {
         self.editorState = editorState
         mtkView.editorState = editorState
         mtkView.toolbarState = toolbarState
         mtkView.nameState = nameState
         
-        mtkView.setInitialContent(editorState.text)
+        mtkView.setInitialContent(coreHandle, editorState.text)
     }
 
     public func makeUIView(context: Context) -> iOSMTK {

--- a/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/EditorView.swift
@@ -51,9 +51,9 @@ public struct EditorView: View {
     
     let nsEditorView: NSEditorView
     
-    public init(_ editorState: EditorState, _ toolbarState: ToolbarState, _ nameState: NameState) {
+    public init(_ editorState: EditorState, _ coreHandle: UnsafeMutableRawPointer?, _ toolbarState: ToolbarState, _ nameState: NameState) {
         self.editorState = editorState
-        nsEditorView = NSEditorView(editorState, toolbarState, nameState)
+        nsEditorView = NSEditorView(editorState, coreHandle, toolbarState, nameState)
     }
     
     public var body: some View {
@@ -77,13 +77,13 @@ public struct NSEditorView: NSViewRepresentable {
     
     let mtkView: MacMTK = MacMTK()
     
-    public init(_ editorState: EditorState, _ toolbarState: ToolbarState, _ nameState: NameState) {
+    public init(_ editorState: EditorState, _ coreHandle: UnsafeMutableRawPointer?, _ toolbarState: ToolbarState, _ nameState: NameState) {
         self.editorState = editorState
         mtkView.editorState = editorState
         mtkView.toolbarState = toolbarState
         mtkView.nameState = nameState
         
-        mtkView.setInitialContent(editorState.text)
+        mtkView.setInitialContent(coreHandle, editorState.text)
     }
     
     public func docChanged(_ s: String) {

--- a/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -107,9 +107,9 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
         self.setNeedsDisplay(self.frame)
     }
         
-    public func setInitialContent(_ s: String) {
+    public func setInitialContent(_ coreHandle: UnsafeMutableRawPointer?, _ s: String) {
         let metalLayer = UnsafeMutableRawPointer(Unmanaged.passUnretained(self.layer).toOpaque())
-        self.editorHandle = init_editor(metalLayer, s, isDarkMode())
+        self.editorHandle = init_editor(coreHandle, metalLayer, s, isDarkMode())
         self.textUndoManager.editorHandle = self.editorHandle
         self.textUndoManager.onUndoRedo = {
             self.setNeedsDisplay(self.frame)

--- a/libs/editor/SwiftEditor/Sources/Editor/macMTK.swift
+++ b/libs/editor/SwiftEditor/Sources/Editor/macMTK.swift
@@ -5,6 +5,7 @@ import Bridge
 public class MacMTK: MTKView, MTKViewDelegate {
     
     var editorHandle: UnsafeMutableRawPointer?
+    var coreHandle: UnsafeMutableRawPointer?
     var trackingArea : NSTrackingArea?
     var pasteBoardEventId: Int = 0
         
@@ -78,9 +79,9 @@ public class MacMTK: MTKView, MTKViewDelegate {
         return true
     }
     
-    public func setInitialContent(_ s: String) {
+    public func setInitialContent(_ coreHandle: UnsafeMutableRawPointer?, _ s: String) {
         let metalLayer = UnsafeMutableRawPointer(Unmanaged.passUnretained(self.layer!).toOpaque())
-        self.editorHandle = init_editor(metalLayer, s, isDarkMode())
+        self.editorHandle = init_editor(coreHandle, metalLayer, s, isDarkMode())
         
         self.toolbarState!.toggleBold = bold
         self.toolbarState!.toggleItalic = italic

--- a/libs/editor/egui_editor/Cargo.toml
+++ b/libs/editor/egui_editor/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "0.11", features = ["blocking"] }
 unicode-segmentation = "1.10.0"
 rand = "0.8.5"
 linkify = "0.10.0"
+lb = { package = "lockbook-core", path = "../../core", default-features = false, features=["native-tls"] }
 
 #eframe = { version = "0.19.0", optional = true, default-features = false, features = ['wgpu', 'dark-light'] }
 eframe = { version = "0.22.0", optional = true }

--- a/libs/editor/egui_editor/src/apple/common_ffi.rs
+++ b/libs/editor/egui_editor/src/apple/common_ffi.rs
@@ -10,8 +10,10 @@ use std::time::Instant;
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn init_editor(
-    metal_layer: *mut c_void, content: *const c_char, dark_mode: bool,
+    core: *mut c_void, metal_layer: *mut c_void, content: *const c_char, dark_mode: bool,
 ) -> *mut c_void {
+    let core = unsafe { &mut *(core as *mut lb::Core) };
+
     let backends = wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all);
     let instance_desc = wgpu::InstanceDescriptor { backends, ..Default::default() };
     let instance = wgpu::Instance::new(instance_desc);
@@ -35,7 +37,7 @@ pub unsafe extern "C" fn init_editor(
 
     let context = Context::default();
     context.set_visuals(if dark_mode { Visuals::dark() } else { Visuals::light() });
-    let mut editor = Editor::default();
+    let mut editor = Editor::new(core.clone());
     editor.set_font(&context);
     editor.buffer = CStr::from_ptr(content).to_str().unwrap().into();
 

--- a/libs/editor/egui_editor/src/draw.rs
+++ b/libs/editor/egui_editor/src/draw.rs
@@ -114,7 +114,7 @@ impl Editor {
                         ui.painter().text(
                             image.location.center_top(),
                             Align2::CENTER_TOP,
-                            format!("Failed to load image."),
+                            "Failed to load image.",
                             FontId::default(),
                             PINK.get(self.appearance.current_theme),
                         );

--- a/libs/editor/egui_editor/src/draw.rs
+++ b/libs/editor/egui_editor/src/draw.rs
@@ -1,4 +1,4 @@
-use crate::appearance::YELLOW;
+use crate::appearance::{BLACK, PINK, YELLOW};
 use crate::images::ImageState;
 use crate::input::canonical::{Location, Modification, Region};
 use crate::layouts::Annotation;
@@ -92,37 +92,31 @@ impl Editor {
 
             // draw images
             if let Some(image) = &galley.image {
-                match image.image_state {
+                match &image.image_state {
                     ImageState::Loading => {
-                        // todo: better icon
-                        ui.painter().line_segment(
-                            [
-                                Pos2 { x: image.location.min.x, y: image.location.max.y },
-                                Pos2 { x: image.location.max.x, y: image.location.min.y },
-                            ],
-                            Stroke {
-                                width: self.appearance.checkbox_slash_width(),
-                                color: self.appearance.text(),
-                            },
+                        self.draw_image_placeholder(ui, image.location);
+                        ui.painter().text(
+                            image.location.center_top(),
+                            Align2::CENTER_TOP,
+                            "Loading image...",
+                            FontId::default(),
+                            PINK.get(self.appearance.current_theme),
                         );
                     }
                     ImageState::Loaded(texture_id) => {
                         let uv =
                             Rect { min: Pos2 { x: 0.0, y: 0.0 }, max: Pos2 { x: 1.0, y: 1.0 } };
                         ui.painter()
-                            .image(texture_id, image.location, uv, Color32::WHITE);
+                            .image(*texture_id, image.location, uv, Color32::WHITE);
                     }
-                    ImageState::Failed => {
-                        // todo: better icon
-                        ui.painter().line_segment(
-                            [
-                                Pos2 { x: image.location.min.x, y: image.location.min.y },
-                                Pos2 { x: image.location.max.x, y: image.location.max.y },
-                            ],
-                            Stroke {
-                                width: self.appearance.checkbox_slash_width(),
-                                color: self.appearance.text(),
-                            },
+                    ImageState::Failed(_) => {
+                        self.draw_image_placeholder(ui, image.location);
+                        ui.painter().text(
+                            image.location.center_top(),
+                            Align2::CENTER_TOP,
+                            format!("Failed to load image."),
+                            FontId::default(),
+                            PINK.get(self.appearance.current_theme),
                         );
                     }
                 }
@@ -140,6 +134,37 @@ impl Editor {
             .size()
             .y;
         ui.allocate_exact_size(ui_size, Sense::hover());
+    }
+
+    pub fn draw_image_placeholder(&self, ui: &mut Ui, location: Rect) {
+        let stroke = Stroke::new(0.3, BLACK.get(self.appearance.current_theme));
+
+        // outer rect
+        let outer_rect = location;
+        ui.painter()
+            .rect(outer_rect, 0.0, Color32::TRANSPARENT, stroke);
+
+        // inner rect
+        let inner_rect = location.expand(-20.0);
+        ui.painter()
+            .rect(inner_rect, 0.0, Color32::TRANSPARENT, stroke);
+
+        // mountain
+        let peak = inner_rect.center() - Vec2 { x: 20.0, y: 0.0 };
+        let base_left = inner_rect.left_bottom() - Vec2 { x: 0.0, y: 20.0 };
+        let base_right = inner_rect.right_bottom() - Vec2 { x: 20.0, y: 0.0 };
+        ui.painter().line_segment([peak, base_left], stroke);
+        ui.painter().line_segment([peak, base_right], stroke);
+
+        let tree_line_left = peak + Vec2 { x: 20.0, y: 20.0 };
+        let tree_line_right = peak + Vec2 { x: -20.0, y: 20.0 };
+        ui.painter()
+            .line_segment([tree_line_left, tree_line_right], stroke);
+
+        // sun
+        let sun_center = inner_rect.right_top() + Vec2 { x: -40.0, y: 40.0 };
+        ui.painter()
+            .circle(sun_center, 10.0, Color32::TRANSPARENT, stroke);
     }
 
     pub fn draw_cursor(&mut self, ui: &mut Ui, touch_mode: bool) {

--- a/libs/editor/egui_editor/src/draw.rs
+++ b/libs/editor/egui_editor/src/draw.rs
@@ -1,4 +1,5 @@
 use crate::appearance::YELLOW;
+use crate::images::ImageState;
 use crate::input::canonical::{Location, Modification, Region};
 use crate::layouts::Annotation;
 use crate::offset_types::RangeExt;
@@ -91,9 +92,40 @@ impl Editor {
 
             // draw images
             if let Some(image) = &galley.image {
-                let uv = Rect { min: Pos2 { x: 0.0, y: 0.0 }, max: Pos2 { x: 1.0, y: 1.0 } };
-                ui.painter()
-                    .image(image.texture, image.location, uv, Color32::WHITE);
+                match image.image_state {
+                    ImageState::Loading => {
+                        // todo: better icon
+                        ui.painter().line_segment(
+                            [
+                                Pos2 { x: image.location.min.x, y: image.location.max.y },
+                                Pos2 { x: image.location.max.x, y: image.location.min.y },
+                            ],
+                            Stroke {
+                                width: self.appearance.checkbox_slash_width(),
+                                color: self.appearance.text(),
+                            },
+                        );
+                    }
+                    ImageState::Loaded(texture_id) => {
+                        let uv =
+                            Rect { min: Pos2 { x: 0.0, y: 0.0 }, max: Pos2 { x: 1.0, y: 1.0 } };
+                        ui.painter()
+                            .image(texture_id, image.location, uv, Color32::WHITE);
+                    }
+                    ImageState::Failed => {
+                        // todo: better icon
+                        ui.painter().line_segment(
+                            [
+                                Pos2 { x: image.location.min.x, y: image.location.min.y },
+                                Pos2 { x: image.location.max.x, y: image.location.max.y },
+                            ],
+                            Stroke {
+                                width: self.appearance.checkbox_slash_width(),
+                                color: self.appearance.text(),
+                            },
+                        );
+                    }
+                }
             }
 
             // draw text

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -105,9 +105,12 @@ pub struct Editor {
     pub id: egui::Id,
     pub initialized: bool,
 
+    // dependencies
+    pub core: lb::Core,
+    pub client: reqwest::blocking::Client,
+
     // config
     pub appearance: Appearance,
-    pub client: reqwest::blocking::Client, // todo: don't download images on the UI thread
 
     // state
     pub buffer: Buffer,
@@ -140,14 +143,16 @@ pub struct Editor {
     pub scroll_area_offset: Vec2,
 }
 
-impl Default for Editor {
-    fn default() -> Self {
+impl Editor {
+    pub fn new(core: lb::Core) -> Self {
         Self {
             id: egui::Id::null(),
             initialized: Default::default(),
 
-            appearance: Default::default(),
+            core,
             client: Default::default(),
+
+            appearance: Default::default(),
 
             buffer: crate::test_input::TEST_MARKDOWN_45.into(),
             pointer_state: Default::default(),
@@ -174,9 +179,7 @@ impl Default for Editor {
             scroll_area_offset: Default::default(),
         }
     }
-}
 
-impl Editor {
     pub fn draw(&mut self, ctx: &Context) -> EditorResponse {
         let fill = if ctx.style().visuals.dark_mode { Color32::BLACK } else { Color32::WHITE };
         egui::CentralPanel::default()

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -329,7 +329,7 @@ impl Editor {
             self.bounds.links = bounds::calc_links(&self.buffer.current, &self.bounds.text);
         }
         if text_updated || selection_updated || theme_updated {
-            self.images = images::calc(&self.ast, &self.images, &self.client, ui);
+            self.images = images::calc(&self.ast, &self.images, &self.client, &self.core, ui);
         }
         self.galleys = galleys::calc(
             &self.ast,

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -149,7 +149,7 @@ impl Default for Editor {
             appearance: Default::default(),
             client: Default::default(),
 
-            buffer: "".into(),
+            buffer: crate::test_input::TEST_MARKDOWN_45.into(),
             pointer_state: Default::default(),
             debug: Default::default(),
             images: Default::default(),

--- a/libs/editor/egui_editor/src/editor.rs
+++ b/libs/editor/egui_editor/src/editor.rs
@@ -154,7 +154,7 @@ impl Editor {
 
             appearance: Default::default(),
 
-            buffer: crate::test_input::TEST_MARKDOWN_45.into(),
+            buffer: "".into(),
             pointer_state: Default::default(),
             debug: Default::default(),
             images: Default::default(),

--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -310,7 +310,7 @@ impl GalleyInfo {
                         image_height * width / image_width + appearance.image_padding() * 2.0;
                     ui.allocate_exact_size(Vec2::new(width, height), Sense::hover())
                 } else {
-                    ui.allocate_exact_size(Vec2::new(100.0, 100.0), Sense::hover())
+                    ui.allocate_exact_size(Vec2::new(200.0, 200.0), Sense::hover())
                 };
                 Some(ImageInfo { location, image_state })
             } else {

--- a/libs/editor/egui_editor/src/images.rs
+++ b/libs/editor/egui_editor/src/images.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
 
 #[derive(Clone, Default)]
 pub struct ImageCache {

--- a/libs/editor/egui_editor/src/images.rs
+++ b/libs/editor/egui_editor/src/images.rs
@@ -55,8 +55,8 @@ pub fn calc(
 
                     // use core for lb:// urls
                     // todo: also handle relative paths
-                    let image_bytes = if url.starts_with("lb://") {
-                        if let Ok(id) = Uuid::parse_str(&url[5..]) {
+                    let image_bytes = if let Some(stripped) = url.strip_prefix("lb://") {
+                        if let Ok(id) = Uuid::parse_str(stripped) {
                             match core.read_document(id) {
                                 Ok(bytes) => bytes,
                                 Err(_) => {

--- a/libs/editor/egui_editor/src/images.rs
+++ b/libs/editor/egui_editor/src/images.rs
@@ -2,10 +2,22 @@ use crate::ast::Ast;
 use crate::style::{InlineNode, MarkdownNode, Url};
 use egui::{ColorImage, TextureId, Ui};
 use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 
 #[derive(Clone, Default)]
 pub struct ImageCache {
-    pub map: HashMap<Url, Option<TextureId>>,
+    pub map: HashMap<Url, Arc<Mutex<ImageState>>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub enum ImageState {
+    #[default]
+    Loading,
+    Loaded(TextureId),
+    Failed,
 }
 
 pub fn calc(
@@ -14,7 +26,6 @@ pub fn calc(
     let mut result = ImageCache::default();
 
     let mut prior_cache = prior_cache.clone();
-    let texture_manager = ui.ctx().tex_manager();
     for node in &ast.nodes {
         if let MarkdownNode::Inline(InlineNode::Image(_, url, title)) = &node.node_type {
             let (url, title) = (url.clone(), title.clone());
@@ -29,40 +40,56 @@ pub fn calc(
                 // re-use image from previous cache (even it if failed to load)
                 result.map.insert(url, cached);
             } else {
+                let url = url.clone();
+                let image_state: Arc<Mutex<ImageState>> = Default::default();
+                let client = client.clone();
+                let ctx = ui.ctx().clone();
+
+                result.map.insert(url.clone(), image_state.clone());
+
                 // download image
-                let image_bytes = match download_image(client, &url) {
-                    Ok(image_bytes) => image_bytes,
-                    Err(_) => {
-                        result.map.insert(url, None);
-                        continue;
-                    }
-                };
-                let image = match image::load_from_memory(&image_bytes) {
-                    Ok(image) => image,
-                    Err(_) => {
-                        result.map.insert(url, None);
-                        continue;
-                    }
-                };
-                let size_pixels = [image.width() as usize, image.height() as usize];
+                thread::spawn(move || {
+                    let texture_manager = ctx.tex_manager();
+                    let image_bytes = match download_image(&client, &url) {
+                        Ok(image_bytes) => image_bytes,
+                        Err(_) => {
+                            *image_state.lock().unwrap() = ImageState::Failed;
+                            ctx.request_repaint();
+                            return;
+                        }
+                    };
+                    let image = match image::load_from_memory(&image_bytes) {
+                        Ok(image) => image,
+                        Err(_) => {
+                            *image_state.lock().unwrap() = ImageState::Failed;
+                            ctx.request_repaint();
+                            return;
+                        }
+                    };
+                    let size_pixels = [image.width() as usize, image.height() as usize];
 
-                let egui_image = egui::ImageData::Color(ColorImage::from_rgba_unmultiplied(
-                    size_pixels,
-                    &image.to_rgba8(),
-                ));
-                let texture_id =
-                    texture_manager
-                        .write()
-                        .alloc(title, egui_image, Default::default());
+                    let egui_image = egui::ImageData::Color(ColorImage::from_rgba_unmultiplied(
+                        size_pixels,
+                        &image.to_rgba8(),
+                    ));
+                    let texture_id =
+                        texture_manager
+                            .write()
+                            .alloc(title, egui_image, Default::default());
 
-                result.map.insert(url, Some(texture_id));
+                    *image_state.lock().unwrap() = ImageState::Loaded(texture_id);
+
+                    // request a frame when the image is done loading
+                    ctx.request_repaint();
+                });
             }
         }
     }
 
+    let texture_manager = ui.ctx().tex_manager();
     for (_, eviction) in prior_cache.map.drain() {
-        if let Some(eviction) = eviction {
-            texture_manager.write().free(eviction);
+        if let ImageState::Loaded(eviction) = eviction.lock().unwrap().deref() {
+            texture_manager.write().free(*eviction);
         }
     }
 

--- a/libs/editor/egui_editor/src/main.rs
+++ b/libs/editor/egui_editor/src/main.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "debug-window")]
 fn main() {
-    #[derive(Default)]
     struct TestApp {
         editor: egui_editor::editor::Editor,
     }
@@ -11,12 +10,19 @@ fn main() {
         }
     }
 
+    let core = lb::Core::init(&lb::Config {
+        logs: false,
+        colored_logs: false,
+        writeable_path: format!("{}/.lockbook/cli", std::env::var("HOME").unwrap()),
+    })
+    .unwrap();
+
     let options = eframe::NativeOptions::default();
     eframe::run_native(
         "My egui App",
         options,
         Box::new(|cc| {
-            let app = TestApp::default();
+            let app = TestApp { editor: egui_editor::editor::Editor::new(core) };
             app.editor.set_font(&cc.egui_ctx);
             Box::new(app)
         }),


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2077

- [x] images loaded in background thread
- [x] better icons for loading/failed images
- [x] editor connected to core (macOS)
- [x] editor connected to core (iOS)
- [x] editor resolves lockbook links (absolute paths)
- [ ] ~editor resolves lockbook links (relative paths)~: tracked by https://github.com/lockbook/lockbook/issues/2031

https://github.com/lockbook/lockbook/assets/6198756/af2d23b1-e83c-4508-9218-40830869891e

<img width="868" alt="Screenshot 2023-09-20 at 6 50 36 PM" src="https://github.com/lockbook/lockbook/assets/6198756/721d7a96-e48d-405b-893a-727af539eec1">
