### PR TITLE
egui: smooth and storage efficient pen tool

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -808,7 +808,7 @@ impl AccountScreen {
                         } else if ext == "pdf" {
                             TabContent::Pdf(PdfViewer::boxed(&bytes, &ctx))
                         } else if ext == "svg" {
-                            TabContent::Svg(SVGEditor::boxed(&bytes, &ctx))
+                            TabContent::Svg(SVGEditor::boxed(&bytes))
                         } else {
                             TabContent::PlainText(PlainText::boxed(&bytes))
                         }

--- a/clients/egui/src/account/tabs/svg_editor/main.rs
+++ b/clients/egui/src/account/tabs/svg_editor/main.rs
@@ -1,5 +1,4 @@
 use std::borrow::BorrowMut;
-use std::f32::consts::PI;
 use std::fmt::Write;
 use std::sync::mpsc;
 
@@ -8,12 +7,10 @@ use minidom::Element;
 use resvg::tiny_skia::{Path, PathBuilder, PathSegment, Pixmap};
 use resvg::usvg::{self, Size, TreeWriting};
 
-use crate::theme::{Icon, ThemePalette};
-use crate::widgets::Button;
-const ICON_SIZE: f32 = 30.0;
-const COLOR_SWATCH_BTN_RADIUS: f32 = 9.0;
-const THICKNESS_BTN_X_MARGIN: f32 = 5.0;
-const THICKNESS_BTN_WIDTH: f32 = 30.0;
+use crate::theme::ThemePalette;
+
+use super::toolbar::{ColorSwatch, Toolbar, Component};
+
 const INITIAL_SVG_CONTENT: &str = "<svg xmlns=\"http://www.w3.org/2000/svg\" ></svg>";
 const ZOOM_STOP: f32 = 0.1;
 
@@ -25,15 +22,9 @@ pub struct SVGEditor {
     path_builder: PathBuilder,
     zoom_factor: f32,
     id_counter: usize,
-    toolbar: Toolbar,
+    pub toolbar: Toolbar,
     inner_rect: egui::Rect,
     sao_offset: egui::Vec2,
-}
-
-struct Toolbar {
-    components: Vec<Component>,
-    active_color: Option<ColorSwatch>,
-    active_stroke_width: u32,
 }
 
 impl SVGEditor {
@@ -47,42 +38,6 @@ impl SVGEditor {
         }
         let root: Element = content.parse().unwrap();
 
-        let components = vec![
-            Component::Button(SimpleButton {
-                icon: Icon::UNDO,
-                margin: egui::Margin::symmetric(4.0, 7.0),
-                coming_soon_text: Some(
-                    "Undo/Redo will be added in the next version. Stay Tuned!".to_string(),
-                ),
-            }),
-            Component::Button(SimpleButton {
-                icon: Icon::REDO,
-                margin: egui::Margin::symmetric(4.0, 7.0),
-                coming_soon_text: Some(
-                    "Undo/Redo will be added in the next version. Stay Tuned!".to_string(),
-                ),
-            }),
-            Component::Separator(egui::Margin::symmetric(10.0, 0.0)),
-            Component::Button(SimpleButton {
-                icon: Icon::BRUSH,
-                coming_soon_text: None,
-                margin: egui::Margin::symmetric(4.0, 7.0),
-            }),
-            Component::Button(SimpleButton {
-                icon: Icon::ERASER,
-                coming_soon_text: Some(
-                    "Eraser will be added in the next version. Stay Tuned!".to_string(),
-                ),
-                margin: egui::Margin::symmetric(4.0, 7.0),
-            }),
-            Component::Separator(egui::Margin::symmetric(10.0, 0.0)),
-            Component::StrokeWidth(3),
-            Component::StrokeWidth(6),
-            Component::StrokeWidth(9),
-            Component::Separator(egui::Margin::symmetric(10.0, 0.0)),
-        ];
-
-        let toolbar = Toolbar { components, active_color: None, active_stroke_width: 3 };
         let max_id = root
             .children()
             .map(|el| {
@@ -99,7 +54,7 @@ impl SVGEditor {
             draw_tx,
             id_counter: max_id as usize,
             root,
-            toolbar,
+            toolbar: Toolbar::new(),
             sao_offset: egui::vec2(0.0, 0.0),
             path_builder: PathBuilder::new(),
             inner_rect: egui::Rect::NOTHING,
@@ -337,164 +292,4 @@ fn get_path_data(path: Path) -> String {
 
     s.pop(); // ' '
     s
-}
-
-#[derive(Clone)]
-enum Component {
-    Button(SimpleButton),
-    ColorSwatch(ColorSwatch),
-    StrokeWidth(u32),
-    Separator(egui::Margin),
-}
-#[derive(Clone)]
-struct SimpleButton {
-    icon: Icon,
-    margin: egui::Margin,
-    coming_soon_text: Option<String>,
-}
-#[derive(Clone)]
-struct ColorSwatch {
-    id: String,
-    color: egui::Color32,
-}
-
-trait SizableComponent {
-    fn get_width(&self) -> f32;
-}
-impl SizableComponent for Component {
-    fn get_width(&self) -> f32 {
-        match self {
-            Component::Button(btn) => btn.margin.sum().x + ICON_SIZE,
-            Component::Separator(margin) => margin.sum().x,
-            Component::ColorSwatch(_color_btn) => COLOR_SWATCH_BTN_RADIUS * PI,
-            Component::StrokeWidth(_) => THICKNESS_BTN_WIDTH + THICKNESS_BTN_X_MARGIN * 2.0,
-        }
-    }
-}
-
-impl Toolbar {
-    fn width(&self) -> f32 {
-        self.components.iter().map(|c| c.get_width()).sum()
-    }
-    fn calculate_rect(&self, ui: &mut egui::Ui) -> egui::Rect {
-        let height = 0.0;
-        let available_rect = ui.available_rect_before_wrap();
-
-        let maximized_min_x = (available_rect.width() - self.width()) / 2.0 + available_rect.left();
-
-        let min_pos = egui::Pos2 { x: maximized_min_x, y: available_rect.top() + height };
-
-        let maximized_max_x =
-            available_rect.right() - (available_rect.width() - self.width()) / 2.0;
-
-        let max_pos = egui::Pos2 { x: maximized_max_x, y: available_rect.top() };
-        egui::Rect { min: min_pos, max: max_pos }
-    }
-
-    fn show(&mut self, ui: &mut egui::Ui) {
-        let rect = self.calculate_rect(ui);
-
-        ui.allocate_ui_at_rect(rect, |ui| {
-            ui.horizontal(|ui| {
-                self.components.iter().for_each(|c| match c {
-                    Component::Button(btn) => {
-                        egui::Frame::default()
-                            .inner_margin(btn.margin)
-                            .show(ui, |ui| {
-                                let btn_res = Button::default().icon(&btn.icon).show(ui);
-
-                                if let Some(tooltip_text) = &btn.coming_soon_text {
-                                    btn_res.on_hover_text(tooltip_text);
-                                }
-                            });
-                    }
-                    Component::Separator(margin) => {
-                        ui.add_space(margin.right);
-                        ui.add(egui::Separator::default().shrink(ui.available_height() * 0.3));
-                        ui.add_space(margin.left);
-                    }
-                    Component::ColorSwatch(btn) => {
-                        let (response, painter) = ui.allocate_painter(
-                            egui::vec2(COLOR_SWATCH_BTN_RADIUS * PI, ui.available_height()),
-                            egui::Sense::click(),
-                        );
-                        if response.clicked() {
-                            self.active_color =
-                                Some(ColorSwatch { id: btn.id.clone(), color: btn.color });
-                        }
-                        if let Some(active_color) = &self.active_color {
-                            let opacity = if active_color.id.eq(&btn.id) {
-                                1.0
-                            } else if response.hovered() {
-                                ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
-                                0.9
-                            } else {
-                                0.5
-                            };
-
-                            if active_color.id.eq(&btn.id) {
-                                painter.rect_filled(
-                                    response.rect.shrink2(egui::vec2(0.0, 5.0)),
-                                    egui::Rounding::same(8.0),
-                                    btn.color.gamma_multiply(0.2),
-                                )
-                            }
-                            painter.circle_filled(
-                                response.rect.center(),
-                                COLOR_SWATCH_BTN_RADIUS,
-                                btn.color.gamma_multiply(opacity),
-                            );
-                        }
-                    }
-                    Component::StrokeWidth(thickness) => {
-                        ui.add_space(THICKNESS_BTN_X_MARGIN);
-                        let (response, painter) = ui.allocate_painter(
-                            egui::vec2(THICKNESS_BTN_WIDTH, ui.available_height()),
-                            egui::Sense::click(),
-                        );
-
-                        let rect = egui::Rect {
-                            min: egui::Pos2 {
-                                x: response.rect.left(),
-                                y: response.rect.center().y - (*thickness as f32 / 3.0),
-                            },
-                            max: egui::Pos2 {
-                                x: response.rect.right(),
-                                y: response.rect.center().y + (*thickness as f32 / 3.0),
-                            },
-                        };
-
-                        if thickness.eq(&self.active_stroke_width) {
-                            painter.rect_filled(
-                                response.rect.shrink2(egui::vec2(0.0, 5.0)),
-                                egui::Rounding::same(8.0),
-                                egui::Color32::GRAY.gamma_multiply(0.1),
-                            )
-                        }
-                        if response.clicked() {
-                            self.active_stroke_width = *thickness;
-                        }
-                        if response.hovered() {
-                            ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
-                        }
-
-                        painter.rect_filled(
-                            rect,
-                            egui::Rounding::same(2.0),
-                            ui.visuals().text_color().gamma_multiply(0.8),
-                        );
-                        ui.add_space(THICKNESS_BTN_X_MARGIN);
-                    }
-                });
-            });
-        });
-        ui.visuals_mut().widgets.noninteractive.bg_stroke.color = ui
-            .visuals()
-            .widgets
-            .noninteractive
-            .bg_stroke
-            .color
-            .gamma_multiply(0.4);
-        ui.separator();
-    }
 }

--- a/clients/egui/src/account/tabs/svg_editor/mod.rs
+++ b/clients/egui/src/account/tabs/svg_editor/mod.rs
@@ -4,3 +4,4 @@ mod pen;
 
 pub use main::SVGEditor;
 pub use pen::CubicBezBuilder;
+pub use pen::PenEvent;

--- a/clients/egui/src/account/tabs/svg_editor/mod.rs
+++ b/clients/egui/src/account/tabs/svg_editor/mod.rs
@@ -1,5 +1,6 @@
 mod main;
 mod toolbar;
-
+mod pen;
 
 pub use main::SVGEditor;
+pub use pen::CubicBezBuilder;

--- a/clients/egui/src/account/tabs/svg_editor/mod.rs
+++ b/clients/egui/src/account/tabs/svg_editor/mod.rs
@@ -1,0 +1,5 @@
+mod main;
+mod toolbar;
+
+
+pub use main::SVGEditor;

--- a/clients/egui/src/account/tabs/svg_editor/mod.rs
+++ b/clients/egui/src/account/tabs/svg_editor/mod.rs
@@ -1,6 +1,6 @@
 mod main;
-mod toolbar;
 mod pen;
+mod toolbar;
 
 pub use main::SVGEditor;
 pub use pen::CubicBezBuilder;

--- a/clients/egui/src/account/tabs/svg_editor/pen.rs
+++ b/clients/egui/src/account/tabs/svg_editor/pen.rs
@@ -1,0 +1,187 @@
+use eframe::egui;
+use std::collections::VecDeque;
+
+/// Build a cubic bézier path with Cat-mull smoothing    
+pub struct CubicBezBuilder {
+    /// store the 4 past points (control and knots)
+    prev_points_window: VecDeque<egui::Pos2>,
+    points: Vec<egui::Pos2>,
+    pub data: String,
+    needs_move: bool,
+}
+
+impl CubicBezBuilder {
+    pub fn new() -> Self {
+        CubicBezBuilder {
+            prev_points_window: VecDeque::from(vec![]),
+            points: vec![],
+            data: String::new(),
+            needs_move: true,
+        }
+    }
+
+    fn cat_mull_to(&mut self, dest: egui::Pos2) {
+        if self.needs_move {
+            self.data = format!("M {} {}", dest.x, dest.y);
+            self.needs_move = false;
+        }
+
+        self.prev_points_window.push_back(dest);
+        if self.prev_points_window.len() < 4 {
+            return;
+        }
+
+        let k = 1.0; //tension
+
+        let p0 = self.prev_points_window[0];
+        let p1 = self.prev_points_window[1];
+        let p2 = self.prev_points_window[2];
+        let p3 = self.prev_points_window[3];
+
+        let cp1x = p1.x + (p2.x - p0.x) / 6.0 * k;
+        let cp1y = p1.y + (p2.y - p0.y) / 6.0 * k;
+
+        let cp2x = p2.x - (p3.x - p1.x) / 6.0 * k;
+        let cp2y = p2.y - (p3.y - p1.y) / 6.0 * k;
+
+        // convert to cubic bezier curve
+        self.data
+            .push_str(format!("C {cp1x},{cp1y},{cp2x},{cp2y},{},{}", p2.x, p2.y).as_str());
+
+        // shift the window
+        self.prev_points_window.pop_front();
+    }
+
+    pub fn cubic_to(&mut self, dest: egui::Pos2) {
+        // calculate cat-mull points
+        self.points.push(dest);
+        self.cat_mull_to(dest);
+    }
+
+    pub fn finish(&mut self) {
+        // https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm#/media/File:RDP,_varying_epsilon.gif
+        let epsilon = 1.5;
+        self.simplify(epsilon);
+
+        self.data = String::default();
+        self.needs_move = true;
+        self.prev_points_window = VecDeque::default();
+
+        self.points.clone().iter().for_each(|p| {
+            self.cat_mull_to(*p);
+        });
+
+        // delete what we have and redraw using rdp
+    }
+
+    pub fn clear(&mut self) {
+        self.prev_points_window = VecDeque::default();
+        self.data = String::default();
+        self.needs_move = true;
+        self.points = vec![];
+    }
+
+    /// Ramer–Douglas–Peucker algorithm courtesy of @author: Michael-F-Bryan
+    /// https://github.com/Michael-F-Bryan/arcs/blob/master/core/src/algorithms/line_simplification.rs
+    fn simplify(&mut self, tolerance: f32) {
+        if self.points.len() <= 2 {
+            return;
+        }
+
+        let mut buffer = Vec::new();
+
+        // push the first point
+        buffer.push(self.points[0]);
+        // then simplify every point in between the start and end
+        self.simplify_points(&self.points[..], tolerance, &mut buffer);
+        // and finally the last one
+        buffer.push(*self.points.last().unwrap());
+
+        self.points = buffer;
+    }
+
+    fn simplify_points(&self, points: &[egui::Pos2], tolerance: f32, buffer: &mut Vec<egui::Pos2>) {
+        // TODO: replace this with `if let [first, rest @ .., last]` in rust 1.42
+        if points.len() < 2 {
+            return;
+        }
+        let first = points.first().unwrap();
+        let last = points.last().unwrap();
+        let rest = &points[1..points.len() - 1];
+
+        let line_segment = Line::new(*first, *last);
+
+        if let Some((ix, distance)) =
+            self.max_by_key(rest, |p| line_segment.perpendicular_distance_to(*p))
+        {
+            if distance > tolerance {
+                // note: index is the index into `rest`, but we want it relative
+                // to `point`
+                let ix = ix + 1;
+
+                self.simplify_points(&points[..=ix], tolerance, buffer);
+                buffer.push(points[ix]);
+                self.simplify_points(&points[ix..], tolerance, buffer);
+            }
+        }
+    }
+
+    fn max_by_key<T, F, K>(&self, items: &[T], mut key_func: F) -> Option<(usize, K)>
+    where
+        F: FnMut(&T) -> K,
+        K: PartialOrd,
+    {
+        let mut best_so_far = None;
+
+        for (i, item) in items.iter().enumerate() {
+            let key = key_func(item);
+
+            let is_better = match best_so_far {
+                Some((_, ref best_key)) => key > *best_key,
+                None => true,
+            };
+
+            if is_better {
+                best_so_far = Some((i, key));
+            }
+        }
+        best_so_far
+    }
+}
+
+struct Line {
+    start: egui::Pos2,
+    end: egui::Pos2,
+}
+
+impl Line {
+    fn new(start: egui::Pos2, end: egui::Pos2) -> Self {
+        Line { start, end }
+    }
+
+    fn length(&self) -> f32 {
+        let dx = self.end.x - self.start.x;
+        let dy = self.end.y - self.start.y;
+
+        // Using the Pythagorean theorem to calculate the length
+        (dx * dx + dy * dy).sqrt()
+    }
+
+    fn perpendicular_distance_to(&self, point: egui::Pos2) -> f32 {
+        const SOME_SMALL_NUMBER: f32 = std::f32::EPSILON * 100.0;
+
+        let side_a = self.start - point;
+        let side_b = self.end - point;
+
+        let area = (side_a.x * side_b.y - side_a.y * side_b.x) / 2.0;
+
+        // area = base * height / 2
+        let base_length = self.length();
+
+        if base_length.abs() < SOME_SMALL_NUMBER {
+            side_a.length()
+        } else {
+            area.abs() * 2.0 / base_length
+        }
+    }
+}

--- a/clients/egui/src/account/tabs/svg_editor/pen.rs
+++ b/clients/egui/src/account/tabs/svg_editor/pen.rs
@@ -1,7 +1,6 @@
 use eframe::egui;
 use std::collections::VecDeque;
 
-
 pub enum PenEvent {
     Draw(egui::Pos2, usize),
     End(egui::Pos2, usize),

--- a/clients/egui/src/account/tabs/svg_editor/toolbar.rs
+++ b/clients/egui/src/account/tabs/svg_editor/toolbar.rs
@@ -1,0 +1,216 @@
+use eframe::egui;
+use std::f32::consts::PI;
+
+use crate::{theme::Icon, widgets::Button};
+
+const ICON_SIZE: f32 = 30.0;
+const COLOR_SWATCH_BTN_RADIUS: f32 = 9.0;
+const THICKNESS_BTN_X_MARGIN: f32 = 5.0;
+const THICKNESS_BTN_WIDTH: f32 = 30.0;
+
+pub struct Toolbar {
+    pub components: Vec<Component>,
+    pub active_color: Option<ColorSwatch>,
+    pub active_stroke_width: u32,
+}
+
+#[derive(Clone)]
+pub enum Component {
+    Button(SimpleButton),
+    ColorSwatch(ColorSwatch),
+    StrokeWidth(u32),
+    Separator(egui::Margin),
+}
+#[derive(Clone)]
+struct SimpleButton {
+    icon: Icon,
+    margin: egui::Margin,
+    coming_soon_text: Option<String>,
+}
+#[derive(Clone)]
+pub struct ColorSwatch {
+    pub id: String,
+    pub color: egui::Color32,
+}
+
+trait SizableComponent {
+    fn get_width(&self) -> f32;
+}
+
+impl SizableComponent for Component {
+    fn get_width(&self) -> f32 {
+        match self {
+            Component::Button(btn) => btn.margin.sum().x + ICON_SIZE,
+            Component::Separator(margin) => margin.sum().x,
+            Component::ColorSwatch(_color_btn) => COLOR_SWATCH_BTN_RADIUS * PI,
+            Component::StrokeWidth(_) => THICKNESS_BTN_WIDTH + THICKNESS_BTN_X_MARGIN * 2.0,
+        }
+    }
+}
+
+impl Toolbar {
+    fn width(&self) -> f32 {
+        self.components.iter().map(|c| c.get_width()).sum()
+    }
+    fn calculate_rect(&self, ui: &mut egui::Ui) -> egui::Rect {
+        let height = 0.0;
+        let available_rect = ui.available_rect_before_wrap();
+
+        let maximized_min_x = (available_rect.width() - self.width()) / 2.0 + available_rect.left();
+
+        let min_pos = egui::Pos2 { x: maximized_min_x, y: available_rect.top() + height };
+
+        let maximized_max_x =
+            available_rect.right() - (available_rect.width() - self.width()) / 2.0;
+
+        let max_pos = egui::Pos2 { x: maximized_max_x, y: available_rect.top() };
+        egui::Rect { min: min_pos, max: max_pos }
+    }
+
+    pub fn new() -> Self {
+        let default_stroke_width = 3;
+        let components = vec![
+            Component::Button(SimpleButton {
+                icon: Icon::UNDO,
+                margin: egui::Margin::symmetric(4.0, 7.0),
+                coming_soon_text: Some(
+                    "Undo/Redo will be added in the next version. Stay Tuned!".to_string(),
+                ),
+            }),
+            Component::Button(SimpleButton {
+                icon: Icon::REDO,
+                margin: egui::Margin::symmetric(4.0, 7.0),
+                coming_soon_text: Some(
+                    "Undo/Redo will be added in the next version. Stay Tuned!".to_string(),
+                ),
+            }),
+            Component::Separator(egui::Margin::symmetric(10.0, 0.0)),
+            Component::Button(SimpleButton {
+                icon: Icon::BRUSH,
+                coming_soon_text: None,
+                margin: egui::Margin::symmetric(4.0, 7.0),
+            }),
+            Component::Button(SimpleButton {
+                icon: Icon::ERASER,
+                coming_soon_text: Some(
+                    "Eraser will be added in the next version. Stay Tuned!".to_string(),
+                ),
+                margin: egui::Margin::symmetric(4.0, 7.0),
+            }),
+            Component::Separator(egui::Margin::symmetric(10.0, 0.0)),
+            Component::StrokeWidth(default_stroke_width),
+            Component::StrokeWidth(default_stroke_width * 2),
+            Component::StrokeWidth(default_stroke_width * 3),
+            Component::Separator(egui::Margin::symmetric(10.0, 0.0)),
+        ];
+
+        Toolbar { components, active_color: None, active_stroke_width: default_stroke_width }
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui) {
+        let rect = self.calculate_rect(ui);
+
+        ui.allocate_ui_at_rect(rect, |ui| {
+            ui.horizontal(|ui| {
+                self.components.iter().for_each(|c| match c {
+                    Component::Button(btn) => {
+                        egui::Frame::default()
+                            .inner_margin(btn.margin)
+                            .show(ui, |ui| {
+                                let btn_res = Button::default().icon(&btn.icon).show(ui);
+
+                                if let Some(tooltip_text) = &btn.coming_soon_text {
+                                    btn_res.on_hover_text(tooltip_text);
+                                }
+                            });
+                    }
+                    Component::Separator(margin) => {
+                        ui.add_space(margin.right);
+                        ui.add(egui::Separator::default().shrink(ui.available_height() * 0.3));
+                        ui.add_space(margin.left);
+                    }
+                    Component::ColorSwatch(btn) => {
+                        let (response, painter) = ui.allocate_painter(
+                            egui::vec2(COLOR_SWATCH_BTN_RADIUS * PI, ui.available_height()),
+                            egui::Sense::click(),
+                        );
+                        if response.clicked() {
+                            self.active_color =
+                                Some(ColorSwatch { id: btn.id.clone(), color: btn.color });
+                        }
+                        if let Some(active_color) = &self.active_color {
+                            let opacity = if active_color.id.eq(&btn.id) {
+                                1.0
+                            } else if response.hovered() {
+                                ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
+                                0.9
+                            } else {
+                                0.5
+                            };
+
+                            if active_color.id.eq(&btn.id) {
+                                painter.rect_filled(
+                                    response.rect.shrink2(egui::vec2(0.0, 5.0)),
+                                    egui::Rounding::same(8.0),
+                                    btn.color.gamma_multiply(0.2),
+                                )
+                            }
+                            painter.circle_filled(
+                                response.rect.center(),
+                                COLOR_SWATCH_BTN_RADIUS,
+                                btn.color.gamma_multiply(opacity),
+                            );
+                        }
+                    }
+                    Component::StrokeWidth(thickness) => {
+                        ui.add_space(THICKNESS_BTN_X_MARGIN);
+                        let (response, painter) = ui.allocate_painter(
+                            egui::vec2(THICKNESS_BTN_WIDTH, ui.available_height()),
+                            egui::Sense::click(),
+                        );
+
+                        let rect = egui::Rect {
+                            min: egui::Pos2 {
+                                x: response.rect.left(),
+                                y: response.rect.center().y - (*thickness as f32 / 3.0),
+                            },
+                            max: egui::Pos2 {
+                                x: response.rect.right(),
+                                y: response.rect.center().y + (*thickness as f32 / 3.0),
+                            },
+                        };
+
+                        if thickness.eq(&self.active_stroke_width) {
+                            painter.rect_filled(
+                                response.rect.shrink2(egui::vec2(0.0, 5.0)),
+                                egui::Rounding::same(8.0),
+                                egui::Color32::GRAY.gamma_multiply(0.1),
+                            )
+                        }
+                        if response.clicked() {
+                            self.active_stroke_width = *thickness;
+                        }
+                        if response.hovered() {
+                            ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
+                        }
+
+                        painter.rect_filled(
+                            rect,
+                            egui::Rounding::same(2.0),
+                            ui.visuals().text_color().gamma_multiply(0.8),
+                        );
+                        ui.add_space(THICKNESS_BTN_X_MARGIN);
+                    }
+                });
+            });
+        });
+        ui.visuals_mut().widgets.noninteractive.bg_stroke.color = ui
+            .visuals()
+            .widgets
+            .noninteractive
+            .bg_stroke
+            .color
+            .gamma_multiply(0.4);
+        ui.separator();
+    }
+}

--- a/clients/egui/src/account/tabs/svg_editor/toolbar.rs
+++ b/clients/egui/src/account/tabs/svg_editor/toolbar.rs
@@ -22,7 +22,7 @@ pub enum Component {
     Separator(egui::Margin),
 }
 #[derive(Clone)]
-struct SimpleButton {
+pub struct SimpleButton {
     icon: Icon,
     margin: egui::Margin,
     coming_soon_text: Option<String>,


### PR DESCRIPTION
Introduce curve smoothing and reduce space consumption by  _40-50%_  (based on this rough unscientific example where the old pen's file size 10k , and the new one's file size is 16k).   

fixes: #2262
<details>

![image](https://github.com/lockbook/lockbook/assets/66345861/c8222a18-d22d-4407-a065-e5dd7b452893)
![image](https://github.com/lockbook/lockbook/assets/66345861/da75a421-2ef2-4d18-b530-9af503218850)

</details>