### PR TITLE
egui: improve running out of storage experience

### DIFF
--- a/clients/egui/src/account/modals/mod.rs
+++ b/clients/egui/src/account/modals/mod.rs
@@ -19,7 +19,7 @@ pub use file_picker::FilePickerAction;
 pub use help::HelpModal;
 pub use new_file::{NewFileParams, NewFolderModal};
 pub use search::SearchModal;
-pub use settings::{SettingsModal, SettingsResponse};
+pub use settings::{SettingsModal, SettingsResponse, SettingsTab};
 
 use crate::widgets::ToolBarVisibility;
 

--- a/clients/egui/src/account/modals/settings/mod.rs
+++ b/clients/egui/src/account/modals/settings/mod.rs
@@ -16,7 +16,7 @@ use self::account_tab::*;
 use self::usage_tab::*;
 
 #[derive(PartialEq)]
-enum SettingsTab {
+pub enum SettingsTab {
     Account,
     Usage,
     Appearance,
@@ -28,7 +28,7 @@ pub struct SettingsModal {
     settings: Arc<RwLock<Settings>>,
     account: AccountSettings,
     usage: UsageSettings,
-    active_tab: SettingsTab,
+    pub active_tab: SettingsTab,
     version: String,
 }
 

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -24,7 +24,7 @@ pub enum SyncStatusError {
 impl SyncPanel {
     pub fn new(status: Result<String, String>) -> Self {
         Self {
-            status: status.map_err(|err| SyncStatusError::Msg(err)),
+            status: status.map_err(SyncStatusError::Msg),
             lock: Arc::new(Mutex::new(())),
             phase: SyncPhase::IdleGood,
         }
@@ -122,7 +122,7 @@ impl super::AccountScreen {
 
                         ProgressBar::new()
                             .percent(usage.percent)
-                            .is_error(matches!(
+                            .error(matches!(
                                 self.sync.status,
                                 Err(SyncStatusError::UsageIsOverDataCap)
                             ))

--- a/clients/egui/src/model.rs
+++ b/clients/egui/src/model.rs
@@ -63,12 +63,16 @@ impl DocType {
 pub enum SyncError {
     Major(String),
     Minor(String),
+    UsageIsOverDataCap,
 }
 
 impl From<lb::LbError> for SyncError {
     fn from(err: lb::LbError) -> Self {
         match err.kind {
             lb::CoreError::Unexpected(msg) => Self::Major(msg),
+            lb::CoreError::UsageIsOverDataCap | lb::CoreError::UsageIsOverFreeTierDataCap => {
+                Self::UsageIsOverDataCap
+            }
             _ => Self::Minor(format!("{:?}", err)),
         }
     }

--- a/clients/egui/src/onboard.rs
+++ b/clients/egui/src/onboard.rs
@@ -103,6 +103,10 @@ impl OnboardScreen {
                         match err {
                             SyncError::Major(msg) => self.import_err = Some(msg),
                             SyncError::Minor(msg) => self.import_err = Some(msg),
+                            SyncError::UsageIsOverDataCap => {
+                                self.import_err =
+                                    Some("Usage is over data dap. You need to Upgrade".to_string())
+                            }
                         }
                     } else {
                         self.import_status = Some("Loading account data...".to_string());

--- a/clients/egui/src/widgets/progress_bar.rs
+++ b/clients/egui/src/widgets/progress_bar.rs
@@ -3,15 +3,21 @@ use eframe::{egui, epaint};
 pub struct ProgressBar {
     height: f32,
     percent: f32,
+    is_error: bool,
 }
 
 impl ProgressBar {
     pub fn new() -> Self {
-        Self { height: 5.0, percent: 0.0 }
+        Self { height: 5.0, percent: 0.0, is_error: false }
     }
 
     pub fn percent(self, percent: f32) -> Self {
         Self { percent, ..self }
+    }
+
+    pub fn is_error(mut self, is_error: bool) -> Self {
+        self.is_error = is_error;
+        self
     }
 
     pub fn show(self, ui: &mut egui::Ui) -> egui::Response {
@@ -39,7 +45,11 @@ impl ProgressBar {
             ui.painter().add(epaint::RectShape {
                 rect: progress_rect,
                 rounding,
-                fill: ui.visuals().widgets.active.bg_fill,
+                fill: if self.is_error {
+                    ui.visuals().error_fg_color
+                } else {
+                    ui.visuals().widgets.active.bg_fill
+                },
                 stroke,
             });
         }

--- a/clients/egui/src/widgets/progress_bar.rs
+++ b/clients/egui/src/widgets/progress_bar.rs
@@ -15,7 +15,7 @@ impl ProgressBar {
         Self { percent, ..self }
     }
 
-    pub fn is_error(mut self, is_error: bool) -> Self {
+    pub fn error(mut self, is_error: bool) -> Self {
         self.is_error = is_error;
         self
     }


### PR DESCRIPTION
fixes #2156

## New approach:
if sync fails with `UsageIsOverDataCap` or `UsageIsOverFreeTierDataCap`,  display the progress bar filled with red instead of the usual accent color. Note that the percentage of fill might not show the bar full, it will display the percentage based on the storage in server, and not local. 
Upwards of the red progress bar there will be an upgrade button (in lieu of the error message) that takes the user to `settings -> usage`

### Possible improvements: 
just a red status bar, and upgrade button might not be enough to information communicated to the user. They might still be confused of what went wrong:
- still display the run out of storage error somewhere in the sidepanel 
- leverage toasts to notify the user  that they run out of storage. 
- deffer communication to the settings modal, and display an error message inside the settings usage tab.