### PR TITLE
egui: less frequent dirty state warnings

### DIFF
--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -153,9 +153,9 @@ impl super::AccountScreen {
             err_msg.to_owned()
         } else {
             let dirty_files_count = self.workspace.pers_status.dirtyness.dirty_files.len();
-            if dirty_files_count > 0 {
+            if dirty_files_count > 5 {
                 format!(
-                    "{} file{} needs to be synced",
+                    "{} change{} needs to be synced",
                     dirty_files_count,
                     if dirty_files_count > 1 { "s" } else { "" }
                 )


### PR DESCRIPTION
each time you make a file change (delete,upsert, create, share, etc), you'd get a warning that you're workspace is dirty. Given that we auto sync, there's no need to flash out a message immediately after one change makes the workspace dirty. 

this pr sets a limit of **at least 6 changes for the warning to be displayed.** this way the user is informed about the dirty state when they're offline, or experiencing sync issues that without being annoyed in their normal day to day use. 
![image](https://github.com/lockbook/lockbook/assets/66345861/d5d31b33-9f91-4699-a239-4e2edfe08a0f)
