### PR TITLE
cli: lockbook stream in && lockbook stream out

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -5,11 +5,9 @@ mod imex;
 mod input;
 mod list;
 mod share;
+mod stream;
 
-use std::{
-    io::{self, Write},
-    path::PathBuf,
-};
+use std::path::PathBuf;
 
 use account::ApiUrl;
 use cli_rs::{
@@ -42,35 +40,29 @@ fn run() -> CliResult<()> {
                         })
                 )
                 .subcommand(
-                    Command::name("import")
-                        .description("import an existing account by piping in the account string")
+                    Command::name("import").description("import an existing account by piping in the account string")
                         .handler(|| account::import(core))
                 )
                 .subcommand(
-                    Command::name("export")
-                        .description("reveal your account's private key")
+                    Command::name("export").description("reveal your account's private key")
                         .input(Flag::bool("skip-check").description("don't ask for confirmation to reveal the private key"))
                         .handler(|skip_check| account::export(core, skip_check.get()))
                 )
                 .subcommand(
-                    Command::name("subscribe")
-                        .description("start a monthly subscription for massively increased storage")
+                    Command::name("subscribe").description("start a monthly subscription for massively increased storage")
                         .handler(|| account::subscribe(core))
                 )
                 .subcommand(
-                    Command::name("unsubscribe")
-                        .description("cancel an existing subscription")
+                    Command::name("unsubscribe").description("cancel an existing subscription")
                         .handler(|| account::unsubscribe(core))
                 )
                 .subcommand(
-                    Command::name("status")
-                        .description("show your account status")
+                    Command::name("status").description("show your account status")
                         .handler(|| account::status(core))
                 )
         )
         .subcommand(
-            Command::name("copy")
-                .description("import files from your file system into lockbook")
+            Command::name("copy").description("import files from your file system into lockbook")
                 .input(Arg::<PathBuf>::name("disk-path").description("path of file on disk"))
                 .input(Arg::<FileInput>::name("dest")
                        .description("the path or id of a folder within lockbook to place the file.")
@@ -78,58 +70,49 @@ fn run() -> CliResult<()> {
                 .handler(|disk, parent| imex::copy(core, disk.get(), parent.get()))
         )
         .subcommand(
-            Command::name("debug")
-                .description("investigative commands")
+            Command::name("debug").description("investigative commands")
                 .subcommand(
-                    Command::name("validate")
-                        .description("helps find invalid states within your lockbook")
+                    Command::name("validate").description("helps find invalid states within your lockbook")
                         .handler(|| debug::validate(core))
                 )
                 .subcommand(
-                    Command::name("info")
-                        .description("print metadata associated with a file")
+                    Command::name("info").description("print metadata associated with a file")
                         .input(Arg::<FileInput>::name("target").description("id or path of file to debug")
                             .completor(|prompt| input::file_completor(core, prompt, None)))
                         .handler(|target| debug::info(core, target.get()))
                 )
                 .subcommand(
-                    Command::name("whoami")
-                        .description("print who is logged into this lockbook")
+                    Command::name("whoami").description("print who is logged into this lockbook")
                         .handler(|| debug::whoami(core))
                 )
                 .subcommand(
-                    Command::name("whereami")
-                        .description("print information about where this lockbook is stored and it's server url")
+                    Command::name("whereami").description("print information about where this lockbook is stored and it's server url")
                         .handler(|| debug::whereami(core))
                 )
         )
         .subcommand(
-            Command::name("delete")
-                .description("delete a file")
+            Command::name("delete").description("delete a file")
                 .input(Flag::bool("force"))
                 .input(Arg::<FileInput>::name("target").description("path of id of file to delete")
                             .completor(|prompt| input::file_completor(core, prompt, None)))
                 .handler(|force, target| delete(core, force.get(), target.get()))
         )
         .subcommand(
-            Command::name("edit")
-                .description("edit a document")
+            Command::name("edit").description("edit a document")
                 .input(edit::editor_flag())
                 .input(Arg::<FileInput>::name("target").description("path or id of file to edit")
                             .completor(|prompt| input::file_completor(core, prompt, None)))
                 .handler(|editor, target| edit::edit(core, editor.get(), target.get()))
         )
         .subcommand(
-            Command::name("export")
-                .description("export a lockbook file to your file system")
+            Command::name("export").description("export a lockbook file to your file system")
                 .input(Arg::<FileInput>::name("target")
                             .completor(|prompt| input::file_completor(core, prompt, None)))
                 .input(Arg::<PathBuf>::name("dest"))
                 .handler(|target, dest| imex::export(core, target.get(), dest.get()))
         )
         .subcommand(
-            Command::name("list")
-                .description("list files and file information")
+            Command::name("list").description("list files and file information")
                 .input(Flag::bool("long").description("display more information"))
                 .input(Flag::bool("recursive").description("include all children of the given directory, recursively"))
                 .input(Flag::bool("paths").description("include more info (such as the file ID)"))
@@ -139,8 +122,7 @@ fn run() -> CliResult<()> {
                 .handler(|long, recur, paths, target| list::list(core, long.get(), recur.get(), paths.get(), target.get()))
         )
         .subcommand(
-            Command::name("move")
-                .description("move a file to a new parent")
+            Command::name("move").description("move a file to a new parent")
                 .input(Arg::<FileInput>::name("src-target").description("lockbook file path or ID of the file to move")
                             .completor(|prompt| input::file_completor(core, prompt, None)))
                 .input(Arg::<FileInput>::name("dest").description("lockbook file path or ID of the new parent folder")
@@ -148,30 +130,38 @@ fn run() -> CliResult<()> {
                 .handler(|src, dst| move_file(core, src.get(), dst.get()))
         )
         .subcommand(
-            Command::name("new")
-                .description("create a new file at the given path or do nothing if it exists")
+            Command::name("new").description("create a new file at the given path or do nothing if it exists")
                 .input(Arg::<FileInput>::name("path").description("create a new file at the given path or do nothing if it exists")
                             .completor(|prompt| input::file_completor(core, prompt, Some(Filter::FoldersOnly))))
                 .handler(|target| create_file(core, target.get()))
         )
         .subcommand(
-            Command::name("print")
-                .description("print a document to stdout")
-                .input(Arg::<FileInput>::name("target").description("lockbook file path or ID")
+            Command::name("stream")
+                .subcommand(
+                    Command::name("out")
+                        .description("print a document to stdout")
+                        .input(Arg::<FileInput>::name("target").description("lockbook file path or ID")
                             .completor(|prompt| input::file_completor(core, prompt, None)))
-                .handler(|target| print(core, target.get()))
+                        .handler(|target| stream::stdout(core, target.get()))
+                )
+                .subcommand(
+                    Command::name("in")
+                        .description("write stdin to a document")
+                        .input(Arg::<FileInput>::name("target").description("lockbook file path or ID")
+                            .completor(|prompt| input::file_completor(core, prompt, None)))
+                        .input(Flag::bool("append").description("don't overwrite the specified lb file, append to it"))
+                        .handler(|target, append| stream::stdin(core, target.get(), append.get()))
+                )
         )
         .subcommand(
-            Command::name("rename")
-                .description("rename a file")
+            Command::name("rename").description("rename a file")
                 .input(Arg::<FileInput>::name("target").description("lockbook file path or ID of file to rename")
                             .completor(|prompt| input::file_completor(core, prompt, None)))
                 .input(Arg::str("new_name"))
                 .handler(|target, new_name| rename(core, target.get(), new_name.get()))
         )
         .subcommand(
-            Command::name("share")
-                .description("sharing related commands")
+            Command::name("share").description("sharing related commands")
                 .subcommand(
                     Command::name("new")
                         .input(Arg::<FileInput>::name("target").description("lockbook file path or ID of file to rename")
@@ -181,13 +171,11 @@ fn run() -> CliResult<()> {
                         .handler(|target, username, ro| share::new(core, target.get(), username.get(), ro.get()))
                 )
                 .subcommand(
-                    Command::name("pending")
-                        .description("list pending shares")
+                    Command::name("pending").description("list pending shares")
                         .handler(|| share::pending(core))
                 )
                 .subcommand(
-                    Command::name("accept")
-                        .description("accept a pending share by adding it to your file tree")
+                    Command::name("accept").description("accept a pending share by adding it to your file tree")
                         .input(Arg::<Uuid>::name("pending-share-id").description("ID of pending share")
                                     .completor(|prompt| share::pending_share_completor(core, prompt)))
                         .input(Arg::<FileInput>::name("target").description("lockbook file path or ID of the folder you want to place this shared file")
@@ -195,16 +183,14 @@ fn run() -> CliResult<()> {
                         .handler(|id, dest| share::accept(core, id.get(), dest.get()))
                 )
                 .subcommand(
-                    Command::name("delete")
-                        .description("delete a pending share")
+                    Command::name("delete").description("delete a pending share")
                         .input(Arg::<Uuid>::name("share-id").description("ID of pending share to delete")
                                .completor(|prompt| share::pending_share_completor(core, prompt)))
                         .handler(|target| share::delete(core, target.get()))
                 )
         )
         .subcommand(
-            Command::name("sync")
-                .description("sync your local changes back to lockbook servers")
+            Command::name("sync").description("sync your local changes back to lockbook servers") // todo also back
                 .handler(|| sync(core))
         )
         .with_completions()
@@ -289,23 +275,13 @@ fn create_file(core: &Core, path: FileInput) -> CliResult<()> {
     match core.get_by_path(&path) {
         Ok(_f) => Ok(()),
         Err(err) => match err.kind {
-            lb::CoreError::FileNonexistent => match core.create_at_path(&path) {
+            CoreError::FileNonexistent => match core.create_at_path(&path) {
                 Ok(_f) => Ok(()),
                 Err(err) => Err(err.into()),
             },
             _ => Err(err.into()),
         },
     }
-}
-
-fn print(core: &Core, target: FileInput) -> Result<(), CliError> {
-    ensure_account_and_root(core)?;
-
-    let id = target.find(core)?.id;
-    let content = core.read_document(id)?;
-    print!("{}", String::from_utf8_lossy(&content));
-    io::stdout().flush()?;
-    Ok(())
 }
 
 fn rename(core: &Core, target: FileInput, new_name: String) -> Result<(), CliError> {

--- a/clients/cli/src/stream.rs
+++ b/clients/cli/src/stream.rs
@@ -1,0 +1,35 @@
+use crate::ensure_account_and_root;
+use crate::input::FileInput;
+use cli_rs::cli_error::CliResult;
+use lb::Core;
+use std::io;
+use std::io::{Read, Write};
+
+pub fn stdin(core: &Core, target: FileInput, append: bool) -> CliResult<()> {
+    ensure_account_and_root(core)?;
+    let id = target.find(core)?.id;
+
+    let mut stdin = io::stdin().lock();
+    let mut buffer = [0; 512];
+    let mut document = if append { core.read_document(id)? } else { vec![] };
+
+    loop {
+        let bytes = stdin.read(&mut buffer)?;
+        if bytes == 0 {
+            break;
+        }
+        document.extend_from_slice(&buffer[..bytes]);
+        core.write_document(id, &document)?;
+    }
+    Ok(())
+}
+
+pub fn stdout(core: &Core, target: FileInput) -> CliResult<()> {
+    ensure_account_and_root(core)?;
+
+    let id = target.find(core)?.id;
+    let content = core.read_document(id)?;
+    print!("{}", String::from_utf8_lossy(&content));
+    io::stdout().flush()?;
+    Ok(())
+}


### PR DESCRIPTION
Main thing to review: `clients/cli/src/stream.rs`
+ defines the `stream in` and `stream out` (formerly `print`) subcommand in the `lockbook` cli. 
+ allows someone to write pretty big files via std stream, along with blocking indefinitely on the output of a program (`tail -f` for instance).
+ also allows someone to specify the `--append` flag to append to the file within lockbook, rather than overwrite it.

fixes #2181