### PR TITLE
windows: drawing refinements

### DIFF
--- a/clients/egui/src/lib.rs
+++ b/clients/egui/src/lib.rs
@@ -156,6 +156,7 @@ pub struct WgpuLockbook {
 
     pub context: egui::Context,
     pub raw_input: egui::RawInput,
+    pub queued_events: Vec<egui::Event>,
 
     pub app: Lockbook,
 }
@@ -229,6 +230,9 @@ impl WgpuLockbook {
         self.rpass
             .remove_textures(tdelta)
             .expect("remove texture ok");
+
+        // Queue up the events for the next frame
+        self.raw_input.events.extend(self.queued_events.drain(..));
 
         out.redraw_in = full_output.repaint_after.as_millis() as u64;
         out.egui = full_output.platform_output;

--- a/clients/egui/src/lib.rs
+++ b/clients/egui/src/lib.rs
@@ -156,7 +156,10 @@ pub struct WgpuLockbook {
 
     pub context: egui::Context,
     pub raw_input: egui::RawInput,
+
+    // events for the subsequent two frames, because canvas expects buttons to be down for two frames
     pub queued_events: Vec<egui::Event>,
+    pub double_queued_events: Vec<egui::Event>,
 
     pub app: Lockbook,
 }
@@ -233,6 +236,11 @@ impl WgpuLockbook {
 
         // Queue up the events for the next frame
         self.raw_input.events.extend(self.queued_events.drain(..));
+        self.queued_events
+            .extend(self.double_queued_events.drain(..));
+        if !self.raw_input.events.is_empty() {
+            self.context.request_repaint();
+        }
 
         out.redraw_in = full_output.repaint_after.as_millis() as u64;
         out.egui = full_output.platform_output;

--- a/clients/egui/src/lib.rs
+++ b/clients/egui/src/lib.rs
@@ -235,9 +235,8 @@ impl WgpuLockbook {
             .expect("remove texture ok");
 
         // Queue up the events for the next frame
-        self.raw_input.events.extend(self.queued_events.drain(..));
-        self.queued_events
-            .extend(self.double_queued_events.drain(..));
+        self.raw_input.events.append(&mut self.queued_events);
+        self.queued_events.append(&mut self.double_queued_events);
         if !self.raw_input.events.is_empty() {
             self.context.request_repaint();
         }

--- a/clients/linux/src/window.rs
+++ b/clients/linux/src/window.rs
@@ -368,6 +368,7 @@ pub fn init<W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRaw
         context,
         raw_input: Default::default(),
         queued_events: Default::default(),
+        double_queued_events: Default::default(),
         app,
         surface_width: 0,
         surface_height: 0,

--- a/clients/linux/src/window.rs
+++ b/clients/linux/src/window.rs
@@ -367,6 +367,7 @@ pub fn init<W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRaw
         screen,
         context,
         raw_input: Default::default(),
+        queued_events: Default::default(),
         app,
         surface_width: 0,
         surface_height: 0,

--- a/clients/windows/src/input/message.rs
+++ b/clients/windows/src/input/message.rs
@@ -34,6 +34,7 @@ pub enum Message<'a> {
 pub enum MessageNoDeps<'a> {
     Create { create_struct: &'a CREATESTRUCTA },
     Destroy,
+    Quit,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -300,7 +301,7 @@ impl<'a> Message<'a> {
             WM_QUERYOPEN => Message::Unhandled { const_name: "WM_QUERYOPEN" },
             WM_QUERYUISTATE => Message::Unhandled { const_name: "WM_QUERYUISTATE" },
             WM_QUEUESYNC => Message::Unhandled { const_name: "WM_QUEUESYNC" },
-            WM_QUIT => Message::Unhandled { const_name: "WM_QUIT" },
+            WM_QUIT => Message::NoDeps(MessageNoDeps::Quit),
             WM_RBUTTONDBLCLK => Message::Unhandled { const_name: "WM_RBUTTONDBLCLK" },
             WM_RBUTTONDOWN => Message::AppDep(MessageAppDep::RButtonDown { pos: lparam.into() }),
             WM_RBUTTONUP => Message::AppDep(MessageAppDep::RButtonUp { pos: lparam.into() }),

--- a/clients/windows/src/input/mouse.rs
+++ b/clients/windows/src/input/mouse.rs
@@ -24,27 +24,12 @@ pub fn handle(
             message,
             MessageAppDep::LButtonDown { .. } | MessageAppDep::RButtonDown { .. }
         );
-        pointer_button_event(pos, button, pressed, modifiers, app);
+        app.raw_input
+            .events
+            .push(egui::Event::PointerButton { pos, button, pressed, modifiers });
     }
 
     true
-}
-
-pub fn pointer_button_event(
-    pos: egui::Pos2, button: egui::PointerButton, pressed: bool, modifiers: egui::Modifiers,
-    app: &mut WgpuLockbook,
-) {
-    app.raw_input
-        .events
-        .push(egui::Event::PointerButton { pos, button, pressed, modifiers });
-}
-
-pub fn queue_pointer_button_event(
-    pos: egui::Pos2, button: egui::PointerButton, pressed: bool, modifiers: egui::Modifiers,
-    app: &mut WgpuLockbook,
-) {
-    app.queued_events
-        .push(egui::Event::PointerButton { pos, button, pressed, modifiers });
 }
 
 pub fn handle_wheel(app: &mut WgpuLockbook, message: MessageAppDep, delta: i16) -> bool {

--- a/clients/windows/src/input/mouse.rs
+++ b/clients/windows/src/input/mouse.rs
@@ -39,6 +39,14 @@ pub fn pointer_button_event(
         .push(egui::Event::PointerButton { pos, button, pressed, modifiers });
 }
 
+pub fn queue_pointer_button_event(
+    pos: egui::Pos2, button: egui::PointerButton, pressed: bool, modifiers: egui::Modifiers,
+    app: &mut WgpuLockbook,
+) {
+    app.queued_events
+        .push(egui::Event::PointerButton { pos, button, pressed, modifiers });
+}
+
 pub fn handle_wheel(app: &mut WgpuLockbook, message: MessageAppDep, delta: i16) -> bool {
     if matches!(message, MessageAppDep::MouseWheel { .. }) {
         let y = delta as f32 / WHEEL_DELTA as f32;

--- a/clients/windows/src/window.rs
+++ b/clients/windows/src/window.rs
@@ -330,15 +330,6 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
                             // https://stackoverflow.com/questions/5841299/difference-between-getdc-and-beginpaint
                             unsafe { BeginPaint(hwnd, std::ptr::null_mut()) };
 
-                            println!(
-                                "> PAINT {:?}",
-                                app.raw_input
-                                    .events
-                                    .iter()
-                                    .filter(|&e| matches!(e, &egui::Event::PointerButton { .. }))
-                                    .collect::<Vec<_>>()
-                            );
-
                             let IntegrationOutput {
                                 redraw_in: _, // todo: handle? how's this different from checking egui context?
                                 egui: PlatformOutput { cursor_icon, open_url, copied_text, .. },
@@ -436,6 +427,7 @@ pub fn init<W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRaw
         context,
         raw_input: Default::default(),
         queued_events: Default::default(),
+        double_queued_events: Default::default(),
         app,
         surface_width: 0,
         surface_height: 0,

--- a/clients/windows/src/window.rs
+++ b/clients/windows/src/window.rs
@@ -14,16 +14,13 @@ use raw_window_handle::{
     HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle, Win32WindowHandle,
     WindowsDisplayHandle,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 use windows::{
     core::*, Win32::Foundation::*, Win32::Graphics::Direct3D12::*, Win32::Graphics::Dxgi::*,
     Win32::Graphics::Gdi::*, Win32::System::LibraryLoader::*, Win32::System::Ole::*,
     Win32::UI::HiDpi::*, Win32::UI::Input::KeyboardAndMouse::*, Win32::UI::WindowsAndMessaging::*,
 };
-
-// todo: improve
-// instead of redrawing at a particulr time in the future, we redraw it constantly until that time
-static mut REDRAW_UNTIL: Option<Instant> = None;
 
 pub struct WindowHandle {
     handle: Win32WindowHandle,
@@ -144,10 +141,17 @@ pub fn main() -> Result<()> {
     unsafe { dxgi_factory.MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER) }?;
 
     let app = init(&WindowHandle::new(hwnd), false);
+
+    let got_events_atomic = std::sync::Arc::new(AtomicBool::new(false));
+    let got_events_clone = got_events_atomic.clone();
     app.context.set_request_repaint_callback(move |rri| {
-        unsafe { InvalidateRect(hwnd, None, false) };
-        unsafe { REDRAW_UNTIL = Some(Instant::now() + rri.after) };
+        let got_events_clone = got_events_clone.clone();
+        let _ = std::thread::spawn(move || {
+            std::thread::sleep(rri.after);
+            got_events_clone.store(true, Ordering::SeqCst);
+        });
     });
+
     window.maybe_app = Some(app);
     window.dpi_scale = dpi_to_scale_factor(unsafe { GetDpiForWindow(hwnd) } as _);
 
@@ -164,27 +168,41 @@ pub fn main() -> Result<()> {
         unsafe { RegisterDragDrop(hwnd, &file_drop_handler) }?;
         file_drop_handler
     };
-
-    // "If the window was previously visible, the return value is nonzero."
-    // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
     unsafe { ShowWindow(hwnd, SW_SHOW) };
 
-    let mut message = MSG::default();
-    // "If the function retrieves the WM_QUIT message, the return value is zero."
-    // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessagea
-    while unsafe { GetMessageA(&mut message, None, 0, 0) }.into() {
+    let mut messages = Vec::new();
+    let mut msg = MSG::default();
+    loop {
+        let mut got_events = got_events_atomic.load(Ordering::SeqCst);
         unsafe {
-            // "If the message is translated [...], the return value is nonzero."
-            // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-translatemessage
-            TranslateMessage(&message);
+            while PeekMessageA(&mut msg, HWND(0), 0, 0, PM_REMOVE).into() {
+                if msg.message == WM_QUIT {
+                    return Ok(());
+                }
 
-            // "...the return value generally is ignored."
-            // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-dispatchmessage
-            DispatchMessageA(&message);
+                messages.push(msg);
+
+                if msg.message == WM_PAINT {
+                    break;
+                }
+
+                got_events = true;
+            }
+
+            for msg in messages.drain(..) {
+                TranslateMessage(&msg);
+                DispatchMessageA(&msg);
+            }
+
+            if got_events {
+                got_events_atomic.store(false, Ordering::SeqCst);
+                InvalidateRect(hwnd, None, false);
+            }
+
+            // wait a lil before possibly rendering another frame
+            std::thread::sleep(std::time::Duration::from_millis(1));
         }
     }
-
-    Ok(())
 }
 
 // callback invoked when Windows sends a message to the window
@@ -237,6 +255,9 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
                 MessageNoDeps::Destroy => {
                     unsafe { PostQuitMessage(0) };
                 }
+                MessageNoDeps::Quit => {
+                    unsafe { DestroyWindow(hwnd).expect("destroy window") };
+                }
             }
             true
         }
@@ -278,7 +299,6 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
 
                     match message {
                         MessageAppDep::KeyDown { key } | MessageAppDep::KeyUp { key } => {
-                            unsafe { InvalidateRect(hwnd, None, false) };
                             input::key::handle(app, message, key, modifiers)
                         }
                         MessageAppDep::LButtonDown { pos }
@@ -286,24 +306,19 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
                         | MessageAppDep::RButtonDown { pos }
                         | MessageAppDep::RButtonUp { pos }
                         | MessageAppDep::MouseMove { pos } => {
-                            unsafe { InvalidateRect(hwnd, None, false) };
                             input::mouse::handle(app, message, pos, modifiers, window.dpi_scale)
                         }
                         MessageAppDep::PointerDown { pointer_id }
                         | MessageAppDep::PointerUpdate { pointer_id }
-                        | MessageAppDep::PointerUp { pointer_id } => {
-                            unsafe { InvalidateRect(hwnd, None, false) };
-                            window.pointer_manager.handle(
-                                app,
-                                hwnd,
-                                modifiers,
-                                window.dpi_scale,
-                                pointer_id,
-                            )
-                        }
+                        | MessageAppDep::PointerUp { pointer_id } => window.pointer_manager.handle(
+                            app,
+                            hwnd,
+                            modifiers,
+                            window.dpi_scale,
+                            pointer_id,
+                        ),
                         MessageAppDep::MouseWheel { delta }
                         | MessageAppDep::MouseHWheel { delta } => {
-                            unsafe { InvalidateRect(hwnd, None, false) };
                             input::mouse::handle_wheel(app, message, delta)
                         }
                         MessageAppDep::SetCursor => output::cursor::handle(),
@@ -315,11 +330,20 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
                             // https://stackoverflow.com/questions/5841299/difference-between-getdc-and-beginpaint
                             unsafe { BeginPaint(hwnd, std::ptr::null_mut()) };
 
+                            println!(
+                                "> PAINT {:?}",
+                                app.raw_input
+                                    .events
+                                    .iter()
+                                    .filter(|&e| matches!(e, &egui::Event::PointerButton { .. }))
+                                    .collect::<Vec<_>>()
+                            );
+
                             let IntegrationOutput {
                                 redraw_in: _, // todo: handle? how's this different from checking egui context?
                                 egui: PlatformOutput { cursor_icon, open_url, copied_text, .. },
                                 update_output: UpdateOutput { close, set_window_title },
-                            } = app.frame();
+                            } = window.maybe_app.as_mut().unwrap().frame();
 
                             output::clipboard_copy::handle(copied_text);
                             output::close::handle(close);
@@ -328,15 +352,6 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
                             output::open_url::handle(open_url);
 
                             unsafe { EndPaint(hwnd, std::ptr::null_mut()) };
-
-                            if let Some(redraw_until) = unsafe { REDRAW_UNTIL } {
-                                if redraw_until < Instant::now() {
-                                    unsafe { REDRAW_UNTIL = None };
-                                } else {
-                                    // if a redraw is pending, invalidate the window so that we get another paint message
-                                    unsafe { InvalidateRect(hwnd, None, false) };
-                                }
-                            }
 
                             true
                         }
@@ -359,7 +374,6 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
                         input::file_drop::Message::DragOver { .. } => true,
                         input::file_drop::Message::DragLeave => true,
                         input::file_drop::Message::Drop { object, .. } => {
-                            unsafe { InvalidateRect(hwnd, None, false) };
                             input::file_drop::handle(app, object)
                         }
                     }
@@ -421,6 +435,7 @@ pub fn init<W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRaw
         screen,
         context,
         raw_input: Default::default(),
+        queued_events: Default::default(),
         app,
         surface_width: 0,
         surface_height: 0,


### PR DESCRIPTION
* rework event loop to match linux (decreases CPU from ~5% to ~1% with no visible degradation)
* adds event queues for the next two frames (supports quick, one-frame pen contacts)
* fix all sorts of egregious errors in pointer logic (e.g. pointer releases without corresponding presses)
* _disable long press right-clicks because they are causing infuriating pen input delay_