### PR TITLE
canvas: selection scale

### DIFF
--- a/libs/content/workspace/src/tab/svg_editor/eraser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/eraser.rs
@@ -38,7 +38,6 @@ impl Eraser {
                         return;
                     }
 
-                    println!("{:#?}", id);
                     if pointer_interests_path(path, pos, self.last_pos, ERASER_THICKNESS as f64) {
                         if let Some(n) = buffer
                             .current

--- a/libs/content/workspace/src/tab/svg_editor/eraser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/eraser.rs
@@ -38,6 +38,7 @@ impl Eraser {
                         return;
                     }
 
+                    println!("{:#?}", id);
                     if pointer_interests_path(path, pos, self.last_pos, ERASER_THICKNESS as f64) {
                         if let Some(n) = buffer
                             .current

--- a/libs/content/workspace/src/tab/svg_editor/selection.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection.rs
@@ -1,8 +1,20 @@
+<<<<<<< HEAD:libs/content/workspace/src/tab/svg_editor/selection.rs
 use super::{
     history::TransformElement,
     node_by_id,
     util::{deserialize_transform, pointer_interests_path, serialize_transform},
     Buffer, DeleteElement,
+=======
+use bezier_rs::Subpath;
+use eframe::egui;
+use glam::{DAffine2, DMat2, DVec2};
+
+use super::{
+    history::ManipulatorGroupId,
+    node_by_id, pointer_interests_path,
+    util::{deserialize_transform, serialize_transform},
+    Buffer, DeleteElement, TransformElement,
+>>>>>>> 5ce97131 (Mouse based element scaling):clients/egui/src/account/tabs/svg_editor/selection.rs
 };
 
 pub struct Selection {
@@ -10,6 +22,7 @@ pub struct Selection {
     selected_elements: Vec<SelectedElement>,
     laso_original_pos: Option<egui::Pos2>,
     laso_rect: Option<egui::Rect>,
+    current_op: SelectionOperation,
 }
 
 struct SelectedElement {
@@ -31,6 +44,7 @@ impl Selection {
             selected_elements: vec![],
             laso_original_pos: None,
             laso_rect: None,
+            current_op: SelectionOperation::Drag,
         }
     }
 
@@ -48,9 +62,13 @@ impl Selection {
             None => egui::Pos2::ZERO,
         };
 
-        let maybe_selected_el = self.detect_drag(buffer, pos, ui);
-        if maybe_selected_el.is_some() {
-            ui.output_mut(|r| r.cursor_icon = egui::CursorIcon::Grab);
+        let mut maybe_selected_el = None;
+
+        if matches!(self.current_op, SelectionOperation::Idle) {
+            maybe_selected_el = self.detect_drag(buffer, pos);
+            if maybe_selected_el.is_some() {
+                ui.output_mut(|r| r.cursor_icon = egui::CursorIcon::Grab);
+            }
         }
 
         // build up selected elements
@@ -61,7 +79,9 @@ impl Selection {
                 let rect = egui::Rect {
                     min: egui::pos2(bb[0].x as f32, bb[0].y as f32),
                     max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
-                };
+                }
+                .expand(6.0);
+
                 rect.contains(pos)
             });
 
@@ -74,6 +94,7 @@ impl Selection {
                     } else {
                         self.selected_elements = vec![new_selected_el]
                     }
+                    // this is a bit hacky, try to use the current_op instead of relying on the cursor icon
                 } else {
                     self.selected_elements.clear();
                     self.laso_original_pos = Some(pos);
@@ -142,34 +163,44 @@ impl Selection {
 
         for el in self.selected_elements.iter_mut() {
             let path = buffer.paths.get(&el.id).unwrap();
-            let bb = path.bounding_box().unwrap();
-            let rect = egui::Rect {
-                min: egui::pos2(bb[0].x as f32, bb[0].y as f32),
-                max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
-            };
-
-            if rect.contains(pos) {
-                ui.output_mut(|r| r.cursor_icon = egui::CursorIcon::Grab);
-            }
-
-            show_bb_rect(ui, bb, working_rect);
+            let res = show_bb_rect(ui, &path, working_rect, pos); // based on the response we know the intent
 
             if ui.input(|r| r.pointer.primary_released()) {
                 transform_origin_dirty = true;
                 history_dirty = true;
-                break;
+                self.current_op = SelectionOperation::Idle;
             } else if ui.input(|r| r.pointer.primary_clicked()) {
                 transform_origin_dirty = true;
-                break;
             } else if ui.input(|r| r.pointer.primary_down()) {
-                ui.output_mut(|r| r.cursor_icon = egui::CursorIcon::Grabbing);
-                let mut delta = egui::pos2(pos.x - el.original_pos.x, pos.y - el.original_pos.y);
-                if let Some(transform) = buffer.current.attr("transform") {
-                    let transform = deserialize_transform(transform);
-                    delta.x /= transform[0] as f32;
-                    delta.y /= transform[3] as f32;
+                if matches!(self.current_op, SelectionOperation::Idle) {
+                    if let Some(r) = res {
+                        self.current_op = r.current_op;
+                        ui.output_mut(|w| w.cursor_icon = r.cursor_icon);
+                    }
                 }
-                drag(delta, el, buffer);
+
+                match self.current_op {
+                    SelectionOperation::Drag => {
+                        let mut delta =
+                            egui::pos2(pos.x - el.original_pos.x, pos.y - el.original_pos.y);
+                        if let Some(transform) = buffer.current.attr("transform") {
+                            let transform = deserialize_transform(transform);
+                            delta.x /= transform[0] as f32;
+                            delta.y /= transform[3] as f32;
+                        }
+                        drag(delta, el, buffer);
+                        ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::Grabbing);
+                    }
+                    SelectionOperation::HorizontalZoom | SelectionOperation::VerticalZoom => {
+                        zoom_to_pos(pos, el, buffer, &self.current_op);
+                        ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::None);
+                    }
+                    SelectionOperation::Idle => {}
+                }
+            } else {
+                if let Some(r) = res {
+                    ui.output_mut(|w| w.cursor_icon = r.cursor_icon);
+                }
             }
 
             if ui.input(|r| r.key_pressed(egui::Key::ArrowDown))
@@ -201,11 +232,11 @@ impl Selection {
             }
 
             if ui.input(|r| r.key_pressed(egui::Key::PlusEquals)) {
-                zoom(1.1, el, buffer, working_rect);
+                zoom_from_center(1.1, el, buffer);
                 transform_origin_dirty = true;
                 history_dirty = true;
             } else if ui.input(|r| r.key_pressed(egui::Key::Minus)) {
-                zoom(0.9, el, buffer, working_rect);
+                zoom_from_center(0.9, el, buffer);
                 transform_origin_dirty = true;
                 history_dirty = true;
             }
@@ -239,12 +270,9 @@ impl Selection {
         self.last_pos = Some(pos);
     }
 
-    fn detect_drag(
-        &mut self, buffer: &mut Buffer, pos: egui::Pos2, ui: &mut egui::Ui,
-    ) -> Option<SelectedElement> {
+    fn detect_drag(&mut self, buffer: &mut Buffer, pos: egui::Pos2) -> Option<SelectedElement> {
         for (id, path) in buffer.paths.iter() {
             if pointer_interests_path(path, pos, self.last_pos, 10.0) {
-                ui.output_mut(|r| r.cursor_icon = egui::CursorIcon::Grab);
                 let transform = buffer
                     .current
                     .children()
@@ -308,32 +336,210 @@ fn end_drag(buffer: &mut Buffer, els: &mut [SelectedElement], pos: egui::Pos2, s
     }
 }
 
-fn show_bb_rect(ui: &mut egui::Ui, mut bb: [glam::DVec2; 2], working_rect: egui::Rect) {
-    bb[0].x = bb[0].x.max(working_rect.left() as f64);
-    bb[0].y = bb[0].y.max(working_rect.top() as f64);
+#[derive(Default)]
+struct SelectionRect {
+    left: Option<Subpath<ManipulatorGroupId>>,
+    right: Option<Subpath<ManipulatorGroupId>>,
+    top: Option<Subpath<ManipulatorGroupId>>,
+    bottom: Option<Subpath<ManipulatorGroupId>>,
+}
 
-    bb[1].x = bb[1].x.min(working_rect.right() as f64);
-    bb[1].y = bb[1].y.min(working_rect.bottom() as f64);
+impl SelectionRect {
+    fn show(&self, ui: &mut egui::Ui) {
+        if let Some(top_path) = &self.top {
+            self.show_subpath(&top_path, ui);
+        };
+        if let Some(bottom_path) = &self.bottom {
+            self.show_subpath(&bottom_path, ui);
+        };
 
-    if bb[1].x < bb[0].x || bb[1].y < bb[0].y {
-        return;
+        if let Some(left_path) = &self.left {
+            self.show_subpath(&left_path, ui);
+
+            if let Some(_) = &self.top {
+                let corner = left_path.get_segment(0).unwrap().start();
+                self.show_corner(corner, ui);
+            }
+            if let Some(_) = &self.bottom {
+                let corner = left_path.get_segment(0).unwrap().end();
+                self.show_corner(corner, ui);
+            }
+        };
+        if let Some(right_path) = &self.right {
+            self.show_subpath(&right_path, ui);
+
+            if let Some(_) = &self.top {
+                let corner = right_path.get_segment(0).unwrap().start();
+                self.show_corner(corner, ui);
+            }
+            if let Some(_) = &self.bottom {
+                let corner = right_path.get_segment(0).unwrap().end();
+                self.show_corner(corner, ui);
+            }
+        };
     }
 
-    let line_segments = [
-        [egui::pos2(bb[0].x as f32, bb[0].y as f32), egui::pos2(bb[1].x as f32, bb[0].y as f32)],
-        [egui::pos2(bb[0].x as f32, bb[1].y as f32), egui::pos2(bb[1].x as f32, bb[1].y as f32)],
-        [egui::pos2(bb[0].x as f32, bb[0].y as f32), egui::pos2(bb[0].x as f32, bb[1].y as f32)],
-        [egui::pos2(bb[1].x as f32, bb[0].y as f32), egui::pos2(bb[1].x as f32, bb[1].y as f32)],
-    ];
-
-    line_segments.iter().for_each(|line_segment| {
-        ui.painter().add(egui::Shape::dashed_line(
+    fn show_subpath(&self, path: &Subpath<ManipulatorGroupId>, ui: &mut egui::Ui) {
+        let line_segment = path.get_segment(0).unwrap();
+        let line_segment = [
+            egui::pos2(line_segment.start().x as f32, line_segment.start().y as f32),
+            egui::pos2(line_segment.end().x as f32, line_segment.end().y as f32),
+        ];
+        ui.painter().line_segment(
             line_segment,
             egui::Stroke { width: 1.0, color: ui.visuals().hyperlink_color },
-            3.,
-            6.,
-        ));
-    });
+        );
+    }
+
+    fn show_corner(&self, corner: DVec2, ui: &mut egui::Ui) {
+        let handle_side_length = 8.0; // handle is a square
+        let corner = egui::pos2(corner.x as f32, corner.y as f32);
+        let rect = egui::Rect {
+            min: egui::pos2(
+                corner.x - handle_side_length / 2.0,
+                corner.y - handle_side_length / 2.0,
+            ),
+            max: egui::pos2(
+                corner.x + handle_side_length / 2.0,
+                corner.y + handle_side_length / 2.0,
+            ),
+        };
+        ui.painter().rect(
+            rect,
+            egui::Rounding::none(),
+            egui::Color32::WHITE,
+            egui::Stroke { width: 1.0, color: ui.visuals().hyperlink_color },
+        )
+    }
+}
+
+enum SelectionOperation {
+    Drag,
+    HorizontalZoom,
+    VerticalZoom,
+    Idle,
+}
+
+struct SelectionResponse {
+    current_op: SelectionOperation,
+    cursor_icon: egui::CursorIcon,
+}
+
+fn show_bb_rect(
+    ui: &mut egui::Ui, path: &Subpath<ManipulatorGroupId>, working_rect: egui::Rect,
+    cursor_pos: egui::Pos2,
+) -> Option<SelectionResponse> {
+    let bb = match path.bounding_box() {
+        Some(b) => b,
+        None => {
+            println!("none");
+            return None;
+        }
+    };
+    let mut clipped_bb = bb.clone();
+    clipped_bb[0].x = clipped_bb[0].x.max(working_rect.left() as f64);
+    clipped_bb[0].y = clipped_bb[0].y.max(working_rect.top() as f64);
+
+    clipped_bb[1].x = clipped_bb[1].x.min(working_rect.right() as f64);
+    clipped_bb[1].y = clipped_bb[1].y.min(working_rect.bottom() as f64);
+
+    let selection_rect = SelectionRect {
+        left: if clipped_bb[0].x == bb[0].x {
+            Some(Subpath::from_anchors(
+                [
+                    DVec2 { x: clipped_bb[0].x, y: clipped_bb[0].y },
+                    DVec2 { x: clipped_bb[0].x, y: clipped_bb[1].y },
+                ],
+                false,
+            ))
+        } else {
+            None
+        },
+        right: if clipped_bb[1].x == bb[1].x {
+            Some(Subpath::from_anchors(
+                [
+                    DVec2 { x: clipped_bb[1].x, y: clipped_bb[0].y },
+                    DVec2 { x: clipped_bb[1].x, y: clipped_bb[1].y },
+                ],
+                false,
+            ))
+        } else {
+            None
+        },
+        top: if clipped_bb[0].y == bb[0].y {
+            Some(Subpath::from_anchors(
+                [
+                    DVec2 { x: clipped_bb[0].x, y: clipped_bb[0].y },
+                    DVec2 { x: clipped_bb[1].x, y: clipped_bb[0].y },
+                ],
+                false,
+            ))
+        } else {
+            None
+        },
+        bottom: if clipped_bb[1].y == bb[1].y {
+            Some(Subpath::from_anchors(
+                [
+                    DVec2 { x: clipped_bb[0].x, y: clipped_bb[1].y },
+                    DVec2 { x: clipped_bb[1].x, y: clipped_bb[1].y },
+                ],
+                false,
+            ))
+        } else {
+            None
+        },
+    };
+
+    selection_rect.show(ui);
+    get_cursor_icon(selection_rect, cursor_pos, bb)
+}
+
+fn get_cursor_icon(
+    selection_rect: SelectionRect, cursor_pos: egui::Pos2, bb: [DVec2; 2],
+) -> Option<SelectionResponse> {
+    let rect = egui::Rect {
+        min: egui::pos2(bb[0].x as f32, bb[0].y as f32),
+        max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
+    };
+
+    // todo: adjust this based on the size of the rect
+    let error_radius = 10.0;
+
+    let mut res = SelectionResponse {
+        current_op: SelectionOperation::HorizontalZoom,
+        cursor_icon: egui::CursorIcon::ResizeColumn,
+    };
+
+    if let Some(left_path) = &selection_rect.left {
+        if pointer_interests_path(left_path, cursor_pos, None, error_radius) {
+            return Some(res);
+        }
+    };
+    if let Some(right_path) = &selection_rect.right {
+        if pointer_interests_path(right_path, cursor_pos, None, error_radius) {
+            return Some(res);
+        }
+    };
+
+    res.cursor_icon = egui::CursorIcon::ResizeRow;
+    res.current_op = SelectionOperation::VerticalZoom;
+    if let Some(top_path) = &selection_rect.top {
+        if pointer_interests_path(top_path, cursor_pos, None, error_radius) {
+            return Some(res);
+        }
+    };
+    if let Some(bottom_path) = &selection_rect.bottom {
+        if pointer_interests_path(bottom_path, cursor_pos, None, error_radius) {
+            return Some(res);
+        }
+    };
+
+    res.cursor_icon = egui::CursorIcon::Grab;
+    res.current_op = SelectionOperation::Drag;
+    if rect.contains(cursor_pos) {
+        return Some(res);
+    }
+    None
 }
 
 fn drag(delta: egui::Pos2, de: &mut SelectedElement, buffer: &mut Buffer) {
@@ -352,14 +558,59 @@ fn drag(delta: egui::Pos2, de: &mut SelectedElement, buffer: &mut Buffer) {
     }
 }
 
-fn zoom(factor: f64, de: &mut SelectedElement, buffer: &mut Buffer, element_rect: egui::Rect) {
+fn zoom_from_center(factor: f64, de: &mut SelectedElement, buffer: &mut Buffer) {
+    let path = match buffer.paths.get_mut(&de.id) {
+        None => return,
+        Some(p) => p,
+    };
+
+    // the inverse of the master transform will get the location of the
+    // path's in terms of the svg viewport instead of the default egui
+    // viewport. those cords are used for center based scaling.
+    if let Some(transform) = buffer.current.attr("transform") {
+        let [a, b, c, d, e, f] = deserialize_transform(transform);
+        path.apply_transform(
+            DAffine2 {
+                matrix2: DMat2 { x_axis: DVec2 { x: a, y: b }, y_axis: DVec2 { x: c, y: d } },
+                translation: DVec2 { x: e, y: f },
+            }
+            .inverse(),
+        );
+    }
+
+    let bb = path.bounding_box().unwrap();
+    let element_rect = egui::Rect {
+        min: egui::pos2(bb[0].x as f32, bb[0].y as f32),
+        max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
+    };
+
     if let Some(node) = node_by_id(&mut buffer.current, de.id.clone()) {
-        let mut scaled_matrix = de.original_matrix.1.clone().map(|val| val * factor);
-        scaled_matrix[4] += (1. - factor) * element_rect.center().x as f64;
-        scaled_matrix[5] += (1. - factor) * element_rect.center().y as f64;
-        // println!("before {:#?}", de.original_matrix);
-        // println!("after {:#?}", scaled_matrix);
+        let mut scaled_matrix = de.original_matrix.1.clone();
+        scaled_matrix = scaled_matrix.map(|n| n * factor);
+
+        // after scaling the matrix, a corrective translate is applied
+        // to ensure that it's scaled from the center
+        scaled_matrix[4] -=
+            (1. - factor) * (element_rect.width() / 2. - element_rect.right()) as f64;
+        scaled_matrix[5] -=
+            (1. - factor) * (element_rect.height() / 2. - element_rect.bottom()) as f64;
+
         node.set_attr("transform", serialize_transform(&scaled_matrix));
         buffer.needs_path_map_update = true;
     }
+}
+
+fn zoom_to_pos(
+    pos: egui::Pos2, de: &mut SelectedElement, buffer: &mut Buffer, current_op: &SelectionOperation,
+) {
+    // so i'm zooming from left, right, top or bottom. need to know which direction.
+    // then get the distance
+
+    let factor = match current_op {
+        SelectionOperation::HorizontalZoom => pos.x / de.original_pos.x,
+        SelectionOperation::VerticalZoom => pos.y / de.original_pos.y,
+        _ => return,
+    } as f64;
+
+    zoom_from_center(factor, de, buffer);
 }

--- a/libs/content/workspace/src/tab/svg_editor/selection.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection.rs
@@ -1,20 +1,11 @@
-<<<<<<< HEAD:libs/content/workspace/src/tab/svg_editor/selection.rs
-use super::{
-    history::TransformElement,
-    node_by_id,
-    util::{deserialize_transform, pointer_interests_path, serialize_transform},
-    Buffer, DeleteElement,
-=======
 use bezier_rs::Subpath;
-use eframe::egui;
 use glam::{DAffine2, DMat2, DVec2};
 
 use super::{
-    history::ManipulatorGroupId,
-    node_by_id, pointer_interests_path,
-    util::{deserialize_transform, serialize_transform},
-    Buffer, DeleteElement, TransformElement,
->>>>>>> 5ce97131 (Mouse based element scaling):clients/egui/src/account/tabs/svg_editor/selection.rs
+    history::{ManipulatorGroupId, TransformElement},
+    node_by_id,
+    util::{deserialize_transform, pointer_interests_path, serialize_transform},
+    Buffer, DeleteElement,
 };
 
 // todo: consider making this value dynamic depending on the scale of the element


### PR DESCRIPTION
Now you can scale elements by dragging their edges or by using the keyboard shortcuts of 
- `+` scale up
-  `-` scale down

--- 

Limitations and future considerations:
- Mouse scaling doesn't snap to the current cursor position.  
- You can't change the aspect ratio of the scaled elements. the scale factor in the x axis and y axis are always the same.
- The ability to rotate elements would be nice

 
# Demo 

https://github.com/lockbook/lockbook/assets/66345861/9d75bf01-b87e-4af4-baf0-f19a47dcb339



