### PR TITLE
core and server large file support

### DIFF
--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -367,7 +367,6 @@ impl<Client: Requester, Docs: DocumentService> CoreLib<Client, Docs> {
             .expected_errs(&[CoreError::ServerUnreachable, CoreError::ClientUpdateRequired])
     }
 
-    // todo: expose work calculated (return value)
     #[instrument(level = "debug", skip_all, err(Debug))]
     pub fn sync(&self, f: Option<Box<dyn Fn(SyncProgress)>>) -> Result<WorkCalculated, LbError> {
         self.in_tx(|s| {


### PR DESCRIPTION
There are some problems to tackle:

# Sync blocking core operations

sync is one of the few core calls that interacts with the network. Such interactions inherently take an unknown amount of time and blocking all other core operations during this time is problematic. 

Hypothesis: it should be fairly easy to release the core locks during these network operations. At a high level core could aquire the lock, calculate last synced release the lock, fetch updates, grab the lock, reconcile the file state, release the lock, fetch any files that we want to keep locally, upload files that we've changed locally, grabbing the lock only to modify core's internal representation of files (successful uploads). I anticipate there will be some small 2PC problems that should be easy to work through.

# Large files support

Presently large files timeout (https://github.com/lockbook/lockbook/issues/1939) during a sync. They probably also shouldn't be retrieved until needed (https://github.com/lockbook/lockbook/issues/1918). And when a set of files is being uploaded or downloaded this should probably happen in parallel (https://github.com/lockbook/lockbook/issues/1940) or in a batch. Additionally if truly large files are in the mix we should be communicative of our current progress. Here are some examples of being communicative of progress:
+ [download](https://gist.github.com/giuliano-oliveira/4d11d6b3bb003dba3a1b53f43d81b30d)
+ [upload](https://stackoverflow.com/questions/70252995/how-to-monitor-reqwest-client-upload-progress)

I believe this is all that's going to be needed, we don't need to manage any chunking of files ourselves with http2, but I need to continue to research to be certain about this.