### PR TITLE
editor: list refinements

### DIFF
--- a/libs/content/editor/egui_editor/src/apple/ios_ffi.rs
+++ b/libs/content/editor/egui_editor/src/apple/ios_ffi.rs
@@ -500,6 +500,7 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
     let buffer = &obj.editor.buffer.current;
     let galleys = &obj.editor.galleys;
     let text = &obj.editor.bounds.text;
+    let appearance = &obj.editor.appearance;
 
     let cursor_representing_rect: Cursor = {
         let range: (DocCharOffset, DocCharOffset) = range.into();
@@ -512,8 +513,8 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
         (selection_start, end_of_rect).into()
     };
 
-    let start_line = cursor_representing_rect.start_line(galleys, text);
-    let end_line = cursor_representing_rect.end_line(galleys, text);
+    let start_line = cursor_representing_rect.start_line(galleys, text, appearance);
+    let end_line = cursor_representing_rect.end_line(galleys, text, appearance);
     CRect {
         min_x: (start_line[1].x + 1.0) as f64,
         min_y: start_line[0].y as f64,
@@ -573,9 +574,10 @@ pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPos
     let obj = &mut *(obj as *mut WgpuEditor);
     let galleys = &obj.editor.galleys;
     let text = &obj.editor.bounds.text;
+    let appearance = &obj.editor.appearance;
 
     let cursor: Cursor = pos.pos.into();
-    let line = cursor.start_line(galleys, text);
+    let line = cursor.start_line(galleys, text, appearance);
     let scroll = obj.editor.scroll_area_offset;
     CRect {
         min_x: (line[0].x - scroll.x) as f64,

--- a/libs/content/editor/egui_editor/src/draw.rs
+++ b/libs/content/editor/egui_editor/src/draw.rs
@@ -152,8 +152,10 @@ impl Editor {
     pub fn draw_cursor(&mut self, ui: &mut Ui, touch_mode: bool) {
         // determine cursor style
         let cursor = self.buffer.current.cursor;
-        let selection_start_line = cursor.start_line(&self.galleys, &self.bounds.text);
-        let selection_end_line = cursor.end_line(&self.galleys, &self.bounds.text);
+        let selection_start_line =
+            cursor.start_line(&self.galleys, &self.bounds.text, &self.appearance);
+        let selection_end_line =
+            cursor.end_line(&self.galleys, &self.bounds.text, &self.appearance);
 
         let color = if touch_mode { self.appearance.cursor() } else { self.appearance.text() };
         let stroke = Stroke { width: 1.0, color };

--- a/libs/content/editor/egui_editor/src/editor.rs
+++ b/libs/content/editor/egui_editor/src/editor.rs
@@ -400,11 +400,11 @@ impl Editor {
                 .unwrap() // there's always a document
         };
         if selection_updated && self.buffer.current.cursor.selection != all_selection {
-            let cursor_end_line = self
-                .buffer
-                .current
-                .cursor
-                .end_line(&self.galleys, &self.bounds.text);
+            let cursor_end_line = self.buffer.current.cursor.end_line(
+                &self.galleys,
+                &self.bounds.text,
+                &self.appearance,
+            );
             let rect = Rect { min: cursor_end_line[0], max: cursor_end_line[1] };
             ui.scroll_to_rect(rect, None);
         }
@@ -605,10 +605,11 @@ impl Editor {
             if touched_cursor || touched_selection || double_touched_for_selection {
                 // set menu location
                 self.maybe_menu_location = Some(
-                    self.buffer
-                        .current
-                        .cursor
-                        .end_line(&self.galleys, &self.bounds.text)[0],
+                    self.buffer.current.cursor.end_line(
+                        &self.galleys,
+                        &self.bounds.text,
+                        &self.appearance,
+                    )[0],
                 );
             } else {
                 self.maybe_menu_location = None;

--- a/libs/content/editor/egui_editor/src/galleys.rs
+++ b/libs/content/editor/egui_editor/src/galleys.rs
@@ -355,7 +355,7 @@ impl GalleyInfo {
     fn annotation_offset(annotation: &Option<Annotation>, appearance: &Appearance) -> Vec2 {
         let mut offset = Vec2::ZERO;
         if let Some(Annotation::Item(_, indent_level)) = annotation {
-            offset.x = *indent_level as f32 * 20.0 + 20.0
+            offset.x = *indent_level as f32 * 20.0 + 30.0
         }
 
         if let Some(Annotation::HeadingRule) = annotation {

--- a/libs/content/editor/egui_editor/src/input/mutation.rs
+++ b/libs/content/editor/egui_editor/src/input/mutation.rs
@@ -59,10 +59,8 @@ pub fn calc(
         Modification::ToggleStyle { region, style } => {
             let cursor = region_to_cursor(region, current_cursor, buffer, galleys, bounds);
             let unapply = region_completely_styled(cursor, &style, ast, &bounds.ast);
-            println!("unapply: {}", unapply);
             if !unapply {
                 for conflict in conflicting_styles(cursor, &style, ast, &bounds.ast) {
-                    println!("conflict");
                     apply_style(cursor, conflict, true, buffer, ast, &bounds.ast, &mut mutation)
                 }
             }
@@ -637,25 +635,15 @@ fn apply_style(
     let start_range = start_range.unwrap();
     let end_range = end_range.unwrap();
 
-    // modify head/tail for nodes containing cursor start and cursor end
+    // find nodes containing cursor start and cursor end
     let mut last_start_ancestor: Option<usize> = None;
     for &ancestor in &start_range.ancestors {
-        // dehead and detail all but the last ancestor applying the style
-        if let Some(prev_ancestor) = last_start_ancestor {
-            dehead_ast_node(prev_ancestor, ast, mutation);
-            detail_ast_node(prev_ancestor, ast, mutation);
-        }
         if ast.nodes[ancestor].node_type == style {
             last_start_ancestor = Some(ancestor);
         }
     }
     let mut last_end_ancestor: Option<usize> = None;
     for &ancestor in &end_range.ancestors {
-        // dehead and detail all but the last ancestor applying the style
-        if let Some(prev_ancestor) = last_end_ancestor {
-            dehead_ast_node(prev_ancestor, ast, mutation);
-            detail_ast_node(prev_ancestor, ast, mutation);
-        }
         if ast.nodes[ancestor].node_type == style {
             last_end_ancestor = Some(ancestor);
         }

--- a/libs/content/editor/egui_editor/src/input/mutation.rs
+++ b/libs/content/editor/egui_editor/src/input/mutation.rs
@@ -654,10 +654,9 @@ fn conflicting_styles(
                 }
             }
 
-            if node.node_type().conflicts_with(&style.node_type()) {
-                if dedup_set.insert(node.clone()) {
-                    result.push(node.clone());
-                }
+            if node.node_type().conflicts_with(&style.node_type()) && dedup_set.insert(node.clone())
+            {
+                result.push(node.clone());
             }
         }
     }

--- a/libs/content/editor/egui_editor/src/input/mutation.rs
+++ b/libs/content/editor/egui_editor/src/input/mutation.rs
@@ -59,8 +59,10 @@ pub fn calc(
         Modification::ToggleStyle { region, style } => {
             let cursor = region_to_cursor(region, current_cursor, buffer, galleys, bounds);
             let unapply = region_completely_styled(cursor, &style, ast, &bounds.ast);
+            println!("unapply: {}", unapply);
             if !unapply {
                 for conflict in conflicting_styles(cursor, &style, ast, &bounds.ast) {
+                    println!("conflict");
                     apply_style(cursor, conflict, true, buffer, ast, &bounds.ast, &mut mutation)
                 }
             }
@@ -96,9 +98,7 @@ pub fn calc(
                 .find_containing(current_cursor.selection.1, true, true)
                 .iter()
                 .last();
-            let in_galley_text = ast_text_range
-                .map(|r| bounds.ast[r].range_type == AstTextRangeType::Text)
-                .unwrap_or_default();
+            let after_galley_head = current_cursor.selection.1 >= galley.text_range().start();
 
             'modification: {
                 if let Some(ast_text_range) = ast_text_range {
@@ -117,7 +117,7 @@ pub fn calc(
                 }
 
                 // insert new list item, remove current list item, or insert newline before current list item
-                if matches!(galley.annotation, Some(Annotation::Item(..))) && in_galley_text {
+                if matches!(galley.annotation, Some(Annotation::Item(..))) && after_galley_head {
                     // cursor at end of list item
                     if galley.size() - galley.head_size - galley.tail_size == 0 {
                         // empty list item -> delete current annotation

--- a/libs/content/editor/egui_editor/src/input/mutation.rs
+++ b/libs/content/editor/egui_editor/src/input/mutation.rs
@@ -96,6 +96,9 @@ pub fn calc(
                 .find_containing(current_cursor.selection.1, true, true)
                 .iter()
                 .last();
+            let in_galley_text = ast_text_range
+                .map(|r| bounds.ast[r].range_type == AstTextRangeType::Text)
+                .unwrap_or_default();
 
             'modification: {
                 if let Some(ast_text_range) = ast_text_range {
@@ -114,7 +117,7 @@ pub fn calc(
                 }
 
                 // insert new list item, remove current list item, or insert newline before current list item
-                if matches!(galley.annotation, Some(Annotation::Item(..))) {
+                if matches!(galley.annotation, Some(Annotation::Item(..))) && in_galley_text {
                     // cursor at end of list item
                     if galley.size() - galley.head_size - galley.tail_size == 0 {
                         // empty list item -> delete current annotation


### PR DESCRIPTION
* 10px more space for numbered list numbers (affects all list types)
* render cursor before annotation if that's where it is
* tune behavior when cursor is before annotation (e.g. newline should not trigger item insertion/deletion/renumbering)
* support changing type of nested list item

fixes https://github.com/lockbook/lockbook/issues/2202
fixes https://github.com/lockbook/lockbook/issues/2193
fixes https://github.com/lockbook/lockbook/issues/2204

<img width="912" alt="Screenshot 2023-11-04 at 2 19 00 PM" src="https://github.com/lockbook/lockbook/assets/6198756/c943b28e-afbf-4c25-b6ac-e2ca256473c7">

https://github.com/lockbook/lockbook/assets/6198756/29245c08-da2d-48d8-8c4e-2e813cad2725
