### PR TITLE
egui: fix outdated sync status bug

### DIFF
--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -7,44 +7,86 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F7E4FBF2521297D0045F606 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7E4FBE2521297D0045F606 /* Colors.swift */; };
 		1F7E4FC02521297D0045F606 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7E4FBE2521297D0045F606 /* Colors.swift */; };
+		4709C77029FDAAE9004449EF /* SuggestedDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C76F29FDAAE9004449EF /* SuggestedDocs.swift */; };
 		4709C77129FDAAE9004449EF /* SuggestedDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C76F29FDAAE9004449EF /* SuggestedDocs.swift */; };
+		4709DC38296609F100426106 /* PendingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC37296609F100426106 /* PendingSharesView.swift */; };
 		4709DC39296609F100426106 /* PendingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC37296609F100426106 /* PendingSharesView.swift */; };
+		4709DC3E2966260500426106 /* AcceptShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC3D2966260500426106 /* AcceptShareSheet.swift */; };
 		4709DC3F2966260500426106 /* AcceptShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC3D2966260500426106 /* AcceptShareSheet.swift */; };
 		47159F4629CFA05B00969DDF /* DSFQuickActionBar in Frameworks */ = {isa = PBXBuildFile; productRef = 47159F4529CFA05B00969DDF /* DSFQuickActionBar */; };
+		471C788D2B4910A80022B3B2 /* SwiftWorkspace in Frameworks */ = {isa = PBXBuildFile; productRef = 471C788C2B4910A80022B3B2 /* SwiftWorkspace */; };
 		471E363529FD5F5C00A1958A /* FileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E8F925ACBCF9005B7B01 /* FileListView.swift */; };
+		473A3DCE29AC354B0017BC6A /* FilePathBreadcrumb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A3DCD29AC354B0017BC6A /* FilePathBreadcrumb.swift */; };
+		4756C4DB2A57CE86002C64B1 /* NewFolderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4756C4DA2A57CE86002C64B1 /* NewFolderSheet.swift */; };
 		4756C4DC2A57CE86002C64B1 /* NewFolderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4756C4DA2A57CE86002C64B1 /* NewFolderSheet.swift */; };
+		4761F30F2A1832B4002ED338 /* ManageSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4761F30E2A1832B4002ED338 /* ManageSubscription.swift */; };
+		476436CC29B7DE4E00FBDC59 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476436CB29B7DE4E00FBDC59 /* SearchService.swift */; };
 		476436CD29B7DE4E00FBDC59 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476436CB29B7DE4E00FBDC59 /* SearchService.swift */; };
+		4772A43A29E8656A0032D586 /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4772A43929E8656A0032D586 /* SearchWrapperView.swift */; };
 		4772A43B29E8656A0032D586 /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4772A43929E8656A0032D586 /* SearchWrapperView.swift */; };
+		4779C62D2AB8C09E007C0100 /* PathSearchActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779C62C2AB8C09E007C0100 /* PathSearchActionBar.swift */; };
 		4779C62E2AB8C09E007C0100 /* PathSearchActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779C62C2AB8C09E007C0100 /* PathSearchActionBar.swift */; };
+		477CC4902967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
 		477CC4912967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
+		47837E292A72EA7500863FA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B273394C26C8A4B400303EAE /* Assets.xcassets */; };
+		47A45FBB2969047B00573044 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A45FBA2969047B00573044 /* ShareService.swift */; };
 		47A45FBC2969047B00573044 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A45FBA2969047B00573044 /* ShareService.swift */; };
+		47B041F32905BFB100A02DA7 /* AlertToast in Frameworks */ = {isa = PBXBuildFile; productRef = 47B041F22905BFB100A02DA7 /* AlertToast */; };
 		47B041F52905BFF100A02DA7 /* AlertToast in Frameworks */ = {isa = PBXBuildFile; productRef = 47B041F42905BFF100A02DA7 /* AlertToast */; };
+		47B53838290EFE150012E542 /* BillingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B53837290EFE150012E542 /* BillingService.swift */; };
 		47B53839290EFE150012E542 /* BillingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B53837290EFE150012E542 /* BillingService.swift */; };
 		47B67289295F977C00DB0D8E /* ManageSubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B67288295F977C00DB0D8E /* ManageSubscriptionView.swift */; };
 		47CEC69D2A182F2A0018FA5C /* UpgradeToPremium.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CEC69C2A182F2A0018FA5C /* UpgradeToPremium.swift */; };
+		47DBF1F12A61A51000F86B3F /* ImportExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DBF1F02A61A51000F86B3F /* ImportExportService.swift */; };
 		47DBF1F22A61A51000F86B3F /* ImportExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DBF1F02A61A51000F86B3F /* ImportExportService.swift */; };
+		47FAA4C829EC830600DB606E /* BranchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FAA4C729EC830600DB606E /* BranchState.swift */; };
 		47FAA4C929EC830600DB606E /* BranchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FAA4C729EC830600DB606E /* BranchState.swift */; };
+		47FB55ED2AF19AD400B74C09 /* RenameFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB55EC2AF19AD400B74C09 /* RenameFileSheet.swift */; };
 		47FB55EE2AF19AD400B74C09 /* RenameFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB55EC2AF19AD400B74C09 /* RenameFileSheet.swift */; };
 		6581A7EF74307EAE69426206 /* SheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581AB54147C2201F8F95500 /* SheetState.swift */; };
+		6581ABD3CA16395327F765E8 /* SheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581AB54147C2201F8F95500 /* SheetState.swift */; };
 		6581AC0512EDB9FBB7106020 /* MenuItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581A11CE95C74B01ED30AEB /* MenuItems.swift */; };
 		870DC09F26BDE6F4002E9A92 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870DC09E26BDE6F4002E9A92 /* SettingsView.swift */; };
 		870DC0A226BF378F002E9A92 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870DC0A126BF378F002E9A92 /* AccountSettingsView.swift */; };
 		870DC0A426BF37C0002E9A92 /* UsageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870DC0A326BF37C0002E9A92 /* UsageSettingsView.swift */; };
+		8715F92827161CC60051689E /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715F92727161CC60051689E /* OnboardingView.swift */; };
 		8715F92927161CC60051689E /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715F92727161CC60051689E /* OnboardingView.swift */; };
+		8715F92C271641CF0051689E /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715F92B271641CF0051689E /* Scanner.swift */; };
+		873559BE26C31210008B3C36 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873559BD26C31210008B3C36 /* SettingsView.swift */; };
+		8741E8E425AAA524005B7B01 /* BottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E8E325AAA524005B7B01 /* BottomBar.swift */; };
+		874A88F526D3E91900F010C8 /* DI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A88F426D3E91900F010C8 /* DI.swift */; };
 		874A88F626D3E91900F010C8 /* DI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A88F426D3E91900F010C8 /* DI.swift */; };
+		877FB54A26D1788D0008AB3F /* CoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54926D1788D0008AB3F /* CoreService.swift */; };
 		877FB54B26D1788D0008AB3F /* CoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54926D1788D0008AB3F /* CoreService.swift */; };
+		877FB55026D17FD00008AB3F /* UnexpectedErrorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54F26D17FD00008AB3F /* UnexpectedErrorService.swift */; };
 		877FB55126D17FD00008AB3F /* UnexpectedErrorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54F26D17FD00008AB3F /* UnexpectedErrorService.swift */; };
+		877FB55326D1854E0008AB3F /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55226D1854E0008AB3F /* SyncService.swift */; };
 		877FB55426D1854E0008AB3F /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55226D1854E0008AB3F /* SyncService.swift */; };
+		877FB55626D18AA60008AB3F /* AccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55526D18AA60008AB3F /* AccountService.swift */; };
 		877FB55726D18AA60008AB3F /* AccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55526D18AA60008AB3F /* AccountService.swift */; };
+		877FB55926D18EC80008AB3F /* FileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55826D18EC80008AB3F /* FileService.swift */; };
 		877FB55A26D18EC80008AB3F /* FileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55826D18EC80008AB3F /* FileService.swift */; };
+		877FB56026D2C7D60008AB3F /* StatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55F26D2C7D60008AB3F /* StatusService.swift */; };
 		877FB56126D2C7D60008AB3F /* StatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55F26D2C7D60008AB3F /* StatusService.swift */; };
+		87BD383826C020B00030D2B1 /* SettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BD383726C020B00030D2B1 /* SettingsService.swift */; };
 		87BD383926C020B00030D2B1 /* SettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BD383726C020B00030D2B1 /* SettingsService.swift */; };
+		87F78F772709352C0001E159 /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F762709352C0001E159 /* LogoView.swift */; };
 		87F78F782709352C0001E159 /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F762709352C0001E159 /* LogoView.swift */; };
+		87F78F7A27094A040001E159 /* BeforeYouStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F7927094A040001E159 /* BeforeYouStart.swift */; };
 		87F78F7B27094A040001E159 /* BeforeYouStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F7927094A040001E159 /* BeforeYouStart.swift */; };
+		B2459BED28DBB43100756D71 /* ColorProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2459BEC28DBB43100756D71 /* ColorProgressBar.swift */; };
 		B2459BEE28DBB43100756D71 /* ColorProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2459BEC28DBB43100756D71 /* ColorProgressBar.swift */; };
+		B249B9E5282AC03A004F5300 /* MoveSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9E4282AC03A004F5300 /* MoveSheet.swift */; };
+		B249B9E7282AF4F4004F5300 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9E6282AF4F4004F5300 /* FileTreeView.swift */; };
+		B249B9E8282AF6B1004F5300 /* OutlineBranch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E90E25AD1565005B7B01 /* OutlineBranch.swift */; };
+		B249B9E9282AF6B4004F5300 /* OutlineSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F6E270785E00001E159 /* OutlineSection.swift */; };
+		B249B9EC282AF6BC004F5300 /* OutlineRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA349F0125BC7C110016241E /* OutlineRow.swift */; };
+		B249B9ED282AF6BF004F5300 /* OutlineContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F742708F1990001E159 /* OutlineContextMenu.swift */; };
 		B249B9F2282C6241004F5300 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9F1282C6241004F5300 /* FileTreeView.swift */; };
 		B249B9F5282FE566004F5300 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9F4282FE566004F5300 /* DataSource.swift */; };
+		B257E5B72A7541820078DA44 /* logo.icns in Resources */ = {isa = PBXBuildFile; fileRef = B257E5B62A7541820078DA44 /* logo.icns */; };
 		B257E5B82A7541820078DA44 /* logo.icns in Resources */ = {isa = PBXBuildFile; fileRef = B257E5B62A7541820078DA44 /* logo.icns */; };
 		B273394F26C8B3EF00303EAE /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B273394E26C8B3EF00303EAE /* Media.xcassets */; };
 		B2A3AB302B27A1E800C2319E /* Bridge in Frameworks */ = {isa = PBXBuildFile; productRef = B2A3AB2F2B27A1E800C2319E /* Bridge */; };
@@ -52,12 +94,22 @@
 		B2A3AB342B27A1E800C2319E /* workspace in Frameworks */ = {isa = PBXBuildFile; productRef = B2A3AB332B27A1E800C2319E /* workspace */; };
 		B2ADC2472833FA8200DB8D3D /* FileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2ADC2462833FA8200DB8D3D /* FileCell.swift */; };
 		B2ADC2492835451000DB8D3D /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = B2ADC2482835451000DB8D3D /* Introspect */; };
+		B2B7E2E225C6411800B9EFAD /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B7E2E125C6411800B9EFAD /* OnboardingState.swift */; };
 		B2B7E2E325C6411800B9EFAD /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B7E2E125C6411800B9EFAD /* OnboardingState.swift */; };
+		EA380B262561FAEF0021C4FA /* FileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA380B242561FAEF0021C4FA /* FileListView.swift */; };
+		EA4559BE25169F7D003AD80A /* CodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4559BD25169F7D003AD80A /* CodeScannerView.swift */; };
+		EA5C7D7B2516606100F7F358 /* LockbookApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C7D682516605F00F7F358 /* LockbookApp.swift */; };
 		EA5C7D7C2516606100F7F358 /* LockbookApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C7D682516605F00F7F358 /* LockbookApp.swift */; };
+		EA82B20C262652F700EE82B9 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = EA82B20B262652F700EE82B9 /* Introspect */; };
+		EA831A552534E3C80048CE26 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA831A542534E3C80048CE26 /* AppView.swift */; };
 		EA831A562534E3C80048CE26 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA831A542534E3C80048CE26 /* AppView.swift */; };
+		EA9079C32569960A00E04F5D /* ListFileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9079C22569960A00E04F5D /* ListFileCell.swift */; };
+		EA9EEFD225FC058100E8C790 /* SwiftLockbookCore in Frameworks */ = {isa = PBXBuildFile; productRef = EA8C627B25EF091900330E27 /* SwiftLockbookCore */; };
 		EA9EEFD525FC058200E8C790 /* SwiftLockbookCore in Frameworks */ = {isa = PBXBuildFile; productRef = EA14E81E2516655B00B9158C /* SwiftLockbookCore */; };
 		EAAA10D925B3FD58005140EE /* BottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E8E325AAA524005B7B01 /* BottomBar.swift */; };
+		EAEDCD0B2516FC1C00EBE313 /* BookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEDCD0A2516FC1C00EBE313 /* BookView.swift */; };
 		EAEDCD0C2516FC1C00EBE313 /* BookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEDCD0A2516FC1C00EBE313 /* BookView.swift */; };
+		EAF96D0C252E8ED000AA1A14 /* ConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF96D0B252E8ED000AA1A14 /* ConfigHelper.swift */; };
 		EAF96D0D252E8ED000AA1A14 /* ConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF96D0B252E8ED000AA1A14 /* ConfigHelper.swift */; };
 /* End PBXBuildFile section */
 
@@ -135,6 +187,7 @@
 		EA380B242561FAEF0021C4FA /* FileListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileListView.swift; sourceTree = "<group>"; };
 		EA4559BD25169F7D003AD80A /* CodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeScannerView.swift; sourceTree = "<group>"; };
 		EA5C7D682516605F00F7F358 /* LockbookApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockbookApp.swift; sourceTree = "<group>"; };
+		EA5C7D6F2516606000F7F358 /* Lockbook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lockbook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA5C7D722516606000F7F358 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EA5C7D772516606000F7F358 /* Lockbook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lockbook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA5C7D792516606100F7F358 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -149,6 +202,17 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		EA5C7D6C2516606000F7F358 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA82B20C262652F700EE82B9 /* Introspect in Frameworks */,
+				47B041F32905BFB100A02DA7 /* AlertToast in Frameworks */,
+				471C788D2B4910A80022B3B2 /* SwiftWorkspace in Frameworks */,
+				EA9EEFD225FC058100E8C790 /* SwiftLockbookCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EA5C7D742516606000F7F358 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -260,6 +324,7 @@
 		EA5C7D702516606000F7F358 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				EA5C7D6F2516606000F7F358 /* Lockbook.app */,
 				EA5C7D772516606000F7F358 /* Lockbook.app */,
 			);
 			name = Products;
@@ -334,6 +399,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		EA5C7D6E2516606000F7F358 /* Lockbook (iOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA5C7D832516606100F7F358 /* Build configuration list for PBXNativeTarget "Lockbook (iOS)" */;
+			buildPhases = (
+				EA5C7D6B2516606000F7F358 /* Sources */,
+				EA5C7D6C2516606000F7F358 /* Frameworks */,
+				EA5C7D6D2516606000F7F358 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Lockbook (iOS)";
+			packageProductDependencies = (
+				EA8C627B25EF091900330E27 /* SwiftLockbookCore */,
+				EA82B20B262652F700EE82B9 /* Introspect */,
+				47B041F22905BFB100A02DA7 /* AlertToast */,
+				471C788C2B4910A80022B3B2 /* SwiftWorkspace */,
+			);
+			productName = "Lockbook (iOS)";
+			productReference = EA5C7D6F2516606000F7F358 /* Lockbook.app */;
+			productType = "com.apple.product-type.application";
+		};
 		EA5C7D762516606000F7F358 /* Lockbook (macOS) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EA5C7D862516606100F7F358 /* Build configuration list for PBXNativeTarget "Lockbook (macOS)" */;
@@ -370,6 +458,9 @@
 				LastSwiftUpdateCheck = 1430;
 				LastUpgradeCheck = 1400;
 				TargetAttributes = {
+					EA5C7D6E2516606000F7F358 = {
+						CreatedOnToolsVersion = 12.2;
+					};
 					EA5C7D762516606000F7F358 = {
 						CreatedOnToolsVersion = 12.2;
 					};
@@ -395,12 +486,22 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				EA5C7D6E2516606000F7F358 /* Lockbook (iOS) */,
 				EA5C7D762516606000F7F358 /* Lockbook (macOS) */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		EA5C7D6D2516606000F7F358 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				47837E292A72EA7500863FA4 /* Assets.xcassets in Resources */,
+				B257E5B72A7541820078DA44 /* logo.icns in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EA5C7D752516606000F7F358 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -413,6 +514,59 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		EA5C7D6B2516606000F7F358 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				47B53838290EFE150012E542 /* BillingService.swift in Sources */,
+				87F78F772709352C0001E159 /* LogoView.swift in Sources */,
+				EA831A552534E3C80048CE26 /* AppView.swift in Sources */,
+				EA380B262561FAEF0021C4FA /* FileListView.swift in Sources */,
+				4709C77029FDAAE9004449EF /* SuggestedDocs.swift in Sources */,
+				4772A43A29E8656A0032D586 /* SearchWrapperView.swift in Sources */,
+				877FB54A26D1788D0008AB3F /* CoreService.swift in Sources */,
+				877FB55926D18EC80008AB3F /* FileService.swift in Sources */,
+				1F7E4FBF2521297D0045F606 /* Colors.swift in Sources */,
+				B2B7E2E225C6411800B9EFAD /* OnboardingState.swift in Sources */,
+				B249B9E5282AC03A004F5300 /* MoveSheet.swift in Sources */,
+				87BD383826C020B00030D2B1 /* SettingsService.swift in Sources */,
+				B249B9ED282AF6BF004F5300 /* OutlineContextMenu.swift in Sources */,
+				8715F92827161CC60051689E /* OnboardingView.swift in Sources */,
+				47FB55ED2AF19AD400B74C09 /* RenameFileSheet.swift in Sources */,
+				47FAA4C829EC830600DB606E /* BranchState.swift in Sources */,
+				4756C4DB2A57CE86002C64B1 /* NewFolderSheet.swift in Sources */,
+				877FB56026D2C7D60008AB3F /* StatusService.swift in Sources */,
+				EA9079C32569960A00E04F5D /* ListFileCell.swift in Sources */,
+				87F78F7A27094A040001E159 /* BeforeYouStart.swift in Sources */,
+				8741E8E425AAA524005B7B01 /* BottomBar.swift in Sources */,
+				B249B9E8282AF6B1004F5300 /* OutlineBranch.swift in Sources */,
+				473A3DCE29AC354B0017BC6A /* FilePathBreadcrumb.swift in Sources */,
+				EA4559BE25169F7D003AD80A /* CodeScannerView.swift in Sources */,
+				4779C62D2AB8C09E007C0100 /* PathSearchActionBar.swift in Sources */,
+				EAEDCD0B2516FC1C00EBE313 /* BookView.swift in Sources */,
+				873559BE26C31210008B3C36 /* SettingsView.swift in Sources */,
+				B2459BED28DBB43100756D71 /* ColorProgressBar.swift in Sources */,
+				4709DC38296609F100426106 /* PendingSharesView.swift in Sources */,
+				B249B9E9282AF6B4004F5300 /* OutlineSection.swift in Sources */,
+				EA5C7D7B2516606100F7F358 /* LockbookApp.swift in Sources */,
+				8715F92C271641CF0051689E /* Scanner.swift in Sources */,
+				874A88F526D3E91900F010C8 /* DI.swift in Sources */,
+				B249B9EC282AF6BC004F5300 /* OutlineRow.swift in Sources */,
+				EAF96D0C252E8ED000AA1A14 /* ConfigHelper.swift in Sources */,
+				4761F30F2A1832B4002ED338 /* ManageSubscription.swift in Sources */,
+				877FB55326D1854E0008AB3F /* SyncService.swift in Sources */,
+				B249B9E7282AF4F4004F5300 /* FileTreeView.swift in Sources */,
+				47A45FBB2969047B00573044 /* ShareService.swift in Sources */,
+				877FB55026D17FD00008AB3F /* UnexpectedErrorService.swift in Sources */,
+				476436CC29B7DE4E00FBDC59 /* SearchService.swift in Sources */,
+				877FB55626D18AA60008AB3F /* AccountService.swift in Sources */,
+				4709DC3E2966260500426106 /* AcceptShareSheet.swift in Sources */,
+				6581ABD3CA16395327F765E8 /* SheetState.swift in Sources */,
+				477CC4902967A53C00714456 /* ShareFileSheet.swift in Sources */,
+				47DBF1F12A61A51000F86B3F /* ImportExportService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EA5C7D732516606000F7F358 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -580,6 +734,70 @@
 			};
 			name = Release;
 		};
+		EA5C7D842516606100F7F358 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = IOSAppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Lockbook (iOS).entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 39ZS78S25U;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = iOS/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lockbook;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios",
+					"$(PROJECT_DIR)",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios_sim";
+				MARKETING_VERSION = 0.5.10;
+				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
+				PRODUCT_NAME = Lockbook;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EA5C7D852516606100F7F358 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = IOSAppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Lockbook (iOS).entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 39ZS78S25U;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = iOS/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lockbook;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios",
+					"$(PROJECT_DIR)",
+				);
+				MARKETING_VERSION = 0.5.10;
+				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
+				PRODUCT_NAME = Lockbook;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		EA5C7D872516606100F7F358 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -592,7 +810,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 82SDU3587V;
+				DEVELOPMENT_TEAM = 39ZS78S25U;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = macOS/Info.plist;
@@ -629,7 +847,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 82SDU3587V;
+				DEVELOPMENT_TEAM = 39ZS78S25U;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -717,6 +935,38 @@
 			};
 			name = Development;
 		};
+		EADA115F25336B97005F69DB /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = IOSAppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Lockbook (iOS).entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 39ZS78S25U;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = iOS/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lockbook;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios",
+					"$(PROJECT_DIR)",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios_sim";
+				MARKETING_VERSION = 0.5.10;
+				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
+				PRODUCT_NAME = Lockbook;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Development;
+		};
 		EADA116025336B97005F69DB /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -729,7 +979,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 82SDU3587V;
+				DEVELOPMENT_TEAM = 39ZS78S25U;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = macOS/Info.plist;
@@ -762,6 +1012,16 @@
 				EA5C7D812516606100F7F358 /* Debug */,
 				EADA115E25336B97005F69DB /* Development */,
 				EA5C7D822516606100F7F358 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EA5C7D832516606100F7F358 /* Build configuration list for PBXNativeTarget "Lockbook (iOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA5C7D842516606100F7F358 /* Debug */,
+				EADA115F25336B97005F69DB /* Development */,
+				EA5C7D852516606100F7F358 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -826,6 +1086,15 @@
 			package = 47159F4429CFA05B00969DDF /* XCRemoteSwiftPackageReference "DSFQuickActionBar" */;
 			productName = DSFQuickActionBar;
 		};
+		471C788C2B4910A80022B3B2 /* SwiftWorkspace */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftWorkspace;
+		};
+		47B041F22905BFB100A02DA7 /* AlertToast */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 47B041F12905BFB100A02DA7 /* XCRemoteSwiftPackageReference "AlertToast" */;
+			productName = AlertToast;
+		};
 		47B041F42905BFF100A02DA7 /* AlertToast */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 47B041F12905BFB100A02DA7 /* XCRemoteSwiftPackageReference "AlertToast" */;
@@ -849,6 +1118,15 @@
 			productName = Introspect;
 		};
 		EA14E81E2516655B00B9158C /* SwiftLockbookCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftLockbookCore;
+		};
+		EA82B20B262652F700EE82B9 /* Introspect */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EA82B20A262652F600EE82B9 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
+			productName = Introspect;
+		};
+		EA8C627B25EF091900330E27 /* SwiftLockbookCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SwiftLockbookCore;
 		};

--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -7,86 +7,44 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1F7E4FBF2521297D0045F606 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7E4FBE2521297D0045F606 /* Colors.swift */; };
 		1F7E4FC02521297D0045F606 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7E4FBE2521297D0045F606 /* Colors.swift */; };
-		4709C77029FDAAE9004449EF /* SuggestedDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C76F29FDAAE9004449EF /* SuggestedDocs.swift */; };
 		4709C77129FDAAE9004449EF /* SuggestedDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C76F29FDAAE9004449EF /* SuggestedDocs.swift */; };
-		4709DC38296609F100426106 /* PendingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC37296609F100426106 /* PendingSharesView.swift */; };
 		4709DC39296609F100426106 /* PendingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC37296609F100426106 /* PendingSharesView.swift */; };
-		4709DC3E2966260500426106 /* AcceptShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC3D2966260500426106 /* AcceptShareSheet.swift */; };
 		4709DC3F2966260500426106 /* AcceptShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709DC3D2966260500426106 /* AcceptShareSheet.swift */; };
 		47159F4629CFA05B00969DDF /* DSFQuickActionBar in Frameworks */ = {isa = PBXBuildFile; productRef = 47159F4529CFA05B00969DDF /* DSFQuickActionBar */; };
-		471C788D2B4910A80022B3B2 /* SwiftWorkspace in Frameworks */ = {isa = PBXBuildFile; productRef = 471C788C2B4910A80022B3B2 /* SwiftWorkspace */; };
 		471E363529FD5F5C00A1958A /* FileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E8F925ACBCF9005B7B01 /* FileListView.swift */; };
-		473A3DCE29AC354B0017BC6A /* FilePathBreadcrumb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A3DCD29AC354B0017BC6A /* FilePathBreadcrumb.swift */; };
-		4756C4DB2A57CE86002C64B1 /* NewFolderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4756C4DA2A57CE86002C64B1 /* NewFolderSheet.swift */; };
 		4756C4DC2A57CE86002C64B1 /* NewFolderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4756C4DA2A57CE86002C64B1 /* NewFolderSheet.swift */; };
-		4761F30F2A1832B4002ED338 /* ManageSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4761F30E2A1832B4002ED338 /* ManageSubscription.swift */; };
-		476436CC29B7DE4E00FBDC59 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476436CB29B7DE4E00FBDC59 /* SearchService.swift */; };
 		476436CD29B7DE4E00FBDC59 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476436CB29B7DE4E00FBDC59 /* SearchService.swift */; };
-		4772A43A29E8656A0032D586 /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4772A43929E8656A0032D586 /* SearchWrapperView.swift */; };
 		4772A43B29E8656A0032D586 /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4772A43929E8656A0032D586 /* SearchWrapperView.swift */; };
-		4779C62D2AB8C09E007C0100 /* PathSearchActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779C62C2AB8C09E007C0100 /* PathSearchActionBar.swift */; };
 		4779C62E2AB8C09E007C0100 /* PathSearchActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779C62C2AB8C09E007C0100 /* PathSearchActionBar.swift */; };
-		477CC4902967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
 		477CC4912967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
-		47837E292A72EA7500863FA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B273394C26C8A4B400303EAE /* Assets.xcassets */; };
-		47A45FBB2969047B00573044 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A45FBA2969047B00573044 /* ShareService.swift */; };
 		47A45FBC2969047B00573044 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A45FBA2969047B00573044 /* ShareService.swift */; };
-		47B041F32905BFB100A02DA7 /* AlertToast in Frameworks */ = {isa = PBXBuildFile; productRef = 47B041F22905BFB100A02DA7 /* AlertToast */; };
 		47B041F52905BFF100A02DA7 /* AlertToast in Frameworks */ = {isa = PBXBuildFile; productRef = 47B041F42905BFF100A02DA7 /* AlertToast */; };
-		47B53838290EFE150012E542 /* BillingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B53837290EFE150012E542 /* BillingService.swift */; };
 		47B53839290EFE150012E542 /* BillingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B53837290EFE150012E542 /* BillingService.swift */; };
 		47B67289295F977C00DB0D8E /* ManageSubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B67288295F977C00DB0D8E /* ManageSubscriptionView.swift */; };
 		47CEC69D2A182F2A0018FA5C /* UpgradeToPremium.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CEC69C2A182F2A0018FA5C /* UpgradeToPremium.swift */; };
-		47DBF1F12A61A51000F86B3F /* ImportExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DBF1F02A61A51000F86B3F /* ImportExportService.swift */; };
 		47DBF1F22A61A51000F86B3F /* ImportExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DBF1F02A61A51000F86B3F /* ImportExportService.swift */; };
-		47FAA4C829EC830600DB606E /* BranchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FAA4C729EC830600DB606E /* BranchState.swift */; };
 		47FAA4C929EC830600DB606E /* BranchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FAA4C729EC830600DB606E /* BranchState.swift */; };
-		47FB55ED2AF19AD400B74C09 /* RenameFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB55EC2AF19AD400B74C09 /* RenameFileSheet.swift */; };
 		47FB55EE2AF19AD400B74C09 /* RenameFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB55EC2AF19AD400B74C09 /* RenameFileSheet.swift */; };
 		6581A7EF74307EAE69426206 /* SheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581AB54147C2201F8F95500 /* SheetState.swift */; };
-		6581ABD3CA16395327F765E8 /* SheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581AB54147C2201F8F95500 /* SheetState.swift */; };
 		6581AC0512EDB9FBB7106020 /* MenuItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581A11CE95C74B01ED30AEB /* MenuItems.swift */; };
 		870DC09F26BDE6F4002E9A92 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870DC09E26BDE6F4002E9A92 /* SettingsView.swift */; };
 		870DC0A226BF378F002E9A92 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870DC0A126BF378F002E9A92 /* AccountSettingsView.swift */; };
 		870DC0A426BF37C0002E9A92 /* UsageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870DC0A326BF37C0002E9A92 /* UsageSettingsView.swift */; };
-		8715F92827161CC60051689E /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715F92727161CC60051689E /* OnboardingView.swift */; };
 		8715F92927161CC60051689E /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715F92727161CC60051689E /* OnboardingView.swift */; };
-		8715F92C271641CF0051689E /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715F92B271641CF0051689E /* Scanner.swift */; };
-		873559BE26C31210008B3C36 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873559BD26C31210008B3C36 /* SettingsView.swift */; };
-		8741E8E425AAA524005B7B01 /* BottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E8E325AAA524005B7B01 /* BottomBar.swift */; };
-		874A88F526D3E91900F010C8 /* DI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A88F426D3E91900F010C8 /* DI.swift */; };
 		874A88F626D3E91900F010C8 /* DI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A88F426D3E91900F010C8 /* DI.swift */; };
-		877FB54A26D1788D0008AB3F /* CoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54926D1788D0008AB3F /* CoreService.swift */; };
 		877FB54B26D1788D0008AB3F /* CoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54926D1788D0008AB3F /* CoreService.swift */; };
-		877FB55026D17FD00008AB3F /* UnexpectedErrorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54F26D17FD00008AB3F /* UnexpectedErrorService.swift */; };
 		877FB55126D17FD00008AB3F /* UnexpectedErrorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB54F26D17FD00008AB3F /* UnexpectedErrorService.swift */; };
-		877FB55326D1854E0008AB3F /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55226D1854E0008AB3F /* SyncService.swift */; };
 		877FB55426D1854E0008AB3F /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55226D1854E0008AB3F /* SyncService.swift */; };
-		877FB55626D18AA60008AB3F /* AccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55526D18AA60008AB3F /* AccountService.swift */; };
 		877FB55726D18AA60008AB3F /* AccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55526D18AA60008AB3F /* AccountService.swift */; };
-		877FB55926D18EC80008AB3F /* FileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55826D18EC80008AB3F /* FileService.swift */; };
 		877FB55A26D18EC80008AB3F /* FileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55826D18EC80008AB3F /* FileService.swift */; };
-		877FB56026D2C7D60008AB3F /* StatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55F26D2C7D60008AB3F /* StatusService.swift */; };
 		877FB56126D2C7D60008AB3F /* StatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877FB55F26D2C7D60008AB3F /* StatusService.swift */; };
-		87BD383826C020B00030D2B1 /* SettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BD383726C020B00030D2B1 /* SettingsService.swift */; };
 		87BD383926C020B00030D2B1 /* SettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BD383726C020B00030D2B1 /* SettingsService.swift */; };
-		87F78F772709352C0001E159 /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F762709352C0001E159 /* LogoView.swift */; };
 		87F78F782709352C0001E159 /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F762709352C0001E159 /* LogoView.swift */; };
-		87F78F7A27094A040001E159 /* BeforeYouStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F7927094A040001E159 /* BeforeYouStart.swift */; };
 		87F78F7B27094A040001E159 /* BeforeYouStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F7927094A040001E159 /* BeforeYouStart.swift */; };
-		B2459BED28DBB43100756D71 /* ColorProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2459BEC28DBB43100756D71 /* ColorProgressBar.swift */; };
 		B2459BEE28DBB43100756D71 /* ColorProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2459BEC28DBB43100756D71 /* ColorProgressBar.swift */; };
-		B249B9E5282AC03A004F5300 /* MoveSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9E4282AC03A004F5300 /* MoveSheet.swift */; };
-		B249B9E7282AF4F4004F5300 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9E6282AF4F4004F5300 /* FileTreeView.swift */; };
-		B249B9E8282AF6B1004F5300 /* OutlineBranch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E90E25AD1565005B7B01 /* OutlineBranch.swift */; };
-		B249B9E9282AF6B4004F5300 /* OutlineSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F6E270785E00001E159 /* OutlineSection.swift */; };
-		B249B9EC282AF6BC004F5300 /* OutlineRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA349F0125BC7C110016241E /* OutlineRow.swift */; };
-		B249B9ED282AF6BF004F5300 /* OutlineContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F78F742708F1990001E159 /* OutlineContextMenu.swift */; };
 		B249B9F2282C6241004F5300 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9F1282C6241004F5300 /* FileTreeView.swift */; };
 		B249B9F5282FE566004F5300 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B249B9F4282FE566004F5300 /* DataSource.swift */; };
-		B257E5B72A7541820078DA44 /* logo.icns in Resources */ = {isa = PBXBuildFile; fileRef = B257E5B62A7541820078DA44 /* logo.icns */; };
 		B257E5B82A7541820078DA44 /* logo.icns in Resources */ = {isa = PBXBuildFile; fileRef = B257E5B62A7541820078DA44 /* logo.icns */; };
 		B273394F26C8B3EF00303EAE /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B273394E26C8B3EF00303EAE /* Media.xcassets */; };
 		B2A3AB302B27A1E800C2319E /* Bridge in Frameworks */ = {isa = PBXBuildFile; productRef = B2A3AB2F2B27A1E800C2319E /* Bridge */; };
@@ -94,22 +52,12 @@
 		B2A3AB342B27A1E800C2319E /* workspace in Frameworks */ = {isa = PBXBuildFile; productRef = B2A3AB332B27A1E800C2319E /* workspace */; };
 		B2ADC2472833FA8200DB8D3D /* FileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2ADC2462833FA8200DB8D3D /* FileCell.swift */; };
 		B2ADC2492835451000DB8D3D /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = B2ADC2482835451000DB8D3D /* Introspect */; };
-		B2B7E2E225C6411800B9EFAD /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B7E2E125C6411800B9EFAD /* OnboardingState.swift */; };
 		B2B7E2E325C6411800B9EFAD /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B7E2E125C6411800B9EFAD /* OnboardingState.swift */; };
-		EA380B262561FAEF0021C4FA /* FileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA380B242561FAEF0021C4FA /* FileListView.swift */; };
-		EA4559BE25169F7D003AD80A /* CodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4559BD25169F7D003AD80A /* CodeScannerView.swift */; };
-		EA5C7D7B2516606100F7F358 /* LockbookApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C7D682516605F00F7F358 /* LockbookApp.swift */; };
 		EA5C7D7C2516606100F7F358 /* LockbookApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C7D682516605F00F7F358 /* LockbookApp.swift */; };
-		EA82B20C262652F700EE82B9 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = EA82B20B262652F700EE82B9 /* Introspect */; };
-		EA831A552534E3C80048CE26 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA831A542534E3C80048CE26 /* AppView.swift */; };
 		EA831A562534E3C80048CE26 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA831A542534E3C80048CE26 /* AppView.swift */; };
-		EA9079C32569960A00E04F5D /* ListFileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9079C22569960A00E04F5D /* ListFileCell.swift */; };
-		EA9EEFD225FC058100E8C790 /* SwiftLockbookCore in Frameworks */ = {isa = PBXBuildFile; productRef = EA8C627B25EF091900330E27 /* SwiftLockbookCore */; };
 		EA9EEFD525FC058200E8C790 /* SwiftLockbookCore in Frameworks */ = {isa = PBXBuildFile; productRef = EA14E81E2516655B00B9158C /* SwiftLockbookCore */; };
 		EAAA10D925B3FD58005140EE /* BottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8741E8E325AAA524005B7B01 /* BottomBar.swift */; };
-		EAEDCD0B2516FC1C00EBE313 /* BookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEDCD0A2516FC1C00EBE313 /* BookView.swift */; };
 		EAEDCD0C2516FC1C00EBE313 /* BookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEDCD0A2516FC1C00EBE313 /* BookView.swift */; };
-		EAF96D0C252E8ED000AA1A14 /* ConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF96D0B252E8ED000AA1A14 /* ConfigHelper.swift */; };
 		EAF96D0D252E8ED000AA1A14 /* ConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF96D0B252E8ED000AA1A14 /* ConfigHelper.swift */; };
 /* End PBXBuildFile section */
 
@@ -187,7 +135,6 @@
 		EA380B242561FAEF0021C4FA /* FileListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileListView.swift; sourceTree = "<group>"; };
 		EA4559BD25169F7D003AD80A /* CodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeScannerView.swift; sourceTree = "<group>"; };
 		EA5C7D682516605F00F7F358 /* LockbookApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockbookApp.swift; sourceTree = "<group>"; };
-		EA5C7D6F2516606000F7F358 /* Lockbook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lockbook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA5C7D722516606000F7F358 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EA5C7D772516606000F7F358 /* Lockbook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lockbook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA5C7D792516606100F7F358 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -202,17 +149,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		EA5C7D6C2516606000F7F358 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				EA82B20C262652F700EE82B9 /* Introspect in Frameworks */,
-				47B041F32905BFB100A02DA7 /* AlertToast in Frameworks */,
-				471C788D2B4910A80022B3B2 /* SwiftWorkspace in Frameworks */,
-				EA9EEFD225FC058100E8C790 /* SwiftLockbookCore in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		EA5C7D742516606000F7F358 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -324,7 +260,6 @@
 		EA5C7D702516606000F7F358 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				EA5C7D6F2516606000F7F358 /* Lockbook.app */,
 				EA5C7D772516606000F7F358 /* Lockbook.app */,
 			);
 			name = Products;
@@ -399,29 +334,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		EA5C7D6E2516606000F7F358 /* Lockbook (iOS) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = EA5C7D832516606100F7F358 /* Build configuration list for PBXNativeTarget "Lockbook (iOS)" */;
-			buildPhases = (
-				EA5C7D6B2516606000F7F358 /* Sources */,
-				EA5C7D6C2516606000F7F358 /* Frameworks */,
-				EA5C7D6D2516606000F7F358 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Lockbook (iOS)";
-			packageProductDependencies = (
-				EA8C627B25EF091900330E27 /* SwiftLockbookCore */,
-				EA82B20B262652F700EE82B9 /* Introspect */,
-				47B041F22905BFB100A02DA7 /* AlertToast */,
-				471C788C2B4910A80022B3B2 /* SwiftWorkspace */,
-			);
-			productName = "Lockbook (iOS)";
-			productReference = EA5C7D6F2516606000F7F358 /* Lockbook.app */;
-			productType = "com.apple.product-type.application";
-		};
 		EA5C7D762516606000F7F358 /* Lockbook (macOS) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EA5C7D862516606100F7F358 /* Build configuration list for PBXNativeTarget "Lockbook (macOS)" */;
@@ -458,9 +370,6 @@
 				LastSwiftUpdateCheck = 1430;
 				LastUpgradeCheck = 1400;
 				TargetAttributes = {
-					EA5C7D6E2516606000F7F358 = {
-						CreatedOnToolsVersion = 12.2;
-					};
 					EA5C7D762516606000F7F358 = {
 						CreatedOnToolsVersion = 12.2;
 					};
@@ -486,22 +395,12 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				EA5C7D6E2516606000F7F358 /* Lockbook (iOS) */,
 				EA5C7D762516606000F7F358 /* Lockbook (macOS) */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		EA5C7D6D2516606000F7F358 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				47837E292A72EA7500863FA4 /* Assets.xcassets in Resources */,
-				B257E5B72A7541820078DA44 /* logo.icns in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		EA5C7D752516606000F7F358 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -514,59 +413,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		EA5C7D6B2516606000F7F358 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				47B53838290EFE150012E542 /* BillingService.swift in Sources */,
-				87F78F772709352C0001E159 /* LogoView.swift in Sources */,
-				EA831A552534E3C80048CE26 /* AppView.swift in Sources */,
-				EA380B262561FAEF0021C4FA /* FileListView.swift in Sources */,
-				4709C77029FDAAE9004449EF /* SuggestedDocs.swift in Sources */,
-				4772A43A29E8656A0032D586 /* SearchWrapperView.swift in Sources */,
-				877FB54A26D1788D0008AB3F /* CoreService.swift in Sources */,
-				877FB55926D18EC80008AB3F /* FileService.swift in Sources */,
-				1F7E4FBF2521297D0045F606 /* Colors.swift in Sources */,
-				B2B7E2E225C6411800B9EFAD /* OnboardingState.swift in Sources */,
-				B249B9E5282AC03A004F5300 /* MoveSheet.swift in Sources */,
-				87BD383826C020B00030D2B1 /* SettingsService.swift in Sources */,
-				B249B9ED282AF6BF004F5300 /* OutlineContextMenu.swift in Sources */,
-				8715F92827161CC60051689E /* OnboardingView.swift in Sources */,
-				47FB55ED2AF19AD400B74C09 /* RenameFileSheet.swift in Sources */,
-				47FAA4C829EC830600DB606E /* BranchState.swift in Sources */,
-				4756C4DB2A57CE86002C64B1 /* NewFolderSheet.swift in Sources */,
-				877FB56026D2C7D60008AB3F /* StatusService.swift in Sources */,
-				EA9079C32569960A00E04F5D /* ListFileCell.swift in Sources */,
-				87F78F7A27094A040001E159 /* BeforeYouStart.swift in Sources */,
-				8741E8E425AAA524005B7B01 /* BottomBar.swift in Sources */,
-				B249B9E8282AF6B1004F5300 /* OutlineBranch.swift in Sources */,
-				473A3DCE29AC354B0017BC6A /* FilePathBreadcrumb.swift in Sources */,
-				EA4559BE25169F7D003AD80A /* CodeScannerView.swift in Sources */,
-				4779C62D2AB8C09E007C0100 /* PathSearchActionBar.swift in Sources */,
-				EAEDCD0B2516FC1C00EBE313 /* BookView.swift in Sources */,
-				873559BE26C31210008B3C36 /* SettingsView.swift in Sources */,
-				B2459BED28DBB43100756D71 /* ColorProgressBar.swift in Sources */,
-				4709DC38296609F100426106 /* PendingSharesView.swift in Sources */,
-				B249B9E9282AF6B4004F5300 /* OutlineSection.swift in Sources */,
-				EA5C7D7B2516606100F7F358 /* LockbookApp.swift in Sources */,
-				8715F92C271641CF0051689E /* Scanner.swift in Sources */,
-				874A88F526D3E91900F010C8 /* DI.swift in Sources */,
-				B249B9EC282AF6BC004F5300 /* OutlineRow.swift in Sources */,
-				EAF96D0C252E8ED000AA1A14 /* ConfigHelper.swift in Sources */,
-				4761F30F2A1832B4002ED338 /* ManageSubscription.swift in Sources */,
-				877FB55326D1854E0008AB3F /* SyncService.swift in Sources */,
-				B249B9E7282AF4F4004F5300 /* FileTreeView.swift in Sources */,
-				47A45FBB2969047B00573044 /* ShareService.swift in Sources */,
-				877FB55026D17FD00008AB3F /* UnexpectedErrorService.swift in Sources */,
-				476436CC29B7DE4E00FBDC59 /* SearchService.swift in Sources */,
-				877FB55626D18AA60008AB3F /* AccountService.swift in Sources */,
-				4709DC3E2966260500426106 /* AcceptShareSheet.swift in Sources */,
-				6581ABD3CA16395327F765E8 /* SheetState.swift in Sources */,
-				477CC4902967A53C00714456 /* ShareFileSheet.swift in Sources */,
-				47DBF1F12A61A51000F86B3F /* ImportExportService.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		EA5C7D732516606000F7F358 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -734,70 +580,6 @@
 			};
 			name = Release;
 		};
-		EA5C7D842516606100F7F358 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = IOSAppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "Lockbook (iOS).entitlements";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 39ZS78S25U;
-				ENABLE_PREVIEWS = YES;
-				INFOPLIST_FILE = iOS/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Lockbook;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios",
-					"$(PROJECT_DIR)",
-				);
-				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios_sim";
-				MARKETING_VERSION = 0.5.10;
-				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
-				PRODUCT_NAME = Lockbook;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		EA5C7D852516606100F7F358 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = IOSAppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "Lockbook (iOS).entitlements";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 39ZS78S25U;
-				ENABLE_PREVIEWS = YES;
-				INFOPLIST_FILE = iOS/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Lockbook;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios",
-					"$(PROJECT_DIR)",
-				);
-				MARKETING_VERSION = 0.5.10;
-				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
-				PRODUCT_NAME = Lockbook;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 		EA5C7D872516606100F7F358 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -810,7 +592,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 39ZS78S25U;
+				DEVELOPMENT_TEAM = 82SDU3587V;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = macOS/Info.plist;
@@ -847,7 +629,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 39ZS78S25U;
+				DEVELOPMENT_TEAM = 82SDU3587V;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -935,38 +717,6 @@
 			};
 			name = Development;
 		};
-		EADA115F25336B97005F69DB /* Development */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = IOSAppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "Lockbook (iOS).entitlements";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 39ZS78S25U;
-				ENABLE_PREVIEWS = YES;
-				INFOPLIST_FILE = iOS/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Lockbook;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios",
-					"$(PROJECT_DIR)",
-				);
-				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "${PROJECT_DIR}/CLockbookCore/Sources/CLockbookCore/lib_ios_sim";
-				MARKETING_VERSION = 0.5.10;
-				PRODUCT_BUNDLE_IDENTIFIER = app.lockbook;
-				PRODUCT_NAME = Lockbook;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Development;
-		};
 		EADA116025336B97005F69DB /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -979,7 +729,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 39ZS78S25U;
+				DEVELOPMENT_TEAM = 82SDU3587V;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = macOS/Info.plist;
@@ -1012,16 +762,6 @@
 				EA5C7D812516606100F7F358 /* Debug */,
 				EADA115E25336B97005F69DB /* Development */,
 				EA5C7D822516606100F7F358 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		EA5C7D832516606100F7F358 /* Build configuration list for PBXNativeTarget "Lockbook (iOS)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EA5C7D842516606100F7F358 /* Debug */,
-				EADA115F25336B97005F69DB /* Development */,
-				EA5C7D852516606100F7F358 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1086,15 +826,6 @@
 			package = 47159F4429CFA05B00969DDF /* XCRemoteSwiftPackageReference "DSFQuickActionBar" */;
 			productName = DSFQuickActionBar;
 		};
-		471C788C2B4910A80022B3B2 /* SwiftWorkspace */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SwiftWorkspace;
-		};
-		47B041F22905BFB100A02DA7 /* AlertToast */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 47B041F12905BFB100A02DA7 /* XCRemoteSwiftPackageReference "AlertToast" */;
-			productName = AlertToast;
-		};
 		47B041F42905BFF100A02DA7 /* AlertToast */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 47B041F12905BFB100A02DA7 /* XCRemoteSwiftPackageReference "AlertToast" */;
@@ -1118,15 +849,6 @@
 			productName = Introspect;
 		};
 		EA14E81E2516655B00B9158C /* SwiftLockbookCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SwiftLockbookCore;
-		};
-		EA82B20B262652F700EE82B9 /* Introspect */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = EA82B20A262652F600EE82B9 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
-			productName = Introspect;
-		};
-		EA8C627B25EF091900330E27 /* SwiftLockbookCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SwiftLockbookCore;
 		};

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -137,10 +137,9 @@ impl AccountScreen {
                     ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
 
                     egui::Frame::default()
-                        .inner_margin(egui::Margin::symmetric(30.0, 20.0))
+                        .inner_margin(egui::Margin::symmetric(20.0, 20.0))
                         .show(ui, |ui| {
                             self.show_sync_panel(ui);
-                            separator(ui);
                             self.show_nav_panel(ui);
                         });
 
@@ -443,10 +442,10 @@ impl AccountScreen {
     }
 
     fn show_nav_panel(&mut self, ui: &mut egui::Ui) {
-        let visuals_before_button = ui.visuals().clone();
+        let visuals_before_button = ui.style().clone();
 
         ui.allocate_ui_with_layout(
-            egui::vec2(ui.available_size_before_wrap().x, 70.0),
+            egui::vec2(ui.available_size_before_wrap().x, 40.0),
             egui::Layout::left_to_right(egui::Align::Center),
             |ui| {
                 // ui.add_space(10.0);
@@ -465,36 +464,22 @@ impl AccountScreen {
                 ui.visuals_mut().widgets.active.bg_fill =
                     ui.visuals().widgets.active.bg_fill.gamma_multiply(0.2);
 
-                ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
-                    ui.add_space(10.0);
-                    if Button::default()
-                        .text("Sync")
-                        .icon(&Icon::SYNC)
-                        .icon_alignment(egui::Align::RIGHT)
-                        .padding(egui::vec2(10.0, 7.0))
-                        .frame(true)
-                        .rounding(egui::Rounding::same(5.0))
-                        .show(ui)
-                        .clicked()
-                    {
-                        self.workspace.perform_sync();
-                    }
-                });
+                if Button::default()
+                    .text("Sync")
+                    .icon(&Icon::SYNC)
+                    .icon_alignment(egui::Align::RIGHT)
+                    .padding(egui::vec2(10.0, 7.0))
+                    .frame(true)
+                    .rounding(egui::Rounding::same(5.0))
+                    .show(ui)
+                    .clicked()
+                {
+                    self.workspace.perform_sync();
+                }
 
-                
+                ui.set_style(visuals_before_button);
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    let zen_mode_btn = Button::default().icon(&Icon::HIDE_SIDEBAR).show(ui);
-
-                    if zen_mode_btn.clicked() {
-                        self.settings.write().unwrap().zen_mode = true;
-                        if let Err(err) = self.settings.read().unwrap().to_file() {
-                            self.modals.error = Some(ErrorModal::new(err));
-                        }
-                    }
-
-                    zen_mode_btn.on_hover_text("Hide side panel");
-
                     let settings_btn = Button::default().icon(&Icon::SETTINGS).show(ui);
                     if settings_btn.clicked() {
                         self.update_tx.send(OpenModal::Settings.into()).unwrap();
@@ -520,6 +505,17 @@ impl AccountScreen {
                         ui.ctx().request_repaint();
                     };
                     incoming_shares_btn.on_hover_text("Incoming shares");
+
+                    let zen_mode_btn = Button::default().icon(&Icon::TOGGLE_SIDEBAR).show(ui);
+
+                    if zen_mode_btn.clicked() {
+                        self.settings.write().unwrap().zen_mode = true;
+                        if let Err(err) = self.settings.read().unwrap().to_file() {
+                            self.modals.error = Some(ErrorModal::new(err));
+                        }
+                    }
+
+                    zen_mode_btn.on_hover_text("Hide side panel");
                 });
             },
         );

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -145,7 +145,6 @@ impl AccountScreen {
 
                             ui.add_space(15.0);
                             self.show_sync_error_warn(ui);
-
                         });
 
                     ui.vertical(|ui| {
@@ -447,74 +446,14 @@ impl AccountScreen {
     }
 
     fn show_nav_panel(&mut self, ui: &mut egui::Ui) {
-        let visuals_before_button = ui.style().clone();
-
+        
         ui.allocate_ui_with_layout(
             egui::vec2(ui.available_size_before_wrap().x, 40.0),
             egui::Layout::left_to_right(egui::Align::Center),
             |ui| {
                 // ui.add_space(10.0);
-
-                let text_stroke = egui::Stroke {
-                    color: ui.visuals().widgets.active.bg_fill,
-                    ..Default::default()
-                };
-                ui.visuals_mut().widgets.inactive.fg_stroke = text_stroke;
-                ui.visuals_mut().widgets.hovered.fg_stroke = text_stroke;
-                ui.visuals_mut().widgets.active.fg_stroke = text_stroke;
-
-                ui.visuals_mut().widgets.inactive.bg_fill =
-                    ui.visuals().widgets.active.bg_fill.gamma_multiply(0.1);
-                ui.visuals_mut().widgets.hovered.bg_fill =
-                    ui.visuals().widgets.active.bg_fill.gamma_multiply(0.2);
-
-                ui.visuals_mut().widgets.active.bg_fill =
-                    ui.visuals().widgets.active.bg_fill.gamma_multiply(0.3);
-
-                let sync_btn = Button::default()
-                    .text("Sync")
-                    .icon(&Icon::SYNC)
-                    .icon_alignment(egui::Align::RIGHT)
-                    .padding(egui::vec2(10.0, 7.0))
-                    .frame(true)
-                    .rounding(egui::Rounding::same(5.0))
-                    .is_loading(self.workspace.pers_status.syncing)
-                    .show(ui);
-
-                if sync_btn.clicked() {
-                    self.workspace.perform_sync();
-                    self.sync.btn_lost_hover_after_sync = false;
-                }
-
-                if sync_btn.lost_focus() {
-                    self.sync.btn_lost_hover_after_sync = true;
-                }
-
-                let tooltip_msg = if !self.sync.btn_lost_hover_after_sync {
-                    let dirty_files_count = self.workspace.pers_status.dirtyness.dirty_files.len();
-                    let dirty_msg = format!(
-                        ", {} file{} needs to be synced",
-                        dirty_files_count,
-                        if dirty_files_count > 1 { "s" } else { "" }
-                    );
-
-                    Some(format!(
-                        "Updated {}{}",
-                        &self.workspace.pers_status.dirtyness.last_synced,
-                        if dirty_files_count > 0 { dirty_msg } else { "".to_string() }
-                    ))
-                } else {
-                    self.workspace.pers_status.sync_message.to_owned()
-                };
-
-                if let Some(msg) = tooltip_msg {
-                    sync_btn.on_hover_ui_at_pointer(|ui| {
-                        ui.label(msg);
-                    });
-                }
-
-                ui.set_style(visuals_before_button);
-
+                self.show_sync_btn(ui);
+                
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let settings_btn = Button::default().icon(&Icon::SETTINGS).show(ui);
                     if settings_btn.clicked() {

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -139,8 +139,7 @@ impl AccountScreen {
                     egui::Frame::default()
                         .inner_margin(egui::Margin::symmetric(20.0, 20.0))
                         .show(ui, |ui| {
-                            self.show_sync_panel(ui);
-
+                            self.show_usage_panel(ui);
                             self.show_nav_panel(ui);
 
                             ui.add_space(15.0);
@@ -450,7 +449,6 @@ impl AccountScreen {
             egui::vec2(ui.available_size_before_wrap().x, 40.0),
             egui::Layout::left_to_right(egui::Align::Center),
             |ui| {
-                // ui.add_space(10.0);
                 self.show_sync_btn(ui);
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -18,7 +18,7 @@ use workspace_rs::tab::markdown::Markdown;
 use workspace_rs::tab::plain_text::PlainText;
 use workspace_rs::tab::{Tab, TabContent, TabFailure};
 use workspace_rs::theme::icons::Icon;
-use workspace_rs::widgets::{separator, Button};
+use workspace_rs::widgets::Button;
 use workspace_rs::workspace::{Workspace, WsConfig};
 
 use crate::model::{AccountScreenInitData, Usage};
@@ -446,14 +446,13 @@ impl AccountScreen {
     }
 
     fn show_nav_panel(&mut self, ui: &mut egui::Ui) {
-        
         ui.allocate_ui_with_layout(
             egui::vec2(ui.available_size_before_wrap().x, 40.0),
             egui::Layout::left_to_right(egui::Align::Center),
             |ui| {
                 // ui.add_space(10.0);
                 self.show_sync_btn(ui);
-                
+
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let settings_btn = Button::default().icon(&Icon::SETTINGS).show(ui);
                     if settings_btn.clicked() {

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -450,31 +450,54 @@ impl AccountScreen {
             |ui| {
                 // ui.add_space(10.0);
 
-                let text_stroke =
-                    egui::Stroke { color: ui.visuals().hyperlink_color, ..Default::default() };
+                let text_stroke = egui::Stroke {
+                    color: ui.visuals().widgets.active.bg_fill,
+                    ..Default::default()
+                };
                 ui.visuals_mut().widgets.inactive.fg_stroke = text_stroke;
                 ui.visuals_mut().widgets.hovered.fg_stroke = text_stroke;
                 ui.visuals_mut().widgets.active.fg_stroke = text_stroke;
 
                 ui.visuals_mut().widgets.inactive.bg_fill =
-                    ui.visuals().widgets.active.bg_fill.gamma_multiply(0.05);
-                ui.visuals_mut().widgets.hovered.bg_fill =
                     ui.visuals().widgets.active.bg_fill.gamma_multiply(0.1);
-
-                ui.visuals_mut().widgets.active.bg_fill =
+                ui.visuals_mut().widgets.hovered.bg_fill =
                     ui.visuals().widgets.active.bg_fill.gamma_multiply(0.2);
 
-                if Button::default()
+                ui.visuals_mut().widgets.active.bg_fill =
+                    ui.visuals().widgets.active.bg_fill.gamma_multiply(0.3);
+
+                let sync_btn = Button::default()
                     .text("Sync")
                     .icon(&Icon::SYNC)
                     .icon_alignment(egui::Align::RIGHT)
                     .padding(egui::vec2(10.0, 7.0))
                     .frame(true)
                     .rounding(egui::Rounding::same(5.0))
-                    .show(ui)
-                    .clicked()
-                {
+                    .is_loading(self.workspace.pers_status.syncing)
+                    .show(ui);
+
+                if sync_btn.clicked() {
                     self.workspace.perform_sync();
+                }
+
+                if let Some(sync_message) = &self.workspace.pers_status.sync_message {
+                    sync_btn.on_hover_ui_at_pointer(|ui| {
+                        ui.label(sync_message);
+                    });
+                } else {
+                    if let Ok(sync_freshness) = &self.sync.status {
+                        sync_btn.on_hover_ui_at_pointer(|ui| {
+                            ui.label(format!("Synced {sync_freshness}"));
+                        });
+                    }
+                    // match &self.sync.status {
+                    //     Ok(s) => ui.label(
+                    //         egui::RichText::new(format!("Updated {s}"))
+                    //             .color(ui.visuals().widgets.active.bg_fill)
+                    //             .size(15.0),
+                    //     ),
+                    //     Err(msg) => ui.label(egui::RichText::new(msg).color(egui::Color32::RED)),
+                    // };
                 }
 
                 ui.set_style(visuals_before_button);

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -9,7 +9,7 @@ use workspace_rs::widgets::ProgressBar;
 use super::AccountUpdate;
 
 pub struct SyncPanel {
-    status: Result<String, String>,
+    pub status: Result<String, String>,
     lock: Arc<Mutex<()>>,
     usage_msg_gained_hover: Option<Instant>,
     expanded_usage_msg_rect: egui::Rect,

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -10,8 +10,8 @@ use workspace_rs::widgets::{Button, ProgressBar};
 use super::AccountUpdate;
 
 pub struct SyncPanel {
-    pub initial_status: Result<String, String>,
-    pub btn_lost_hover_after_sync: bool,
+    initial_status: Result<String, String>,
+    btn_lost_hover_after_sync: bool,
     lock: Arc<Mutex<()>>,
     usage_msg_gained_hover: Option<Instant>,
     expanded_usage_msg_rect: egui::Rect,
@@ -30,7 +30,7 @@ impl SyncPanel {
 }
 
 impl super::AccountScreen {
-    pub fn show_sync_panel(&mut self, ui: &mut egui::Ui) {
+    pub fn show_usage_panel(&mut self, ui: &mut egui::Ui) {
         if self.settings.read().unwrap().sidebar_usage {
             match &self.usage {
                 Ok(usage) => {
@@ -48,7 +48,6 @@ impl super::AccountScreen {
                         } else {
                             format!("{} out of {} used", usage.used, usage.available)
                         };
-                        // )
 
                         let text: egui::WidgetText = text.into();
                         let text = text.color(ui.visuals().text_color().gamma_multiply(0.8));

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -12,7 +12,6 @@ use super::AccountUpdate;
 pub struct SyncPanel {
     pub initial_status: Result<String, String>,
     pub btn_lost_hover_after_sync: bool,
-    last_sync: Instant,
     lock: Arc<Mutex<()>>,
     usage_msg_gained_hover: Option<Instant>,
     expanded_usage_msg_rect: egui::Rect,
@@ -24,7 +23,6 @@ impl SyncPanel {
             initial_status,
             lock: Arc::new(Mutex::new(())),
             usage_msg_gained_hover: None,
-            last_sync: Instant::now(),
             expanded_usage_msg_rect: egui::Rect::NOTHING,
             btn_lost_hover_after_sync: false,
         }

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -1,20 +1,28 @@
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::{Instant, SystemTime};
 
 use eframe::egui;
-use workspace_rs::theme::icons::Icon;
-use workspace_rs::widgets::{Button, ProgressBar};
+use lb::Duration;
+use workspace_rs::widgets::ProgressBar;
 
 use super::AccountUpdate;
 
 pub struct SyncPanel {
     status: Result<String, String>,
     lock: Arc<Mutex<()>>,
+    usage_msg_gained_hover: Option<Instant>,
+    expanded_usage_msg_rect: egui::Rect,
 }
 
 impl SyncPanel {
     pub fn new(status: Result<String, String>) -> Self {
-        Self { status, lock: Arc::new(Mutex::new(())) }
+        Self {
+            status,
+            lock: Arc::new(Mutex::new(())),
+            usage_msg_gained_hover: None,
+            expanded_usage_msg_rect: egui::Rect::NOTHING,
+        }
     }
 }
 
@@ -23,36 +31,59 @@ impl super::AccountScreen {
         if self.settings.read().unwrap().sidebar_usage {
             match &self.usage {
                 Ok(usage) => {
-                    egui::Frame::none().inner_margin(0.0).show(ui, |ui| {
-                        // ui.horizontal(|ui| {
-                        //     ui.columns(2, |uis| {
-                        //         uis[0].horizontal(|ui| {
-                        //             ui.add_space(2.0);
-                        //             ui.label(egui::RichText::new(&usage.used).size(15.));
-                        //         });
+                    egui::Frame::none().show(ui, |ui| {
+                        let is_throttled_hover =
+                            if let Some(hover_origin) = self.sync.usage_msg_gained_hover {
+                                let throttle_duration = Duration::milliseconds(100);
+                                (Instant::now() - hover_origin) > throttle_duration
+                            } else {
+                                false
+                            };
 
-                        //         uis[1].with_layout(
-                        //             egui::Layout::right_to_left(egui::Align::Min),
-                        //             |ui| {
-                        //                 ui.add_space(5.0);
-                        //                 ui.label(
-                        //                     egui::RichText::new(&usage.available)
-                        //                         .strong()
-                        //                         .size(15.),
-                        //                 );
-                        //             },
-                        //         );
-                        //     });
-                        // });
+                        let text = if is_throttled_hover {
+                            format!("{:.1}% used", usage.percent * 100.)
+                        } else {
+                            format!("{} out of {} used", usage.used, usage.available)
+                        };
+                        // )
 
-                        ui.label(
-                            egui::RichText::new(format!(
-                                "{} out of {} used",
-                                usage.used, usage.available,
-                            ))
-                            .color(egui::Color32::GRAY)
-                            .size(15.0),
+                        let text: egui::WidgetText = text.into();
+                        let text = text.color(ui.visuals().text_color().gamma_multiply(0.8));
+                        let galley = text.into_galley(
+                            ui,
+                            Some(false),
+                            ui.available_width(),
+                            egui::TextStyle::Small,
                         );
+
+                        let desired_size = egui::vec2(galley.size().x, galley.size().y);
+                        let (rect, resp) = ui.allocate_at_least(desired_size, egui::Sense::click());
+
+                        if self.sync.usage_msg_gained_hover.is_none()
+                            && !self.sync.expanded_usage_msg_rect.eq(&rect)
+                        {
+                            self.sync.expanded_usage_msg_rect = rect;
+                        }
+
+                        galley.paint_with_visuals(
+                            ui.painter(),
+                            rect.left_top(),
+                            ui.style().interact(&resp),
+                        );
+
+                        if self
+                            .sync
+                            .expanded_usage_msg_rect
+                            .expand(5.0)
+                            .contains(ui.input(|i| i.pointer.hover_pos().unwrap_or_default()))
+                        {
+                            if self.sync.usage_msg_gained_hover.is_none() {
+                                self.sync.usage_msg_gained_hover = Some(Instant::now());
+                            }
+                        } else {
+                            self.sync.usage_msg_gained_hover = None;
+                        }
+
                         ui.add_space(8.0);
 
                         ProgressBar::new().percent(usage.percent).show(ui);
@@ -77,22 +108,20 @@ impl super::AccountScreen {
             |ui| {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     // todo: make sure this shows for at least 1 second even if sync finishes before that
-                    if self.workspace.pers_status.syncing {
-                        ui.spinner();
-                    }
-                    match &self.sync.status {
-                        Ok(s) => ui.label(
-                            egui::RichText::new(format!("Updated {s}"))
-                                .color(ui.visuals().widgets.active.bg_fill)
-                                .size(15.0),
-                        ),
-                        Err(msg) => ui.label(egui::RichText::new(msg).color(egui::Color32::RED)),
-                    };
+                    // if self.workspace.pers_status.syncing {
+                    //     ui.spinner();
+                    // }
+                    // match &self.sync.status {
+                    //     Ok(s) => ui.label(
+                    //         egui::RichText::new(format!("Updated {s}"))
+                    //             .color(ui.visuals().widgets.active.bg_fill)
+                    //             .size(15.0),
+                    //     ),
+                    //     Err(msg) => ui.label(egui::RichText::new(msg).color(egui::Color32::RED)),
+                    // };
                 });
             },
         );
-
-        ui.add_space(20.0);
     }
 
     pub fn set_sync_status<T: ToString>(&mut self, res: Result<String, T>) {

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use eframe::egui;
+use workspace_rs::theme::icons::Icon;
 use workspace_rs::widgets::{Button, ProgressBar};
 
 use super::AccountUpdate;
@@ -19,29 +20,39 @@ impl SyncPanel {
 
 impl super::AccountScreen {
     pub fn show_sync_panel(&mut self, ui: &mut egui::Ui) {
-        ui.add_space(20.0);
-
         if self.settings.read().unwrap().sidebar_usage {
             match &self.usage {
                 Ok(usage) => {
-                    egui::Frame::none().inner_margin(6.0).show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.columns(2, |uis| {
-                                uis[0].horizontal(|ui| {
-                                    ui.add_space(2.0);
-                                    ui.label(&usage.used);
-                                });
+                    egui::Frame::none().inner_margin(0.0).show(ui, |ui| {
+                        // ui.horizontal(|ui| {
+                        //     ui.columns(2, |uis| {
+                        //         uis[0].horizontal(|ui| {
+                        //             ui.add_space(2.0);
+                        //             ui.label(egui::RichText::new(&usage.used).size(15.));
+                        //         });
 
-                                uis[1].with_layout(
-                                    egui::Layout::right_to_left(egui::Align::Min),
-                                    |ui| {
-                                        ui.add_space(5.0);
-                                        ui.label(&usage.available);
-                                    },
-                                );
-                            });
-                        });
+                        //         uis[1].with_layout(
+                        //             egui::Layout::right_to_left(egui::Align::Min),
+                        //             |ui| {
+                        //                 ui.add_space(5.0);
+                        //                 ui.label(
+                        //                     egui::RichText::new(&usage.available)
+                        //                         .strong()
+                        //                         .size(15.),
+                        //                 );
+                        //             },
+                        //         );
+                        //     });
+                        // });
 
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "{} out of {} used",
+                                usage.used, usage.available,
+                            ))
+                            .color(egui::Color32::GRAY)
+                            .size(15.0),
+                        );
                         ui.add_space(8.0);
 
                         ProgressBar::new().percent(usage.percent).show(ui);
@@ -64,36 +75,16 @@ impl super::AccountScreen {
             desired_size,
             egui::Layout::left_to_right(egui::Align::Center),
             |ui| {
-                ui.add_space(5.0);
-
-                ui.visuals_mut().widgets.inactive.fg_stroke =
-                    egui::Stroke { color: ui.visuals().hyperlink_color, ..Default::default() };
-
-                ui.visuals_mut().widgets.hovered.fg_stroke =
-                    egui::Stroke { color: ui.visuals().hyperlink_color, ..Default::default() };
-
-                ui.visuals_mut().widgets.active.fg_stroke =
-                    egui::Stroke { color: ui.visuals().hyperlink_color, ..Default::default() };
-
-                if !self.workspace.pers_status.syncing
-                    && Button::default()
-                        .text("Sync")
-                        .padding((6.0, 6.0))
-                        .show(ui)
-                        .clicked()
-                {
-                    self.workspace.perform_sync();
-                }
-
-                if self.workspace.pers_status.syncing {
-                    ui.spinner();
-                }
-
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    ui.add_space(10.0);
+                    // todo: make sure this shows for at least 1 second even if sync finishes before that
+                    if self.workspace.pers_status.syncing {
+                        ui.spinner();
+                    }
                     match &self.sync.status {
                         Ok(s) => ui.label(
-                            egui::RichText::new(format!("Updated {s}")).color(egui::Color32::GRAY),
+                            egui::RichText::new(format!("Updated {s}"))
+                                .color(ui.visuals().widgets.active.bg_fill)
+                                .size(15.0),
                         ),
                         Err(msg) => ui.label(egui::RichText::new(msg).color(egui::Color32::RED)),
                     };

--- a/libs/content/workspace/src/tab/pdf_viewer.rs
+++ b/libs/content/workspace/src/tab/pdf_viewer.rs
@@ -239,7 +239,7 @@ impl PdfViewer {
 
         if let Some(sidebar) = &mut self.sidebar {
             ui.allocate_ui_at_rect(end_of_line_rect, |ui| {
-                let icon = if sidebar_is_visible { Icon::SHOW_SIDEBAR } else { Icon::HIDE_SIDEBAR };
+                let icon = Icon::TOGGLE_SIDEBAR;
                 if Button::default().icon(&icon).show(ui).clicked() {
                     sidebar.is_visible = !sidebar.is_visible;
                 }

--- a/libs/content/workspace/src/theme/icons.rs
+++ b/libs/content/workspace/src/theme/icons.rs
@@ -37,7 +37,7 @@ impl Icon {
     pub const HISTORY: Self = ic("\u{e889}"); // History
     pub const HIGHLIGHT_OFF: Self = ic("\u{e888}"); // Highlight Off
     pub const HEADER_1: Self = ic("\u{e262}"); // Header 11
-    pub const TOGGLE_SIDEBAR: Self = ic("\u{f7e4}"); 
+    pub const TOGGLE_SIDEBAR: Self = ic("\u{f7e4}");
     pub const HAND: Self = ic("\u{eb03}"); // Selection tool
     pub const IMAGE: Self = ic("\u{e3f4}"); // Image
     pub const INFO: Self = ic("\u{e88e}");
@@ -123,8 +123,7 @@ impl Icon {
             let visuals = ui.style().interact(&resp);
             let wrap_width = ui.available_width();
 
-            let icon_pos =
-                egui::pos2(rect.min.x + padding.x, rect.center().y - self.size / 4.1 - 1.0);
+            let icon_pos = egui::pos2(rect.min.x + padding.x, rect.center().y - self.size / 2.0);
 
             let icon: egui::WidgetText = self.into();
             let icon = icon.into_galley(ui, Some(false), wrap_width, egui::TextStyle::Body);

--- a/libs/content/workspace/src/theme/icons.rs
+++ b/libs/content/workspace/src/theme/icons.rs
@@ -37,9 +37,8 @@ impl Icon {
     pub const HISTORY: Self = ic("\u{e889}"); // History
     pub const HIGHLIGHT_OFF: Self = ic("\u{e888}"); // Highlight Off
     pub const HEADER_1: Self = ic("\u{e262}"); // Header 11
-    pub const HIDE_SIDEBAR: Self = ic("\u{e317}"); // Keyboard tab
+    pub const TOGGLE_SIDEBAR: Self = ic("\u{f7e4}"); 
     pub const HAND: Self = ic("\u{eb03}"); // Selection tool
-    pub const SHOW_SIDEBAR: Self = ic("\u{e31c}");
     pub const IMAGE: Self = ic("\u{e3f4}"); // Image
     pub const INFO: Self = ic("\u{e88e}");
     pub const ITALIC: Self = ic("\u{e23f}");

--- a/libs/content/workspace/src/theme/visuals.rs
+++ b/libs/content/workspace/src/theme/visuals.rs
@@ -15,6 +15,10 @@ pub fn init(ctx: &egui::Context, dark_mode: bool) {
         .insert(egui::TextStyle::Body, egui::FontId::new(17.0, egui::FontFamily::Proportional));
     style
         .text_styles
+        .insert(egui::TextStyle::Small, egui::FontId::new(15.0, egui::FontFamily::Proportional));
+
+    style
+        .text_styles
         .insert(egui::TextStyle::Monospace, egui::FontId::new(17.0, egui::FontFamily::Monospace));
     style
         .text_styles

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -87,7 +87,6 @@ impl<'a> Button<'a> {
             let icon_visuals = icon_visuals.interact(&resp);
 
             let bg_fill = if resp.hovered() {
-                ui.output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
                 text_visuals.bg_fill
             } else {
                 self.default_fill.unwrap_or(text_visuals.bg_fill)

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -151,28 +151,11 @@ impl<'a> Button<'a> {
 
         resp
     }
+
+    //  copied from the egui spinner impl.  
     fn show_spinner(ui: &mut egui::Ui, spinner_pos: egui::Pos2) {
         let color = ui.visuals().strong_text_color();
 
-        // ui.ctx().request_repaint();
-
-        // let radius = (containing_rect.height() / 2.0) - 2.0;
-        // let n_points = 20;
-        // let time = ui.input(|i| i.time);
-        // let start_angle = time * std::f64::consts::TAU;
-        // let end_angle = start_angle + 240f64.to_radians() * time.sin();
-        // let points: Vec<egui::Pos2> = (0..n_points)
-        //     .map(|i| {
-        //         let angle = egui::lerp(start_angle..=end_angle, i as f64 / n_points as f64);
-        //         let (sin, cos) = angle.sin_cos();
-        //         containing_rect.center() + radius * egui::vec2(cos as f32, sin as f32)
-        //     })
-        //     .collect();
-        // painter.add(egui::Shape::line(points, egui::Stroke::new(3.0, color)));
-
-        // let (rect, response) = ui.all(egui::vec2(size, size), egui::Sense::hover());
-
-        // if ui.is_rect_visible(rect) {
         ui.ctx().request_repaint();
 
         let n_points = 20;
@@ -188,8 +171,5 @@ impl<'a> Button<'a> {
             .collect();
         ui.painter()
             .add(egui::Shape::line(points, egui::Stroke::new(3.0, color)));
-        // }
-
-        // response
     }
 }

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -152,7 +152,7 @@ impl<'a> Button<'a> {
         resp
     }
 
-    //  copied from the egui spinner impl.  
+    //  copied from the egui spinner impl.
     fn show_spinner(ui: &mut egui::Ui, spinner_pos: egui::Pos2) {
         let color = ui.visuals().strong_text_color();
 

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -6,6 +6,7 @@ pub struct Button<'a> {
     text: Option<&'a str>,
     text_style: Option<egui::TextStyle>,
     icon_style: Option<egui::Style>,
+    icon_alignment: Option<egui::Align>,
     padding: Option<egui::Vec2>,
     rounding: egui::Rounding,
     stroke: egui::Stroke,
@@ -17,6 +18,13 @@ pub struct Button<'a> {
 impl<'a> Button<'a> {
     pub fn icon(self, icon: &'a Icon) -> Self {
         Self { icon: Some(icon), ..self }
+    }
+    pub fn icon_alignment(self, align: egui::Align) -> Self {
+        let alignment = match align {
+            egui::Align::Center | egui::Align::Min => egui::Align::LEFT,
+            egui::Align::Max => egui::Align::RIGHT,
+        };
+        Self { icon_alignment: Some(alignment), ..self }
     }
 
     pub fn text(self, text: &'a str) -> Self {
@@ -53,7 +61,7 @@ impl<'a> Button<'a> {
             let galley = icon.into_galley(ui, Some(false), wrap_width, icon_text_style);
             width += galley.size().x;
             if self.text.is_some() {
-                width += padding.x;
+                width += padding.x / 2.;
             }
             galley
         });
@@ -96,11 +104,18 @@ impl<'a> Button<'a> {
                 egui::pos2(rect.min.x + padding.x, rect.center().y - 0.5 * text_height);
 
             if let Some(icon) = maybe_icon_galley {
-                let icon_pos =
-                    egui::pos2(rect.min.x + padding.x, rect.center().y - icon.size().y / 4.1 - 1.0);
-                text_pos.x += icon.size().x + padding.x;
-
+                let alignment = self.icon_alignment.unwrap_or(egui::Align::LEFT);
                 let icon_width = icon.size().x;
+
+                let icon_x_pos = match alignment {
+                    egui::Align::LEFT => {
+                        text_pos.x += icon_width + padding.x / 2.0;
+                        rect.min.x + padding.x
+                    }
+                    egui::Align::Center | egui::Align::RIGHT => rect.max.x - padding.x - icon_width,
+                };
+
+                let icon_pos = egui::pos2(icon_x_pos, rect.center().y - icon.size().y / 3.);
 
                 icon.paint_with_visuals(ui.painter(), icon_pos, icon_visuals);
 

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -114,7 +114,7 @@ impl<'a> Button<'a> {
                     rect.center().y,
                 );
 
-                Self::show_spinner(ui, rect, spinner_pos);
+                Self::show_spinner(ui, spinner_pos);
             } else if let Some(icon) = maybe_icon_galley {
                 let alignment = self.icon_alignment.unwrap_or(egui::Align::LEFT);
                 let icon_width = icon.size().x;
@@ -151,7 +151,7 @@ impl<'a> Button<'a> {
 
         resp
     }
-    fn show_spinner(ui: &mut egui::Ui, containing_rect: egui::Rect, spinner_pos: egui::Pos2) {
+    fn show_spinner(ui: &mut egui::Ui, spinner_pos: egui::Pos2) {
         let color = ui.visuals().strong_text_color();
 
         // ui.ctx().request_repaint();

--- a/libs/content/workspace/src/widgets/progress_bar.rs
+++ b/libs/content/workspace/src/widgets/progress_bar.rs
@@ -11,7 +11,7 @@ impl Default for ProgressBar {
 
 impl ProgressBar {
     pub fn new() -> Self {
-        Self { height: 5.0, percent: 0.0 }
+        Self { height: 10.0, percent: 0.0 }
     }
 
     pub fn percent(self, percent: f32) -> Self {

--- a/libs/content/workspace/src/widgets/progress_bar.rs
+++ b/libs/content/workspace/src/widgets/progress_bar.rs
@@ -11,7 +11,7 @@ impl Default for ProgressBar {
 
 impl ProgressBar {
     pub fn new() -> Self {
-        Self { height: 10.0, percent: 0.0 }
+        Self { height: 8.0, percent: 0.0 }
     }
 
     pub fn percent(self, percent: f32) -> Self {

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -219,7 +219,7 @@ impl Workspace {
             let rect = egui::Rect { min, max };
             ui.allocate_ui_at_rect(rect, |ui| {
                 let zen_mode_btn = Button::default()
-                    .icon(&Icon::SHOW_SIDEBAR)
+                    .icon(&Icon::TOGGLE_SIDEBAR)
                     .frame(true)
                     .show(ui);
                 if zen_mode_btn.clicked() {

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -665,7 +665,6 @@ impl Workspace {
                 }
                 WsMsg::SyncMsg(prog) => self.sync_message(prog),
                 WsMsg::FileRenamed { id, new_name } => {
-                    println! {"8"};
                     out.file_renamed = Some((id, new_name.clone()));
                     if let Some(tab) = self.get_mut_tab_by_id(id) {
                         tab.name = new_name.clone();


### PR DESCRIPTION
fixes #2464 


other changes in this PR:
- avoids polluting std out by removing  a `println!("8")` statement in workspace that happened after each file rename.  
- displays storage percentage in a smart way
- fix this bug noted in qa: offline mode doesn't work on egui because the error text does not wrap


---
related issues to sync on egui that this pr can impact:
- #2244


# Demo 
## Sync error 
![image](https://github.com/lockbook/lockbook/assets/66345861/e83e409c-ce0c-4181-aa96-302e1596b4db)

## Dirty state

![image](https://github.com/lockbook/lockbook/assets/66345861/b4c4d56c-efa2-41ee-aa90-ca844519140c)

## Normal 
![image](https://github.com/lockbook/lockbook/assets/66345861/285a828b-dfca-487e-a552-72628c32c45d)

