### PR TITLE
egui: fix file tree regressions caused by workspace 

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -616,9 +616,9 @@ impl AccountScreen {
 
     fn focused_parent(&mut self) -> Uuid {
         let mut focused_parent = self.tree.root.file.id;
-        // for id in self.tree.state.selected.iter() {
-        //     focused_parent = *id;
-        // }
+        for id in self.tree.state.selected.iter() {
+            focused_parent = *id;
+        }
 
         focused_parent
     }

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -712,18 +712,16 @@ impl AccountScreen {
         let update_tx = self.update_tx.clone();
         let ctx = ctx.clone();
 
-        let tab_ids = self
-            .workspace
-            .tabs
-            .iter()
-            .map(|t| t.id)
-            .collect::<Vec<lb::Uuid>>();
-
-        for (i, f) in files.iter().enumerate() {
-            if tab_ids.contains(&f.id) {
-                self.workspace.close_tab(i)
+        let mut tabs_to_delete = vec![];
+        for (i, tab) in self.workspace.tabs.iter().enumerate() {
+            if files.iter().find(|f| f.id.eq(&tab.id)).is_some() {
+                tabs_to_delete.push(i);
             }
         }
+        for i in tabs_to_delete {
+            self.workspace.close_tab(i);
+        }
+
         thread::spawn(move || {
             for f in &files {
                 core.delete_file(f.id).unwrap(); // TODO

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -714,7 +714,7 @@ impl AccountScreen {
 
         let mut tabs_to_delete = vec![];
         for (i, tab) in self.workspace.tabs.iter().enumerate() {
-            if files.iter().find(|f| f.id.eq(&tab.id)).is_some() {
+            if files.iter().any(|f| f.id.eq(&tab.id)) {
                 tabs_to_delete.push(i);
             }
         }

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -192,8 +192,11 @@ impl AccountScreen {
                 }
 
                 if let Some(file) = wso.selected_file {
-                    self.tree.reveal_file(file, &self.core);
-                    ctx.request_repaint();
+                    if !self.tree.state.selected.contains(&file) {
+                        println!("wso tree: {:#?}", self.tree.state.selected);
+                        self.tree.reveal_file(file, &self.core);
+                        ctx.request_repaint();
+                    }
                 }
 
                 if let Some(done) = wso.sync_done {
@@ -617,9 +620,9 @@ impl AccountScreen {
 
     fn focused_parent(&mut self) -> Uuid {
         let mut focused_parent = self.tree.root.file.id;
-        for id in self.tree.state.selected.drain() {
-            focused_parent = id;
-        }
+        // for id in self.tree.state.selected.drain() {
+        //     focused_parent = id;
+        // }
 
         focused_parent
     }

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -192,11 +192,7 @@ impl AccountScreen {
                 }
 
                 if let Some(file) = wso.selected_file {
-                    if !self.tree.state.selected.contains(&file) {
-                        println!("wso tree: {:#?}", self.tree.state.selected);
-                        self.tree.reveal_file(file, &self.core);
-                        ctx.request_repaint();
-                    }
+                    self.tree.reveal_file(file, ctx);
                 }
 
                 if let Some(done) = wso.sync_done {
@@ -620,8 +616,8 @@ impl AccountScreen {
 
     fn focused_parent(&mut self) -> Uuid {
         let mut focused_parent = self.tree.root.file.id;
-        // for id in self.tree.state.selected.drain() {
-        //     focused_parent = id;
+        // for id in self.tree.state.selected.iter() {
+        //     focused_parent = *id;
         // }
 
         focused_parent
@@ -745,7 +741,7 @@ impl AccountScreen {
             Ok(f) => {
                 let (id, is_doc) = (f.id, f.is_document());
                 self.tree.root.insert(f);
-                self.tree.reveal_file(id, &self.core);
+                self.tree.reveal_file(id, ctx);
                 if is_doc {
                     self.workspace.open_file(id, true);
                 }

--- a/clients/egui/src/account/tree/mod.rs
+++ b/clients/egui/src/account/tree/mod.rs
@@ -2,8 +2,6 @@ mod node;
 mod response;
 mod state;
 
-use std::thread;
-
 pub use self::node::TreeNode;
 
 use eframe::egui;
@@ -77,15 +75,6 @@ impl FileTree {
 
         while let Ok(update) = self.state.update_rx.try_recv() {
             match update {
-                TreeUpdate::RevealFileDone((expanded_files, selected)) => {
-                    self.state.request_scroll = true;
-
-                    expanded_files.iter().for_each(|f| {
-                        self.state.expanded.insert(*f);
-                    });
-                    self.state.selected.clear();
-                    self.state.selected.insert(selected);
-                }
                 TreeUpdate::ExportFile((exported_file, dest)) => {
                     match self
                         .core
@@ -163,27 +152,23 @@ impl FileTree {
     }
 
     /// expand the parents of the file and select it
-    // todo: remove this, duplicate of expand_to()
     // todo: this doesn't request a repaint
-    pub fn reveal_file(&mut self, id: lb::Uuid, core: &lb::Core) {
-        let core = core.clone();
-        let update_tx = self.state.update_tx.clone();
-        thread::spawn(move || {
-            let mut curr = core.get_file_by_id(id).unwrap();
-            let mut expanded = vec![];
-            loop {
-                let parent = core.get_file_by_id(curr.parent).unwrap();
-                expanded.push(parent.id);
-                if parent == curr {
-                    break;
-                }
-                curr = parent;
-            }
+    pub fn reveal_file(&mut self, id: lb::Uuid, ctx: &egui::Context) {
+        self.state.selected.clear();
+        self.state.selected.insert(id);
 
-            update_tx
-                .send(TreeUpdate::RevealFileDone((expanded, id)))
-                .unwrap();
-        });
+        self.state.request_scroll = true;
+
+        let mut curr = self.core.get_file_by_id(id).unwrap();
+        loop {
+            let parent = self.core.get_file_by_id(curr.parent).unwrap();
+            self.state.expanded.insert(parent.id);
+            if parent == curr {
+                break;
+            }
+            curr = parent;
+        }
+        ctx.request_repaint();
     }
 }
 

--- a/clients/egui/src/account/tree/mod.rs
+++ b/clients/egui/src/account/tree/mod.rs
@@ -152,7 +152,6 @@ impl FileTree {
     }
 
     /// expand the parents of the file and select it
-    // todo: this doesn't request a repaint
     pub fn reveal_file(&mut self, id: lb::Uuid, ctx: &egui::Context) {
         self.state.selected.clear();
         self.state.selected.insert(id);

--- a/clients/egui/src/account/tree/mod.rs
+++ b/clients/egui/src/account/tree/mod.rs
@@ -106,17 +106,11 @@ impl FileTree {
             .allocate_ui_at_rect(egui::Rect::from_two_pos(hover_pos, end), |ui| {
                 ui.with_layer_id(layer_id, |ui| {
                     egui::Frame::none()
+                        .fill(ui.visuals().extreme_bg_color.gamma_multiply(0.6))
                         .rounding(3.0)
-                        .inner_margin(1.0)
-                        .fill(ui.visuals().widgets.active.fg_stroke.color)
+                        .inner_margin(egui::style::Margin::symmetric(12.0, 7.0))
                         .show(ui, |ui| {
-                            egui::Frame::none()
-                                .rounding(3.0)
-                                .inner_margin(egui::style::Margin::symmetric(12.0, 7.0))
-                                .fill(ui.visuals().faint_bg_color)
-                                .show(ui, |ui| {
-                                    ui.label(self.state.drag_caption());
-                                });
+                            ui.label(self.state.drag_caption());
                         });
                 })
             })

--- a/clients/egui/src/account/tree/node.rs
+++ b/clients/egui/src/account/tree/node.rs
@@ -144,7 +144,7 @@ impl TreeNode {
         }
 
         resp = ui.interact(resp.rect, resp.id, egui::Sense::click());
-        if resp.double_clicked() {
+        if resp.clicked() {
             if self.file.is_folder() {
                 if !state.expanded.remove(&self.file.id) {
                     state.expanded.insert(self.file.id);
@@ -178,7 +178,13 @@ impl TreeNode {
         let wrap_width = ui.available_width();
 
         let icon = if self.file.is_folder() {
-            let wt: egui::WidgetText = (&Icon::FOLDER_OPEN).into();
+            let wt: egui::WidgetText = if state.expanded.contains(&self.file.id) {
+                &Icon::FOLDER_OPEN
+            } else {
+                &Icon::FOLDER
+            }
+            .into();
+
             wt.color(ui.visuals().hyperlink_color)
         } else {
             let wt: egui::WidgetText = (&self.icon()).into();
@@ -204,7 +210,7 @@ impl TreeNode {
             let bg = if state.selected.contains(&self.file.id) {
                 ui.visuals().code_bg_color.gamma_multiply(0.6)
             } else if resp.hovered() {
-                ui.visuals().code_bg_color.gamma_multiply(0.3)
+                ui.visuals().code_bg_color.gamma_multiply(0.2)
             } else {
                 ui.visuals().panel_fill
             };

--- a/clients/egui/src/account/tree/state.rs
+++ b/clients/egui/src/account/tree/state.rs
@@ -6,6 +6,7 @@ use std::{
 
 use eframe::egui;
 
+#[derive(Debug)]
 pub struct TreeState {
     pub id: egui::Id,
     pub max_node_width: f32,
@@ -36,7 +37,6 @@ impl Default for TreeState {
 }
 
 pub enum TreeUpdate {
-    RevealFileDone((Vec<lb::Uuid>, lb::Uuid)),
     ExportFile((lb::File, PathBuf)),
 }
 
@@ -63,14 +63,14 @@ impl TreeState {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct TreeDragAndDropState {
     pub is_primary_down: bool,
     pub has_moved: bool,
     pub dropped: Option<egui::Pos2>,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct NodeRenamingState {
     pub id: Option<lb::Uuid>,
     pub tmp_name: String,

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -205,8 +205,6 @@ impl Workspace {
         self.process_keys(&mut output);
         self.pers_status.populate_message();
 
-        // output.selected_file = self.tabs.get(self.active_tab).map(|t| t.id);
-
         if self.is_empty() {
             self.show_empty_workspace(ui, &mut output);
         } else {

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -200,10 +200,12 @@ impl Workspace {
 
     pub fn show_workspace(&mut self, ui: &mut egui::Ui) -> WsOutput {
         let mut output = WsOutput::default();
+
         self.process_updates(&mut output);
         self.process_keys(&mut output);
         self.pers_status.populate_message();
-        output.selected_file = self.tabs.get(self.active_tab).map(|t| t.id);
+
+        // output.selected_file = self.tabs.get(self.active_tab).map(|t| t.id);
 
         if self.is_empty() {
             self.show_empty_workspace(ui, &mut output);
@@ -582,7 +584,7 @@ impl Workspace {
             );
         }
 
-        // Alt-{1-9} to easily navigate tabs (9 will always go to the last tab).
+        // Ctrl-{1-9} to easily navigate tabs (9 will always go to the last tab).
         self.ctx.clone().input_mut(|input| {
             for i in 1..10 {
                 if input.consume_key(CTRL, NUM_KEYS[i - 1]) {
@@ -598,6 +600,7 @@ impl Workspace {
                     }
                     if let Some(tab) = self.current_tab() {
                         output.window_title = Some(tab.name.clone());
+                        output.selected_file = Some(tab.id);
                     }
                     break;
                 }


### PR DESCRIPTION
fixes: [#2405](https://github.com/lockbook/lockbook/issues/2405)
fixes: https://github.com/lockbook/lockbook/issues/2403

includes some quality of life improvements:
-  one press to open files/folders
-  folder icons are now dynamic to reflects whether they are expanded

and some other bugs:
-  if you deleted a file that is opened but not currently selected, you'll close the incorrect tab
- dragging info in the file tree doesn't adopt to light/dark mode. now it does