### PR TITLE
apple: multi-threaded path search

### DIFF
--- a/clients/apple/Shared/Stateful Logic/SearchService.swift
+++ b/clients/apple/Shared/Stateful Logic/SearchService.swift
@@ -135,7 +135,7 @@ class SearchService: ObservableObject {
             }
         }
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: newPathSearchTask)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200), execute: newPathSearchTask)
         
         pathSearchTask = newPathSearchTask
     }

--- a/clients/apple/Shared/Stateful Logic/SearchService.swift
+++ b/clients/apple/Shared/Stateful Logic/SearchService.swift
@@ -135,7 +135,7 @@ class SearchService: ObservableObject {
             }
         }
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200), execute: newPathSearchTask)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: newPathSearchTask)
         
         pathSearchTask = newPathSearchTask
     }


### PR DESCRIPTION
fixes #2282

### results

multi-threaded approach:
```
"cookie" search duration 1143
"apple" search duration 498
"lockbook" search duration 1165
"e" search duration 584
```

single-threaded approach:
```
"cookie" search duration 941
"apple" search duration 550
"lockbook" search duration 799
"e" search duration 961
```