### PR TITLE
workspace: add scrolling to images

### DIFF
--- a/libs/content/workspace/src/tab/image_viewer.rs
+++ b/libs/content/workspace/src/tab/image_viewer.rs
@@ -14,7 +14,9 @@ impl ImageViewer {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
-        self.img.show(ui);
+        egui::ScrollArea::both().show(ui, |ui| {
+            self.img.show(ui);
+        });
     }
 }
 

--- a/libs/content/workspace/src/tab/image_viewer.rs
+++ b/libs/content/workspace/src/tab/image_viewer.rs
@@ -15,7 +15,18 @@ impl ImageViewer {
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
         egui::ScrollArea::both().show(ui, |ui| {
-            self.img.show(ui);
+            if ui.available_width() < self.img.width() as f32
+                || ui.available_height() < self.img.height() as f32
+            {
+                ui.with_layout(
+                    egui::Layout::left_to_right(egui::Align::Center).with_cross_justify(true),
+                    |ui| {
+                        self.img.show(ui);
+                    },
+                );
+            } else {
+                self.img.show(ui);
+            }
         });
     }
 }


### PR DESCRIPTION
fixes [#2325](https://github.com/lockbook/lockbook/issues/2325)
# Before
![image](https://github.com/lockbook/lockbook/assets/66345861/21dbafc6-d2fd-4cd2-8ef9-25f266398307)

# After
![image](https://github.com/lockbook/lockbook/assets/66345861/c0f161ea-4d18-46dc-aebd-c04ef771a0cb)

