### PR TITLE
apple: fix double tap to switch to previous tool on canvas 

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/ios_ffi.rs
@@ -801,7 +801,7 @@ pub unsafe extern "C" fn toggle_drawing_tool(obj: *mut c_void) {
 
     if let Some(svg) = obj.workspace.current_tab_svg_mut() {
         svg.toolbar
-            .set_tool(svg.toolbar.prev_non_eraser_tool.unwrap_or(Tool::Pen));
+            .set_tool(svg.toolbar.previous_tool.unwrap_or(Tool::Pen));
     }
 }
 

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -17,7 +17,7 @@ pub struct Toolbar {
     pub eraser: Eraser,
     pub selection: Selection,
 
-    pub prev_non_eraser_tool: Option<Tool>,
+    pub previous_tool: Option<Tool>,
 }
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
@@ -64,11 +64,10 @@ impl SizableComponent for Component {
 
 macro_rules! set_tool {
     ($obj:expr, $new_tool:expr) => {
-        if $obj.active_tool != Tool::Eraser {
-            $obj.prev_non_eraser_tool = Some($obj.active_tool);
+        if $obj.active_tool != $new_tool {
+            $obj.previous_tool = Some($obj.active_tool);
+            $obj.active_tool = $new_tool;
         }
-
-        $obj.active_tool = $new_tool;
     };
 }
 
@@ -97,7 +96,7 @@ impl Toolbar {
 
     pub fn toggle_tool_between_eraser(&mut self) {
         let new_tool = if self.active_tool == Tool::Eraser {
-            self.prev_non_eraser_tool.unwrap_or(Tool::Pen)
+            self.previous_tool.unwrap_or(Tool::Pen)
         } else {
             Tool::Eraser
         };
@@ -149,7 +148,7 @@ impl Toolbar {
         Toolbar {
             components,
             active_tool: Tool::Pen,
-            prev_non_eraser_tool: None,
+            previous_tool: None,
             pen: Pen::new(max_id),
             eraser: Eraser::new(),
             selection: Selection::new(),


### PR DESCRIPTION
fixes #2432 