### PR TITLE
workspace: can't edit documents with a scrollable tab strip

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -196,7 +196,7 @@ impl Editor {
 
                 Frame::default()
                     .fill(fill)
-                    .inner_margin(egui::Margin::symmetric(7.0, 15.0))
+                    .inner_margin(egui::Margin::symmetric(0.0, 15.0))
                     .show(ui, |ui| {
                         ui.vertical_centered(|ui| self.ui(ui, self.id, touch_mode, &events))
                     })
@@ -231,6 +231,8 @@ impl Editor {
         let max_width = 800.0;
         if ui.max_rect().width() > max_width {
             ui.set_max_width(max_width);
+        } else {
+            ui.set_max_width(ui.max_rect().width() - 15.);
         }
 
         // process events

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -9,17 +9,6 @@ use super::{
 pub const G_CONTAINER_ID: &str = "lb:zoom_container";
 
 pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &mut Buffer) {
-    let pos = match ui.ctx().pointer_hover_pos() {
-        Some(cp) => {
-            if ui.is_enabled() && working_rect.contains(cp) {
-                cp
-            } else {
-                egui::Pos2::ZERO
-            }
-        }
-        None => egui::Pos2::ZERO,
-    };
-
     let zoom_delta = ui.input(|r| r.zoom_delta());
     let is_zooming = zoom_delta != 0.0;
 
@@ -38,6 +27,17 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
             None
         }
     });
+
+    let pos = match ui.ctx().pointer_hover_pos() {
+        Some(cp) => {
+            if ui.is_enabled() && working_rect.contains(cp) {
+                cp
+            } else {
+                return; // todo: check this doesn't break zoom on touch devices
+            }
+        }
+        None => egui::Pos2::ZERO,
+    };
 
     if pan.is_some() || is_zooming {
         let mut original_matrix =

--- a/libs/content/workspace/src/widgets/toolbar.rs
+++ b/libs/content/workspace/src/widgets/toolbar.rs
@@ -73,6 +73,10 @@ impl ToolBar {
             let pointer = ui.ctx().pointer_hover_pos().unwrap_or_default();
             let toolbar_rect = self.calculate_rect(ui, editor);
 
+            if ui.available_rect_before_wrap().width() < toolbar_rect.width() {
+                return;
+            }
+
             if toolbar_rect.contains(pointer) {
                 if editor.has_focus {
                     editor.has_focus = false

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -370,71 +370,75 @@ impl Workspace {
     }
 
     fn show_tab_strip(&mut self, ui: &mut egui::Ui, output: &mut WsOutput) {
-        egui::ScrollArea::horizontal().show(ui, |ui| {
-            ui.horizontal(|ui| {
-                for (i, maybe_resp) in self
-                    .tabs
-                    .iter_mut()
-                    .enumerate()
-                    .map(|(i, t)| (tab_label(ui, t, self.active_tab == i)))
-                    .collect::<Vec<Option<TabLabelResponse>>>()
-                    .iter()
-                    .enumerate()
-                {
-                    if let Some(resp) = maybe_resp {
-                        match resp {
-                            TabLabelResponse::Clicked => {
-                                if self.active_tab == i {
-                                    // we should rename the file.
+        ui.horizontal(|ui| {
+            egui::ScrollArea::horizontal()
+                .max_width(ui.available_width())
+                .show(ui, |ui| {
+                    for (i, maybe_resp) in self
+                        .tabs
+                        .iter_mut()
+                        .enumerate()
+                        .map(|(i, t)| (tab_label(ui, t, self.active_tab == i)))
+                        .collect::<Vec<Option<TabLabelResponse>>>()
+                        .iter()
+                        .enumerate()
+                    {
+                        if let Some(resp) = maybe_resp {
+                            match resp {
+                                TabLabelResponse::Clicked => {
+                                    if self.active_tab == i {
+                                        // we should rename the file.
 
-                                    output.tab_title_clicked = true;
-                                    let active_name = self.tabs[i].name.clone();
+                                        output.tab_title_clicked = true;
+                                        let active_name = self.tabs[i].name.clone();
 
-                                    let mut rename_edit_state =
-                                        egui::text_edit::TextEditState::default();
-                                    rename_edit_state.set_ccursor_range(Some(
-                                        egui::text_edit::CCursorRange {
-                                            primary: egui::text::CCursor::new(
-                                                active_name.rfind('.').unwrap_or(active_name.len()),
-                                            ),
-                                            secondary: egui::text::CCursor::new(0),
-                                        },
-                                    ));
-                                    egui::TextEdit::store_state(
-                                        ui.ctx(),
-                                        egui::Id::new("rename_tab"),
-                                        rename_edit_state,
-                                    );
-                                    self.tabs[i].rename = Some(active_name);
-                                } else {
-                                    self.tabs[i].rename = None;
-                                    self.active_tab = i;
-                                    output.window_title = Some(self.tabs[i].name.clone());
-                                    output.selected_file = Some(self.tabs[i].id);
-                                }
-                            }
-                            TabLabelResponse::Closed => {
-                                self.close_tab(i);
-                                output.window_title = Some(match self.current_tab() {
-                                    Some(tab) => tab.name.clone(),
-                                    None => "Lockbook".to_owned(),
-                                });
-                            }
-                            TabLabelResponse::Renamed(name) => {
-                                self.tabs[i].rename = None;
-                                let id = self.current_tab().unwrap().id;
-                                if let Some(tab) = self.get_mut_tab_by_id(id) {
-                                    if let Some(TabContent::Markdown(md)) = &mut tab.content {
-                                        md.needs_name = false;
+                                        let mut rename_edit_state =
+                                            egui::text_edit::TextEditState::default();
+                                        rename_edit_state.set_ccursor_range(Some(
+                                            egui::text_edit::CCursorRange {
+                                                primary: egui::text::CCursor::new(
+                                                    active_name
+                                                        .rfind('.')
+                                                        .unwrap_or(active_name.len()),
+                                                ),
+                                                secondary: egui::text::CCursor::new(0),
+                                            },
+                                        ));
+                                        egui::TextEdit::store_state(
+                                            ui.ctx(),
+                                            egui::Id::new("rename_tab"),
+                                            rename_edit_state,
+                                        );
+                                        self.tabs[i].rename = Some(active_name);
+                                    } else {
+                                        self.tabs[i].rename = None;
+                                        self.active_tab = i;
+                                        output.window_title = Some(self.tabs[i].name.clone());
+                                        output.selected_file = Some(self.tabs[i].id);
                                     }
                                 }
-                                self.rename_file((id, name.clone()));
+                                TabLabelResponse::Closed => {
+                                    self.close_tab(i);
+                                    output.window_title = Some(match self.current_tab() {
+                                        Some(tab) => tab.name.clone(),
+                                        None => "Lockbook".to_owned(),
+                                    });
+                                }
+                                TabLabelResponse::Renamed(name) => {
+                                    self.tabs[i].rename = None;
+                                    let id = self.current_tab().unwrap().id;
+                                    if let Some(tab) = self.get_mut_tab_by_id(id) {
+                                        if let Some(TabContent::Markdown(md)) = &mut tab.content {
+                                            md.needs_name = false;
+                                        }
+                                    }
+                                    self.rename_file((id, name.clone()));
+                                }
                             }
+                            ui.ctx().request_repaint();
                         }
-                        ui.ctx().request_repaint();
                     }
-                }
-            });
+                });
         });
     }
 


### PR DESCRIPTION
fixes #2572, #2497

small writeup on how i addressed this issue. it's fixed for now, but there's underlying focus issue that we need to deal with in the near future. 

**so what's the problem?** 
when the tab strip is scrollable, it gets focus away from the editor which mans that if you want to click on the editor you'll end up scrolling on the scrollbar instead. This focus behavior only happens in the editor and not on canvas. 

**how is this problem fixed?**
surprisingly if you nest the scrollarea inside of a horizontal layout `ui.horizonal()`, all the focus problems go away!!! my hypothesis is that if two scrollareas are sibling they might fight for focus but if you nest one the un-nested scrollarea will have higher priority and get the focus. 