### PR TITLE
workspace: only configure non-empty surfaces

### DIFF
--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -362,7 +362,9 @@ impl WgpuWorkspace {
             alpha_mode: CompositeAlphaMode::Auto,
             view_formats: vec![],
         };
-        self.surface.configure(&self.device, &surface_config);
+        if surface_config.width * surface_config.height != 0 {
+            self.surface.configure(&self.device, &surface_config);
+        }
     }
 }
 #[repr(C)]


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2473

Applies a fix that was already applied to a copy of this function in clients/egui/src/lib.rs. De-duplication tracked by https://github.com/lockbook/lockbook/issues/2475.