### PR TITLE
infra: rust-toolchain.toml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,8 +16,6 @@ jobs:
       CARGO_TARGET_DIR: /home/lockbook-ci/.lockbook-dev/target
     steps:
     - uses: actions/checkout@v2
-    - name: Set Rust Version
-      run: rustup default 1.72
     - name: Install Nightly
       run: rustup toolchain install nightly
     - name: Install udeps

--- a/libs/content/editor/egui_editor/src/bounds.rs
+++ b/libs/content/editor/egui_editor/src/bounds.rs
@@ -91,7 +91,6 @@ pub fn calc_words(
 
 pub fn calc_lines(galleys: &Galleys, ast: &AstTextRanges, text: &Text) -> Lines {
     let mut result = vec![];
-    let galleys = galleys;
     let mut text_range_iter = ast.iter();
     for (galley_idx, galley) in galleys.galleys.iter().enumerate() {
         for (row_idx, _) in galley.galley.rows.iter().enumerate() {

--- a/libs/lb/lb-rs/src/model/drawing.rs
+++ b/libs/lb/lb-rs/src/model/drawing.rs
@@ -259,17 +259,9 @@ pub fn get_drawing_bounds(strokes: &[Stroke]) -> (u32, u32) {
             .unwrap_or(0)
     };
 
-    let max_x_and_girth = strokes
-        .iter()
-        .map(stroke_to_max_x)
-        .max()
-        .unwrap_or(0);
+    let max_x_and_girth = strokes.iter().map(stroke_to_max_x).max().unwrap_or(0);
 
-    let max_y_and_girth = strokes
-        .iter()
-        .map(stroke_to_max_y)
-        .max()
-        .unwrap_or(0);
+    let max_y_and_girth = strokes.iter().map(stroke_to_max_y).max().unwrap_or(0);
 
     (max_x_and_girth + 20, max_y_and_girth + 20)
 }

--- a/libs/lb/lb-rs/src/model/drawing.rs
+++ b/libs/lb/lb-rs/src/model/drawing.rs
@@ -261,13 +261,13 @@ pub fn get_drawing_bounds(strokes: &[Stroke]) -> (u32, u32) {
 
     let max_x_and_girth = strokes
         .iter()
-        .map(|stroke| stroke_to_max_x(stroke))
+        .map(stroke_to_max_x)
         .max()
         .unwrap_or(0);
 
     let max_y_and_girth = strokes
         .iter()
-        .map(|stroke| stroke_to_max_y(stroke))
+        .map(stroke_to_max_y)
         .max()
         .unwrap_or(0);
 

--- a/libs/lb/lb_external_interface/Makefile
+++ b/libs/lb/lb_external_interface/Makefile
@@ -1,9 +1,6 @@
 .PHONY: android
 android:
-	cargo ndk --target aarch64-linux-android --platform $(MIN_VER) -- build --release
-	cargo ndk --target armv7-linux-androideabi --platform $(MIN_VER) -- build --release
-	cargo ndk --target i686-linux-android --platform $(MIN_VER) -- build --release
-	cargo ndk --target x86_64-linux-android --platform $(MIN_VER) -- build --release
+	cargo ndk --target aarch64-linux-android --target armv7-linux-androideabi --target i686-linux-android --target x86_64-linux-android --platform $(MIN_VER) -- build --release
 
 	@echo "Cleaning up old .so's if they exist"
 	@rm -rf $(jniLibs)/*
@@ -58,34 +55,26 @@ linux_jni:
 
 	@cp ../../../target/release/$(libName) $(jniLibs)/desktop/$(libName)
 
-.PHONY: lib_c_for_swift_ios
-lib_c_for_swift_ios:
-	@{ command -v cargo || { echo "Y'ain't got cargo"; exit 1; } }
-	@echo "Creating header"
+.PHONY: swift_libs
+swift_libs:
 	@rm ${swift_inc}lb_rs.h || true
-	cbindgen src/c_interface.rs -l c > lb_rs.h
+	@rm -rf ${swift_lib} ${swift_lib_ios} ${swift_lib_ios_sim}
+	rm -rf ../../../target/xcode-lipo-universal
+
 	@mkdir -p ${swift_inc}
-	cp lb_rs.h ${swift_inc}
-	@echo "Building fat library"
-	@rm ${swift_lib_ios}liblb_external_interface.a || true
-	cargo build --release --target=aarch64-apple-ios
+	@mkdir -p ${swift_lib}
 	@mkdir -p ${swift_lib_ios}
+	@mkdir -p ${swift_lib_ios_sim}
+	@mkdir -p ../../../target/xcode-lipo-universal
+
+	cbindgen src/c_interface.rs -l c > lb_rs.h
+	cargo build --release --target=aarch64-apple-ios-sim --target=aarch64-apple-ios --target=x86_64-apple-ios --target=x86_64-apple-darwin --target=aarch64-apple-darwin
+
+	cp lb_rs.h ${swift_inc}
 	cp ../../../target/aarch64-apple-ios/release/liblb_external_interface.a ${swift_lib_ios}
 
-.PHONY: lib_c_for_swift_ios_sim
-lib_c_for_swift_ios_sim:
-	@{ command -v cargo || { echo "Y'ain't got cargo"; exit 1; } }
-	@echo "Creating header"
-	@rm ${swift_inc}lb_rs.h || true
-	cbindgen src/c_interface.rs -l c > lb_rs.h
-	@mkdir -p ${swift_inc}
-	cp lb_rs.h ${swift_inc}
-	@echo "Building fat library"
-	@rm ${swift_lib_ios_sim}liblb_external_interface.a || true
-	cargo build --release --target=aarch64-apple-ios-sim
-	cargo build --release --target=x86_64-apple-ios
-	@mkdir -p ${swift_lib_ios_sim}
 	lipo -create -output ${swift_lib_ios_sim}liblb_external_interface.a ../../../target/aarch64-apple-ios-sim/release/liblb_external_interface.a ../../../target/x86_64-apple-ios/release/liblb_external_interface.a
+	lipo -create -output ${swift_lib}liblb_external_interface.a ../../../target/x86_64-apple-darwin/release/liblb_external_interface.a ../../../target/aarch64-apple-darwin/release/liblb_external_interface.a
 
 # for non lipo builds (linux)
 .PHONY: lib_c_for_swift_native
@@ -97,31 +86,9 @@ lib_c_for_swift_native:
 	@mkdir -p ${swift_inc}
 	cp lb_rs.h ${swift_inc}
 	@echo "Building fat library"
-	@rm ${swift_lib}liblb_external_interface.a || echo "no prior .a"
 	cargo build --release
 	@mkdir -p ${swift_lib}
 	cp ../../../target/release/liblb_external_interface.a ${swift_lib}
-
-.PHONY: lib_c_for_swift_universal
-lib_c_for_swift_universal:
-	@{ command -v cargo || { echo "Y'ain't got cargo"; exit 1; } }
-	@echo "Creating header"
-	@rm ${swift_inc}lb_rs.h || echo "no prior .h"
-	cbindgen src/c_interface.rs -l c > lb_rs.h
-	@mkdir -p ${swift_inc}
-	cp lb_rs.h ${swift_inc}
-	@echo "Building fat library"
-	@rm ${swift_lib}liblb_external_interface.a || echo "no prior .a"
-	cargo build --release --target=x86_64-apple-darwin
-	cargo build --release --target=aarch64-apple-darwin
-	rm -rf ../../../target/xcode-lipo-universal
-	mkdir ../../../target/xcode-lipo-universal
-	lipo -create -output ../../../target/xcode-lipo-universal/liblb_external_interface.a ../../../target/x86_64-apple-darwin/release/liblb_external_interface.a ../../../target/aarch64-apple-darwin/release/liblb_external_interface.a
-	@mkdir -p ${swift_lib}
-	cp ../../../target/xcode-lipo-universal/liblb_external_interface.a ${swift_lib}
-
-.PHONY: swift_libs
-swift_libs: lib_c_for_swift_universal lib_c_for_swift_ios lib_c_for_swift_ios_sim
 
 .PHONY: lib_c_for_windows
 lib_c_for_windows:

--- a/libs/lb/lb_external_interface/rust-toolchain.toml
+++ b/libs/lb/lb_external_interface/rust-toolchain.toml
@@ -1,0 +1,12 @@
+[toolchain]
+targets = [
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios-sim",
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android"
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.73.0"

--- a/server/server/src/billing/stripe_service.rs
+++ b/server/server/src/billing/stripe_service.rs
@@ -9,7 +9,7 @@ use lockbook_shared::api::{
     PaymentMethod, StripeAccountState, StripeAccountTier, UpgradeAccountStripeError,
 };
 use lockbook_shared::file_metadata::Owner;
-use std::ops::Deref;
+
 use stripe::{Invoice, WebhookEvent};
 use tracing::*;
 use uuid::Uuid;
@@ -163,7 +163,6 @@ where
                     "Cannot retrieve the customer_id".to_string(),
                 ))
             })?
-            .deref()
         {
             stripe::Expandable::Id(id) => id.to_string(),
             stripe::Expandable::Object(customer) => customer.id.to_string(),

--- a/server/server/src/billing/stripe_service.rs
+++ b/server/server/src/billing/stripe_service.rs
@@ -155,15 +155,11 @@ where
     pub fn get_public_key_from_invoice(
         &self, invoice: &Invoice,
     ) -> Result<PublicKey, ServerError<StripeWebhookError>> {
-        let customer_id = match invoice
-            .customer
-            .as_ref()
-            .ok_or_else(|| {
-                ClientError(StripeWebhookError::InvalidBody(
-                    "Cannot retrieve the customer_id".to_string(),
-                ))
-            })?
-        {
+        let customer_id = match invoice.customer.as_ref().ok_or_else(|| {
+            ClientError(StripeWebhookError::InvalidBody(
+                "Cannot retrieve the customer_id".to_string(),
+            ))
+        })? {
             stripe::Expandable::Id(id) => id.to_string(),
             stripe::Expandable::Object(customer) => customer.id.to_string(),
         };

--- a/server/server/src/file_service.rs
+++ b/server/server/src/file_service.rs
@@ -953,5 +953,5 @@ where
 }
 
 fn insert<K: Hash + Eq, V: Hash + Eq>(map: &mut HashMap<K, HashSet<V>>, k: K, v: V) {
-    map.entry(k).or_insert_with(Default::default).insert(v);
+    map.entry(k).or_default().insert(v);
 }


### PR DESCRIPTION
+ specify rust version using `rust-toolchain.toml` eliminating the "can you tell me the output of `cargo --version`?"
+ in only `lb_external_interface` add `targets` via `rust-toolchain.toml` eliminating the need to `rustup` manually when you `make swift_libs`
+ build many targets with a single `cargo build --release` call, greatly speeding up compile times for people building for Apple & Android.
+ fix new clippy problems

fixes #1858