### PR TITLE
apple: hide upgrade to premium button when user is already premium

### DIFF
--- a/clients/apple/Shared/Views/BottomBar.swift
+++ b/clients/apple/Shared/Views/BottomBar.swift
@@ -125,7 +125,7 @@ struct BottomBar: View {
                         .foregroundColor(.gray)
                         .font(.callout)
                     
-                    if settings.usageProgress <= 0.8 {
+                    if settings.usageProgress <= 0.8 && settings.tier != .Premium {
                         Button(action: {
                             showUpgradeToPremium()
                         }, label: {


### PR DESCRIPTION
fixes #2129