### PR TITLE
apple, android: fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,9 +3874,8 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lb-fonts"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615e43ce60261fb305818a26fbe1eaf50f1dc15ac846c5b8adaf2defbf4e2ab2"
+version = "0.1.4"
+source = "git+https://github.com/lockbook/lb-fonts#e959233c1e357ea3799c4bc20900350e1e47d137"
 
 [[package]]
 name = "lb-fs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,8 +3874,8 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lb-fonts"
-version = "0.1.4"
-source = "git+https://github.com/lockbook/lb-fonts#e959233c1e357ea3799c4bc20900350e1e47d137"
+version = "0.1.5"
+source = "git+https://github.com/lockbook/lb-fonts#b2718aad58a7ff1c7bbe85f03cb37cec14517b56"
 
 [[package]]
 name = "lb-fs"

--- a/clients/egui/Cargo.toml
+++ b/clients/egui/Cargo.toml
@@ -23,7 +23,7 @@ image = { version = "0.24", default-features = false, features = [
 lb = { package = "lb-rs", path = "../../libs/lb/lb-rs", default-features = false, features = [
     "native-tls",
 ] }
-lb-fonts = "0.1.2"
+lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
 lbeditor = { package = "egui_editor", path = "../../libs/content/editor/egui_editor" }
 minidom = { git = "https://github.com/lockbook/minidom" }
 pdfium-render = "0.8.5"

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -13,7 +13,7 @@ egui_extras = { version = "0.26.2", features = ["image"] }
 epaint = "0.26.2"
 glam = "0.22.0"
 image = "0.24"
-lb-fonts = "0.1.2"
+lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
 lb-pdf = { git = "https://github.com/lockbook/lb-pdf" }
 linkify = "0.10.0"
 minidom = { git = "https://github.com/lockbook/minidom" }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -21,15 +21,23 @@ pub mod test_input;
 pub mod unicode_segs;
 
 pub fn register_fonts(fonts: &mut FontDefinitions) {
+    let (pt_sans, pt_mono, pt_bold) = if cfg!(target_vendor = "apple") {
+        (lb_fonts::SF_PRO_TEXT_REGULAR, lb_fonts::SF_MONO_REGULAR, lb_fonts::SF_PRO_TEXT_BOLD)
+    } else if cfg!(target_os = "android") {
+        (lb_fonts::ROBOTO_REGULAR, lb_fonts::ROBOTO_MONO_REGULAR, lb_fonts::ROBOTO_BOLD)
+    } else {
+        (lb_fonts::PT_SANS_REGULAR, lb_fonts::PT_MONO_REGULAR, lb_fonts::PT_SANS_BOLD)
+    };
+
     fonts
         .font_data
-        .insert("pt_sans".to_string(), FontData::from_static(lb_fonts::PT_SANS_REGULAR));
+        .insert("pt_sans".to_string(), FontData::from_static(pt_sans));
     fonts
         .font_data
-        .insert("pt_mono".to_string(), FontData::from_static(lb_fonts::PT_MONO_REGULAR));
+        .insert("pt_mono".to_string(), FontData::from_static(pt_mono));
     fonts
         .font_data
-        .insert("pt_bold".to_string(), FontData::from_static(lb_fonts::PT_SANS_BOLD));
+        .insert("pt_bold".to_string(), FontData::from_static(pt_bold));
     fonts.font_data.insert("material_icons".to_owned(), {
         let mut font = egui::FontData::from_static(lb_fonts::MATERIAL_SYMBOLS_OUTLINED);
         font.tweak.y_offset_factor = -0.1;

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -22,7 +22,7 @@ pub mod unicode_segs;
 
 pub fn register_fonts(fonts: &mut FontDefinitions) {
     let (pt_sans, pt_mono, pt_bold) = if cfg!(target_vendor = "apple") {
-        (lb_fonts::SF_PRO_TEXT_REGULAR, lb_fonts::SF_MONO_REGULAR, lb_fonts::SF_PRO_TEXT_BOLD)
+        (lb_fonts::SF_PRO_REGULAR, lb_fonts::SF_MONO_REGULAR, lb_fonts::SF_PRO_TEXT_BOLD)
     } else if cfg!(target_os = "android") {
         (lb_fonts::ROBOTO_REGULAR, lb_fonts::ROBOTO_MONO_REGULAR, lb_fonts::ROBOTO_BOLD)
     } else {


### PR DESCRIPTION
Native fonts for the Apple platforms and Android.

**Android**
<details>
Before:

![android-before](https://github.com/lockbook/lockbook/assets/20663038/1b1023cb-d9c7-4301-b062-b88791370893)

After:
![android-after](https://github.com/lockbook/lockbook/assets/20663038/26ca7a8b-6d2c-465e-b573-e72e5283ce84)

</details>

**Apple (macOS)**
<details>

Before:
<img width="1306" alt="macos-before" src="https://github.com/lockbook/lockbook/assets/20663038/2af37982-a1c7-48a5-bb60-8c9de0635e73">


After:
<img width="1408" alt="macos-after" src="https://github.com/lockbook/lockbook/assets/20663038/172668f8-446c-44b4-be56-7106231bb6c1">

</details>

fixes #1626
