### PR TITLE
egui: fix hover states and add pointer hand for tabs

### DIFF
--- a/clients/egui/src/account/workspace.rs
+++ b/clients/egui/src/account/workspace.rs
@@ -138,6 +138,12 @@ fn tab_label(ui: &mut egui::Ui, t: &mut Tab, is_active: bool) -> Option<TabLabel
                 lbl_resp = Some(TabLabelResponse::Renamed(str.to_owned()))
             }
         } else {
+            if resp.hovered() {
+                ui.output_mut(|o: &mut egui::PlatformOutput| {
+                    o.cursor_icon = egui::CursorIcon::PointingHand
+                });
+            }
+
             let bg = if resp.hovered() && !close_hovered {
                 ui.visuals().widgets.hovered.bg_fill
             } else {

--- a/libs/content/editor/egui_editor/src/editor.rs
+++ b/libs/content/editor/egui_editor/src/editor.rs
@@ -502,8 +502,6 @@ impl Editor {
                 ui.output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
             } else if hovering_text {
                 ui.output_mut(|o| o.cursor_icon = egui::CursorIcon::Text);
-            } else {
-                ui.output_mut(|o| o.cursor_icon = egui::CursorIcon::Default);
             }
         }
 


### PR DESCRIPTION
# What
- Fixes a variety of pointer hover states in the egui version
- Adds pointer cursor for tab hover

# How
- Stops the editor from setting the default cursor, which was overriding other cursor styling in the app (search input, setting, sync, and collapse button)
- Adds pointer styling for tabs when any hovering occurs

# Screenshots
![image](https://github.com/lockbook/lockbook/assets/3434045/6dc04401-9215-4475-9923-b6826a97dde3)
![image](https://github.com/lockbook/lockbook/assets/3434045/dfafb8f2-7079-49da-bcc7-69db33a94717)
![image](https://github.com/lockbook/lockbook/assets/3434045/32574725-eeea-4d5d-bd2b-466deb29e8b8)
