### PR TITLE
iOS, iPadOS: fix checkboxes

### DIFF
--- a/libs/content/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
+++ b/libs/content/editor/SwiftEditor/Sources/Editor/iOSMTK.swift
@@ -44,6 +44,14 @@ public class iOSMTK: MTKView, MTKViewDelegate, UITextInput, UIEditMenuInteractio
         // selection support
         textInteraction.textInput = self
         self.addInteraction(textInteraction)
+        
+        for gestureRecognizer in textInteraction.gesturesForFailureRequirements {
+            let gestureName = gestureRecognizer.name?.lowercased()
+            
+            if(gestureName?.contains("tap") ?? false) {
+                gestureRecognizer.cancelsTouchesInView = false
+            }
+        }
 
         // drop support
         let dropInteraction = UIDropInteraction(delegate: self)


### PR DESCRIPTION
fixes #2301 

# Details

Two gestures that are a part of `UITextInteraction`, which are `UITextMultiTapRecognizer` and `UITapAndAHalfRecognizer`, were consuming single tap events. These gestures are a part of a list of other gestures, all of which are private classes. So I had to do string comparisons to get these two gestures, and stop their gestures from canceling touches in the mtk view.

Even when a checkbox is checked with a tap, selection can change at the same time. That is because both operations are happening simultaneously, rather than depending on one another.