### PR TITLE
Windows rescue

### DIFF
--- a/clients/windows/src/input/mod.rs
+++ b/clients/windows/src/input/mod.rs
@@ -5,5 +5,4 @@ pub mod message;
 pub mod mouse;
 pub mod pointer;
 
-pub use message::Message;
 pub use message::Point;

--- a/libs/lb-fs/src/mount.rs
+++ b/libs/lb-fs/src/mount.rs
@@ -71,5 +71,6 @@ pub async fn umount() {
 
 #[cfg(target_os = "windows")]
 pub async fn umount() {
+    info!("todo");
     todo!()
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.77.0"

--- a/utils/releaser/src/windows/desktop.rs
+++ b/utils/releaser/src/windows/desktop.rs
@@ -29,7 +29,7 @@ fn build_x86() -> CliResult<()> {
 
     Command::new("cargo")
         .env("LB_TARGET", "x86_64-pc-windows-msvc")
-        .args(["build", "-p", "winstaller", "--release", "--target=x86_64-pc-windows-msvc"])
+        .args(["build", "-p", "winstaller", "--release", "--target=x86_64-pc-windows-msvc", "--feature", "releaser"])
         .assert_success();
 
     Ok(())

--- a/utils/releaser/src/windows/desktop.rs
+++ b/utils/releaser/src/windows/desktop.rs
@@ -29,7 +29,15 @@ fn build_x86() -> CliResult<()> {
 
     Command::new("cargo")
         .env("LB_TARGET", "x86_64-pc-windows-msvc")
-        .args(["build", "-p", "winstaller", "--release", "--target=x86_64-pc-windows-msvc", "--feature", "releaser"])
+        .args([
+            "build",
+            "-p",
+            "winstaller",
+            "--release",
+            "--target=x86_64-pc-windows-msvc",
+            "--feature",
+            "releaser",
+        ])
         .assert_success();
 
     Ok(())

--- a/utils/winstaller/Cargo.toml
+++ b/utils/winstaller/Cargo.toml
@@ -8,3 +8,6 @@ eframe = "0.22.0"
 egui_extras = { version = "0.22.0", features = ["image"] }
 image = { version = "0.24", features = ["png"] }
 mslnk = "0.1.8"
+
+[features]
+releaser = []

--- a/utils/winstaller/src/main.rs
+++ b/utils/winstaller/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "releaser"))]
 fn main() {
     use std::env;
     use std::fs;
@@ -163,5 +163,5 @@ fn main() {
     .unwrap()
 }
 
-#[cfg(not(windows))]
+#[cfg(any(not(windows), not(feature = "releaser")))]
 fn main() {}


### PR DESCRIPTION
Adding a feature flag for releaser to use to activate winstaller. Some uncertainties:

1. Does the name I chose for the feature flag make sense to you?
2. Is the windows flag now redundant in winstaller? I think not since the winstaller flag shouldn't ever be used if it's not on windows, but maybe it's worth keeping both?
3. How should I go about testing that the releaser isn't broken? Is that already integrated into ci?
