### PR TITLE
apple: increase debounce for path search

### DIFF
--- a/clients/apple/Shared/Stateful Logic/SearchService.swift
+++ b/clients/apple/Shared/Stateful Logic/SearchService.swift
@@ -132,7 +132,7 @@ class SearchService: ObservableObject {
             }
         }
         
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(500), execute: newPathSearchTask)
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(550), execute: newPathSearchTask)
         
         pathSearchTask = newPathSearchTask
     }

--- a/clients/apple/Shared/Stateful Logic/SearchService.swift
+++ b/clients/apple/Shared/Stateful Logic/SearchService.swift
@@ -135,7 +135,7 @@ class SearchService: ObservableObject {
             }
         }
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200), execute: newPathSearchTask)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: newPathSearchTask)
         
         pathSearchTask = newPathSearchTask
     }

--- a/clients/apple/Shared/Stateful Logic/SearchService.swift
+++ b/clients/apple/Shared/Stateful Logic/SearchService.swift
@@ -117,25 +117,22 @@ class SearchService: ObservableObject {
         let currentSearchTimestamp = lastSearchTimestamp
         
         let newPathSearchTask = DispatchWorkItem {
-            DispatchQueue.global(qos: .userInteractive).async {
-                
-                let result = self.core.searchFilePaths(input: input)
-                
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success(let paths):
-                        if currentSearchTimestamp == self.lastSearchTimestamp && self.pathSearchState != .NotSearching {
-                            self.pathSearchState = .SearchSuccessful(paths)
-                        }
-                    case .failure(let err):
-                        self.pathSearchState = .Idle
-                        DI.errors.handleError(err)
+            let result = self.core.searchFilePaths(input: input)
+            
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let paths):
+                    if currentSearchTimestamp == self.lastSearchTimestamp && self.pathSearchState != .NotSearching {
+                        self.pathSearchState = .SearchSuccessful(paths)
                     }
+                case .failure(let err):
+                    self.pathSearchState = .Idle
+                    DI.errors.handleError(err)
                 }
             }
         }
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: newPathSearchTask)
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(500), execute: newPathSearchTask)
         
         pathSearchTask = newPathSearchTask
     }


### PR DESCRIPTION
fixes #2282

Our previous debounce timer would wait `200 ms` before starting a search. This would cause a lot of searches to kick off while the user is typing, and since searches cannot happen concurrently, each search would have to wait for the subsequent search to complete (due to the mutex on core). 

So I increased the debounce duration to `550 ms`. This makes searching more forgiving for slow types, although the problem won't truly be fixed unless we can interrupt searches, or allow concurrent searches.

I also did a small refactor.