### PR TITLE
apple: fix significant cpu usage in editor

### DIFF
--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -207,7 +207,7 @@
 		B2063A4C27D01BF900A0783C /* EditorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EditorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2063A5627D01CAA00A0783C /* Lockbook (macOS)Development.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Lockbook (macOS)Development.entitlements"; sourceTree = "<group>"; };
 		B210637C2AD5EA3800E3D85D /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = ../../libs/content/editor/SwiftEditor/Package.swift; sourceTree = "<group>"; };
-		B217A97429661F21002339E0 /* SwiftEditor */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SwiftEditor; path = ../../libs/editor/SwiftEditor; sourceTree = "<group>"; };
+		B217A97429661F21002339E0 /* SwiftEditor */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SwiftEditor; path = ../../libs/content/editor/SwiftEditor; sourceTree = "<group>"; };
 		B2459BEC28DBB43100756D71 /* ColorProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorProgressBar.swift; sourceTree = "<group>"; };
 		B249B9E4282AC03A004F5300 /* MoveSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveSheet.swift; sourceTree = "<group>"; };
 		B249B9E6282AF4F4004F5300 /* FileTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeView.swift; sourceTree = "<group>"; };

--- a/libs/content/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/content/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -298,11 +298,15 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
         redrawTask?.cancel()
         self.isPaused = output.redraw_in > 100
         if self.isPaused {
-            let newRedrawTask = DispatchWorkItem {
-                self.setNeedsDisplay(self.frame)
+            let redrawIn = Int(truncatingIfNeeded: output.redraw_in)
+            
+            if redrawIn != -1 {
+                let newRedrawTask = DispatchWorkItem {
+                    self.setNeedsDisplay(self.frame)
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(redrawIn), execute: newRedrawTask)
+                redrawTask = newRedrawTask
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Int(truncatingIfNeeded: output.redraw_in)), execute: newRedrawTask)
-            redrawTask = newRedrawTask
         }
     }
     


### PR DESCRIPTION
fixes #2192

The high cpu/energy usage was due to two bugs:
1. Every open tab would be re-rendered when the mouse moved
2. Converting `redraw_in`'s `u64` value to swift's `Int` would result in an overflow, and due to the way we schedule re-draws, this caused the editor to re-render immediately.