### PR TITLE
windows/linux: clipboard fixes

### DIFF
--- a/clients/egui/src/lib.rs
+++ b/clients/egui/src/lib.rs
@@ -192,10 +192,6 @@ impl<'window> WgpuLockbook<'window> {
         self.context.begin_frame(self.raw_input.take());
         out.update_output = self.app.update(&self.context);
         let full_output = self.context.end_frame();
-        if !full_output.platform_output.copied_text.is_empty() {
-            self.context
-                .output_mut(|o| o.copied_text = full_output.platform_output.copied_text.clone());
-        }
         let paint_jobs = self
             .context
             .tessellate(full_output.shapes, full_output.pixels_per_point);

--- a/clients/windows/src/output/clipboard_copy.rs
+++ b/clients/windows/src/output/clipboard_copy.rs
@@ -1,6 +1,9 @@
-pub fn handle(copied_text: String) {
+use clipboard_win::SysResult;
+
+pub fn handle(copied_text: String) -> SysResult<()> {
     if !copied_text.is_empty() {
         clipboard_win::set_clipboard(clipboard_win::formats::Unicode, copied_text)
-            .expect("set clipboard");
+    } else {
+        Ok(())
     }
 }

--- a/clients/windows/src/window.rs
+++ b/clients/windows/src/window.rs
@@ -349,7 +349,10 @@ fn handle_message(hwnd: HWND, message: Message) -> bool {
                                 update_output: UpdateOutput { close, set_window_title },
                             } = app.frame();
 
-                            output::clipboard_copy::handle(copied_text);
+                            if let Err(_) = output::clipboard_copy::handle(copied_text.clone()) {
+                                // windows clipboard sometimes has transient errors
+                                app.context.output_mut(|o| o.copied_text = copied_text);
+                            }
                             output::close::handle(close);
                             output::window_title::handle(hwnd, set_window_title);
                             output::cursor::update(cursor_icon); // output saved and handled by 'SetCursor' message


### PR DESCRIPTION
* fixes an egui client issue where clipboard would be written each frame
* gracefully handles clipboard write errors on windows, which were crashing the app