### PR TITLE
editor: always render images

### DIFF
--- a/libs/editor/egui_editor/src/galleys.rs
+++ b/libs/editor/egui_editor/src/galleys.rs
@@ -108,7 +108,7 @@ pub fn calc(
             if text_range.range_type == AstTextRangeType::Head
                 && text_range.range.start() == text_range_portion.start()
                 && (captured
-                    || text_range.annotation(ast) == Some(Annotation::HeadingRule)) // heading rules drawn reglardless of capture
+                    || matches!(text_range.annotation(ast), Some(Annotation::HeadingRule | Annotation::Image(..)))) // heading rules and images drawn reglardless of capture
                 && annotation.is_none()
             {
                 annotation = text_range.annotation(ast);


### PR DESCRIPTION
...even if the cursor is in the markdown source for the image or whatever


https://github.com/lockbook/lockbook/assets/6198756/61b46d69-935a-4b65-9484-03d7643a4c63

