### PR TITLE
canvas: pan and zoom on ios 

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
@@ -566,6 +566,8 @@ public class iOSMTKDrawingWrapper: UIView, UIPencilInteractionDelegate {
                         
         pencilInteraction.delegate = self
         addInteraction(pencilInteraction)
+        
+        self.isMultipleTouchEnabled = true
     }
     
     public func pencilInteractionDidTap(_ interaction: UIPencilInteraction) {

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
@@ -796,39 +796,50 @@ public class iOSMTK: MTKView, MTKViewDelegate {
     }
     
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        let point = Unmanaged.passUnretained(touches.first!).toOpaque()
-        let value = UInt64(UInt(bitPattern: point))
-        let location = touches.first!.location(in: self)
+        for touch in touches {
+            let point = Unmanaged.passUnretained(touch).toOpaque()
+            let value = UInt64(UInt(bitPattern: point))
+            let location = touch.location(in: self)
+            
+            touches_began(wsHandle, value, Float(location.x), Float(location.y), Float(touch.force))
+        }
         
-        touches_began(wsHandle, value, Float(location.x), Float(location.y), Float(touches.first?.force ?? 0))
         self.setNeedsDisplay(self.frame)
     }
     
     public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        let point = Unmanaged.passUnretained(touches.first!).toOpaque()
-        let value = UInt64(UInt(bitPattern: point))
-        let location = touches.first!.location(in: self)
+        for touch in touches {
+            let point = Unmanaged.passUnretained(touch).toOpaque()
+            let value = UInt64(UInt(bitPattern: point))
+            let location = touch.location(in: self)
+
+            touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(touch.force))
+        }
         
-        touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(touches.first?.force ?? 0))
         self.setNeedsDisplay(self.frame)
     }
     
     public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        let point = Unmanaged.passUnretained(touches.first!).toOpaque()
-        let value = UInt64(UInt(bitPattern: point))
-        let location = touches.first!.location(in: self)
+        for touch in touches {
+            let point = Unmanaged.passUnretained(touch).toOpaque()
+            let value = UInt64(UInt(bitPattern: point))
+            let location = touch.location(in: self)
+            
+            touches_ended(wsHandle, value, Float(location.x), Float(location.y), Float(touch.force))
+        }
         
-        touches_ended(wsHandle, value, Float(location.x), Float(location.y), Float(touches.first?.force ?? 0))
         self.setNeedsDisplay(self.frame)
     }
 
     public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
-        let point = Unmanaged.passUnretained(touches.first!).toOpaque()
-        let value = UInt64(UInt(bitPattern: point))
-        let location = touches.first!.location(in: self)
+        for touch in touches {
+            let point = Unmanaged.passUnretained(touch).toOpaque()
+            let value = UInt64(UInt(bitPattern: point))
+            let location = touch.location(in: self)
+            
+            touches_cancelled(wsHandle, value, Float(location.x), Float(location.y), Float(touch.force))
+        }
         
-        touches_cancelled(wsHandle, value, Float(location.x), Float(location.y), Float(touches.first?.force ?? 0))
-    
         self.setNeedsDisplay(self.frame)
     }
     

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -70,7 +70,6 @@ impl SVGEditor {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
-        println!("{:#?}", ui.input(|r| r.multi_touch()));
         ui.vertical(|ui| {
             egui::Frame::default()
                 .fill(if ui.visuals().dark_mode {
@@ -79,12 +78,18 @@ impl SVGEditor {
                     ui.visuals().faint_bg_color
                 })
                 .show(ui, |ui| {
-                    self.toolbar.show(ui, &mut self.buffer);
+                    self.toolbar.show(ui, &mut self.buffer, self.inner_rect);
                 });
 
             self.inner_rect = ui.available_rect_before_wrap();
             self.render_svg(ui);
         });
+
+        handle_zoom_input(ui, self.inner_rect, &mut self.buffer);
+
+        if ui.input(|r| r.multi_touch().is_some()) {
+            return;
+        }
 
         match self.toolbar.active_tool {
             Tool::Pen => {
@@ -106,7 +111,6 @@ impl SVGEditor {
             }
         }
 
-        handle_zoom_input(ui, self.inner_rect, &mut self.buffer);
         handle_clip_input(ui, &mut self.buffer);
 
         Self::define_dynamic_colors(

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -93,10 +93,9 @@ impl SVGEditor {
 
         match self.toolbar.active_tool {
             Tool::Pen => {
-                self.toolbar.pen.setup_events(ui, self.inner_rect);
-                while let Ok(event) = self.toolbar.pen.rx.try_recv() {
-                    self.toolbar.pen.handle_events(event, &mut self.buffer);
-                }
+                self.toolbar
+                    .pen
+                    .handle_input(ui, self.inner_rect, &mut self.buffer);
             }
             Tool::Eraser => {
                 self.toolbar.eraser.setup_events(ui, self.inner_rect);

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -70,6 +70,7 @@ impl SVGEditor {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
+        println!("{:#?}", ui.input(|r| r.multi_touch()));
         ui.vertical(|ui| {
             egui::Frame::default()
                 .fill(if ui.visuals().dark_mode {

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -1,5 +1,5 @@
 use minidom::Element;
-use std::{collections::VecDeque, sync::mpsc};
+use std::collections::VecDeque;
 
 use super::{
     toolbar::ColorSwatch,
@@ -12,27 +12,26 @@ pub struct Pen {
     pub active_stroke_width: u32,
     path_builder: CubicBezBuilder,
     current_id: usize,
-    pub rx: mpsc::Receiver<PathEvent>,
-    pub tx: mpsc::Sender<PathEvent>,
 }
 
 impl Pen {
     pub fn new(max_id: usize) -> Self {
         let default_stroke_width = 3;
-        let (tx, rx) = mpsc::channel();
 
         Pen {
             active_color: None,
             active_stroke_width: default_stroke_width,
             current_id: max_id,
-            rx,
-            tx,
             path_builder: CubicBezBuilder::new(),
         }
     }
 
-    // todo: come up with a better name
-    pub fn handle_events(&mut self, event: PathEvent, buffer: &mut Buffer) {
+    pub fn handle_input(&mut self, ui: &mut egui::Ui, inner_rect: egui::Rect, buffer: &mut Buffer) {
+        let event = match self.setup_events(ui, inner_rect) {
+            Some(e) => e,
+            None => return,
+        };
+
         match event {
             PathEvent::Draw(mut pos, id) => {
                 apply_transform_to_pos(&mut pos, buffer);
@@ -60,9 +59,14 @@ impl Pen {
                     buffer.current.append_child(child);
                 }
             }
-            PathEvent::End(mut pos, id) => {
-                apply_transform_to_pos(&mut pos, buffer);
-
+            PathEvent::End(pos, id) => {
+                let pos = match pos {
+                    Some(mut p) => {
+                        apply_transform_to_pos(&mut p, buffer);
+                        Some(p)
+                    }
+                    None => None,
+                };
                 self.path_builder.finish(pos);
 
                 if self.path_builder.points.len() < 2 {
@@ -86,10 +90,10 @@ impl Pen {
         }
     }
 
-    pub fn setup_events(&mut self, ui: &mut egui::Ui, inner_rect: egui::Rect) {
+    pub fn setup_events(&mut self, ui: &mut egui::Ui, inner_rect: egui::Rect) -> Option<PathEvent> {
         if let Some(cursor_pos) = ui.ctx().pointer_hover_pos() {
             if !ui.is_enabled() {
-                return;
+                return None;
             };
 
             if inner_rect.contains(cursor_pos) {
@@ -104,29 +108,29 @@ impl Pen {
                 ui.input(|i| i.pointer.primary_down()) && inner_rect.contains(cursor_pos);
 
             if pointer_gone_out_of_canvas || pointer_released_in_canvas {
-                self.tx
-                    .send(PathEvent::End(cursor_pos, self.current_id))
-                    .unwrap();
-
+                let curr_id = self.current_id;
                 self.current_id += 1;
+
+                Some(PathEvent::End(Some(cursor_pos), curr_id))
             } else if pointer_pressed_in_canvas {
-                self.tx
-                    .send(PathEvent::Draw(cursor_pos, self.current_id))
-                    .unwrap();
+                Some(PathEvent::Draw(cursor_pos, self.current_id))
+            } else {
+                None
             }
         } else if !self.path_builder.points.is_empty() {
-            self.tx
-                .send(PathEvent::End(*self.path_builder.points.last().unwrap(), self.current_id))
-                .unwrap();
-
+            let curr_id = self.current_id;
             self.current_id += 1;
+
+            Some(PathEvent::End(None, curr_id))
+        } else {
+            None
         }
     }
 }
 
 pub enum PathEvent {
     Draw(egui::Pos2, usize),
-    End(egui::Pos2, usize),
+    End(Option<egui::Pos2>, usize),
 }
 
 /// Build a cubic bézier path with Catmull-Rom smoothing and Ramer–Douglas–Peucker compression
@@ -199,10 +203,12 @@ impl CubicBezBuilder {
         self.catmull_to(dest, false);
     }
 
-    pub fn finish(&mut self, pos: egui::Pos2) {
-        self.points.push(pos);
-        self.catmull_to(pos, false); // todo: get rid of the double call if possible
-        self.catmull_to(pos, true);
+    pub fn finish(&mut self, pos: Option<egui::Pos2>) {
+        if let Some(pos) = pos {
+            self.points.push(pos);
+            self.catmull_to(pos, false); // todo: get rid of the double call if possible
+            self.catmull_to(pos, true);
+        }
 
         self.simplify(2.);
 

--- a/libs/content/workspace/src/tab/svg_editor/selection.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection.rs
@@ -50,7 +50,7 @@ impl Selection {
                 if ui.is_enabled() {
                     cp
                 } else {
-                    return;
+                    egui::Pos2::ZERO
                 }
             }
             None => egui::Pos2::ZERO,

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -1,5 +1,7 @@
 use std::f32::consts::PI;
 
+use egui::ScrollArea;
+
 use crate::{theme::icons::Icon, widgets::Button};
 
 use super::{selection::Selection, Buffer, Eraser, Pen};
@@ -156,8 +158,8 @@ impl Toolbar {
         }
     }
 
-    pub fn show(&mut self, ui: &mut egui::Ui, buffer: &mut Buffer) {
-        let rect = self.calculate_rect(ui);
+    pub fn show(&mut self, ui: &mut egui::Ui, buffer: &mut Buffer, available_rect: egui::Rect) {
+        let toolbar_rect = self.calculate_rect(ui);
         if ui.is_enabled() {
             self.components
                 .iter()
@@ -193,162 +195,15 @@ impl Toolbar {
                 });
         }
 
-        ui.allocate_ui_at_rect(rect, |ui| {
-            ui.horizontal(|ui| {
-                for c in self.components.iter() {
-                    match c {
-                        Component::Button(btn) => {
-                            egui::Frame::default()
-                                .inner_margin(btn.margin)
-                                .show(ui, |ui| {
-                                    let enabled = match btn.id.as_str() {
-                                        "Undo" => buffer.has_undo(),
-                                        "Redo" => buffer.has_redo(),
-                                        _ => true,
-                                    };
-
-                                    let btn_res = ui
-                                        .add_enabled_ui(enabled, |ui| {
-                                            Button::default().icon(&btn.icon).show(ui)
-                                        })
-                                        .inner;
-
-                                    if btn_res.clicked() {
-                                        match btn.id.as_str() {
-                                            "Pen" => {
-                                                set_tool!(self, Tool::Pen);
-                                            }
-                                            "Eraser" => {
-                                                set_tool!(self, Tool::Eraser);
-                                            }
-                                            "Selection" => {
-                                                set_tool!(self, Tool::Selection);
-                                            }
-                                            "Undo" => buffer.undo(),
-                                            "Redo" => buffer.redo(),
-                                            _ => {}
-                                        }
-                                    }
-                                    let is_active = match self.active_tool {
-                                        Tool::Pen => btn.id.eq("Pen"),
-                                        Tool::Eraser => btn.id.eq("Eraser"),
-                                        Tool::Selection => btn.id.eq("Selection"),
-                                    };
-                                    if is_active {
-                                        ui.painter().rect_filled(
-                                            btn_res.rect.expand2(egui::vec2(2.0, 2.0)),
-                                            egui::Rounding::same(8.0),
-                                            egui::Color32::GRAY.gamma_multiply(0.1),
-                                        )
-                                    }
-                                    if let Some(shortcut) = &btn.key_shortcut {
-                                        let mut is_mac = false;
-                                        if cfg!(target_os = "macos") {
-                                            is_mac = true;
-                                        }
-
-                                        if shortcut.0.is_none() {
-                                            btn_res.on_hover_text(format!(
-                                                "{} ({})",
-                                                btn.id,
-                                                shortcut.1.name()
-                                            ));
-                                        } else {
-                                            let modifier = egui::ModifierNames::NAMES
-                                                .format(&shortcut.0, is_mac);
-                                            btn_res.on_hover_text(format!(
-                                                "{} ({} + {})",
-                                                btn.id,
-                                                modifier,
-                                                shortcut.1.name()
-                                            ));
-                                        }
-                                    }
-                                });
-                        }
-                        Component::Separator(margin) => {
-                            ui.add_space(margin.right);
-                            ui.add(egui::Separator::default().shrink(ui.available_height() * 0.3));
-                            ui.add_space(margin.left);
-                        }
-                        Component::ColorSwatch(btn) => {
-                            let (response, painter) = ui.allocate_painter(
-                                egui::vec2(COLOR_SWATCH_BTN_RADIUS * PI, ui.available_height()),
-                                egui::Sense::click(),
-                            );
-                            if response.clicked() {
-                                self.pen.active_color =
-                                    Some(ColorSwatch { id: btn.id.clone(), color: btn.color });
-                            }
-                            if let Some(active_color) = &self.pen.active_color {
-                                let opacity = if active_color.id.eq(&btn.id) {
-                                    1.0
-                                } else if response.hovered() {
-                                    ui.output_mut(|w| {
-                                        w.cursor_icon = egui::CursorIcon::PointingHand
-                                    });
-                                    0.9
-                                } else {
-                                    0.5
-                                };
-
-                                if active_color.id.eq(&btn.id) {
-                                    painter.rect_filled(
-                                        response.rect.shrink2(egui::vec2(0.0, 5.0)),
-                                        egui::Rounding::same(8.0),
-                                        btn.color.gamma_multiply(0.2),
-                                    )
-                                }
-                                painter.circle_filled(
-                                    response.rect.center(),
-                                    COLOR_SWATCH_BTN_RADIUS,
-                                    btn.color.gamma_multiply(opacity),
-                                );
-                            }
-                        }
-                        Component::StrokeWidth(thickness) => {
-                            ui.add_space(THICKNESS_BTN_X_MARGIN);
-                            let (response, painter) = ui.allocate_painter(
-                                egui::vec2(THICKNESS_BTN_WIDTH, ui.available_height()),
-                                egui::Sense::click(),
-                            );
-
-                            let rect = egui::Rect {
-                                min: egui::Pos2 {
-                                    x: response.rect.left(),
-                                    y: response.rect.center().y - (*thickness as f32 / 3.0),
-                                },
-                                max: egui::Pos2 {
-                                    x: response.rect.right(),
-                                    y: response.rect.center().y + (*thickness as f32 / 3.0),
-                                },
-                            };
-
-                            if thickness.eq(&self.pen.active_stroke_width) {
-                                painter.rect_filled(
-                                    response.rect.shrink2(egui::vec2(0.0, 5.0)),
-                                    egui::Rounding::same(8.0),
-                                    egui::Color32::GRAY.gamma_multiply(0.1),
-                                )
-                            }
-                            if response.clicked() {
-                                self.pen.active_stroke_width = *thickness;
-                            }
-                            if response.hovered() {
-                                ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
-                            }
-
-                            painter.rect_filled(
-                                rect,
-                                egui::Rounding::same(2.0),
-                                ui.visuals().text_color().gamma_multiply(0.8),
-                            );
-                            ui.add_space(THICKNESS_BTN_X_MARGIN);
-                        }
-                    };
-                }
-            })
-        });
+        if available_rect.width() < toolbar_rect.width() {
+            ScrollArea::horizontal().show(ui, |ui| {
+                self.show_toolbar(ui, buffer);
+            });
+        } else {
+            ui.allocate_ui_at_rect(toolbar_rect, |ui| {
+                self.show_toolbar(ui, buffer);
+            });
+        }
 
         ui.visuals_mut().widgets.noninteractive.bg_stroke.color = ui
             .visuals()
@@ -358,5 +213,160 @@ impl Toolbar {
             .color
             .gamma_multiply(0.4);
         ui.separator();
+    }
+
+    fn show_toolbar(&mut self, ui: &mut egui::Ui, buffer: &mut Buffer) {
+        ui.horizontal(|ui| {
+            for c in self.components.iter() {
+                match c {
+                    Component::Button(btn) => {
+                        egui::Frame::default()
+                            .inner_margin(btn.margin)
+                            .show(ui, |ui| {
+                                let enabled = match btn.id.as_str() {
+                                    "Undo" => buffer.has_undo(),
+                                    "Redo" => buffer.has_redo(),
+                                    _ => true,
+                                };
+
+                                let btn_res = ui
+                                    .add_enabled_ui(enabled, |ui| {
+                                        Button::default().icon(&btn.icon).show(ui)
+                                    })
+                                    .inner;
+
+                                if btn_res.clicked() {
+                                    match btn.id.as_str() {
+                                        "Pen" => {
+                                            set_tool!(self, Tool::Pen);
+                                        }
+                                        "Eraser" => {
+                                            set_tool!(self, Tool::Eraser);
+                                        }
+                                        "Selection" => {
+                                            set_tool!(self, Tool::Selection);
+                                        }
+                                        "Undo" => buffer.undo(),
+                                        "Redo" => buffer.redo(),
+                                        _ => {}
+                                    }
+                                }
+                                let is_active = match self.active_tool {
+                                    Tool::Pen => btn.id.eq("Pen"),
+                                    Tool::Eraser => btn.id.eq("Eraser"),
+                                    Tool::Selection => btn.id.eq("Selection"),
+                                };
+                                if is_active {
+                                    ui.painter().rect_filled(
+                                        btn_res.rect.expand2(egui::vec2(2.0, 2.0)),
+                                        egui::Rounding::same(8.0),
+                                        egui::Color32::GRAY.gamma_multiply(0.1),
+                                    )
+                                }
+                                if let Some(shortcut) = &btn.key_shortcut {
+                                    let mut is_mac = false;
+                                    if cfg!(target_os = "macos") {
+                                        is_mac = true;
+                                    }
+
+                                    if shortcut.0.is_none() {
+                                        btn_res.on_hover_text(format!(
+                                            "{} ({})",
+                                            btn.id,
+                                            shortcut.1.name()
+                                        ));
+                                    } else {
+                                        let modifier =
+                                            egui::ModifierNames::NAMES.format(&shortcut.0, is_mac);
+                                        btn_res.on_hover_text(format!(
+                                            "{} ({} + {})",
+                                            btn.id,
+                                            modifier,
+                                            shortcut.1.name()
+                                        ));
+                                    }
+                                }
+                            });
+                    }
+                    Component::Separator(margin) => {
+                        ui.add_space(margin.right);
+                        ui.add(egui::Separator::default().shrink(ui.available_height() * 0.3));
+                        ui.add_space(margin.left);
+                    }
+                    Component::ColorSwatch(btn) => {
+                        let (response, painter) = ui.allocate_painter(
+                            egui::vec2(COLOR_SWATCH_BTN_RADIUS * PI, ui.available_height()),
+                            egui::Sense::click(),
+                        );
+                        if response.clicked() {
+                            self.pen.active_color =
+                                Some(ColorSwatch { id: btn.id.clone(), color: btn.color });
+                        }
+                        if let Some(active_color) = &self.pen.active_color {
+                            let opacity = if active_color.id.eq(&btn.id) {
+                                1.0
+                            } else if response.hovered() {
+                                ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
+                                0.9
+                            } else {
+                                0.5
+                            };
+
+                            if active_color.id.eq(&btn.id) {
+                                painter.rect_filled(
+                                    response.rect.shrink2(egui::vec2(0.0, 5.0)),
+                                    egui::Rounding::same(8.0),
+                                    btn.color.gamma_multiply(0.2),
+                                )
+                            }
+                            painter.circle_filled(
+                                response.rect.center(),
+                                COLOR_SWATCH_BTN_RADIUS,
+                                btn.color.gamma_multiply(opacity),
+                            );
+                        }
+                    }
+                    Component::StrokeWidth(thickness) => {
+                        ui.add_space(THICKNESS_BTN_X_MARGIN);
+                        let (response, painter) = ui.allocate_painter(
+                            egui::vec2(THICKNESS_BTN_WIDTH, ui.available_height()),
+                            egui::Sense::click(),
+                        );
+
+                        let rect = egui::Rect {
+                            min: egui::Pos2 {
+                                x: response.rect.left(),
+                                y: response.rect.center().y - (*thickness as f32 / 3.0),
+                            },
+                            max: egui::Pos2 {
+                                x: response.rect.right(),
+                                y: response.rect.center().y + (*thickness as f32 / 3.0),
+                            },
+                        };
+
+                        if thickness.eq(&self.pen.active_stroke_width) {
+                            painter.rect_filled(
+                                response.rect.shrink2(egui::vec2(0.0, 5.0)),
+                                egui::Rounding::same(8.0),
+                                egui::Color32::GRAY.gamma_multiply(0.1),
+                            )
+                        }
+                        if response.clicked() {
+                            self.pen.active_stroke_width = *thickness;
+                        }
+                        if response.hovered() {
+                            ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
+                        }
+
+                        painter.rect_filled(
+                            rect,
+                            egui::Rounding::same(2.0),
+                            ui.visuals().text_color().gamma_multiply(0.8),
+                        );
+                        ui.add_space(THICKNESS_BTN_X_MARGIN);
+                    }
+                };
+            }
+        });
     }
 }

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -14,36 +14,49 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
             if ui.is_enabled() && working_rect.contains(cp) {
                 cp
             } else {
-                return;
+                egui::Pos2::ZERO
             }
         }
         None => egui::Pos2::ZERO,
     };
 
-    let dx = ui.input(|r| r.scroll_delta.x) as f64;
-    let dy = ui.input(|r| r.scroll_delta.y) as f64;
-    let zoom_delta = ui.input(|r| r.zoom_delta());
+    println!("{:#?}", pos);
 
-    let is_panning = dx.abs() > 0.0 || dy.abs() > 0.0;
+    let zoom_delta = ui.input(|r| r.zoom_delta());
     let is_zooming = zoom_delta != 0.0;
 
-    if is_panning || is_zooming {
+    let pan = ui.input(|r| {
+        if r.scroll_delta.x.abs() > 0.0 || r.scroll_delta.y.abs() > 0.0 {
+            Some(r.scroll_delta)
+        } else if let Some(touch_gesture) = r.multi_touch() {
+            if touch_gesture.translation_delta.x.abs() > 0.0
+                || touch_gesture.translation_delta.y.abs() > 0.0
+            {
+                Some(touch_gesture.translation_delta)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    });
+
+    if pan.is_some() || is_zooming {
         let mut original_matrix =
             deserialize_transform(buffer.current.attr("transform").unwrap_or_default());
 
-        let new_transform = if is_panning {
-            original_matrix[4] += dx;
-            original_matrix[5] += dy;
-            serialize_transform(&original_matrix)
-        } else {
-            let mut original_matrix: Vec<f64> = original_matrix
-                .iter()
-                .map(|x| zoom_delta as f64 * x)
-                .collect();
-            original_matrix[4] += ((1.0 - zoom_delta) * pos.x) as f64;
-            original_matrix[5] += ((1.0 - zoom_delta) * pos.y) as f64;
-            serialize_transform(original_matrix.as_slice())
-        };
+        // apply pan
+        original_matrix[4] += pan.unwrap_or_default().x as f64;
+        original_matrix[5] += pan.unwrap_or_default().y as f64;
+
+        // apply zoom/scale
+        let mut scaled_matrix: Vec<f64> = original_matrix
+            .iter()
+            .map(|x| zoom_delta as f64 * x)
+            .collect();
+        scaled_matrix[4] += ((1.0 - zoom_delta) * pos.x) as f64;
+        scaled_matrix[5] += ((1.0 - zoom_delta) * pos.y) as f64;
+        let new_transform = serialize_transform(scaled_matrix.as_slice());
 
         buffer.current.set_attr("transform", new_transform);
         buffer.needs_path_map_update = true;

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -20,8 +20,6 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
         None => egui::Pos2::ZERO,
     };
 
-    println!("{:#?}", pos);
-
     let zoom_delta = ui.input(|r| r.zoom_delta());
     let is_zooming = zoom_delta != 0.0;
 


### PR DESCRIPTION
fixes: #2478, #2530

other issues relating to drawing for ios (by order of importance):
- [x] RELEASE BLOCKER: pen can get into a bad state that's hard to get out of
- [ ] sometimes multi touch is still interpreted as a pointer press.   
- [ ] the render looks a bit pixelated
- [ ] you can't delete an element after selection 
- [ ] you can't draw on the left edge of the screen because it's registered as back to file tree swipe 
- [ ] selection seems to be in un-precise, as if bounding box have huge padding  

# Demo
![image](https://github.com/lockbook/lockbook/assets/66345861/642ccac5-b5ca-422d-bd1c-7c4f8ca4672c)

