### PR TITLE
windows: only reconfigure surface when resized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "lb-pdf"
 version = "0.2.3"
-source = "git+https://github.com/lockbook/lb-pdf#445ada45289c612b06e2eade6bc125b1c10a1f6d"
+source = "git+https://github.com/lockbook/lb-pdf#bca6b7fbd1b6ed369b32a910c411bb9aaf76a0e1"
 dependencies = [
  "link-cplusplus",
  "pdfium-render",

--- a/clients/egui/src/lib.rs
+++ b/clients/egui/src/lib.rs
@@ -147,6 +147,10 @@ pub struct WgpuLockbook {
     pub surface: wgpu::Surface,
     pub adapter: wgpu::Adapter,
 
+    // remember size last frame to detect resize
+    pub surface_width: u32,
+    pub surface_height: u32,
+
     pub rpass: egui_wgpu_backend::RenderPass,
     pub screen: egui_wgpu_backend::ScreenDescriptor,
 
@@ -248,18 +252,23 @@ impl WgpuLockbook {
         self.surface.get_capabilities(&self.adapter).formats[0]
     }
 
-    pub fn configure_surface(&self) {
-        let surface_config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: self.surface_format(),
-            width: self.screen.physical_width,
-            height: self.screen.physical_height,
-            present_mode: wgpu::PresentMode::Fifo,
-            alpha_mode: CompositeAlphaMode::Auto,
-            view_formats: vec![],
-        };
-        if surface_config.width * surface_config.height != 0 {
+    pub fn configure_surface(&mut self) {
+        let resized = self.screen.physical_width != self.surface_width
+            || self.screen.physical_height != self.surface_height;
+        let visible = self.screen.physical_width * self.screen.physical_height != 0;
+        if resized && visible {
+            let surface_config = wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: self.surface_format(),
+                width: self.screen.physical_width,
+                height: self.screen.physical_height,
+                present_mode: wgpu::PresentMode::Fifo,
+                alpha_mode: CompositeAlphaMode::Auto,
+                view_formats: vec![],
+            };
             self.surface.configure(&self.device, &surface_config);
+            self.surface_width = self.screen.physical_width;
+            self.surface_height = self.screen.physical_height;
         }
     }
 }

--- a/clients/linux/src/window.rs
+++ b/clients/linux/src/window.rs
@@ -343,6 +343,8 @@ pub fn init<W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRaw
         context,
         raw_input: Default::default(),
         app,
+        surface_width: 0,
+        surface_height: 0,
     };
 
     obj.frame();

--- a/clients/windows/src/window.rs
+++ b/clients/windows/src/window.rs
@@ -421,6 +421,8 @@ pub fn init<W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRaw
         context,
         raw_input: Default::default(),
         app,
+        surface_width: 0,
+        surface_height: 0,
     };
 
     obj.frame();

--- a/libs/content/workspace-ffi/src/android/android_ffi.rs
+++ b/libs/content/workspace-ffi/src/android/android_ffi.rs
@@ -70,6 +70,8 @@ pub extern "system" fn Java_app_lockbook_egui_1editor_EGUIEditor_createWgpuCanva
         from_egui: None,
         from_host: None,
         workspace: editor,
+        surface_width: 0,
+        surface_height: 0,
     };
 
     obj.frame();

--- a/libs/content/workspace-ffi/src/apple/common_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/common_ffi.rs
@@ -60,6 +60,8 @@ pub unsafe extern "C" fn init_ws(
         context,
         raw_input: Default::default(),
         workspace,
+        surface_width: 0,
+        surface_height: 0,
     };
 
     obj.frame();


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2482

me:
> I took some measurements and wgpu::SurfaceTexture.present() is taking >30ms per frame. Is that normal? Can you suggest troubleshooting next steps?

chatgpt:
> Experiment with disabling VSync or using adaptive sync techniques if your application's performance profile allows for it.

me:
> I disabled vsync by passing wgpu::PresentMode::Immediate. Now my timing statements indicate that configuring the surface is taking ~30ms

chatgpt:
> To optimize and avoid unnecessary reconfigurations (and thus minimize delays), you should track the current configuration of the surface and only reconfigure when there's an actual change in the parameters (e.g., width, height, or present_mode). As there's no direct wgpu API call to retrieve the current configuration of a surface, you'll need to manually track these parameters within your application's state