### PR TITLE
Center the new document button on the welcome screen

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -446,8 +446,6 @@ impl AccountScreen {
                 };
                 settings_btn.on_hover_text("Settings");
 
-                // ui.add_space(5.0);
-
                 let incoming_shares_btn = Button::default()
                     .icon(&Icon::SHARED_FOLDER.badge(self.has_pending_shares))
                     .show(ui);

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -447,7 +447,7 @@ impl AccountScreen {
                 settings_btn.on_hover_text("Settings");
 
                 // ui.add_space(5.0);
-                
+
                 let incoming_shares_btn = Button::default()
                     .icon(&Icon::SHARED_FOLDER.badge(self.has_pending_shares))
                     .show(ui);

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -446,8 +446,8 @@ impl AccountScreen {
                 };
                 settings_btn.on_hover_text("Settings");
 
-                ui.add_space(5.0);
-
+                // ui.add_space(5.0);
+                
                 let incoming_shares_btn = Button::default()
                     .icon(&Icon::SHARED_FOLDER.badge(self.has_pending_shares))
                     .show(ui);

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -31,6 +31,10 @@ impl<'a> Button<'a> {
         Self { padding: Some(padding.into()), ..self }
     }
 
+    pub fn rounding(self, rounding: egui::Rounding) -> Self {
+        Self { rounding, ..self }
+    }
+
     pub fn frame(self, frame: bool) -> Self {
         Self { frame, ..self }
     }
@@ -48,13 +52,16 @@ impl<'a> Button<'a> {
             let icon: egui::WidgetText = icon.into();
             let galley = icon.into_galley(ui, Some(false), wrap_width, icon_text_style);
             width += galley.size().x;
+            if self.text.is_some() {
+                width += padding.x;
+            }
             galley
         });
 
         let maybe_text_galley = self.text.map(|text| {
             let text: egui::WidgetText = text.into();
             let galley = text.into_galley(ui, Some(false), wrap_width, text_style);
-            width += galley.size().x + padding.x;
+            width += galley.size().x;
             galley
         });
 

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -258,12 +258,14 @@ impl Workspace {
 
             if Button::default()
                 .text("New document")
+                .rounding(egui::Rounding::same(3.0))
                 .frame(true)
                 .show(ui)
                 .clicked()
             {
                 self.create_file(false);
             }
+
             ui.visuals_mut().widgets.inactive.fg_stroke =
                 egui::Stroke { color: ui.visuals().widgets.active.bg_fill, ..Default::default() };
             ui.visuals_mut().widgets.hovered.fg_stroke =

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -265,7 +265,6 @@ impl Workspace {
             {
                 self.create_file(false);
             }
-
             ui.visuals_mut().widgets.inactive.fg_stroke =
                 egui::Stroke { color: ui.visuals().widgets.active.bg_fill, ..Default::default() };
             ui.visuals_mut().widgets.hovered.fg_stroke =


### PR DESCRIPTION

fixes #2397 

## After
![image](https://github.com/lockbook/lockbook/assets/66345861/6d58d4a5-8619-4c81-8454-db5dfb8745b7)

## Before
![image](https://github.com/lockbook/lockbook/assets/66345861/fe4c6425-dceb-467c-94ff-729975395f4b)

