### PR TITLE
cli: cli_rs 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,9 +1001,9 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cli-rs"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5369d0e9f71fb3c8d323e858f56d2070ae1ed6ab94034adde801ecfab12dd2a"
+checksum = "4b7ac7347ae96dbff4c6b254e3834cc2f0465778309ec6afb9c43e7b1b0abe8a"
 dependencies = [
  "cli-rs-command-gen",
  "colored",
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "cli-rs-command-gen"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae859a5e4bdd51e4ea8eaecbef63b3213a521e35474e1326fd8751b9b4768a59"
+checksum = "86d5e98ab2d417550cfa67d3e2ae37d92dccf356ae106d4fe86eec9e756e64ce"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,9 +1001,9 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cli-rs"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7ac7347ae96dbff4c6b254e3834cc2f0465778309ec6afb9c43e7b1b0abe8a"
+checksum = "34194db8c4f7513bb150a09cf56b076edfe8a1dcd26e693233f3ae1a03082b0c"
 dependencies = [
  "cli-rs-command-gen",
  "colored",
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "cli-rs-command-gen"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d5e98ab2d417550cfa67d3e2ae37d92dccf356ae106d4fe86eec9e756e64ce"
+checksum = "f1a66f7d50c22b4c92e23097441a2ada7354424a1393917c14e22597d0369fde"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ name = "lockbook"
 path = "src/main.rs"
 
 [dependencies]
-cli-rs = "0.1.7"
+cli-rs = "0.1.10"
 lb = { path = "../../libs/core", package = "lockbook-core" }
 is-terminal = "0.4.7"
 hotwatch = "0.5.0"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ name = "lockbook"
 path = "src/main.rs"
 
 [dependencies]
-cli-rs = "0.1.10"
+cli-rs = "0.1.11"
 lb = { path = "../../libs/core", package = "lockbook-core" }
 is-terminal = "0.4.7"
 hotwatch = "0.5.0"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ name = "lockbook"
 path = "src/main.rs"
 
 [dependencies]
-cli-rs = "0.1.11"
+cli-rs = "0.1.12"
 lb = { path = "../../libs/core", package = "lockbook-core" }
 is-terminal = "0.4.7"
 hotwatch = "0.5.0"

--- a/clients/cli/src/input.rs
+++ b/clients/cli/src/input.rs
@@ -73,6 +73,7 @@ pub fn file_completor(core: &Core, prompt: &str, filter: Option<Filter>) -> CliR
                 format!("{working_dir}{name}")
             }
         })
+        .filter(|completion| completion.starts_with(prompt))
         .collect();
 
     Ok(candidates)

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -28,6 +28,7 @@ fn run() -> CliResult<()> {
 
     Command::name("lockbook")
         .description("The private, polished note-taking platform.") 
+        .version(env!("CARGO_PKG_VERSION"))
         .subcommand(
             Command::name("account")
                 .description("account management commands")

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 edition = "2021"
 
 [dependencies]
-cli-rs = "0.1.11"
+cli-rs = "0.1.12"
 gh_release = "0.1.1"
 toml = "0.7.0"
 toml_edit = "0.19.0"

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 edition = "2021"
 
 [dependencies]
-cli-rs = "0.1.8"
+cli-rs = "0.1.11"
 gh_release = "0.1.1"
 toml = "0.7.0"
 toml_edit = "0.19.0"


### PR DESCRIPTION
adds version support to the CLI and uses a number of fixes and features in the latest cli_rs (https://github.com/lockbook/cli-rs/pull/20)