### PR TITLE
cli: respect more system env vars: EDITOR, VISUAL, and HOMEPATH (windows)

### DIFF
--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -79,10 +79,23 @@ impl Default for Editor {
 
         env::var("LOCKBOOK_EDITOR")
             .map(|s| s.parse().unwrap())
+            .or(Self::from_sys_env_var())
             .unwrap_or_else(|_| {
-                eprintln!("LOCKBOOK_EDITOR not set, assuming {:?}", default);
+                eprintln!("LOCKBOOK_EDITOR, VISUAL or EDITOR not set, assuming {:?}", default);
                 default
             })
+    }
+}
+
+impl Editor {
+    fn from_sys_env_var() -> CliResult<Self> {
+        let editor = env::var("VISUAL")
+            .or(env::var("EDITOR"))
+            .map_err(|_| "no EDITOR or VISUAL")?;
+
+        let editor = editor.split('/').last().unwrap();
+
+        Ok(editor.parse().unwrap())
     }
 }
 

--- a/clients/cli/src/edit.rs
+++ b/clients/cli/src/edit.rs
@@ -95,7 +95,7 @@ impl Editor {
 
         let editor = editor.split('/').last().unwrap();
 
-        Ok(editor.parse().unwrap())
+        Ok(editor.parse().map_err(|_| "no EDITOR or VISUAL")?)
     }
 }
 


### PR DESCRIPTION
+ makes CLI usable on windows out of the box (#2227 but a lil nicer)
+ in addition to LOCKBOOK_EDITOR also try to detect if VISUAL or EDITOR is a value we recognize
+ ultimately fallback to vim if all else fails 

fixes #2180 