### PR TITLE
editor: link refinements

### DIFF
--- a/libs/content/editor/egui_editor/src/draw.rs
+++ b/libs/content/editor/egui_editor/src/draw.rs
@@ -1,4 +1,5 @@
 use crate::appearance::{GRAY, YELLOW};
+use crate::bounds::RangesExt;
 use crate::images::ImageState;
 use crate::input::canonical::{Location, Modification, Region};
 use crate::layouts::Annotation;
@@ -189,6 +190,15 @@ impl Editor {
                     }
                     _ => {}
                 }
+            }
+
+            if !self
+                .bounds
+                .links
+                .find_containing(cursor.selection.1, true, true)
+                .is_empty()
+            {
+                stroke.color = self.appearance.link();
             }
 
             (selection_end_line, stroke)

--- a/libs/content/editor/egui_editor/src/editor.rs
+++ b/libs/content/editor/egui_editor/src/editor.rs
@@ -10,13 +10,13 @@ use egui::{Color32, Context, Event, FontDefinitions, Frame, Pos2, Rect, Sense, U
 
 use crate::appearance::Appearance;
 use crate::ast::Ast;
-use crate::bounds::{BoundCase, Bounds, RangesExt};
+use crate::bounds::{BoundCase, Bounds};
 use crate::buffer::Buffer;
 use crate::debug::DebugInfo;
 use crate::galleys::Galleys;
 use crate::images::ImageCache;
 use crate::input::canonical::{Bound, Modification, Offset, Region};
-use crate::input::click_checker::{self, ClickChecker, EditorClickChecker};
+use crate::input::click_checker::{ClickChecker, EditorClickChecker};
 use crate::input::cursor::{Cursor, PointerState};
 use crate::input::events;
 use crate::offset_types::{DocCharOffset, RangeExt};

--- a/libs/content/editor/egui_editor/src/editor.rs
+++ b/libs/content/editor/egui_editor/src/editor.rs
@@ -357,7 +357,8 @@ impl Editor {
                 self.buffer.current.cursor,
                 self.hover_syntax_reveal_debounce_state,
             );
-            self.bounds.links = bounds::calc_links(&self.buffer.current, &self.bounds.text);
+            self.bounds.links =
+                bounds::calc_links(&self.buffer.current, &self.bounds.text, &self.ast);
         }
         if text_updated || selection_updated || theme_updated {
             self.images = images::calc(&self.ast, &self.images, &self.client, &self.core, ui);

--- a/libs/content/editor/egui_editor/src/galleys.rs
+++ b/libs/content/editor/egui_editor/src/galleys.rs
@@ -98,7 +98,7 @@ pub fn calc(
                 cursor_paragraphs,
             );
 
-            // construct text format using all styles except the last (current node)
+            // construct text format using styles for all ancestor nodes
             // only actual text (not head/tail) of each element gets the actual element style
             let mut text_format = TextFormat::default();
             for &node_idx in &text_range.ancestors[0..text_range.ancestors.len()] {

--- a/libs/content/editor/egui_editor/src/galleys.rs
+++ b/libs/content/editor/egui_editor/src/galleys.rs
@@ -99,7 +99,6 @@ pub fn calc(
             );
 
             // construct text format using styles for all ancestor nodes
-            // only actual text (not head/tail) of each element gets the actual element style
             let mut text_format = TextFormat::default();
             for &node_idx in &text_range.ancestors[0..text_range.ancestors.len()] {
                 RenderStyle::Markdown(ast.nodes[node_idx].node_type.clone())

--- a/libs/content/editor/egui_editor/src/galleys.rs
+++ b/libs/content/editor/egui_editor/src/galleys.rs
@@ -101,7 +101,7 @@ pub fn calc(
             // construct text format using all styles except the last (current node)
             // only actual text (not head/tail) of each element gets the actual element style
             let mut text_format = TextFormat::default();
-            for &node_idx in &text_range.ancestors[0..text_range.ancestors.len() - 1] {
+            for &node_idx in &text_range.ancestors[0..text_range.ancestors.len()] {
                 RenderStyle::Markdown(ast.nodes[node_idx].node_type.clone())
                     .apply_style(&mut text_format, appearance);
             }
@@ -136,7 +136,6 @@ pub fn calc(
                 }
                 this
             };
-            RenderStyle::Markdown(text_range.node(ast)).apply_style(&mut text_format, appearance);
             match text_range.range_type {
                 AstTextRangeType::Head => {
                     if captured {

--- a/libs/content/editor/egui_editor/src/input/canonical.rs
+++ b/libs/content/editor/egui_editor/src/input/canonical.rs
@@ -327,7 +327,7 @@ pub fn calc(
             if let Some(galley_idx) = click_checker.checkbox(*pos, touch_mode) {
                 Some(Modification::ToggleCheckbox(galley_idx))
             } else if let Some(url) = click_checker.link(*pos) {
-                if touch_mode || click_mods.command {
+                if (touch_mode && !click_dragged) || click_mods.command {
                     Some(Modification::OpenUrl(url))
                 } else {
                     None

--- a/libs/content/editor/egui_editor/src/style.rs
+++ b/libs/content/editor/egui_editor/src/style.rs
@@ -242,6 +242,7 @@ impl RenderStyle {
             }
             RenderStyle::PlaintextLink => {
                 text_format.color = vis.link();
+                text_format.underline = Stroke { width: 1.5, color: vis.link() };
             }
             RenderStyle::Syntax => {
                 text_format.color = vis.syntax();
@@ -269,6 +270,7 @@ impl RenderStyle {
             }
             RenderStyle::Markdown(MarkdownNode::Inline(InlineNode::Link(..))) => {
                 text_format.color = vis.link();
+                text_format.underline = Stroke { width: 1.5, color: vis.link() };
             }
             RenderStyle::Markdown(MarkdownNode::Inline(InlineNode::Image(..))) => {
                 text_format.italics = true;

--- a/libs/content/editor/egui_editor/src/test_input.rs
+++ b/libs/content/editor/egui_editor/src/test_input.rs
@@ -272,7 +272,7 @@ pub static TEST_MARKDOWN_50: &str = r#"# Editor Demo
     - [ ] a `code` list item,
 
 ```
-a code block
+a code block with a plaintextlink.com
 ```
 
 > a quote,


### PR DESCRIPTION
* links are underlined
* links are blue even in inline code sections or other places they might be another color
* cursor is styled blue in plaintext links
* plaintext links ignored in code blocks
* pointing hand cursor icon when cmd+hovering a link
* enter finishes link workflow even in a list item
* in touch mode, don't open links when dragging

fixes https://github.com/lockbook/lockbook/issues/2209
fixes https://github.com/lockbook/lockbook/issues/2172
fixes https://github.com/lockbook/lockbook/issues/2173
fixes https://github.com/lockbook/lockbook/issues/2189


https://github.com/lockbook/lockbook/assets/6198756/1127c1a5-b392-4f54-9491-cdbb9e08ddf9

https://github.com/lockbook/lockbook/assets/6198756/1a943404-8146-4cfa-bd4a-b1c79072ab72

https://github.com/lockbook/lockbook/assets/6198756/86c65f9e-1bed-4eae-8c1b-820b9f3829fb