### PR TITLE
canvas: fix empty selection on tool switch

### DIFF
--- a/libs/content/workspace/src/tab/svg_editor/selection.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection.rs
@@ -398,18 +398,13 @@ impl SelectionRect {
         )
     }
 }
-
+#[derive(Default)]
 enum SelectionOperation {
     Drag,
     HorizontalScale,
     VerticalScale,
+    #[default]
     Idle,
-}
-
-impl Default for SelectionOperation {
-    fn default() -> Self {
-        SelectionOperation::Idle
-    }
 }
 
 struct SelectionResponse {

--- a/libs/content/workspace/src/tab/svg_editor/selection.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection.rs
@@ -11,6 +11,7 @@ use super::{
 // todo: consider making this value dynamic depending on the scale of the element
 const SCALE_BRUSH_SIZE: f64 = 10.0;
 
+#[derive(Default)]
 pub struct Selection {
     last_pos: Option<egui::Pos2>,
     selected_elements: Vec<SelectedElement>,
@@ -25,23 +26,7 @@ struct SelectedElement {
     original_matrix: (String, [f64; 6]),
 }
 
-impl Default for Selection {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Selection {
-    pub fn new() -> Self {
-        Selection {
-            last_pos: None,
-            selected_elements: vec![],
-            laso_original_pos: None,
-            laso_rect: None,
-            current_op: SelectionOperation::Idle,
-        }
-    }
-
     pub fn handle_input(
         &mut self, ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &mut Buffer,
     ) {
@@ -419,6 +404,12 @@ enum SelectionOperation {
     HorizontalScale,
     VerticalScale,
     Idle,
+}
+
+impl Default for SelectionOperation {
+    fn default() -> Self {
+        SelectionOperation::Idle
+    }
 }
 
 struct SelectionResponse {

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -67,6 +67,9 @@ impl SizableComponent for Component {
 macro_rules! set_tool {
     ($obj:expr, $new_tool:expr) => {
         if $obj.active_tool != $new_tool {
+            if (matches!($new_tool, Tool::Selection)) {
+                $obj.selection = Selection::default();
+            }
             $obj.previous_tool = Some($obj.active_tool);
             $obj.active_tool = $new_tool;
         }
@@ -153,7 +156,7 @@ impl Toolbar {
             previous_tool: None,
             pen: Pen::new(max_id),
             eraser: Eraser::new(),
-            selection: Selection::new(),
+            selection: Selection::default(),
         }
     }
 


### PR DESCRIPTION
fixes #2488