### PR TITLE
all: 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "admin"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "clap 4.3.11",
  "dialoguer",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "c_interface_v2"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "lb-rs",
  "libc",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "egui_editor"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "egui",
  "image",
@@ -3397,7 +3397,7 @@ checksum = "615e43ce60261fb305818a26fbe1eaf50f1dc15ac846c5b8adaf2defbf4e2ab2"
 
 [[package]]
 name = "lb-fs"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cli-rs",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "lb-rs"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "base64 0.13.1",
  "basic-human-duration",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "lb_external_interface"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "basic-human-duration",
  "crossbeam",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-cli"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "cli-rs",
  "fs_extra",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-dev"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "clap 4.3.11",
  "dotenvy",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-egui"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "dark-light",
  "eframe",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-linux"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "egui",
  "egui_editor",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-server"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "async-stripe",
  "async-trait",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-shared"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-windows"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "array-init",
  "clipboard-win",
@@ -5045,7 +5045,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "releaser"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "cli-rs",
  "fs_extra",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "itertools",
@@ -7499,7 +7499,7 @@ dependencies = [
 
 [[package]]
 name = "winstaller"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "eframe",
  "egui_extras",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "workspace"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "bezier-rs",
  "egui",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-ffi"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "egui",
  "egui_editor",

--- a/clients/admin/Cargo.toml
+++ b/clients/admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "admin"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "app.lockbook"
         minSdkVersion 22
         targetSdkVersion 33
-        versionCode 37
-        versionName "0.8.4"
+        versionCode 38
+        versionName "0.9.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/clients/apple/iOS/Info.plist
+++ b/clients/apple/iOS/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.4</string>
+	<string>0.9.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20231110</string>
+	<string>20240216</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/clients/apple/macOS/Info.plist
+++ b/clients/apple/macOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.4</string>
+	<string>0.9.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20231110</string>
+	<string>20240216</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.8.4"
+version = "0.9.0"
 name = "lockbook-cli"
 edition = "2021"
 

--- a/clients/egui/Cargo.toml
+++ b/clients/egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-egui"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-linux"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/clients/windows/Cargo.toml
+++ b/clients/windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-windows"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 [target.'cfg(windows)'.dependencies]

--- a/libs/content/editor/egui_editor/Cargo.toml
+++ b/libs/content/editor/egui_editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_editor"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/libs/content/workspace-ffi/Cargo.toml
+++ b/libs/content/workspace-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-ffi"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/libs/lb-fs/Cargo.toml
+++ b/libs/lb-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lb-fs"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/libs/lb/c_interface_v2/Cargo.toml
+++ b/libs/lb/c_interface_v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c_interface_v2"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lb-rs"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 description = "The functional components of the iOS and Android lockbook clients."
 license = "BSD-3-Clause"

--- a/libs/lb/lb-rs/libs/shared/Cargo.toml
+++ b/libs/lb/lb-rs/libs/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-shared"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/libs/lb/lb-rs/libs/test_utils/Cargo.toml
+++ b/libs/lb/lb-rs/libs/test_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_utils"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/libs/lb/lb_external_interface/Cargo.toml
+++ b/libs/lb/lb_external_interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lb_external_interface"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-server"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 build = "build.rs"
 

--- a/utils/dev-tool/Cargo.toml
+++ b/utils/dev-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockbook-dev"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "releaser"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/utils/winstaller/Cargo.toml
+++ b/utils/winstaller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winstaller"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
bumping minor version because when struggling to deploy last time I had to deploy an 0.8.42 to the app store, and 0.8.5 is considered less than 0.8.42 because 42 > 5...

so just to avoid any releasing problems going to 0.9.0

fixes #2430