### PR TITLE
core: publish lb-rs to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-shared"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aead",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "lockbook-shared"
-version = "0.9.2"
+version = "0.9.1"
 dependencies = [
  "aead",
  "aes-gcm",

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -34,7 +34,7 @@ tracing-subscriber = "0.3.9"
 tracing-appender = "0.2"
 sublime_fuzzy = "0.7.0"
 crossbeam = "0.8.1"
-lockbook-shared = { path = "libs/shared" }
+lockbook-shared = { version = "0.9.1", path = "libs/shared" }
 qrcode-generator = "4.1.6"
 db-rs = "0.2.1"
 db-rs-derive = "0.2.1"

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -39,7 +39,7 @@ qrcode-generator = "4.1.6"
 db-rs = "0.2.1"
 db-rs-derive = "0.2.1"
 
-lockbook-server = { path = "../../../server/server", optional = true }
+lockbook-server = { version = "0.9.1", path = "../../../server/server", optional = true }
 tokio = { version = "1.5.0", optional = true }
 
 [dev-dependencies]

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -2,8 +2,11 @@
 name = "lb-rs"
 version = "0.9.1"
 edition = "2021"
-description = "The functional components of the iOS and Android lockbook clients."
+description = "The rust library for interacting with your lockbook."
+repository = "https://github.com/lockbook/lockbook"
+homepage = "https://lockbook.net"
 license = "BSD-3-Clause"
+keywords = ["notes", "encryption", "productivity", "automation", "security"]
 
 [lib]
 name = "lb_rs"

--- a/libs/lb/lb-rs/libs/shared/Cargo.toml
+++ b/libs/lb/lb-rs/libs/shared/Cargo.toml
@@ -3,7 +3,7 @@ name = "lockbook-shared"
 version = "0.9.1"
 edition = "2021"
 description = "the code shared between lb and our server"
-license = "UNLICENSE"
+license = "BSD-3-Clause"
 
 [dependencies]
 base64 = "0.13.0"

--- a/libs/lb/lb-rs/libs/shared/Cargo.toml
+++ b/libs/lb/lb-rs/libs/shared/Cargo.toml
@@ -2,6 +2,8 @@
 name = "lockbook-shared"
 version = "0.9.1"
 edition = "2021"
+description = "the code shared between lb and our server"
+license = "UNLICENSE"
 
 [dependencies]
 base64 = "0.13.0"

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -3,6 +3,8 @@ name = "lockbook-server"
 version = "0.9.1"
 edition = "2021"
 build = "build.rs"
+description = "Lockbook's server, exposed as a library for testing."
+license = "BSD-3-Clause"
 
 [features]
 default = ["no-network"]
@@ -22,7 +24,7 @@ base64 = "0.13.0"
 bincode = "1.2.1"
 time = "0.3.20"
 futures = "0.3.13"
-lockbook-shared = { path = "../../libs/lb/lb-rs/libs/shared" }
+lockbook-shared = { version = "0.9.1", path = "../../libs/lb/lb-rs/libs/shared" }
 pagerduty-rs = { version = "0.1.5", default-features = false, features = ["async", "rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"


### PR DESCRIPTION
To publish `lb-rs` on [crates.io](https://crates.io/crates/lb-rs), we can't have relative path dependencies. Initially I thought this would require a more substantial change but cargo has explicit support for [this situation](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations). Study the behavior of [resolver](https://doc.rust-lang.org/cargo/reference/resolver.html) to reason about how this is going to behave for us. But as far as I can tell here are the salient implications:

- locally it's going to use the relative path
- when we bump the version, if we just bump the patch, no further action is required
- if we bump the minor (or maj) version, cargo will fail to compile because the, so the person performing the bump will have to go through and fix those things.
- we should still be able to bump at the start of a release cycle, as local dependency resolution will work fine. If someone were to grab our lib via `git =`, this would potentially be a problem as they underlying version specified for `lockbook_shared` would not be published to crates.io.
- why don't we just roll `lockbook_shared` into `core` like I initially proposed? This would mean no relative imports, no resolver complexities, and no broken `git =` behaviors when we bump maj. In this universe server would depend on core, but core also depends on server (for fuzzer reasons). So `lockbook_shared` has a strong reason to exist -- breaks the cycle between core & server. We could potentially isolate fuzzer and allow someone to modify lb's networking implementation external to the crate to drive this behavior and then perform the same simplification. If we want to.

Potential outstanding items:
- [ ] document lib.rs fns a bit better prior to a reddit post
- [ ] add `cargo publish` to releaser 