### PR TITLE
macos: private key hint string to match iOS

### DIFF
--- a/clients/apple/macOS/Settings/AccountSettingsView.swift
+++ b/clients/apple/macOS/Settings/AccountSettingsView.swift
@@ -38,7 +38,7 @@ struct AccountSettingsView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             HStack (alignment: .top) {
-                Text("Account Secret:")
+                Text("Private Key:")
                     .frame(maxWidth: 175, alignment: .trailing)
                 VStack {
                     Button(action: settings.copyAccountString, label: {


### PR DESCRIPTION
<img width="712" alt="image" src="https://github.com/lockbook/lockbook/assets/4467106/dc16ddea-81da-4a64-b29c-ad9b3c357b64">
