### PR TITLE
docs: update apple build guide

### DIFF
--- a/docs/guides/build/apple.md
+++ b/docs/guides/build/apple.md
@@ -15,4 +15,7 @@ rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-darwin x86_64
 
 Steps:
 1. In `/libs/lb/lb_external_interface` run `make swift_libs` which will generate lb-rs libs and place them into the correct location within your Xcode project.
-2. Open Xcode, import the project and hit the Run button.
+2. In `/libs/content/workspace-ffi/SwiftWorkspace` run `./create_libs.sh` to create the ffi binary artifact in `/libs/content/workspace-ffi/SwiftWorkspace/Libs/workspace.xcframework`.
+3. Open the `clients/apple` folder in Xcode.
+4. In Xcode, open the "Signing & Capabilities" tab and set the team to your personal developer email and change the "Bundle Identifier" to something new.
+5. Change the build target to macos or ios and hit the Run button.


### PR DESCRIPTION
* added step to run the workspace-ffi create_libs.sh
* added what to open with xcode
* added how to sign the app