### PR TITLE
canvas: replace resvg with epaint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8464,7 +8464,6 @@ dependencies = [
  "lb-pdf",
  "lb-rs",
  "linkify",
- "minidom",
  "ndk-sys 0.4.1+23.1.7779620",
  "pollster",
  "pulldown-cmark",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,7 +839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6228d36f205328c4633194f55592b4bee584f4e1651b41210485c07e89bc85b"
 dependencies = [
  "glam",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6228d36f205328c4633194f55592b4bee584f4e1651b41210485c07e89bc85b"
 dependencies = [
  "glam",
+ "serde",
 ]
 
 [[package]]
@@ -2486,16 +2493,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020e203f177c0fb250fb19455a252e838d2bbbce1f80f25ecc42402aafa8cd38"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
 dependencies = [
  "fontconfig-parser",
  "log 0.4.21",
- "memmap2 0.8.0",
+ "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.19.2",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -2781,16 +2788,6 @@ checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
  "polyval",
-]
-
-[[package]]
-name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -3502,7 +3499,7 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif 0.13.1",
+ "gif",
  "jpeg-decoder",
  "num-traits",
  "png",
@@ -3520,7 +3517,7 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif 0.13.1",
+ "gif",
  "image-webp",
  "num-traits",
  "png",
@@ -3858,6 +3855,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5aa9f0f96a938266bdb12928a67169e8d22c6a786fda8ed984b85e6ba93c3c"
+dependencies = [
+ "arrayvec",
+ "smallvec",
 ]
 
 [[package]]
@@ -4357,15 +4364,6 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
-name = "memmap2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memmap2"
@@ -5043,7 +5041,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
 dependencies = [
- "ttf-parser 0.20.0",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -5808,17 +5806,17 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.36.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7980f653f9a7db31acff916a262c3b78c562919263edea29bf41a056e20497"
+checksum = "c2327ced609dadeed3e9702fec3e6b2ddd208758a9268d13e06566c6101ba533"
 dependencies = [
- "gif 0.12.0",
+ "gif",
  "jpeg-decoder",
  "log 0.4.21",
  "pico-args",
  "png",
  "rgb",
- "svgtypes 0.12.0",
+ "svgtypes 0.15.0",
  "tiny-skia",
  "usvg",
 ]
@@ -6051,14 +6049,14 @@ dependencies = [
 
 [[package]]
 name = "rustybuzz"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cd15fef9112a1f94ac64b58d1e4628192631ad6af4dc69997f995459c874e7"
+checksum = "88117946aa1bfb53c2ae0643ceac6506337f44887f8c9fbfb43587b1cc52ba49"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "bytemuck",
  "smallvec",
- "ttf-parser 0.19.2",
+ "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -6146,7 +6144,7 @@ checksum = "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550"
 dependencies = [
  "ab_glyph",
  "log 0.4.21",
- "memmap2 0.9.4",
+ "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -6439,6 +6437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6496,7 +6500,7 @@ dependencies = [
  "cursor-icon",
  "libc",
  "log 0.4.21",
- "memmap2 0.9.4",
+ "memmap2",
  "rustix 0.38.32",
  "thiserror",
  "wayland-backend",
@@ -6651,8 +6655,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71499ff2d42f59d26edb21369a308ede691421f79ebc0f001e2b1fd3a7c9e52"
 dependencies = [
- "kurbo",
- "siphasher",
+ "kurbo 0.9.5",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -6661,8 +6665,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70"
 dependencies = [
- "kurbo",
- "siphasher",
+ "kurbo 0.9.5",
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97ca9a891c9c70da8139ac9d8e8ea36a210fa21bb50eccd75d4a9561c83e87f"
+dependencies = [
+ "kurbo 0.11.0",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -7178,12 +7192,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
-
-[[package]]
-name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
@@ -7296,15 +7304,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-bidi-mirroring"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
 
 [[package]]
 name = "unicode-ccc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
@@ -7413,16 +7421,28 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.36.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51daa774fe9ee5efcf7b4fec13019b8119cda764d9a8b5b06df02bb1445c656"
+checksum = "5c704361d822337cfc00387672c7b59eaa72a1f0744f62b2a68aa228a0c6927d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo 0.11.0",
  "log 0.4.21",
  "pico-args",
- "usvg-parser",
- "usvg-text-layout",
- "usvg-tree",
+ "roxmltree 0.19.0",
+ "rustybuzz",
+ "simplecss",
+ "siphasher 1.0.1",
+ "strict-num",
+ "svgtypes 0.15.0",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
  "xmlwriter",
 ]
 
@@ -7435,28 +7455,12 @@ dependencies = [
  "data-url",
  "flate2",
  "imagesize",
- "kurbo",
+ "kurbo 0.9.5",
  "log 0.4.21",
  "roxmltree 0.18.1",
  "simplecss",
- "siphasher",
+ "siphasher 0.3.11",
  "svgtypes 0.12.0",
- "usvg-tree",
-]
-
-[[package]]
-name = "usvg-text-layout"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2374378cb7a3fb8f33894e0fdb8625e1bbc4f25312db8d91f862130b541593"
-dependencies = [
- "fontdb",
- "kurbo",
- "log 0.4.21",
- "rustybuzz",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
  "usvg-tree",
 ]
 
@@ -8369,7 +8373,7 @@ dependencies = [
  "js-sys",
  "libc",
  "log 0.4.21",
- "memmap2 0.9.4",
+ "memmap2",
  "ndk",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc2 0.4.1",

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -16,7 +16,6 @@ image = "0.24"
 lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
 lb-pdf = { git = "https://github.com/lockbook/lb-pdf" }
 linkify = "0.10.0"
-minidom = { git = "https://github.com/lockbook/minidom" }
 pulldown-cmark = { version = "0.9.2", default-features = false }
 rand = "0.8.5"
 resvg = "0.41.0"

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 name = "workspace_rs"
 
 [dependencies]
-bezier-rs = "0.2.0"
+bezier-rs ={version= "0.2.0", features=["serde"]}
 egui = "0.26.2"
 egui_extras = { version = "0.26.2", features = ["image"] }
 epaint = "0.26.2"
@@ -19,7 +19,7 @@ linkify = "0.10.0"
 minidom = { git = "https://github.com/lockbook/minidom" }
 pulldown-cmark = { version = "0.9.2", default-features = false }
 rand = "0.8.5"
-resvg = "0.36.0"
+resvg = "0.41.0"
 serde = { version = "1.0.171", features = ["derive"] }
 svgtypes = "0.13.0"
 unicode-segmentation = "1.10.0"

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 name = "workspace_rs"
 
 [dependencies]
-bezier-rs ={version= "0.2.0", features=["serde"]}
+bezier-rs = "0.2.0"
 egui = "0.26.2"
 egui_extras = { version = "0.26.2", features = ["image"] }
 epaint = "0.26.2"

--- a/libs/content/workspace/src/tab/markdown_editor/images.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/images.rs
@@ -3,7 +3,7 @@ use crate::tab::markdown_editor::style::{InlineNode, MarkdownNode, Url};
 use egui::{ColorImage, TextureId, Ui};
 use lb_rs::Uuid;
 use resvg::tiny_skia::Pixmap;
-use resvg::usvg::{self, Transform, TreeParsing as _};
+use resvg::usvg::{self, Options, Transform};
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
@@ -70,40 +70,44 @@ pub fn calc(
                         };
 
                         // convert lockbook drawings to images
-                        let image_bytes = if let Some(id) = maybe_lb_id {
-                            let file = core.get_file_by_id(id).map_err(|e| e.to_string())?;
-                            if file.name.ends_with(".svg") {
-                                // todo: check errors
-                                let tree = usvg::Tree::from_data(&image_bytes, &Default::default())
-                                    .map_err(|e| e.to_string())?;
-                                let tree = resvg::Tree::from_usvg(&tree);
-                                if let Some(content_area) = tree.content_area {
-                                    // dimensions & transform chosen so that all svg content appears in the result
-                                    let mut pix_map = Pixmap::new(
-                                        content_area.width() as _,
-                                        content_area.height() as _,
-                                    )
-                                    .ok_or("failed to create pixmap")
-                                    .map_err(|e| e.to_string())?;
-                                    let transform = Transform::identity()
-                                        .post_translate(-content_area.left(), -content_area.top());
-                                    tree.render(transform, &mut pix_map.as_mut());
-                                    pix_map.encode_png().map_err(|e| e.to_string())?
-                                } else {
-                                    // empty svg
-                                    Pixmap::new(100, 100)
-                                        .unwrap()
-                                        .encode_png()
-                                        .map_err(|e| e.to_string())?
-                                }
-                            } else {
-                                // leave non-drawings alone
-                                image_bytes
-                            }
-                        } else {
-                            // leave non-lockbook images alone
-                            image_bytes
-                        };
+                        // let image_bytes = if let Some(id) = maybe_lb_id {
+                        //     let file = core.get_file_by_id(id).map_err(|e| e.to_string())?;
+                        //     if file.name.ends_with(".svg") {
+                        //         // todo: check errors
+                        //         let tree = usvg::Tree::from_data(
+                        //             &image_bytes,
+                        //             &Options::default(),
+                        //             &usvg::fontdb::Database::new(),
+                        //         )
+                        //         .map_err(|e| e.to_string())?;
+                        //         let tree = resvg::Tree::from_usvg(&tree);
+                        //         if let Some(content_area) = tree.content_area {
+                        //             // dimensions & transform chosen so that all svg content appears in the result
+                        //             let mut pix_map = Pixmap::new(
+                        //                 content_area.width() as _,
+                        //                 content_area.height() as _,
+                        //             )
+                        //             .ok_or("failed to create pixmap")
+                        //             .map_err(|e| e.to_string())?;
+                        //             let transform = Transform::identity()
+                        //                 .post_translate(-content_area.left(), -content_area.top());
+                        //             tree.render(transform, &mut pix_map.as_mut());
+                        //             pix_map.encode_png().map_err(|e| e.to_string())?
+                        //         } else {
+                        //             // empty svg
+                        //             Pixmap::new(100, 100)
+                        //                 .unwrap()
+                        //                 .encode_png()
+                        //                 .map_err(|e| e.to_string())?
+                        //         }
+                        //     } else {
+                        //         // leave non-drawings alone
+                        //         image_bytes
+                        //     }
+                        // } else {
+                        //     // leave non-lockbook images alone
+                        //     image_bytes
+                        // };
 
                         let image =
                             image::load_from_memory(&image_bytes).map_err(|e| e.to_string())?;

--- a/libs/content/workspace/src/tab/markdown_editor/images.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/images.rs
@@ -2,8 +2,6 @@ use crate::tab::markdown_editor::ast::Ast;
 use crate::tab::markdown_editor::style::{InlineNode, MarkdownNode, Url};
 use egui::{ColorImage, TextureId, Ui};
 use lb_rs::Uuid;
-use resvg::tiny_skia::Pixmap;
-use resvg::usvg::{self, Options, Transform};
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -1,3 +1,5 @@
+use std::fmt::format;
+
 use resvg::usvg::{AspectRatio, NonZeroRect, Transform, ViewBox};
 
 use crate::tab::{ClipContent, EventManager as _};
@@ -13,12 +15,11 @@ impl SVGEditor {
                     for clip in content {
                         match clip {
                             ClipContent::Png(data) => {
-                                let _file =
+                                let file =
                                     crate::tab::import_image(&self.core, self.open_file, &data);
-                                // let image_href = format!("lb://{}", file.id);
-                                println!("pasted image: {:?} bytes", data.len());
 
                                 let img = image::load_from_memory(&data).unwrap();
+
                                 self.buffer.elements.insert(
                                     self.toolbar.pen.current_id.to_string(),
                                     crate::tab::svg_editor::parser::Element::Image(
@@ -37,6 +38,7 @@ impl SVGEditor {
                                                 aspect: AspectRatio::default(),
                                             },
                                             texture: None,
+                                            href: Some(file.id),
                                         },
                                     ),
                                 );

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -1,5 +1,3 @@
-use std::fmt::format;
-
 use resvg::usvg::{AspectRatio, NonZeroRect, Transform, ViewBox};
 
 use crate::tab::{ClipContent, EventManager as _};

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -8,8 +8,7 @@ impl SVGEditor {
     pub fn handle_clip_input(&mut self, ui: &mut egui::Ui) {
         for custom_event in ui.ctx().pop_events() {
             match custom_event {
-                crate::Event::Drop { content, position }
-                | crate::Event::Paste { content, position } => {
+                crate::Event::Drop { content, .. } | crate::Event::Paste { content, .. } => {
                     for clip in content {
                         match clip {
                             ClipContent::Png(data) => {
@@ -18,6 +17,9 @@ impl SVGEditor {
 
                                 let img = image::load_from_memory(&data).unwrap();
 
+                                let position = ui.input(|r| {
+                                    r.pointer.hover_pos().unwrap_or(self.inner_rect.center())
+                                });
                                 self.buffer.elements.insert(
                                     self.toolbar.pen.current_id.to_string(),
                                     crate::tab::svg_editor::parser::Element::Image(

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -37,6 +37,7 @@ impl SVGEditor {
                                             },
                                             texture: None,
                                             href: Some(file.id),
+                                            opacity: 1.0,
                                         },
                                     ),
                                 );

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -1,3 +1,5 @@
+use resvg::usvg::{AspectRatio, NonZeroRect, Transform, ViewBox};
+
 use crate::tab::{ClipContent, EventManager as _};
 
 use super::SVGEditor;
@@ -10,18 +12,34 @@ impl SVGEditor {
                     for clip in content {
                         match clip {
                             ClipContent::Png(data) => {
-                                // let file =
-                                //     crate::tab::import_image(&self.core, self.open_file, &data);
+                                let file =
+                                    crate::tab::import_image(&self.core, self.open_file, &data);
                                 // let image_href = format!("lb://{}", file.id);
 
-                                // let child = Element::builder("image", "")
-                                //     .attr("id", self.toolbar.pen.current_id)
-                                //     .attr("href", image_href)
-                                //     .build();
-
-                                // self.buffer.current.append_child(child);
-                                // self.toolbar.pen.current_id += 1;
-                                // println!("pasted image: {:?} bytes", data.len());
+                                let bytes = self.core.read_document(file.id).unwrap();
+                                self.buffer.elements.insert(
+                                    self.toolbar.pen.current_id.to_string(),
+                                    crate::tab::svg_editor::parser::Element::Image(
+                                        crate::tab::svg_editor::parser::Image {
+                                            data: resvg::usvg::ImageKind::PNG(bytes.into()),
+                                            visibility: resvg::usvg::Visibility::Visible,
+                                            transform: Transform::identity(),
+                                            view_box: ViewBox {
+                                                rect: NonZeroRect::from_ltrb(
+                                                    ui.available_rect_before_wrap().left(),
+                                                    ui.available_rect_before_wrap().top(),
+                                                    ui.available_rect_before_wrap().right(),
+                                                    ui.available_rect_before_wrap().bottom(),
+                                                )
+                                                .unwrap(),
+                                                aspect: AspectRatio::default(),
+                                            },
+                                            texture: None,
+                                        },
+                                    ),
+                                );
+                                self.toolbar.pen.current_id += 1;
+                                println!("pasted image: {:?} bytes", data.len());
                             }
                             ClipContent::Files(..) => unimplemented!(), // todo: support file drop & paste
                         }

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -1,5 +1,3 @@
-use minidom::Element;
-
 use crate::tab::{ClipContent, EventManager as _};
 
 use super::SVGEditor;
@@ -12,18 +10,18 @@ impl SVGEditor {
                     for clip in content {
                         match clip {
                             ClipContent::Png(data) => {
-                                let file =
-                                    crate::tab::import_image(&self.core, self.open_file, &data);
-                                let image_href = format!("lb://{}", file.id);
+                                // let file =
+                                //     crate::tab::import_image(&self.core, self.open_file, &data);
+                                // let image_href = format!("lb://{}", file.id);
 
-                                let child = Element::builder("image", "")
-                                    .attr("id", self.toolbar.pen.current_id)
-                                    .attr("href", image_href)
-                                    .build();
+                                // let child = Element::builder("image", "")
+                                //     .attr("id", self.toolbar.pen.current_id)
+                                //     .attr("href", image_href)
+                                //     .build();
 
-                                self.buffer.current.append_child(child);
-                                self.toolbar.pen.current_id += 1;
-                                println!("pasted image: {:?} bytes", data.len());
+                                // self.buffer.current.append_child(child);
+                                // self.toolbar.pen.current_id += 1;
+                                // println!("pasted image: {:?} bytes", data.len());
                             }
                             ClipContent::Files(..) => unimplemented!(), // todo: support file drop & paste
                         }

--- a/libs/content/workspace/src/tab/svg_editor/eraser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/eraser.rs
@@ -1,4 +1,3 @@
-use resvg::usvg::Visibility;
 use std::collections::HashSet;
 use std::sync::mpsc;
 

--- a/libs/content/workspace/src/tab/svg_editor/eraser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/eraser.rs
@@ -40,7 +40,7 @@ impl Eraser {
                     if self.delete_candidates.contains(id) {
                         return;
                     }
-                    if pointer_intersects_element(&el, pos, self.last_pos, self.thickness as f64) {
+                    if pointer_intersects_element(el, pos, self.last_pos, self.thickness as f64) {
                         self.delete_candidates.insert(id.clone());
                     }
                 });
@@ -108,13 +108,13 @@ impl Eraser {
             }
             if ui.input(|i| i.pointer.primary_released()) {
                 self.last_pos = None;
-                return Some(EraseEvent::End);
+                Some(EraseEvent::End)
             } else {
-                return None;
+                None
             }
         } else {
             self.last_pos = None;
-            return Some(EraseEvent::End);
+            Some(EraseEvent::End)
         }
     }
 }

--- a/libs/content/workspace/src/tab/svg_editor/eraser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/eraser.rs
@@ -72,13 +72,16 @@ impl Eraser {
                         path.visibility = Visibility::Hidden;
                     }
                 });
-
-                history.save(super::Event::Delete(
+                let event = super::Event::Delete(
                     self.paths_to_delete
                         .iter()
                         .map(|id| DeleteElement { id: id.to_owned() })
                         .collect(),
-                ));
+                );
+
+                // todo: figure out if the history api should automatically apply the event on save
+                history.save(event.clone());
+                history.apply_event(&event, buffer);
 
                 self.paths_to_delete.clear();
             }

--- a/libs/content/workspace/src/tab/svg_editor/history.rs
+++ b/libs/content/workspace/src/tab/svg_editor/history.rs
@@ -259,7 +259,7 @@ impl Buffer {
     }
 }
 
-fn apply_compounded_transforms(
+pub fn apply_compounded_transforms(
     master_transform: Option<[f64; 6]>, local_transform: Option<&str>,
     subpath: &mut Subpath<ManipulatorGroupId>,
 ) {

--- a/libs/content/workspace/src/tab/svg_editor/history.rs
+++ b/libs/content/workspace/src/tab/svg_editor/history.rs
@@ -1,8 +1,12 @@
 use std::{collections::VecDeque, fmt::Debug};
 
 use glam::DAffine2;
+use resvg::usvg::Transform;
 
-use super::parser;
+use super::{
+    parser,
+    selection::{bezier_transform_to_u, u_transform_to_bezier},
+};
 
 #[derive(Default)]
 pub struct History {
@@ -66,6 +70,11 @@ impl History {
                         match el {
                             parser::Element::Path(p) => {
                                 p.data.apply_transform(transform_payload.transform);
+                            }
+                            parser::Element::Image(img) => {
+                                img.apply_transform(bezier_transform_to_u(
+                                    &transform_payload.transform,
+                                ));
                             }
                             _ => {}
                         }

--- a/libs/content/workspace/src/tab/svg_editor/history.rs
+++ b/libs/content/workspace/src/tab/svg_editor/history.rs
@@ -4,8 +4,6 @@ use glam::DAffine2;
 
 use super::parser;
 
-const MAX_UNDOS: usize = 100;
-
 #[derive(Default)]
 pub struct History {
     undo: VecDeque<Event>,
@@ -42,9 +40,6 @@ impl History {
         }
 
         self.undo.push_back(event);
-        if self.undo.len() > MAX_UNDOS {
-            self.undo.pop_front();
-        }
     }
 
     pub fn apply_event(&mut self, event: &Event, buffer: &mut parser::Buffer) {

--- a/libs/content/workspace/src/tab/svg_editor/history.rs
+++ b/libs/content/workspace/src/tab/svg_editor/history.rs
@@ -1,12 +1,6 @@
-use std::{
-    borrow::BorrowMut,
-    collections::{HashMap, VecDeque},
-    fmt::Debug,
-    mem,
-};
+use std::{collections::VecDeque, fmt::Debug};
 
 use glam::DAffine2;
-use resvg::usvg::{Transform, Visibility};
 
 use super::parser;
 

--- a/libs/content/workspace/src/tab/svg_editor/history.rs
+++ b/libs/content/workspace/src/tab/svg_editor/history.rs
@@ -1,12 +1,8 @@
 use std::{collections::VecDeque, fmt::Debug};
 
 use glam::DAffine2;
-use resvg::usvg::Transform;
 
-use super::{
-    parser,
-    selection::{bezier_transform_to_u, u_transform_to_bezier},
-};
+use super::{parser, selection::bezier_transform_to_u};
 
 #[derive(Default)]
 pub struct History {

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -158,87 +158,86 @@ impl SVGEditor {
         let painter = ui
             .allocate_painter(self.inner_rect.size(), egui::Sense::click_and_drag())
             .1;
-        for (id, el) in self.buffer.elements.iter_mut() {
-            match el {
-                parser::Element::Image(img) => match &img.data {
-                    ImageKind::JPEG(bytes) | ImageKind::PNG(bytes) => {
-                        let image = image::load_from_memory(&bytes).unwrap();
 
-                        let egui_image = egui::ColorImage::from_rgba_unmultiplied(
-                            [image.width() as usize, image.height() as usize],
-                            &image.to_rgba8(),
-                        );
-                        if img.texture.is_none() {
-                            img.texture = Some(ui.ctx().load_texture(
-                                format!("canvas_img_{}", id),
-                                egui_image,
-                                egui::TextureOptions::LINEAR,
-                            ));
-                        }
+        self.buffer.elements.iter_mut().for_each(|(id, el)| {
+            if let parser::Element::Image(img) = el {
+                render_image(img, ui, id, &painter);
+            }
+        });
 
-                        if let Some(texture) = &img.texture {
-                            let rect = egui::Rect {
-                                min: egui::pos2(img.view_box.rect.left(), img.view_box.rect.top()),
-                                max: egui::pos2(
-                                    img.view_box.rect.right(),
-                                    img.view_box.rect.bottom(),
-                                ),
-                            };
-                            let uv = egui::Rect {
-                                min: egui::Pos2 { x: 0.0, y: 0.0 },
-                                max: egui::Pos2 { x: 1.0, y: 1.0 },
-                            };
-
-                            let mut mesh = egui::Mesh::with_texture(texture.id());
-                            mesh.add_rect_with_uv(
-                                rect,
-                                uv,
-                                egui::Color32::WHITE.gamma_multiply(img.opacity),
-                            );
-                            painter.add(egui::Shape::mesh(mesh));
-                        }
-                    }
-                    ImageKind::GIF(_) => todo!(),
-                    ImageKind::SVG(_) => todo!(),
-                },
-                parser::Element::Path(path) => {
-                    if path.data.len() < 1 || path.visibility.eq(&usvg::Visibility::Hidden) {
-                        continue;
-                    }
-
-                    let stroke = path.stroke.unwrap_or_default();
-                    let alpha_stroke_color = stroke.color.gamma_multiply(path.opacity);
-
-                    if path.data.is_point() {
-                        let origin = &path.data.manipulator_groups()[0];
-                        let origin = egui::pos2(origin.anchor.x as f32, origin.anchor.y as f32);
-                        let circle = epaint::CircleShape::filled(
-                            origin,
-                            stroke.width / 2.0,
-                            alpha_stroke_color,
-                        );
-                        painter.add(circle);
-                    } else {
-                        path.data.iter().for_each(|bezier| {
-                            let bezier = bezier.to_cubic();
-
-                            let points: Vec<egui::Pos2> = bezier
-                                .get_points()
-                                .map(|dvec| egui::pos2(dvec.x as f32, dvec.y as f32))
-                                .collect();
-                            let epath = epaint::CubicBezierShape::from_points_stroke(
-                                points.try_into().unwrap(),
-                                false,
-                                egui::Color32::TRANSPARENT,
-                                egui::Stroke { width: stroke.width, color: alpha_stroke_color },
-                            );
-                            painter.add(epath);
-                        });
-                    };
+        for (_, el) in self.buffer.elements.iter_mut() {
+            if let parser::Element::Path(path) = el {
+                if path.data.len() < 1 || path.visibility.eq(&usvg::Visibility::Hidden) {
+                    continue;
                 }
 
-                parser::Element::Text(_) => todo!(),
+                let stroke = path.stroke.unwrap_or_default();
+                let alpha_stroke_color = stroke.color.gamma_multiply(path.opacity);
+
+                if path.data.is_point() {
+                    let origin = &path.data.manipulator_groups()[0];
+                    let origin = egui::pos2(origin.anchor.x as f32, origin.anchor.y as f32);
+                    let circle =
+                        epaint::CircleShape::filled(origin, stroke.width / 2.0, alpha_stroke_color);
+                    painter.add(circle);
+                } else {
+                    path.data.iter().for_each(|bezier| {
+                        let bezier = bezier.to_cubic();
+
+                        let points: Vec<egui::Pos2> = bezier
+                            .get_points()
+                            .map(|dvec| egui::pos2(dvec.x as f32, dvec.y as f32))
+                            .collect();
+                        let epath = epaint::CubicBezierShape::from_points_stroke(
+                            points.try_into().unwrap(),
+                            false,
+                            egui::Color32::TRANSPARENT,
+                            egui::Stroke {
+                                width: stroke.width * self.buffer.master_transform.sx,
+                                color: alpha_stroke_color,
+                            },
+                        );
+                        painter.add(epath);
+                    });
+                };
             }
         }
+    }
+}
+
+fn render_image(img: &mut parser::Image, ui: &mut egui::Ui, id: &String, painter: &egui::Painter) {
+    match &img.data {
+        ImageKind::JPEG(bytes) | ImageKind::PNG(bytes) => {
+            let image = image::load_from_memory(&bytes).unwrap();
+
+            let egui_image = egui::ColorImage::from_rgba_unmultiplied(
+                [image.width() as usize, image.height() as usize],
+                &image.to_rgba8(),
+            );
+            if img.texture.is_none() {
+                img.texture = Some(ui.ctx().load_texture(
+                    format!("canvas_img_{}", id),
+                    egui_image,
+                    egui::TextureOptions::LINEAR,
+                ));
+            }
+
+            if let Some(texture) = &img.texture {
+                let rect = egui::Rect {
+                    min: egui::pos2(img.view_box.rect.left(), img.view_box.rect.top()),
+                    max: egui::pos2(img.view_box.rect.right(), img.view_box.rect.bottom()),
+                };
+                let uv = egui::Rect {
+                    min: egui::Pos2 { x: 0.0, y: 0.0 },
+                    max: egui::Pos2 { x: 1.0, y: 1.0 },
+                };
+
+                let mut mesh = egui::Mesh::with_texture(texture.id());
+                mesh.add_rect_with_uv(rect, uv, egui::Color32::WHITE.gamma_multiply(img.opacity));
+                painter.add(egui::Shape::mesh(mesh));
+            }
+        }
+        ImageKind::GIF(_) => todo!(),
+        ImageKind::SVG(_) => todo!(),
     }
 }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -134,13 +134,6 @@ impl SVGEditor {
         }
 
         // self.handle_clip_input(ui);
-
-        // Self::define_dynamic_colors(
-        //     &mut self.buffer,
-        //     &mut self.toolbar,
-        //     ui.visuals().dark_mode,
-        //     false,
-        // );
     }
 
     pub fn get_minimal_content(&self) -> String {
@@ -152,7 +145,7 @@ impl SVGEditor {
         for el in self.buffer.elements.values() {
             match el {
                 parser::Element::Path(path) => {
-                    if path.data.len() < 1 {
+                    if path.data.len() < 1 || path.visibility.eq(&usvg::Visibility::Hidden) {
                         continue;
                     }
                     path.data.iter().for_each(|bezier| {
@@ -165,7 +158,10 @@ impl SVGEditor {
                             points.try_into().unwrap(),
                             false,
                             egui::Color32::TRANSPARENT,
-                            egui::Stroke { width: 2.0, color: egui::Color32::BLACK }, // todo determine stroke thickness based on scale
+                            egui::Stroke {
+                                width: path.stroke.unwrap_or_default().width, // todo determine stroke thickness based on scale
+                                color: path.stroke.unwrap_or_default().color,
+                            },
                         );
                         ui.painter().add(epath);
                     });
@@ -175,56 +171,4 @@ impl SVGEditor {
             }
         }
     }
-
-    // if the data-dark mode is different from the ui dark mode, or if this is the first time running the editor
-    // fn define_dynamic_colors(
-    //     buffer: &mut Buffer, toolbar: &mut Toolbar, is_dark_mode: bool, force_update: bool,
-    // ) {
-    //     let needs_update;
-    //     if let Some(svg_flag) = buffer.current.attr("data-dark-mode") {
-    //         let svg_flag: bool = svg_flag.parse().unwrap_or(false);
-
-    //         needs_update = svg_flag != is_dark_mode;
-    //     } else {
-    //         needs_update = true;
-    //     }
-
-    //     if !needs_update && !force_update {
-    //         return;
-    //     }
-
-    //     let gradient_group_id = "lb:gg";
-    //     buffer.current.remove_child(gradient_group_id);
-
-    //     let theme_colors = ThemePalette::as_array(is_dark_mode);
-    //     if toolbar.pen.active_color.is_none() {
-    //         toolbar.pen.active_color = Some(ColorSwatch {
-    //             id: "fg".to_string(),
-    //             color: theme_colors.iter().find(|p| p.0.eq("fg")).unwrap().1,
-    //         });
-    //     }
-
-    //     let mut gradient_group = Element::builder("g", "")
-    //         .attr("id", gradient_group_id)
-    //         .build();
-
-    //     theme_colors.iter().for_each(|theme_color| {
-    //         let rgb_color =
-    //             format!("rgb({} {} {})", theme_color.1.r(), theme_color.1.g(), theme_color.1.b());
-    //         let gradient = Element::builder("linearGradient", "")
-    //             .attr("id", theme_color.0.as_str())
-    //             .append(
-    //                 Element::builder("stop", "")
-    //                     .attr("stop-color", rgb_color)
-    //                     .build(),
-    //             )
-    //             .build();
-    //         gradient_group.append_child(gradient);
-    //     });
-
-    //     buffer.current.append_child(gradient_group);
-    //     buffer
-    //         .current
-    //         .set_attr("data-dark-mode", format!("{}", is_dark_mode));
-    // }
 }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -128,10 +128,9 @@ impl SVGEditor {
                     &mut self.history,
                 );
             }
-            _ => {}
         }
 
-        // self.handle_clip_input(ui);
+        self.handle_clip_input(ui);
     }
 
     pub fn get_minimal_content(&self) -> String {

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -1,6 +1,7 @@
 mod clip;
 mod eraser;
 mod history;
+mod parser;
 mod pen;
 mod selection;
 mod toolbar;
@@ -11,12 +12,11 @@ use crate::tab::svg_editor::toolbar::{ColorSwatch, Toolbar};
 use crate::theme::palette::ThemePalette;
 use egui::load::SizedTexture;
 pub use eraser::Eraser;
-pub use history::Buffer;
 pub use history::DeleteElement;
 pub use history::Event;
 pub use history::InsertElement;
 use lb_rs::Uuid;
-use minidom::Element;
+pub use parser::Buffer;
 pub use pen::CubicBezBuilder;
 pub use pen::Pen;
 use resvg::tiny_skia::Pixmap;
@@ -27,7 +27,6 @@ pub use toolbar::Tool;
 use usvg_parser::Options;
 pub use util::node_by_id;
 
-use self::history::apply_compounded_transforms;
 use self::util::{d_to_subpath, deserialize_transform};
 use self::zoom::handle_zoom_input;
 
@@ -35,7 +34,7 @@ use self::zoom::handle_zoom_input;
 pub type ImageHrefStringResolverFn = Box<dyn Fn(&str, &Options) -> Option<ImageKind> + Send + Sync>;
 
 pub struct SVGEditor {
-    buffer: Buffer,
+    buffer: parser::Buffer,
     pub toolbar: Toolbar,
     inner_rect: egui::Rect,
     content_area: Option<Rect>,
@@ -46,31 +45,20 @@ pub struct SVGEditor {
 
 impl SVGEditor {
     pub fn new(bytes: &[u8], core: lb_rs::Core, open_file: Uuid) -> Self {
-        // todo: handle invalid utf8
-        let mut content = std::str::from_utf8(bytes).unwrap().to_string();
-        if content.is_empty() {
-            content = "<svg xmlns=\"http://www.w3.org/2000/svg\" ></svg>".to_string();
-        } else {
-            content = content.replace("xlink:href", "href"); //risky
-        }
+        let mut content = std::str::from_utf8(bytes).unwrap();
 
-        let root: Element = content.parse().unwrap();
-        let mut buffer = Buffer::new(root);
-
+        let mut buffer = parser::Buffer::new(content);
         let max_id = buffer
-            .current
-            .children()
-            .map(|el| {
-                let id: usize = el.attr("id").unwrap_or("0").parse().unwrap_or_default();
-                id
-            })
-            .max_by(|x, y| x.cmp(y))
+            .elements
+            .keys()
+            .filter_map(|key_str| key_str.parse::<usize>().ok())
+            .max()
             .unwrap_or_default()
             + 1;
 
         let mut toolbar = Toolbar::new(max_id);
 
-        Self::define_dynamic_colors(&mut buffer, &mut toolbar, false, true);
+        // Self::define_dynamic_colors(&mut buffer, &mut toolbar, false, true);
 
         Self {
             buffer,
@@ -85,217 +73,149 @@ impl SVGEditor {
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
         ui.vertical(|ui| {
-            egui::Frame::default()
-                .fill(if ui.visuals().dark_mode {
-                    egui::Color32::GRAY.gamma_multiply(0.03)
-                } else {
-                    ui.visuals().faint_bg_color
-                })
-                .show(ui, |ui| {
-                    self.toolbar
-                        .show(ui, &mut self.buffer, &mut self.skip_frame);
-                });
+            // egui::Frame::default()
+            //     .fill(if ui.visuals().dark_mode {
+            //         egui::Color32::GRAY.gamma_multiply(0.03)
+            //     } else {
+            //         ui.visuals().faint_bg_color
+            //     })
+            //     .show(ui, |ui| {
+            //         self.toolbar
+            //             .show(ui, &mut self.buffer, &mut self.skip_frame);
+            //     });
 
-            self.inner_rect = ui.available_rect_before_wrap();
+            // self.inner_rect = ui.available_rect_before_wrap();
             self.render_svg(ui);
         });
 
-        handle_zoom_input(ui, self.inner_rect, &mut self.buffer);
+        // handle_zoom_input(ui, self.inner_rect, &mut self.buffer);
 
-        if ui.input(|r| r.multi_touch().is_some()) || self.skip_frame {
-            self.skip_frame = false;
-            return;
-        }
+        // if ui.input(|r| r.multi_touch().is_some()) || self.skip_frame {
+        //     self.skip_frame = false;
+        //     return;
+        // }
 
-        match self.toolbar.active_tool {
-            Tool::Pen => {
-                if let Some(res) =
-                    self.toolbar
-                        .pen
-                        .handle_input(ui, self.inner_rect, &mut self.buffer)
-                {
-                    let pen::PenResponse::ToggleSelection(id) = res;
-                    self.toolbar.set_tool(Tool::Selection);
-                    self.toolbar.selection.select_el_by_id(
-                        id.to_string().as_str(),
-                        ui.ctx().pointer_hover_pos().unwrap_or_default(),
-                        &mut self.buffer,
-                    );
-                }
-            }
-            Tool::Eraser => {
-                self.toolbar.eraser.setup_events(ui, self.inner_rect);
-                while let Ok(event) = self.toolbar.eraser.rx.try_recv() {
-                    self.toolbar.eraser.handle_events(event, &mut self.buffer);
-                }
-            }
-            Tool::Selection => {
-                self.toolbar
-                    .selection
-                    .handle_input(ui, self.inner_rect, &mut self.buffer);
-            }
-        }
+        // match self.toolbar.active_tool {
+        //     Tool::Pen => {
+        //         if let Some(res) =
+        //             self.toolbar
+        //                 .pen
+        //                 .handle_input(ui, self.inner_rect, &mut self.buffer)
+        //         {
+        //             let pen::PenResponse::ToggleSelection(id) = res;
+        //             self.toolbar.set_tool(Tool::Selection);
+        //             self.toolbar.selection.select_el_by_id(
+        //                 id.to_string().as_str(),
+        //                 ui.ctx().pointer_hover_pos().unwrap_or_default(),
+        //                 &mut self.buffer,
+        //             );
+        //         }
+        //     }
+        //     Tool::Eraser => {
+        //         self.toolbar.eraser.setup_events(ui, self.inner_rect);
+        //         while let Ok(event) = self.toolbar.eraser.rx.try_recv() {
+        //             self.toolbar.eraser.handle_events(event, &mut self.buffer);
+        //         }
+        //     }
+        //     Tool::Selection => {
+        //         self.toolbar
+        //             .selection
+        //             .handle_input(ui, self.inner_rect, &mut self.buffer);
+        //     }
+        // }
 
-        self.handle_clip_input(ui);
+        // self.handle_clip_input(ui);
 
-        Self::define_dynamic_colors(
-            &mut self.buffer,
-            &mut self.toolbar,
-            ui.visuals().dark_mode,
-            false,
-        );
+        // Self::define_dynamic_colors(
+        //     &mut self.buffer,
+        //     &mut self.toolbar,
+        //     ui.visuals().dark_mode,
+        //     false,
+        // );
     }
 
     pub fn get_minimal_content(&self) -> String {
-        self.buffer.to_string()
+        "".to_string()
+        // self.buffer.to_string()
     }
 
     fn render_svg(&mut self, ui: &mut egui::Ui) {
-        let mut master_transform = None;
-        if let Some(transform) = self.buffer.current.attr("transform") {
-            master_transform = Some(deserialize_transform(transform));
-        }
+        for el in self.buffer.elements.values() {
+            match el {
+                parser::Element::Path(path) => {
+                    if path.data.len() < 1 {
+                        continue;
+                    }
+                    path.data.iter().for_each(|bezier| {
+                        let points: Vec<egui::Pos2> = bezier
+                            .get_points()
+                            .map(|dvec| egui::pos2(dvec.x as f32, dvec.y as f32))
+                            .collect();
 
-        for el in self.buffer.current.children() {
-            if el.name().eq("path") {
-                let data = match el.attr("d") {
-                    Some(d) => d,
-                    None => continue,
-                };
-
-                let mut subpath = d_to_subpath(data);
-
-                apply_compounded_transforms(master_transform, el.attr("transform"), &mut subpath);
-
-                if subpath.len() < 1 {
-                    continue;
+                        let epath = epaint::CubicBezierShape::from_points_stroke(
+                            points.try_into().unwrap(),
+                            false,
+                            egui::Color32::TRANSPARENT,
+                            egui::Stroke { width: 2.0, color: egui::Color32::BLACK }, // todo determine stroke thickness based on scale
+                        );
+                        ui.painter().add(epath);
+                    });
                 }
-                subpath.iter().for_each(|bezier| {
-                    let points: Vec<egui::Pos2> = bezier
-                        .get_points()
-                        .map(|dvec| egui::pos2(dvec.x as f32, dvec.y as f32))
-                        .collect();
-
-                    let epath = epaint::CubicBezierShape::from_points_stroke(
-                        points.try_into().unwrap(),
-                        false,
-                        egui::Color32::TRANSPARENT,
-                        egui::Stroke { width: 2.0, color: egui::Color32::BLACK },
-                    );
-                    ui.painter().add(epath);
-                });
+                parser::Element::Image(img) => todo!(),
+                parser::Element::Text(text) => todo!(),
             }
         }
-
-        // let available_rect = ui.available_rect_before_wrap();
-        // utree.size = Size::from_wh(available_rect.width(), available_rect.height()).unwrap();
-
-        // utree.view_box.rect = usvg::NonZeroRect::from_ltrb(
-        //     available_rect.left(),
-        //     available_rect.top(),
-        //     available_rect.right(),
-        //     available_rect.bottom(),
-        // )
-        // .unwrap();
-
-        // let tree = resvg::Tree::from_usvg(&utree);
-
-        // let pixmap_size = tree.size.to_int_size();
-        // let mut pixmap = Pixmap::new(pixmap_size.width(), pixmap_size.height()).unwrap();
-
-        // tree.render(usvg::Transform::default(), &mut pixmap.as_mut());
-        // self.content_area = tree.content_area;
-
-        // let image = egui::ColorImage::from_rgba_unmultiplied(
-        //     [pixmap.width() as usize, pixmap.height() as usize],
-        //     pixmap.data(),
-        // );
-
-        // let texture = ui
-        //     .ctx()
-        //     .load_texture("svg_image", image, egui::TextureOptions::LINEAR);
-
-        // ui.add(
-        //     egui::Image::new(egui::ImageSource::Texture(SizedTexture::new(
-        //         &texture,
-        //         egui::vec2(texture.size()[0] as f32, texture.size()[1] as f32),
-        //     )))
-        //     .sense(egui::Sense::click()),
-        // );
-    }
-
-    fn lb_local_resolver(core: &lb_rs::Core) -> ImageHrefStringResolverFn {
-        let lb_link_prefix = "lb://";
-        let core = core.clone();
-        Box::new(move |href: &str, _opts: &Options| {
-            if !href.starts_with(lb_link_prefix) {
-                return None;
-            }
-            let id = &href[lb_link_prefix.len()..];
-            let id = lb_rs::Uuid::from_str(id).ok()?;
-            let raw = core.read_document(id).ok()?;
-
-            let name = core.get_file_by_id(id).ok()?.name;
-            let ext = name.split('.').last().unwrap_or_default();
-            match ext {
-                "jpg" | "jpeg" => Some(ImageKind::JPEG(Arc::new(raw))),
-                "png" => Some(ImageKind::PNG(Arc::new(raw))),
-                // "svg" => Some(ImageKind::SVG(Arc::new(raw))), todo: handle nested svg
-                "gif" => Some(ImageKind::GIF(Arc::new(raw))),
-                _ => None,
-            }
-        })
     }
 
     // if the data-dark mode is different from the ui dark mode, or if this is the first time running the editor
-    fn define_dynamic_colors(
-        buffer: &mut Buffer, toolbar: &mut Toolbar, is_dark_mode: bool, force_update: bool,
-    ) {
-        let needs_update;
-        if let Some(svg_flag) = buffer.current.attr("data-dark-mode") {
-            let svg_flag: bool = svg_flag.parse().unwrap_or(false);
+    // fn define_dynamic_colors(
+    //     buffer: &mut Buffer, toolbar: &mut Toolbar, is_dark_mode: bool, force_update: bool,
+    // ) {
+    //     let needs_update;
+    //     if let Some(svg_flag) = buffer.current.attr("data-dark-mode") {
+    //         let svg_flag: bool = svg_flag.parse().unwrap_or(false);
 
-            needs_update = svg_flag != is_dark_mode;
-        } else {
-            needs_update = true;
-        }
+    //         needs_update = svg_flag != is_dark_mode;
+    //     } else {
+    //         needs_update = true;
+    //     }
 
-        if !needs_update && !force_update {
-            return;
-        }
+    //     if !needs_update && !force_update {
+    //         return;
+    //     }
 
-        let gradient_group_id = "lb:gg";
-        buffer.current.remove_child(gradient_group_id);
+    //     let gradient_group_id = "lb:gg";
+    //     buffer.current.remove_child(gradient_group_id);
 
-        let theme_colors = ThemePalette::as_array(is_dark_mode);
-        if toolbar.pen.active_color.is_none() {
-            toolbar.pen.active_color = Some(ColorSwatch {
-                id: "fg".to_string(),
-                color: theme_colors.iter().find(|p| p.0.eq("fg")).unwrap().1,
-            });
-        }
+    //     let theme_colors = ThemePalette::as_array(is_dark_mode);
+    //     if toolbar.pen.active_color.is_none() {
+    //         toolbar.pen.active_color = Some(ColorSwatch {
+    //             id: "fg".to_string(),
+    //             color: theme_colors.iter().find(|p| p.0.eq("fg")).unwrap().1,
+    //         });
+    //     }
 
-        let mut gradient_group = Element::builder("g", "")
-            .attr("id", gradient_group_id)
-            .build();
+    //     let mut gradient_group = Element::builder("g", "")
+    //         .attr("id", gradient_group_id)
+    //         .build();
 
-        theme_colors.iter().for_each(|theme_color| {
-            let rgb_color =
-                format!("rgb({} {} {})", theme_color.1.r(), theme_color.1.g(), theme_color.1.b());
-            let gradient = Element::builder("linearGradient", "")
-                .attr("id", theme_color.0.as_str())
-                .append(
-                    Element::builder("stop", "")
-                        .attr("stop-color", rgb_color)
-                        .build(),
-                )
-                .build();
-            gradient_group.append_child(gradient);
-        });
+    //     theme_colors.iter().for_each(|theme_color| {
+    //         let rgb_color =
+    //             format!("rgb({} {} {})", theme_color.1.r(), theme_color.1.g(), theme_color.1.b());
+    //         let gradient = Element::builder("linearGradient", "")
+    //             .attr("id", theme_color.0.as_str())
+    //             .append(
+    //                 Element::builder("stop", "")
+    //                     .attr("stop-color", rgb_color)
+    //                     .build(),
+    //             )
+    //             .build();
+    //         gradient_group.append_child(gradient);
+    //     });
 
-        buffer.current.append_child(gradient_group);
-        buffer
-            .current
-            .set_attr("data-dark-mode", format!("{}", is_dark_mode));
-    }
+    //     buffer.current.append_child(gradient_group);
+    //     buffer
+    //         .current
+    //         .set_attr("data-dark-mode", format!("{}", is_dark_mode));
+    // }
 }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -9,10 +9,6 @@ mod util;
 mod zoom;
 
 use crate::tab::svg_editor::toolbar::Toolbar;
-use egui::load::SizedTexture;
-use egui::ColorImage;
-use egui::ImageData;
-use egui::Widget;
 pub use eraser::Eraser;
 pub use history::DeleteElement;
 pub use history::Event;
@@ -21,7 +17,7 @@ use lb_rs::Uuid;
 pub use parser::Buffer;
 pub use pen::CubicBezBuilder;
 pub use pen::Pen;
-use resvg::usvg::{self, ImageKind, Rect};
+use resvg::usvg::{self, ImageKind};
 pub use toolbar::Tool;
 use usvg_parser::Options;
 pub use util::node_by_id;
@@ -37,7 +33,6 @@ pub struct SVGEditor {
     history: History,
     pub toolbar: Toolbar,
     inner_rect: egui::Rect,
-    content_area: Option<Rect>,
     core: lb_rs::Core,
     open_file: Uuid,
     skip_frame: bool,
@@ -63,7 +58,6 @@ impl SVGEditor {
             history: History::default(),
             toolbar,
             inner_rect: egui::Rect::NOTHING,
-            content_area: None,
             core,
             open_file,
             skip_frame: false,
@@ -71,50 +65,6 @@ impl SVGEditor {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
-        for (id, el) in self.buffer.elements.iter_mut() {
-            match el {
-                parser::Element::Image(img) => match &img.data {
-                    ImageKind::JPEG(bytes) | ImageKind::PNG(bytes) => {
-                        // let image = image::load_from_memory(&bytes).unwrap();
-                        // let egui_image = egui::ColorImage::from_rgba_unmultiplied(
-                        //     [image.width() as usize, image.height() as usize],
-                        //     &image.to_rgba8(),
-                        // );
-
-                        // if img.texture.is_none() {
-                        //     img.texture = Some(ui.ctx().load_texture(
-                        //         id,
-                        //         egui_image,
-                        //         egui::TextureOptions::LINEAR,
-                        //     ));
-                        //     println!("loading texture");
-                        // }
-
-                        if let Some(texture) = &img.texture {
-                            // egui::Image::from_texture(texture)
-                            //     .paint_at(ui, ui.available_rect_before_wrap());
-                            // egui::Image::from_texture(texture)
-                            //     .paint_at(ui, ui.available_rect_before_wrap());
-                            // texture.ui.image((texture.id(), texture.size_vec2()));
-                            // let uv = egui::Rect {
-                            //     min: egui::Pos2 { x: 0.0, y: 0.0 },
-                            //     max: egui::Pos2 { x: 1.0, y: 1.0 },
-                            // };
-                            // painter.image(
-                            //     texture.id(),
-                            //     ui.available_rect_before_wrap(),
-                            //     uv,
-                            //     egui::Color32::WHITE,
-                            // );
-                        }
-                    }
-                    ImageKind::GIF(_) => todo!(),
-                    ImageKind::SVG(_) => todo!(),
-                },
-                parser::Element::Path(_) => {}
-                parser::Element::Text(_) => {}
-            }
-        }
         ui.vertical(|ui| {
             egui::Frame::default()
                 .fill(if ui.visuals().dark_mode {
@@ -144,7 +94,7 @@ impl SVGEditor {
 
         match self.toolbar.active_tool {
             Tool::Pen => {
-                if let Some(res) = self.toolbar.pen.handle_input(
+                if let Some(_) = self.toolbar.pen.handle_input(
                     ui,
                     self.inner_rect,
                     &mut self.buffer,
@@ -252,7 +202,7 @@ impl SVGEditor {
                     });
                 }
 
-                parser::Element::Text(text) => todo!(),
+                parser::Element::Text(_) => todo!(),
             }
         }
     }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -117,20 +117,12 @@ impl SVGEditor {
 
         match self.toolbar.active_tool {
             Tool::Pen => {
-                if let Some(_) = self.toolbar.pen.handle_input(
+                self.toolbar.pen.handle_input(
                     ui,
                     self.inner_rect,
                     &mut self.buffer,
                     &mut self.history,
-                ) {
-                    // let pen::PenResponse::ToggleSelection(id) = res;
-                    // self.toolbar.set_tool(Tool::Selection);
-                    // self.toolbar.selection.select_el_by_id(
-                    //     id.to_string().as_str(),
-                    //     ui.ctx().pointer_hover_pos().unwrap_or_default(),
-                    //     &mut self.buffer,
-                    // );
-                }
+                );
             }
             Tool::Eraser => {
                 self.toolbar.eraser.handle_input(
@@ -170,7 +162,7 @@ impl SVGEditor {
 
         for (_, el) in self.buffer.elements.iter_mut() {
             if let parser::Element::Path(path) = el {
-                if path.data.len() < 1 || path.visibility.eq(&usvg::Visibility::Hidden) {
+                if path.data.is_empty() || path.visibility.eq(&usvg::Visibility::Hidden) {
                     continue;
                 }
 
@@ -230,7 +222,7 @@ impl SVGEditor {
 fn render_image(img: &mut parser::Image, ui: &mut egui::Ui, id: &String, painter: &egui::Painter) {
     match &img.data {
         ImageKind::JPEG(bytes) | ImageKind::PNG(bytes) => {
-            let image = image::load_from_memory(&bytes).unwrap();
+            let image = image::load_from_memory(bytes).unwrap();
 
             let egui_image = egui::ColorImage::from_rgba_unmultiplied(
                 [image.width() as usize, image.height() as usize],

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -70,13 +70,20 @@ impl SVGEditor {
     pub fn show(&mut self, ui: &mut egui::Ui) {
         let frame_cost = Instant::now() - self.last_render;
         self.last_render = Instant::now();
+        let mut anchor_count = 0;
+        self.buffer.elements.iter().for_each(|(_, el)| {
+            if let parser::Element::Path(p) = el {
+                anchor_count += p.data.len()
+            }
+        });
+
         let mut top = self.inner_rect.right_top();
-        top.x -= 50.0;
+        top.x -= 150.0;
         ui.painter().debug_text(
             top,
             egui::Align2::LEFT_TOP,
             egui::Color32::RED,
-            format!("{}fps", 1000 / frame_cost.as_millis()),
+            format!("{} anchor | {}fps", anchor_count, 1000 / frame_cost.as_millis()),
         );
         ui.vertical(|ui| {
             egui::Frame::default()

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -20,7 +20,6 @@ pub use pen::Pen;
 use resvg::usvg::{self, ImageKind};
 pub use toolbar::Tool;
 use usvg_parser::Options;
-pub use util::node_by_id;
 
 use self::history::History;
 use self::zoom::handle_zoom_input;
@@ -169,7 +168,11 @@ impl SVGEditor {
                                 max: egui::Pos2 { x: 1.0, y: 1.0 },
                             };
                             let mut mesh = egui::Mesh::with_texture(texture.id());
-                            mesh.add_rect_with_uv(rect, uv, egui::Color32::WHITE);
+                            mesh.add_rect_with_uv(
+                                rect,
+                                uv,
+                                egui::Color32::WHITE.gamma_multiply(img.opacity),
+                            );
                             painter.add(egui::Shape::mesh(mesh));
                         }
                     }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -169,33 +169,7 @@ impl SVGEditor {
                     });
                 }
                 parser::Element::Image(img) => match &img.data {
-                    ImageKind::JPEG(bytes) => {
-                        let image = egui::ColorImage::from_rgba_unmultiplied(
-                            [
-                                img.view_box.rect.width() as usize,
-                                img.view_box.rect.height() as usize,
-                            ],
-                            &bytes,
-                        );
-
-                        if img.texture.is_none() {
-                            img.texture = Some(ui.ctx().load_texture(
-                                id,
-                                image,
-                                egui::TextureOptions::LINEAR,
-                            ));
-                        }
-
-                        if let Some(texture) = &img.texture {
-                            let img =
-                                egui::Image::new(egui::ImageSource::Texture(SizedTexture::new(
-                                    texture,
-                                    egui::vec2(texture.size()[0] as f32, texture.size()[1] as f32),
-                                )));
-                            ui.add(img);
-                        }
-                    }
-                    ImageKind::PNG(bytes) => {
+                    ImageKind::JPEG(bytes) | ImageKind::PNG(bytes) => {
                         let image = egui::ColorImage::from_rgba_unmultiplied(
                             [
                                 img.view_box.rect.width() as usize,

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -3,7 +3,7 @@ mod eraser;
 mod history;
 mod parser;
 mod pen;
-// mod selection;
+mod selection;
 mod toolbar;
 mod util;
 mod zoom;
@@ -127,11 +127,14 @@ impl SVGEditor {
                         .handle_events(event, &mut self.buffer, &mut self.history);
                 }
             }
-            // Tool::Selection => {
-            //     self.toolbar
-            //         .selection
-            //         .handle_input(ui, self.inner_rect, &mut self.buffer);
-            // }
+            Tool::Selection => {
+                self.toolbar.selection.handle_input(
+                    ui,
+                    self.inner_rect,
+                    &mut self.buffer,
+                    &mut self.history,
+                );
+            }
             _ => {}
         }
 

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -8,11 +8,8 @@ mod toolbar;
 mod util;
 mod zoom;
 
-use crate::tab::svg_editor::toolbar::{ColorSwatch, Toolbar};
-use crate::theme::palette::ThemePalette;
-use egui::load::SizedTexture;
+use crate::tab::svg_editor::toolbar::Toolbar;
 pub use eraser::Eraser;
-use glam::{DAffine2, DMat2, DVec2};
 pub use history::DeleteElement;
 pub use history::Event;
 pub use history::InsertElement;
@@ -20,17 +17,12 @@ use lb_rs::Uuid;
 pub use parser::Buffer;
 pub use pen::CubicBezBuilder;
 pub use pen::Pen;
-use resvg::tiny_skia::Pixmap;
-use resvg::usvg::{self, ImageHrefResolver, ImageKind, Rect, Size};
-use std::any::Any;
-use std::str::FromStr;
-use std::sync::Arc;
+use resvg::usvg::{self, ImageKind, Rect};
 pub use toolbar::Tool;
 use usvg_parser::Options;
 pub use util::node_by_id;
 
 use self::history::History;
-use self::util::deserialize_transform;
 use self::zoom::handle_zoom_input;
 
 /// A shorthand for [ImageHrefResolver]'s string function.
@@ -142,8 +134,7 @@ impl SVGEditor {
     }
 
     pub fn get_minimal_content(&self) -> String {
-        "".to_string()
-        // self.buffer.to_string()
+        self.buffer.to_string()
     }
 
     fn render_svg(&mut self, ui: &mut egui::Ui) {

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -98,6 +98,7 @@ impl SVGEditor {
                         &mut self.buffer,
                         &mut self.history,
                         &mut self.skip_frame,
+                        self.inner_rect,
                     );
 
                     self.inner_rect = ui.available_rect_before_wrap();

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -68,23 +68,25 @@ impl SVGEditor {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
-        let frame_cost = Instant::now() - self.last_render;
-        self.last_render = Instant::now();
-        let mut anchor_count = 0;
-        self.buffer.elements.iter().for_each(|(_, el)| {
-            if let parser::Element::Path(p) = el {
-                anchor_count += p.data.len()
-            }
-        });
+        if ui.input(|r| r.key_down(egui::Key::F12)) {
+            let frame_cost = Instant::now() - self.last_render;
+            self.last_render = Instant::now();
+            let mut anchor_count = 0;
+            self.buffer.elements.iter().for_each(|(_, el)| {
+                if let parser::Element::Path(p) = el {
+                    anchor_count += p.data.len()
+                }
+            });
 
-        let mut top = self.inner_rect.right_top();
-        top.x -= 150.0;
-        ui.painter().debug_text(
-            top,
-            egui::Align2::LEFT_TOP,
-            egui::Color32::RED,
-            format!("{} anchor | {}fps", anchor_count, 1000 / frame_cost.as_millis()),
-        );
+            let mut top = self.inner_rect.right_top();
+            top.x -= 150.0;
+            ui.painter().debug_text(
+                top,
+                egui::Align2::LEFT_TOP,
+                egui::Color32::RED,
+                format!("{} anchor | {}fps", anchor_count, 1000 / frame_cost.as_millis()),
+            );
+        }
         ui.vertical(|ui| {
             egui::Frame::default()
                 .fill(if ui.visuals().dark_mode {
@@ -131,12 +133,12 @@ impl SVGEditor {
                 }
             }
             Tool::Eraser => {
-                self.toolbar.eraser.setup_events(ui, self.inner_rect);
-                while let Ok(event) = self.toolbar.eraser.rx.try_recv() {
-                    self.toolbar
-                        .eraser
-                        .handle_events(event, &mut self.buffer, &mut self.history);
-                }
+                self.toolbar.eraser.handle_input(
+                    ui,
+                    self.inner_rect,
+                    &mut self.buffer,
+                    &mut self.history,
+                );
             }
             Tool::Selection => {
                 self.toolbar.selection.handle_input(

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -119,17 +119,20 @@ impl SVGEditor {
                     // );
                 }
             }
-            _ => {} // Tool::Eraser => {
-                    //     self.toolbar.eraser.setup_events(ui, self.inner_rect);
-                    //     while let Ok(event) = self.toolbar.eraser.rx.try_recv() {
-                    //         self.toolbar.eraser.handle_events(event, &mut self.buffer);
-                    //     }
-                    // }
-                    // Tool::Selection => {
-                    //     self.toolbar
-                    //         .selection
-                    //         .handle_input(ui, self.inner_rect, &mut self.buffer);
-                    // }
+            Tool::Eraser => {
+                self.toolbar.eraser.setup_events(ui, self.inner_rect);
+                while let Ok(event) = self.toolbar.eraser.rx.try_recv() {
+                    self.toolbar
+                        .eraser
+                        .handle_events(event, &mut self.buffer, &mut self.history);
+                }
+            }
+            // Tool::Selection => {
+            //     self.toolbar
+            //         .selection
+            //         .handle_input(ui, self.inner_rect, &mut self.buffer);
+            // }
+            _ => {}
         }
 
         // self.handle_clip_input(ui);
@@ -158,13 +161,14 @@ impl SVGEditor {
                             .get_points()
                             .map(|dvec| egui::pos2(dvec.x as f32, dvec.y as f32))
                             .collect();
+                        let stroke = path.stroke.unwrap_or_default();
                         let epath = epaint::CubicBezierShape::from_points_stroke(
                             points.try_into().unwrap(),
                             false,
                             egui::Color32::TRANSPARENT,
                             egui::Stroke {
-                                width: path.stroke.unwrap_or_default().width, // todo determine stroke thickness based on scale
-                                color: path.stroke.unwrap_or_default().color,
+                                width: stroke.width, // todo determine stroke thickness based on scale
+                                color: stroke.color.gamma_multiply(path.opacity),
                             },
                         );
                         painter.add(epath);

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -180,28 +180,47 @@ impl SVGEditor {
                 if path.data.is_point() {
                     let origin = &path.data.manipulator_groups()[0];
                     let origin = egui::pos2(origin.anchor.x as f32, origin.anchor.y as f32);
-                    let circle =
-                        epaint::CircleShape::filled(origin, stroke.width / 2.0, alpha_stroke_color);
+                    let circle = epaint::CircleShape::filled(
+                        origin,
+                        stroke.width * self.buffer.master_transform.sx / 2.0,
+                        alpha_stroke_color,
+                    );
                     painter.add(circle);
                 } else {
-                    path.data.iter().for_each(|bezier| {
-                        let bezier = bezier.to_cubic();
+                    let points = path
+                        .data
+                        .manipulator_groups()
+                        .iter()
+                        .map(|m| egui::pos2(m.anchor.x as f32, m.anchor.y as f32))
+                        .collect();
 
-                        let points: Vec<egui::Pos2> = bezier
-                            .get_points()
-                            .map(|dvec| egui::pos2(dvec.x as f32, dvec.y as f32))
-                            .collect();
-                        let epath = epaint::CubicBezierShape::from_points_stroke(
-                            points.try_into().unwrap(),
-                            false,
-                            egui::Color32::TRANSPARENT,
-                            egui::Stroke {
-                                width: stroke.width * self.buffer.master_transform.sx,
-                                color: alpha_stroke_color,
-                            },
-                        );
-                        painter.add(epath);
-                    });
+                    let epath = egui::epaint::PathShape::line(
+                        points,
+                        egui::Stroke {
+                            width: stroke.width * self.buffer.master_transform.sx,
+                            color: alpha_stroke_color,
+                        },
+                    );
+                    painter.add(epath);
+
+                    // path.data.iter().for_each(|bezier| {
+                    //     let bezier = bezier.to_cubic();
+
+                    //     let points: Vec<egui::Pos2> = bezier
+                    //         .get_points()
+                    //         .map(|dvec| egui::pos2(dvec.x as f32, dvec.y as f32))
+                    //         .collect();
+                    //     let epath = epaint::CubicBezierShape::from_points_stroke(
+                    //         points.try_into().unwrap(),
+                    //         false,
+                    //         egui::Color32::TRANSPARENT,
+                    //         egui::Stroke {
+                    //             width: stroke.width * self.buffer.master_transform.sx,
+                    //             color: alpha_stroke_color,
+                    //         },
+                    //     );
+                    //     painter.add(epath);
+                    // });
                 };
             }
         }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -3,7 +3,7 @@ mod eraser;
 mod history;
 mod parser;
 mod pen;
-mod selection;
+// mod selection;
 mod toolbar;
 mod util;
 mod zoom;
@@ -27,7 +27,7 @@ pub use toolbar::Tool;
 use usvg_parser::Options;
 pub use util::node_by_id;
 
-use self::util::{d_to_subpath, deserialize_transform};
+use self::util::deserialize_transform;
 use self::zoom::handle_zoom_input;
 
 /// A shorthand for [ImageHrefResolver]'s string function.

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -76,7 +76,7 @@ impl SVGEditor {
             top,
             egui::Align2::LEFT_TOP,
             egui::Color32::RED,
-            format!("{}ms", frame_cost.as_millis()),
+            format!("{}fps", 1000 / frame_cost.as_millis()),
         );
         ui.vertical(|ui| {
             egui::Frame::default()

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -1,13 +1,11 @@
-use std::{collections::HashMap, fmt::Write, ops::Deref, sync::Arc};
+use std::{collections::HashMap, fmt::Write};
 
 use bezier_rs::{Bezier, Identifier, Subpath};
+use egui::TextureHandle;
 use glam::{DAffine2, DMat2, DVec2};
 use resvg::{
     tiny_skia::Point,
-    usvg::{
-        self, Color, Fill, ImageHrefResolver, ImageHrefStringResolverFn, ImageKind, Options, Paint,
-        Text, Transform, Visibility,
-    },
+    usvg::{self, Fill, ImageKind, Options, Paint, Text, Transform, Visibility},
 };
 
 use super::zoom::G_CONTAINER_ID;
@@ -60,6 +58,8 @@ pub struct Image {
     pub data: ImageKind,
     pub visibility: Visibility,
     pub transform: Transform,
+    pub view_box: usvg::ViewBox,
+    pub texture: Option<TextureHandle>,
 }
 
 impl Buffer {
@@ -92,6 +92,8 @@ impl Buffer {
                             data: img.kind().clone(),
                             visibility: img.visibility(),
                             transform: img.abs_transform(),
+                            view_box: img.view_box(),
+                            texture: None,
                         }),
                     );
                 }
@@ -104,7 +106,6 @@ impl Buffer {
                         }
                         stroke.width = s.width().get();
                         stroke.opacity = s.opacity().get();
-                        println!("{:#?}", s);
                     }
                     buffer.elements.insert(
                         i.to_string(),
@@ -118,7 +119,6 @@ impl Buffer {
                         }),
                     );
                 }
-                _ => {}
             });
         buffer
     }

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{collections::HashMap, fmt::Write, ops::Deref, sync::Arc};
 
 use bezier_rs::{Bezier, Identifier, Subpath};
 use glam::{DAffine2, DMat2, DVec2};
@@ -210,7 +210,22 @@ impl ToString for Buffer {
         // let out = out.replace("xmlns='' ", "");
         // let out = format!("<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">{}</svg>", out);
         // out
-        "todo serialize the buffer".to_string()
+
+        let mut root = r#"<svg xmlns="http://www.w3.org/2000/svg">"#.into();
+        self.elements.iter().for_each(|el| match el.1 {
+            Element::Path(p) => p.data.to_svg(
+                &mut root,
+                r#"stroke-color="red""#.into(),
+                "".into(),
+                "".into(),
+                "".into(),
+            ),
+            Element::Image(_) => todo!(),
+            Element::Text(_) => todo!(),
+        });
+        let _ = write!(&mut root, "</svg>");
+        println!("{:#?}", root);
+        root
     }
 }
 

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -12,8 +12,6 @@ use resvg::{
     },
 };
 
-use super::zoom::G_CONTAINER_ID;
-
 /// A shorthand for [ImageHrefResolver]'s string function.
 pub type ImageHrefStringResolverFn =
     Box<dyn Fn(&str, &Options, &Database) -> Option<ImageKind> + Send + Sync>;
@@ -243,8 +241,10 @@ impl ToString for Buffer {
                             ) // todo: see how to handle opacity
                         );
                     }
-                    p.data
-                        .to_svg(&mut root, curv_attrs, "".into(), "".into(), "".into())
+                    if p.data.len() > 1 {
+                        p.data
+                            .to_svg(&mut root, curv_attrs, "".into(), "".into(), "".into())
+                    }
                 }
                 Element::Image(img) => {
                     let image_element = format!(

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -51,7 +51,12 @@ pub struct Image {
 impl Buffer {
     pub fn new(svg: &str) -> Self {
         let fontdb = usvg::fontdb::Database::new();
-        let utree: usvg::Tree = usvg::Tree::from_str(svg, &Options::default(), &fontdb).unwrap();
+        let maybe_tree = usvg::Tree::from_str(svg, &Options::default(), &fontdb);
+        if let Err(err) = maybe_tree {
+            println!("{:#?}", err);
+            return Self::default();
+        }
+        let utree = maybe_tree.unwrap();
 
         let mut buffer = Buffer::default();
 

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -1,0 +1,199 @@
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
+use bezier_rs::{Bezier, Identifier, Subpath};
+use glam::{DAffine2, DMat2, DVec2};
+use resvg::{
+    tiny_skia::Point,
+    usvg::{self, Fill, ImageHrefStringResolverFn, ImageKind, Stroke, Text, Transform, Visibility},
+};
+use usvg_parser::Options;
+
+use super::zoom::G_CONTAINER_ID;
+
+impl Identifier for ManipulatorGroupId {
+    fn new() -> Self {
+        ManipulatorGroupId
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct ManipulatorGroupId;
+
+#[derive(Default)]
+pub struct Buffer {
+    pub elements: HashMap<String, Element>,
+    pub master_transform: Transform,
+    pub needs_path_map_update: bool,
+}
+
+pub enum Element {
+    Path(Path),
+    Image(Image),
+    Text(Text),
+}
+
+struct Path {
+    pub data: Subpath<ManipulatorGroupId>,
+    pub visibility: Visibility,
+    pub fill: Option<Fill>,
+    pub stroke: Option<Stroke>,
+    pub transform: Transform,
+}
+
+struct Image {
+    pub data: ImageKind,
+    pub visibility: Visibility,
+    pub transform: Transform,
+}
+
+impl Buffer {
+    pub fn new(svg: &str) -> Self {
+        let fontdb = usvg::fontdb::Database::new();
+        let utree: usvg::Tree = usvg::Tree::from_str(
+            svg,
+            &Options { image_href_resolver: lb_local_resolver, ..Default::default() },
+            &fontdb,
+        )
+        .unwrap();
+
+        let mut buffer = Buffer::default();
+
+        utree
+            .root()
+            .children()
+            .iter()
+            .enumerate()
+            .for_each(|(i, u_el)| match &u_el {
+                usvg::Node::Group(group) => {
+                    if group.id().eq(G_CONTAINER_ID) {
+                        buffer.master_transform = group.transform();
+                    }
+                }
+                usvg::Node::Image(img) => {
+                    buffer.elements.insert(
+                        i.to_string(),
+                        Element::Image(Image {
+                            data: img.kind().clone(),
+                            visibility: img.visibility(),
+                            transform: img.abs_transform(),
+                        }),
+                    );
+                }
+                usvg::Node::Text(text) => {
+                    buffer
+                        .elements
+                        .insert(i.to_string(), Element::Text(*text.to_owned().deref()));
+                }
+                usvg::Node::Path(path) => {
+                    buffer.elements.insert(
+                        i.to_string(),
+                        Element::Path(Path {
+                            data: usvg_d_to_subpath(path),
+                            visibility: path.visibility(),
+                            fill: path.fill().cloned(),
+                            stroke: path.stroke().cloned(),
+                            transform: path.abs_transform(),
+                        }),
+                    );
+                }
+                _ => {}
+            });
+        buffer
+    }
+}
+
+fn usvg_d_to_subpath(path: &Box<usvg::Path>) -> Subpath<ManipulatorGroupId> {
+    let mut prev = Point::default();
+    let mut subpath: Subpath<ManipulatorGroupId> = Subpath::new(vec![], false);
+    for segment in path.data().segments() {
+        match segment {
+            resvg::tiny_skia::PathSegment::MoveTo(p) => {
+                prev = p;
+            }
+            resvg::tiny_skia::PathSegment::CubicTo(p1, p2, p3) => {
+                let bez = Bezier::from_cubic_coordinates(
+                    prev.x.into(),
+                    prev.y.into(),
+                    p1.x.into(),
+                    p1.y.into(),
+                    p2.x.into(),
+                    p2.y.into(),
+                    p3.x.into(),
+                    p3.y.into(),
+                );
+                subpath.append_bezier(&bez, bezier_rs::AppendType::IgnoreStart);
+                prev = p3;
+            }
+            resvg::tiny_skia::PathSegment::LineTo(p) => {
+                let bez = Bezier::from_linear_coordinates(
+                    prev.x.into(),
+                    prev.y.into(),
+                    p.x.into(),
+                    p.y.into(),
+                );
+                subpath.append_bezier(&bez, bezier_rs::AppendType::IgnoreStart);
+                prev = p;
+            }
+            _ => {}
+        }
+    }
+
+    let t = path.abs_transform();
+
+    subpath.apply_transform(DAffine2 {
+        matrix2: DMat2 {
+            x_axis: DVec2 { x: t.sx.into(), y: t.ky.into() },
+            y_axis: DVec2 { x: t.kx.into(), y: t.sy.into() },
+        },
+        translation: DVec2 { x: t.tx.into(), y: t.ty.into() },
+    });
+
+    subpath
+}
+
+fn lb_local_resolver(core: &lb_rs::Core) -> ImageHrefStringResolverFn {
+    let lb_link_prefix = "lb://";
+    let core = core.clone();
+    Box::new(move |href: &str, _opts: &Options| {
+        if !href.starts_with(lb_link_prefix) {
+            return None;
+        }
+        let id = &href[lb_link_prefix.len()..];
+        let id = lb_rs::Uuid::from_str(id).ok()?;
+        let raw = core.read_document(id).ok()?;
+
+        let name = core.get_file_by_id(id).ok()?.name;
+        let ext = name.split('.').last().unwrap_or_default();
+        match ext {
+            "jpg" | "jpeg" => Some(ImageKind::JPEG(Arc::new(raw))),
+            "png" => Some(ImageKind::PNG(Arc::new(raw))),
+            // "svg" => Some(ImageKind::SVG(Arc::new(raw))), todo: handle nested svg
+            "gif" => Some(ImageKind::GIF(Arc::new(raw))),
+            _ => None,
+        }
+    })
+}
+
+impl ToString for Buffer {
+    fn to_string(&self) -> String {
+        // let mut out = Vec::new();
+        // if let Err(msg) = self.current.write_to(&mut out) {
+        //     println!("{:#?}", msg);
+        // }
+        // let out = std::str::from_utf8(&out)
+        //     .unwrap()
+        //     .replace("href", "xlink:href"); // risky
+        // let out = out.replace("xmlns='' ", "");
+        // let out = format!("<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">{}</svg>", out);
+        // out
+        "todo serialize the buffer".to_string()
+    }
+}
+
+// impl Debug for Buffer {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         f.debug_struct("Buffer")
+//             .field("undo", &self.undo)
+//             .field("redo", &self.redo)
+//             .finish()
+//     }
+// }

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -107,6 +107,7 @@ impl Buffer {
                         }
                         stroke.width = s.width().get();
                         stroke.opacity = s.opacity().get();
+                        println!("{:#?}", s);
                     }
                     buffer.elements.insert(
                         i.to_string(),
@@ -213,18 +214,22 @@ impl ToString for Buffer {
 
         let mut root = r#"<svg xmlns="http://www.w3.org/2000/svg">"#.into();
         self.elements.iter().for_each(|el| match el.1 {
-            Element::Path(p) => p.data.to_svg(
-                &mut root,
-                r#"stroke-color="red""#.into(),
-                "".into(),
-                "".into(),
-                "".into(),
-            ),
+            Element::Path(p) => {
+                let mut curv_attrs = " ".to_string(); // if it's empty then the curve might not be converted to string via bezier_rs
+                if let Some(stroke) = p.stroke {
+                    curv_attrs = format!(
+                        r#"stroke-width="{}" stroke="{}""#,
+                        stroke.width,
+                        stroke.color.to_hex() // todo: see how to handle opacity
+                    );
+                }
+                p.data
+                    .to_svg(&mut root, curv_attrs, "".into(), "".into(), "".into())
+            }
             Element::Image(_) => todo!(),
             Element::Text(_) => todo!(),
         });
         let _ = write!(&mut root, "</svg>");
-        println!("{:#?}", root);
         root
     }
 }

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -102,7 +102,7 @@ impl Buffer {
     }
 }
 
-fn parse_child(u_el: &usvg::Node, mut buffer: &mut Buffer, i: usize) {
+fn parse_child(u_el: &usvg::Node, buffer: &mut Buffer, i: usize) {
     match &u_el {
         usvg::Node::Group(group) => {
             if group.id().eq(ZOOM_G_ID) {
@@ -235,14 +235,11 @@ impl ToString for Buffer {
                     let mut curv_attrs = " ".to_string(); // if it's empty then the curve might not be converted to string via bezier_rs
                     if let Some(stroke) = p.stroke {
                         curv_attrs = format!(
-                            r#"stroke-width="{}" stroke="{}" fill="none""#,
+                            r#"stroke-width="{}" stroke="\#{:02X}{:02X}{:02X}" fill="none""#,
                             stroke.width,
-                            format!(
-                                "#{:02X}{:02X}{:02X}",
-                                stroke.color.r(),
-                                stroke.color.g(),
-                                stroke.color.b()
-                            ) // todo: see how to handle opacity
+                            stroke.color.r(),
+                            stroke.color.g(),
+                            stroke.color.b(),
                         );
                     }
                     if p.data.len() > 1 {
@@ -276,7 +273,7 @@ impl ToString for Buffer {
             self.master_transform.tx,
             self.master_transform.ty
         );
-        let _ = write!(&mut root, "{} {}", zoom_level, "</svg>");
+        let _ = write!(&mut root, "{} </svg>", zoom_level);
         root
     }
 }

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -78,7 +78,7 @@ impl Buffer {
 
         let lb_local_resolver = ImageHrefResolver {
             resolve_data: ImageHrefResolver::default_data_resolver(),
-            resolve_string: lb_local_resolver(&core),
+            resolve_string: lb_local_resolver(core),
         };
 
         let options =
@@ -112,7 +112,7 @@ fn parse_child(u_el: &usvg::Node, mut buffer: &mut Buffer, i: usize) {
                 .children()
                 .iter()
                 .enumerate()
-                .for_each(|(i, u_el)| parse_child(u_el, &mut buffer, i));
+                .for_each(|(i, u_el)| parse_child(u_el, buffer, i));
         }
         usvg::Node::Image(img) => {
             buffer.elements.insert(
@@ -177,7 +177,7 @@ fn lb_local_resolver(core: &lb_rs::Core) -> ImageHrefStringResolverFn {
     })
 }
 
-fn usvg_d_to_subpath(path: &Box<usvg::Path>) -> Subpath<ManipulatorGroupId> {
+fn usvg_d_to_subpath(path: &usvg::Path) -> Subpath<ManipulatorGroupId> {
     let mut prev = Point::default();
     let mut subpath: Subpath<ManipulatorGroupId> = Subpath::new(vec![], false);
     for segment in path.data().segments() {

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -1,6 +1,5 @@
 use bezier_rs::{Bezier, Subpath};
-use minidom::Element;
-use resvg::usvg::{Color, Transform};
+use resvg::usvg::Transform;
 use std::{
     collections::VecDeque,
     time::{Duration, Instant},
@@ -9,10 +8,8 @@ use std::{
 use crate::theme::palette::ThemePalette;
 
 use super::{
-    history::{self, History},
+    history::History,
     parser::{self, ManipulatorGroupId, Path, Stroke},
-    toolbar::ColorSwatch,
-    util::{self, apply_transform_to_pos, d_to_subpath, deserialize_transform},
     Buffer, InsertElement,
 };
 

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -69,9 +69,15 @@ impl Pen {
         };
 
         match event {
-            PathEvent::Draw(mut pos, id) => {
+            PathEvent::Draw(pos, id) => {
                 // apply_transform_to_pos(&mut pos, buffer);
 
+                // for some reason the integration will send two draw events on the same pos which results in a knot.
+                if let Some(last_pos) = self.path_builder.original_points.last() {
+                    if last_pos.eq(&pos) {
+                        return None;
+                    }
+                }
                 if self.detect_snap(pos, buffer.master_transform) {
                     let curr_id = self.current_id; // needed because end path will advance to the next id
                     self.end_path(buffer, history, true);

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -34,7 +34,11 @@ impl Pen {
             active_color: None,
             active_stroke_width: default_stroke_width,
             current_id: max_id,
-            simplification_tolerance: 1.5,
+            simplification_tolerance: if cfg!(target_os = "ios") || cfg!(target_os = "android") {
+                0.2
+            } else {
+                1.0
+            },
             path_builder: CubicBezBuilder::new(),
             maybe_snap_started: None,
         }

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -68,7 +68,6 @@ impl Pen {
             Some(e) => e,
             None => return None,
         };
-
         match event {
             PathEvent::Draw(pos, id) => {
                 // for some reason in ipad there are  two draw events on the same pos which results in a knot.
@@ -119,7 +118,7 @@ impl Pen {
     }
 
     fn end_path(&mut self, buffer: &mut Buffer, history: &mut History, is_snapped: bool) {
-        if self.path_builder.path.len() > 2 {
+        if self.path_builder.path.len() > 2 && is_snapped {
             self.path_builder
                 .finish(is_snapped, buffer, self.simplification_tolerance);
         }

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -1,10 +1,14 @@
+use bezier_rs::{Bezier, Subpath};
 use minidom::Element;
+use resvg::usvg::{Color, Stroke, Transform};
 use std::{
     collections::VecDeque,
     time::{Duration, Instant},
 };
 
 use super::{
+    history::{self, History},
+    parser::{self, ManipulatorGroupId, Path},
     toolbar::ColorSwatch,
     util::{self, apply_transform_to_pos, d_to_subpath, deserialize_transform},
     Buffer, InsertElement,
@@ -36,7 +40,8 @@ impl Pen {
     }
 
     pub fn handle_input(
-        &mut self, ui: &mut egui::Ui, inner_rect: egui::Rect, buffer: &mut Buffer,
+        &mut self, ui: &mut egui::Ui, inner_rect: egui::Rect, buffer: &mut parser::Buffer,
+        history: &mut History,
     ) -> Option<PenResponse> {
         let event = match self.setup_events(ui, inner_rect) {
             Some(e) => e,
@@ -47,71 +52,61 @@ impl Pen {
             PathEvent::Draw(mut pos, id) => {
                 apply_transform_to_pos(&mut pos, buffer);
 
-                let mut master_transform = None;
-                if let Some(transform) = buffer.current.attr("transform") {
-                    master_transform = Some(deserialize_transform(transform));
-                }
-
-                if self.detect_snap(pos, master_transform) {
+                if self.detect_snap(pos, buffer.master_transform) {
                     let curr_id = self.current_id; // needed because end path will advance to the next id
-                    self.end_path(buffer, true);
+                    self.end_path(buffer, history, true);
                     return Some(PenResponse::ToggleSelection(curr_id));
-                } else if let Some(node) = util::node_by_id(&mut buffer.current, id.to_string()) {
+                } else if let Some(parser::Element::Path(p)) =
+                    buffer.elements.get_mut(&id.to_string())
+                {
                     self.path_builder.cubic_to(pos);
-                    node.set_attr("d", &self.path_builder.data);
+                    p.data = self.path_builder.path.clone();
+                    // node.set_attr("d", &self.path_builder.data);
 
-                    if let Some(color) = &self.active_color {
-                        node.set_attr("stroke", format!("url(#{})", color.id));
-                    } else {
-                        node.set_attr("stroke", "url(#fg)");
-                    }
+                    // if let Some(color) = &self.active_color {
+                    //     node.set_attr("stroke", format!("url(#{})", color.id));
+                    // } else {
+                    //     node.set_attr("stroke", "url(#fg)");
+                    // }
                 } else {
                     self.path_builder.cubic_to(pos);
 
-                    let child = Element::builder("path", "")
-                        .attr("stroke-width", self.active_stroke_width.to_string())
-                        .attr("fill", "none")
-                        .attr("stroke-linejoin", "round")
-                        .attr("stroke-linecap", "round")
-                        .attr("id", id)
-                        .attr("d", &self.path_builder.data)
-                        .build();
-
-                    buffer.current.append_child(child);
+                    buffer.elements.insert(
+                        id.to_string(),
+                        parser::Element::Path(Path {
+                            data: self.path_builder.path.clone(),
+                            visibility: resvg::usvg::Visibility::Visible,
+                            fill: None,
+                            stroke: None,
+                            transform: Transform::default(),
+                            opacity: 1.0,
+                        }),
+                    );
                 }
             }
             PathEvent::End => {
-                self.end_path(buffer, false);
+                self.end_path(buffer, history, false);
                 self.maybe_snap_started = None;
             }
         }
         None
     }
 
-    fn end_path(&mut self, buffer: &mut Buffer, is_snapped: bool) {
+    fn end_path(&mut self, buffer: &mut Buffer, history: &mut History, is_snapped: bool) {
         if self.path_builder.points.len() < 2 {
-            buffer.current.remove_child(&self.current_id.to_string());
+            buffer.elements.remove(&self.current_id.to_string());
             self.path_builder.clear();
             return;
         }
 
         self.path_builder.finish(is_snapped, buffer);
 
-        if let Some(node) = util::node_by_id(&mut buffer.current, self.current_id.to_string()) {
-            node.set_attr("d", &self.path_builder.data);
-
-            let node = node.clone();
-
-            buffer.save(super::Event::Insert(vec![InsertElement {
-                id: self.current_id.to_string(),
-                element: node,
-            }]));
-        }
+        history.save(super::Event::Insert(vec![InsertElement { id: self.current_id.to_string() }]));
         self.path_builder.clear();
         self.current_id += 1;
     }
 
-    fn detect_snap(&mut self, current_pos: egui::Pos2, master_transform: Option<[f64; 6]>) -> bool {
+    fn detect_snap(&mut self, current_pos: egui::Pos2, master_transform: Transform) -> bool {
         if self.path_builder.points.len() < 2 {
             return false;
         }
@@ -120,9 +115,8 @@ impl Pen {
             let dist_diff = last_pos.distance(current_pos).abs();
 
             let mut dist_to_trigger_snap = 1.5;
-            if let Some(t) = master_transform {
-                dist_to_trigger_snap /= t[0] as f32;
-            }
+
+            dist_to_trigger_snap /= master_transform.sx;
 
             let time_to_trigger_snap = Duration::from_secs(1);
 
@@ -187,6 +181,7 @@ pub struct CubicBezBuilder {
     prev_points_window: VecDeque<egui::Pos2>,
     points: Vec<egui::Pos2>,
     pub data: String,
+    path: Subpath<ManipulatorGroupId>,
 }
 
 impl Default for CubicBezBuilder {
@@ -201,6 +196,7 @@ impl CubicBezBuilder {
             prev_points_window: VecDeque::from(vec![]),
             points: vec![],
             data: String::new(),
+            path: Subpath::<ManipulatorGroupId>::from_anchors(vec![], false),
         }
     }
 
@@ -209,10 +205,19 @@ impl CubicBezBuilder {
 
         if is_first_point {
             self.data = format!("M {} {}", dest.x, dest.y);
+        } else {
+            let prev = self.prev_points_window.back().unwrap();
+            let bez = Bezier::from_linear_coordinates(
+                prev.x.into(),
+                prev.y.into(),
+                dest.x.into(),
+                dest.y.into(),
+            );
+            self.path
+                .append_bezier(&bez, bezier_rs::AppendType::IgnoreStart);
         }
         self.data
             .push_str(format!(" L{} {}", dest.x, dest.y).as_str());
-
         self.prev_points_window.push_back(dest);
     }
 
@@ -254,6 +259,19 @@ impl CubicBezBuilder {
         self.data
             .push_str(format!("C {cp1x},{cp1y},{cp2x},{cp2y},{},{}", p2.x, p2.y).as_str());
 
+        let bez = Bezier::from_cubic_coordinates(
+            self.prev_points_window.back().unwrap().x.into(),
+            self.prev_points_window.back().unwrap().y.into(),
+            cp1x.into(),
+            cp1y.into(),
+            cp2x.into(),
+            cp2x.into(),
+            p2.x.into(),
+            p2.y.into(),
+        );
+        self.path
+            .append_bezier(&bez, bezier_rs::AppendType::IgnoreStart);
+
         // shift the window foreword
         self.prev_points_window.pop_front();
     }
@@ -270,9 +288,8 @@ impl CubicBezBuilder {
         } else {
             2.0
         };
-        if let Some(transform) = buffer.current.attr("transform") {
-            tolerance /= deserialize_transform(transform)[0] as f32;
-        }
+
+        tolerance /= buffer.master_transform.sx;
         self.simplify(tolerance);
 
         self.data.clear();

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -67,7 +67,6 @@ impl Pen {
 
         match event {
             PathEvent::Draw(pos, id) => {
-                // apply_transform_to_pos(&mut pos, buffer);
 
                 // for some reason the integration will send two draw events on the same pos which results in a knot.
                 if let Some(last_pos) = self.path_builder.original_points.last() {

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -306,7 +306,7 @@ impl CubicBezBuilder {
             user_tolerance
         };
 
-        tolerance /= buffer.master_transform.sx;
+        tolerance *= buffer.master_transform.sx;
         let maybe_simple_points = self.simplify(tolerance);
 
         self.clear();

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -97,7 +97,8 @@ impl Pen {
                             visibility: resvg::usvg::Visibility::Visible,
                             fill: None,
                             stroke: Some(stroke),
-                            transform: Transform::default(),
+                            transform: Transform::identity()
+                                .post_scale(buffer.master_transform.sx, buffer.master_transform.sy),
                             opacity: 1.0,
                         }),
                     );

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -249,7 +249,7 @@ impl Selection {
             None
         };
 
-        if let Some(_) = delta {
+        if delta.is_some() {
             end_translation(buffer, history, &mut self.selected_elements, pos, true);
         }
 
@@ -289,7 +289,7 @@ impl Selection {
                 buffer
                     .elements
                     .iter()
-                    .find(|(&ref id, _el)| id.eq(&selection.id));
+                    .find(|(id, _el)| id.to_owned().eq(&selection.id));
                 DeleteElement { id: selection.id.clone() }
             })
             .collect();

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -342,3 +342,14 @@ pub fn u_transform_to_bezier(src: &Transform) -> DAffine2 {
         translation: glam::DVec2 { x: src.tx.into(), y: src.ty.into() },
     }
 }
+
+pub fn bezier_transform_to_u(src: &glam::DAffine2) -> Transform {
+    Transform::from_row(
+        src.matrix2.x_axis.x as f32,
+        src.matrix2.x_axis.y as f32,
+        src.matrix2.y_axis.x as f32,
+        src.matrix2.y_axis.y as f32,
+        src.translation.x as f32,
+        src.translation.y as f32,
+    )
+}

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -80,11 +80,9 @@ impl Selection {
             if let Some(new_selected_el) = maybe_selected_el {
                 if ui.input(|r| r.modifiers.shift) {
                     self.selected_elements.push(new_selected_el);
-                    // end_translation(buffer, &mut self.selected_elements, pos);
                 } else if !pos_over_selected_el {
                     self.selected_elements = vec![new_selected_el]
                 }
-                self.current_op = SelectionOperation::Translation;
             } else if !pos_over_selected_el {
                 self.selected_elements.clear();
                 self.laso_original_pos = Some(pos);

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -14,12 +14,7 @@ use self::{
     translate::{detect_translation, end_translation},
 };
 
-use super::{
-    history::{History, TransformElement},
-    parser,
-    util::bb_to_rect,
-    Buffer, DeleteElement,
-};
+use super::{history::History, parser, util::bb_to_rect, Buffer, DeleteElement};
 
 #[derive(Default)]
 pub struct Selection {
@@ -248,7 +243,7 @@ impl Selection {
             None
         };
 
-        if let Some(d) = delta {
+        if let Some(_) = delta {
             end_translation(buffer, history, &mut self.selected_elements, pos, true);
         }
 

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -299,21 +299,6 @@ impl Selection {
         history.save(delete_event);
         self.selected_elements.clear();
     }
-
-    // pub fn select_el_by_id(&mut self, id: &str, current_pos: egui::Pos2, buffer: &mut Buffer) {
-    //     if let Some(el) = buffer
-    //         .current
-    //         .children()
-    //         .find(|el| el.attr("id").unwrap_or_default().eq(id))
-    //     {
-    //         let transform = el.attr("transform").unwrap_or_default();
-    //         self.selected_elements = vec![SelectedElement {
-    //             id: id.to_string(),
-    //             original_pos: current_pos,
-    //             original_matrix: (transform.to_string(), deserialize_transform(transform)),
-    //         }];
-    //     }
-    // }
 }
 
 #[derive(Default, Clone, Copy)]

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -14,12 +14,7 @@ use self::{
     translate::{detect_translation, end_translation},
 };
 
-use super::{
-    history::{self, History},
-    parser,
-    util::{bb_to_rect, deserialize_transform},
-    Buffer, DeleteElement,
-};
+use super::{history::History, parser, util::bb_to_rect, Buffer, DeleteElement};
 
 #[derive(Default)]
 pub struct Selection {
@@ -201,8 +196,8 @@ impl Selection {
                             let transform = glam::DAffine2 {
                                 matrix2: glam::DMat2::IDENTITY,
                                 translation: glam::DVec2 {
-                                    x: (pos.x - selection.prev_pos.x).into(), // todo: divide by master transform[0]
-                                    y: (pos.y - selection.prev_pos.y).into(), // todo: divide by master transform[3]
+                                    x: (pos.x - selection.prev_pos.x).into(),
+                                    y: (pos.y - selection.prev_pos.y).into(),
                                 },
                             };
                             // save_translate(delta, el, buffer);
@@ -249,8 +244,7 @@ impl Selection {
         };
 
         if let Some(d) = delta {
-            // save_translates(d, &mut self.selected_elements, buffer);
-            // end_translation(buffer, &mut self.selected_elements, pos, true);
+            end_translation(buffer, history, &mut self.selected_elements, pos, true);
         }
 
         let is_scaling_up = ui.input(|r| r.key_pressed(egui::Key::Equals));
@@ -271,7 +265,7 @@ impl Selection {
                 self.selection_rect.as_ref().unwrap(), // todo: remove unwrap cus it can be none
                 buffer,
             );
-            // end_translation(buffer, &mut self.selected_elements, pos, true);
+            end_translation(buffer, history, &mut self.selected_elements, pos, true);
         }
 
         if ui.input(|r| r.key_pressed(egui::Key::Backspace)) && !self.selected_elements.is_empty() {

--- a/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
@@ -5,7 +5,7 @@ use super::{SelectedElement, SelectionOperation, SelectionResponse};
 use crate::{
     tab::svg_editor::{
         parser::ManipulatorGroupId,
-        util::{bb_to_rect, deserialize_transform, pointer_interests_path},
+        util::{bb_to_rect, pointer_interests_path},
         Buffer,
     },
     theme::icons::Icon,

--- a/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
@@ -5,7 +5,7 @@ use super::{SelectedElement, SelectionOperation, SelectionResponse};
 use crate::{
     tab::svg_editor::{
         parser::ManipulatorGroupId,
-        util::{bb_to_rect, pointer_interests_path},
+        util::{bb_to_rect, pointer_intersects_outline},
         Buffer,
     },
     theme::icons::Icon,
@@ -30,7 +30,13 @@ impl SelectionRectContainer {
                     crate::tab::svg_editor::parser::Element::Path(p) => {
                         p.data.bounding_box().unwrap()
                     }
-                    crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
+                    crate::tab::svg_editor::parser::Element::Image(img) => {
+                        let rect = img.bounding_box();
+                        [
+                            DVec2 { x: rect.left().into(), y: rect.top().into() },
+                            DVec2 { x: rect.right().into(), y: rect.bottom().into() },
+                        ]
+                    }
                     crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
                 },
                 None => continue,
@@ -57,23 +63,23 @@ impl SelectionRectContainer {
         }
 
         if let Some(left_path) = &self.container.left {
-            if pointer_interests_path(left_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
+            if pointer_intersects_outline(left_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
                 return Some(SelectionResponse::new(SelectionOperation::WestScale));
             }
         };
         if let Some(right_path) = &self.container.right {
-            if pointer_interests_path(right_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
+            if pointer_intersects_outline(right_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
                 return Some(SelectionResponse::new(SelectionOperation::EastScale));
             }
         };
 
         if let Some(top_path) = &self.container.top {
-            if pointer_interests_path(top_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
+            if pointer_intersects_outline(top_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
                 return Some(SelectionResponse::new(SelectionOperation::NorthScale));
             }
         };
         if let Some(bottom_path) = &self.container.bottom {
-            if pointer_interests_path(bottom_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
+            if pointer_intersects_outline(bottom_path, cursor_pos, None, SCALE_BRUSH_SIZE) {
                 return Some(SelectionResponse::new(SelectionOperation::SouthScale));
             }
         };

--- a/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
@@ -4,7 +4,7 @@ use glam::DVec2;
 use super::{SelectedElement, SelectionOperation, SelectionResponse};
 use crate::{
     tab::svg_editor::{
-        history::ManipulatorGroupId,
+        parser::ManipulatorGroupId,
         util::{bb_to_rect, deserialize_transform, pointer_interests_path},
         Buffer,
     },

--- a/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
@@ -25,8 +25,14 @@ impl SelectionRectContainer {
         let mut container_bb = [DVec2::new(f64::MAX, f64::MAX), DVec2::new(f64::MIN, f64::MIN)];
         let mut children = vec![];
         for el in els.iter() {
-            let bb = match buffer.paths.get(&el.id) {
-                Some(path) => path.bounding_box().unwrap_or_default(),
+            let bb = match buffer.elements.get(&el.id) {
+                Some(el) => match el {
+                    crate::tab::svg_editor::parser::Element::Path(p) => {
+                        p.data.bounding_box().unwrap()
+                    }
+                    crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
+                    crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
+                },
                 None => continue,
             };
 
@@ -81,23 +87,10 @@ impl SelectionRectContainer {
         self.container.show(ui, false);
     }
 
-    pub fn show_delete_btn(
-        &self, buffer: &mut Buffer, ui: &mut egui::Ui, working_rect: egui::Rect,
-    ) -> bool {
-        let mut delete_toolbar_dim = egui::pos2(20.0, 20.0);
+    pub fn show_delete_btn(&self, ui: &mut egui::Ui, working_rect: egui::Rect) -> bool {
+        let delete_toolbar_dim = egui::pos2(20.0, 20.0);
         let gap = 15.0;
         let icon_size = 19.0;
-        if let Some(transform) = buffer.current.attr("transform") {
-            let transform = deserialize_transform(transform);
-
-            delete_toolbar_dim.x = (delete_toolbar_dim.x * transform[0] as f32).clamp(20.0, 35.0);
-            delete_toolbar_dim.y = (delete_toolbar_dim.y * transform[3] as f32).clamp(20.0, 35.0);
-
-            if (icon_size * transform[3] as f32) < 5. {
-                println!("{:#?}", icon_size * transform[3] as f32);
-                return false;
-            }
-        }
 
         let delete_toolbar_rect = egui::Rect {
             min: egui::pos2(

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -39,7 +39,7 @@ pub fn scale_from_center(
         max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
     };
 
-    if buffer.elements.get_mut(&el.id).is_some() {
+    if let Some(node) = buffer.elements.get_mut(&el.id) {
         let u_transform = Transform::identity()
             .post_scale(factor, factor)
             .post_translate(

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -40,20 +40,21 @@ pub fn scale_from_center(
     };
 
     if let Some(node) = buffer.elements.get_mut(&el.id) {
+        let u_transform = Transform::identity()
+            .post_scale(factor, factor)
+            .post_translate(
+                -(1. - factor) * (element_rect.width() / 2. - element_rect.right()),
+                -(1. - factor) * (element_rect.height() / 2. - element_rect.bottom()),
+            );
+        let b_transform = u_transform_to_bezier(&u_transform);
+
         match node {
             crate::tab::svg_editor::parser::Element::Path(p) => {
-                let u_transform = Transform::identity()
-                    .post_scale(factor, factor)
-                    .post_translate(
-                        -(1. - factor) * (element_rect.width() / 2. - element_rect.right()),
-                        -(1. - factor) * (element_rect.height() / 2. - element_rect.bottom()),
-                    );
-                let b_transform = u_transform_to_bezier(&u_transform);
                 el.transform = el.transform.post_concat(u_transform);
 
                 p.data.apply_transform(b_transform);
             }
-            crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
+            crate::tab::svg_editor::parser::Element::Image(img) => img.apply_transform(u_transform),
             crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
         }
     }

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -1,8 +1,12 @@
 use bezier_rs::Subpath;
-use glam::DVec2;
+use glam::{DAffine2, DVec2};
 use resvg::usvg::Transform;
 
-use crate::tab::svg_editor::{parser::ManipulatorGroupId, Buffer};
+use crate::tab::svg_editor::{
+    history::{self, History, TransformElement},
+    parser::ManipulatorGroupId,
+    Buffer,
+};
 
 use super::{
     rect::SelectionRectContainer, u_transform_to_bezier, SelectedElement, SelectionOperation,
@@ -13,9 +17,9 @@ pub fn scale_group_from_center(
     factor: f32, els: &mut [SelectedElement], selected_rect: &SelectionRectContainer,
     buffer: &mut Buffer,
 ) {
-    for el in els.iter_mut() {
-        scale_from_center(factor, el, selected_rect, buffer)
-    }
+    els.iter_mut().for_each(|el| {
+        scale_from_center(factor, el, selected_rect, buffer);
+    });
 }
 
 pub fn scale_from_center(
@@ -49,6 +53,8 @@ pub fn scale_from_center(
                         -(1. - factor) * (element_rect.height() / 2. - element_rect.bottom()),
                     );
                 let b_transform = u_transform_to_bezier(&u_transform);
+                el.transform = el.transform.post_concat(u_transform);
+
                 p.data.apply_transform(b_transform);
             }
             crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
@@ -93,8 +99,9 @@ pub fn snap_scale(
         )
     };
 
-    for el in els.iter_mut() {
+    els.iter_mut().for_each(|el| {
         scale_from_center(factor, el, selected_rect, buffer);
-    }
+    });
+
     res_icon
 }

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -2,8 +2,8 @@ use bezier_rs::Subpath;
 use glam::{DAffine2, DMat2, DVec2};
 
 use crate::tab::svg_editor::{
-    history::ManipulatorGroupId,
     node_by_id,
+    parser::ManipulatorGroupId,
     util::{deserialize_transform, serialize_transform},
     Buffer,
 };

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -1,13 +1,8 @@
 use bezier_rs::Subpath;
-use glam::{DAffine2, DMat2, DVec2};
+use glam::DVec2;
 use resvg::usvg::Transform;
 
-use crate::tab::svg_editor::{
-    node_by_id,
-    parser::ManipulatorGroupId,
-    util::{deserialize_transform, serialize_transform},
-    Buffer,
-};
+use crate::tab::svg_editor::{parser::ManipulatorGroupId, Buffer};
 
 use super::{
     rect::SelectionRectContainer, u_transform_to_bezier, SelectedElement, SelectionOperation,

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -39,7 +39,7 @@ pub fn scale_from_center(
         max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
     };
 
-    if let Some(node) = buffer.elements.get_mut(&el.id) {
+    if buffer.elements.get_mut(&el.id).is_some() {
         let u_transform = Transform::identity()
             .post_scale(factor, factor)
             .post_translate(

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -1,12 +1,8 @@
 use bezier_rs::Subpath;
-use glam::{DAffine2, DVec2};
+use glam::DVec2;
 use resvg::usvg::Transform;
 
-use crate::tab::svg_editor::{
-    history::{self, History, TransformElement},
-    parser::ManipulatorGroupId,
-    Buffer,
-};
+use crate::tab::svg_editor::{parser::ManipulatorGroupId, Buffer};
 
 use super::{
     rect::SelectionRectContainer, u_transform_to_bezier, SelectedElement, SelectionOperation,

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -1,5 +1,5 @@
 use crate::tab::svg_editor::{
-    history::TransformElement,
+    history::{self, History, TransformElement},
     node_by_id,
     util::{deserialize_transform, pointer_interests_path},
     Buffer, Event,
@@ -7,103 +7,104 @@ use crate::tab::svg_editor::{
 
 use super::SelectedElement;
 
-pub fn save_translate(delta: egui::Pos2, de: &mut SelectedElement, buffer: &mut Buffer) {
-    if let Some(node) = node_by_id(&mut buffer.current, de.id.clone()) {
-        node.set_attr(
-            "transform",
-            format!(
-                "matrix({},0,0,{},{},{} )",
-                de.original_matrix.1[0],
-                de.original_matrix.1[3],
-                delta.x as f64 + de.original_matrix.clone().1[4],
-                delta.y as f64 + de.original_matrix.clone().1[5]
-            ),
-        );
-        buffer.needs_path_map_update = true;
-    }
-}
+// pub fn save_translate(delta: egui::Pos2, de: &mut SelectedElement, buffer: &mut Buffer) {
+//     if let Some(node) = node_by_id(&mut buffer.current, de.id.clone()) {
+//         node.set_attr(
+//             "transform",
+//             format!(
+//                 "matrix({},0,0,{},{},{} )",
+//                 de.original_matrix.1[0],
+//                 de.original_matrix.1[3],
+//                 delta.x as f64 + de.original_matrix.clone().1[4],
+//                 delta.y as f64 + de.original_matrix.clone().1[5]
+//             ),
+//         );
+//         buffer.needs_path_map_update = true;
+//     }
+// }
 
-pub fn save_translates(delta: egui::Pos2, els: &mut [SelectedElement], buffer: &mut Buffer) {
-    els.iter().for_each(|el| {
-        if let Some(node) = node_by_id(&mut buffer.current, el.id.clone()) {
-            node.set_attr(
-                "transform",
-                format!(
-                    "matrix({},0,0,{},{},{} )",
-                    el.original_matrix.1[0],
-                    el.original_matrix.1[3],
-                    delta.x as f64 + el.original_matrix.clone().1[4],
-                    delta.y as f64 + el.original_matrix.clone().1[5]
-                ),
-            );
-            buffer.needs_path_map_update = true;
-        }
-    });
-}
+// pub fn save_translates(delta: egui::Pos2, els: &mut [SelectedElement], buffer: &mut Buffer) {
+//     els.iter().for_each(|el| {
+//         if let Some(node) = node_by_id(&mut buffer.current, el.id.clone()) {
+//             node.set_attr(
+//                 "transform",
+//                 format!(
+//                     "matrix({},0,0,{},{},{} )",
+//                     el.original_matrix.1[0],
+//                     el.original_matrix.1[3],
+//                     delta.x as f64 + el.original_matrix.clone().1[4],
+//                     delta.y as f64 + el.original_matrix.clone().1[5]
+//                 ),
+//             );
+//             buffer.needs_path_map_update = true;
+//         }
+//     });
+// }
+
 pub fn end_translation(
-    buffer: &mut Buffer, els: &mut [SelectedElement], pos: egui::Pos2, save_event: bool,
+    buffer: &mut Buffer, history: &mut History, els: &mut [SelectedElement], pos: egui::Pos2,
+    save_event: bool,
 ) {
     let events: Vec<TransformElement> = els
         .iter_mut()
         .filter_map(|el| {
-            el.original_pos = pos;
-            if let Some(node) = buffer
-                .current
-                .children()
-                .find(|node| node.attr("id").map_or(false, |id| id.eq(&el.id)))
-            {
-                if let Some(new_transform) = node.attr("transform") {
-                    let new_transform =
-                        (new_transform.to_string(), deserialize_transform(new_transform));
-
-                    let old_transform = el.original_matrix.clone();
-                    let delta = egui::pos2(
-                        (new_transform.1[4] - old_transform.1[4]).abs() as f32,
-                        (new_transform.1[5] - old_transform.1[5]).abs() as f32,
-                    );
-
-                    el.original_matrix = new_transform.clone();
-
-                    let history_threshold = 1.0;
-                    if save_event && (delta.y > history_threshold || delta.x > history_threshold) {
-                        Some(TransformElement {
-                            id: el.id.to_owned(),
-                            old_transform: old_transform.0,
-                            new_transform: new_transform.0,
-                        })
-                    } else {
+            el.prev_pos = pos;
+            if let Some(node) = buffer.elements.get_mut(&el.id) {
+                match node {
+                    crate::tab::svg_editor::parser::Element::Path(p) => {
+                        println!("should push to transform event to hisotry");
                         None
                     }
-                } else {
-                    None
+                    crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
+                    crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
                 }
+                // if let Some(new_transform) = node.attr("transform") {
+                //     let new_transform =
+                //         (new_transform.to_string(), deserialize_transform(new_transform));
+
+                //     let old_transform = el.original_matrix.clone();
+                //     let delta = egui::pos2(
+                //         (new_transform.1[4] - old_transform.1[4]).abs() as f32,
+                //         (new_transform.1[5] - old_transform.1[5]).abs() as f32,
+                //     );
+
+                //     el.original_matrix = new_transform.clone();
+
+                //     let history_threshold = 1.0;
+                //     if save_event && (delta.y > history_threshold || delta.x > history_threshold) {
+                //         Some(TransformElement {
+                //             id: el.id.to_owned(),
+                //             old_transform: old_transform.0,
+                //             new_transform: new_transform.0,
+                //         })
+                //     } else {
+                //         None
+                //     }
+                // } else {
+                //     None
+                // }
             } else {
                 None
             }
         })
         .collect();
     if !events.is_empty() {
-        buffer.save(Event::Transform(events));
+        history.save(Event::Transform(events));
     }
 }
 
 pub fn detect_translation(
     buffer: &mut Buffer, last_pos: Option<egui::Pos2>, current_pos: egui::Pos2,
 ) -> Option<SelectedElement> {
-    for (id, path) in buffer.paths.iter() {
-        if pointer_interests_path(path, current_pos, last_pos, 10.0) {
-            let transform = buffer
-                .current
-                .children()
-                .find(|el| el.attr("id").unwrap_or_default().eq(id))
-                .unwrap()
-                .attr("transform")
-                .unwrap_or_default();
-            return Some(SelectedElement {
-                id: id.clone(),
-                original_pos: current_pos,
-                original_matrix: (transform.to_string(), deserialize_transform(transform)),
-            });
+    for (id, el) in buffer.elements.iter() {
+        match el {
+            crate::tab::svg_editor::parser::Element::Path(p) => {
+                if pointer_interests_path(&p.data, current_pos, last_pos, 10.0) {
+                    return Some(SelectedElement { id: id.clone(), prev_pos: current_pos });
+                }
+            }
+            crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
+            crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
         }
     }
     None

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -17,17 +17,13 @@ pub fn end_translation(
         .filter_map(|el| {
             el.prev_pos = pos;
             if let Some(node) = buffer.elements.get_mut(&el.id) {
-                match node {
-                    _ => {
-                        if save_event {
-                            Some(TransformElement {
-                                id: el.id.to_owned(),
-                                transform: u_transform_to_bezier(&el.transform),
-                            })
-                        } else {
-                            None
-                        }
-                    }
+                if save_event {
+                    Some(TransformElement {
+                        id: el.id.to_owned(),
+                        transform: u_transform_to_bezier(&el.transform),
+                    })
+                } else {
+                    None
                 }
             } else {
                 None
@@ -43,7 +39,7 @@ pub fn detect_translation(
     buffer: &mut Buffer, last_pos: Option<egui::Pos2>, current_pos: egui::Pos2,
 ) -> Option<SelectedElement> {
     for (id, el) in buffer.elements.iter() {
-        if pointer_intersects_element(&el, current_pos, last_pos, 10.0) {
+        if pointer_intersects_element(el, current_pos, last_pos, 10.0) {
             return Some(SelectedElement {
                 id: id.clone(),
                 prev_pos: current_pos,

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -1,47 +1,12 @@
 use resvg::usvg::Transform;
 
 use crate::tab::svg_editor::{
-    history::{self, History, TransformElement},
-    node_by_id,
-    util::{deserialize_transform, pointer_interests_path},
+    history::{History, TransformElement},
+    util::pointer_interests_path,
     Buffer, Event,
 };
 
 use super::{u_transform_to_bezier, SelectedElement};
-
-// pub fn save_translate(delta: egui::Pos2, de: &mut SelectedElement, buffer: &mut Buffer) {
-//     if let Some(node) = node_by_id(&mut buffer.current, de.id.clone()) {
-//         node.set_attr(
-//             "transform",
-//             format!(
-//                 "matrix({},0,0,{},{},{} )",
-//                 de.original_matrix.1[0],
-//                 de.original_matrix.1[3],
-//                 delta.x as f64 + de.original_matrix.clone().1[4],
-//                 delta.y as f64 + de.original_matrix.clone().1[5]
-//             ),
-//         );
-//         buffer.needs_path_map_update = true;
-//     }
-// }
-
-// pub fn save_translates(delta: egui::Pos2, els: &mut [SelectedElement], buffer: &mut Buffer) {
-//     els.iter().for_each(|el| {
-//         if let Some(node) = node_by_id(&mut buffer.current, el.id.clone()) {
-//             node.set_attr(
-//                 "transform",
-//                 format!(
-//                     "matrix({},0,0,{},{},{} )",
-//                     el.original_matrix.1[0],
-//                     el.original_matrix.1[3],
-//                     delta.x as f64 + el.original_matrix.clone().1[4],
-//                     delta.y as f64 + el.original_matrix.clone().1[5]
-//                 ),
-//             );
-//             buffer.needs_path_map_update = true;
-//         }
-//     });
-// }
 
 pub fn end_translation(
     buffer: &mut Buffer, history: &mut History, els: &mut [SelectedElement], pos: egui::Pos2,

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -2,7 +2,7 @@ use resvg::usvg::Transform;
 
 use crate::tab::svg_editor::{
     history::{History, TransformElement},
-    util::pointer_interests_path,
+    util::pointer_intersects_element,
     Buffer, Event,
 };
 
@@ -18,7 +18,7 @@ pub fn end_translation(
             el.prev_pos = pos;
             if let Some(node) = buffer.elements.get_mut(&el.id) {
                 match node {
-                    crate::tab::svg_editor::parser::Element::Path(_) => {
+                    _ => {
                         if save_event {
                             Some(TransformElement {
                                 id: el.id.to_owned(),
@@ -28,8 +28,6 @@ pub fn end_translation(
                             None
                         }
                     }
-                    crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
-                    crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
                 }
             } else {
                 None
@@ -45,18 +43,12 @@ pub fn detect_translation(
     buffer: &mut Buffer, last_pos: Option<egui::Pos2>, current_pos: egui::Pos2,
 ) -> Option<SelectedElement> {
     for (id, el) in buffer.elements.iter() {
-        match el {
-            crate::tab::svg_editor::parser::Element::Path(p) => {
-                if pointer_interests_path(&p.data, current_pos, last_pos, 10.0) {
-                    return Some(SelectedElement {
-                        id: id.clone(),
-                        prev_pos: current_pos,
-                        transform: Transform::identity(),
-                    });
-                }
-            }
-            crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
-            crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
+        if pointer_intersects_element(&el, current_pos, last_pos, 10.0) {
+            return Some(SelectedElement {
+                id: id.clone(),
+                prev_pos: current_pos,
+                transform: Transform::identity(),
+            });
         }
     }
     None

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -52,8 +52,17 @@ pub fn end_translation(
             if let Some(node) = buffer.elements.get_mut(&el.id) {
                 match node {
                     crate::tab::svg_editor::parser::Element::Path(p) => {
-                        println!("should push to transform event to hisotry");
-                        None
+                        if save_event
+                            && (delta.y > history_threshold || delta.x > history_threshold)
+                        {
+                            Some(TransformElement {
+                                id: el.id.to_owned(),
+                                old_transform: old_transform.0,
+                                new_transform: new_transform.0,
+                            })
+                        } else {
+                            None
+                        }
                     }
                     crate::tab::svg_editor::parser::Element::Image(_) => todo!(),
                     crate::tab::svg_editor::parser::Element::Text(_) => todo!(),

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -16,7 +16,7 @@ pub fn end_translation(
         .iter_mut()
         .filter_map(|el| {
             el.prev_pos = pos;
-            if let Some(node) = buffer.elements.get_mut(&el.id) {
+            if buffer.elements.get_mut(&el.id).is_some() {
                 if save_event {
                     Some(TransformElement {
                         id: el.id.to_owned(),

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -226,7 +226,7 @@ impl Toolbar {
                 if let Some(thickness) = self.show_thickness_pickers(
                     ui,
                     self.pen.active_stroke_width as f32,
-                    vec![3.0, 6.0, 9.0],
+                    vec![2.0, 4.0, 6.0],
                 ) {
                     self.pen.active_stroke_width = thickness as u32;
                 }

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -7,9 +7,7 @@ use crate::{
     widgets::Button,
 };
 
-use super::{
-    history::History, parser, selection::Selection, zoom::zoom_to_percentage, Buffer, Eraser, Pen,
-};
+use super::{history::History, parser, selection::Selection, Buffer, Eraser, Pen};
 
 const COLOR_SWATCH_BTN_RADIUS: f32 = 9.0;
 const THICKNESS_BTN_X_MARGIN: f32 = 5.0;
@@ -77,7 +75,7 @@ impl Toolbar {
 
     pub fn show(
         &mut self, ui: &mut egui::Ui, buffer: &mut parser::Buffer, history: &mut History,
-        skip_frame: &mut bool,
+        _skip_frame: &mut bool,
     ) {
         if ui.input_mut(|r| {
             r.consume_key(egui::Modifiers::CTRL | egui::Modifiers::SHIFT, egui::Key::Z)
@@ -112,9 +110,9 @@ impl Toolbar {
                             if let Some(r) = self.right_tab_rect { r.width() } else { 0.0 };
                         ui.add_space(right_bar_width + 10.0);
 
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
-                            self.show_right_toolbar(ui, buffer, skip_frame);
-                        });
+                        // ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                        //     self.show_right_toolbar(ui, buffer, skip_frame);
+                        // });
                     });
                 });
         });
@@ -318,46 +316,46 @@ impl Toolbar {
         chosen
     }
 
-    fn show_right_toolbar(
-        &mut self, ui: &mut egui::Ui, buffer: &mut Buffer, skip_frame: &mut bool,
-    ) {
-        let mut zoom_percentage = 100;
+    // fn show_right_toolbar(
+    //     &mut self, ui: &mut egui::Ui, buffer: &mut Buffer, skip_frame: &mut bool,
+    // ) {
+    //     let mut zoom_percentage = 100;
 
-        // Calculate the zoom percentage
-        zoom_percentage = ((buffer.master_transform.sx + buffer.master_transform.sy) / 2.0 * 100.0)
-            .round() as i32;
+    //     // Calculate the zoom percentage
+    //     zoom_percentage = ((buffer.master_transform.sx + buffer.master_transform.sy) / 2.0 * 100.0)
+    //         .round() as i32;
 
-        if Button::default().icon(&Icon::ZOOM_IN).show(ui).clicked() {
-            zoom_to_percentage(buffer, zoom_percentage + 10, ui.ctx().screen_rect());
-        };
+    //     if Button::default().icon(&Icon::ZOOM_IN).show(ui).clicked() {
+    //         zoom_to_percentage(buffer, zoom_percentage + 10, ui.ctx().screen_rect());
+    //     };
 
-        let mut selected = (zoom_percentage, false);
+    //     let mut selected = (zoom_percentage, false);
 
-        let res = egui::ComboBox::from_id_source("zoom_percentage_combobox")
-            .selected_text(format!("{:?}%", zoom_percentage))
-            .show_ui(ui, |ui| {
-                let btns = [50, 100, 200].iter().map(|&i| {
-                    ui.selectable_value(&mut selected, (i, true), format!("{}%", i))
-                        .rect
-                });
-                btns.reduce(|acc, e| e.union(acc))
-            })
-            .inner;
+    //     let res = egui::ComboBox::from_id_source("zoom_percentage_combobox")
+    //         .selected_text(format!("{:?}%", zoom_percentage))
+    //         .show_ui(ui, |ui| {
+    //             let btns = [50, 100, 200].iter().map(|&i| {
+    //                 ui.selectable_value(&mut selected, (i, true), format!("{}%", i))
+    //                     .rect
+    //             });
+    //             btns.reduce(|acc, e| e.union(acc))
+    //         })
+    //         .inner;
 
-        if let Some(Some(r)) = res {
-            if r.contains(ui.input(|r| r.pointer.hover_pos().unwrap_or_default())) {
-                *skip_frame = true;
-            }
-        }
-        if Button::default().icon(&Icon::ZOOM_OUT).show(ui).clicked() {
-            zoom_to_percentage(buffer, zoom_percentage - 10, ui.ctx().screen_rect());
-        }
+    //     if let Some(Some(r)) = res {
+    //         if r.contains(ui.input(|r| r.pointer.hover_pos().unwrap_or_default())) {
+    //             *skip_frame = true;
+    //         }
+    //     }
+    //     if Button::default().icon(&Icon::ZOOM_OUT).show(ui).clicked() {
+    //         zoom_to_percentage(buffer, zoom_percentage - 10, ui.ctx().screen_rect());
+    //     }
 
-        if selected.1 {
-            zoom_to_percentage(buffer, selected.0, ui.ctx().screen_rect());
-            selected.1 = false;
-        }
+    //     if selected.1 {
+    //         zoom_to_percentage(buffer, selected.0, ui.ctx().screen_rect());
+    //         selected.1 = false;
+    //     }
 
-        self.right_tab_rect = Some(ui.min_rect());
-    }
+    //     self.right_tab_rect = Some(ui.min_rect());
+    // }
 }

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 
-use egui::ScrollArea;
+use egui::{RichText, ScrollArea, Widget};
 
 use crate::{
     theme::{icons::Icon, palette::ThemePalette},
@@ -197,6 +197,23 @@ impl Toolbar {
     fn show_tool_inline_controls(&mut self, ui: &mut egui::Ui) {
         match self.active_tool {
             Tool::Pen => {
+                ui.label(
+                    RichText::from("Smoothing:")
+                        .color(ui.visuals().text_color().gamma_multiply(0.8))
+                        .size(15.0),
+                );
+                ui.add_space(10.0);
+
+                ui.add(
+                    egui::DragValue::new(&mut self.pen.simplification_tolerance)
+                        .clamp_range(0.1..=5.0)
+                        .speed(0.1),
+                );
+
+                ui.add_space(4.0);
+                ui.add(egui::Separator::default().shrink(ui.available_height() * 0.3));
+                ui.add_space(4.0);
+
                 if let Some(thickness) = self.show_thickness_pickers(
                     ui,
                     self.pen.active_stroke_width as f32,

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -37,41 +37,8 @@ pub enum Tool {
 
 #[derive(Clone)]
 pub struct ColorSwatch {
-    pub id: String,
+    pub id: Option<String>,
     pub color: egui::Color32,
-}
-impl ColorSwatch {
-    fn show(&self, ui: &mut egui::Ui, pen_active_color: Option<ColorSwatch>) -> egui::Response {
-        let (response, painter) = ui.allocate_painter(
-            egui::vec2(COLOR_SWATCH_BTN_RADIUS * PI, ui.available_height()),
-            egui::Sense::click(),
-        );
-
-        if let Some(active_color) = pen_active_color {
-            let opacity = if active_color.id.eq(&self.id) {
-                1.0
-            } else if response.hovered() {
-                ui.output_mut(|w| w.cursor_icon = egui::CursorIcon::PointingHand);
-                0.9
-            } else {
-                0.5
-            };
-
-            if active_color.id.eq(&self.id) {
-                painter.rect_filled(
-                    response.rect,
-                    egui::Rounding::same(8.0),
-                    self.color.gamma_multiply(0.2),
-                );
-            }
-            painter.circle_filled(
-                response.rect.center(),
-                COLOR_SWATCH_BTN_RADIUS,
-                self.color.gamma_multiply(opacity),
-            );
-        };
-        response
-    }
 }
 
 macro_rules! set_tool {
@@ -259,11 +226,42 @@ impl Toolbar {
         let theme_colors = ThemePalette::as_array(ui.visuals().dark_mode);
 
         theme_colors.iter().for_each(|theme_color| {
-            let color = ColorSwatch { id: theme_color.0.clone(), color: theme_color.1 };
-            if color.show(ui, self.pen.active_color.clone()).clicked() {
-                self.pen.active_color = Some(color);
+            // let color = ColorSwatch { id: theme_color.0.clone(), color: theme_color.1 };
+            if self.show_color_btn(ui, theme_color.1).clicked() {
+                self.pen.active_color = Some(theme_color.1);
             }
         });
+    }
+
+    fn show_color_btn(&self, ui: &mut egui::Ui, color: egui::Color32) -> egui::Response {
+        let (response, painter) = ui.allocate_painter(
+            egui::vec2(COLOR_SWATCH_BTN_RADIUS * PI, ui.available_height()),
+            egui::Sense::click(),
+        );
+
+        if let Some(active_color) = self.pen.active_color {
+            let opacity = if active_color.eq(&color) {
+                1.0
+            } else if response.hovered() {
+                0.9
+            } else {
+                0.5
+            };
+
+            if active_color.eq(&color) {
+                painter.rect_filled(
+                    response.rect,
+                    egui::Rounding::same(8.0),
+                    color.gamma_multiply(0.2),
+                );
+            }
+            painter.circle_filled(
+                response.rect.center(),
+                COLOR_SWATCH_BTN_RADIUS,
+                color.gamma_multiply(opacity),
+            );
+        };
+        response
     }
 
     fn show_thickness_pickers(

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -110,9 +110,9 @@ impl Toolbar {
                             if let Some(r) = self.right_tab_rect { r.width() } else { 0.0 };
                         ui.add_space(right_bar_width + 10.0);
 
-                        // ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
-                        //     self.show_right_toolbar(ui, buffer, skip_frame);
-                        // });
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                            self.show_right_toolbar(ui, buffer, &mut false);
+                        });
                     });
                 });
         });
@@ -316,46 +316,46 @@ impl Toolbar {
         chosen
     }
 
-    // fn show_right_toolbar(
-    //     &mut self, ui: &mut egui::Ui, buffer: &mut Buffer, skip_frame: &mut bool,
-    // ) {
-    //     let mut zoom_percentage = 100;
+    fn show_right_toolbar(
+        &mut self, ui: &mut egui::Ui, buffer: &mut Buffer, skip_frame: &mut bool,
+    ) {
+        let mut zoom_percentage = 100;
 
-    //     // Calculate the zoom percentage
-    //     zoom_percentage = ((buffer.master_transform.sx + buffer.master_transform.sy) / 2.0 * 100.0)
-    //         .round() as i32;
+        // Calculate the zoom percentage
+        zoom_percentage = ((buffer.master_transform.sx + buffer.master_transform.sy) / 2.0 * 100.0)
+            .round() as i32;
 
-    //     if Button::default().icon(&Icon::ZOOM_IN).show(ui).clicked() {
-    //         zoom_to_percentage(buffer, zoom_percentage + 10, ui.ctx().screen_rect());
-    //     };
+        if Button::default().icon(&Icon::ZOOM_IN).show(ui).clicked() {
+            // zoom_to_percentage(buffer, zoom_percentage + 10, ui.ctx().screen_rect());
+        };
 
-    //     let mut selected = (zoom_percentage, false);
+        let mut selected = (zoom_percentage, false);
 
-    //     let res = egui::ComboBox::from_id_source("zoom_percentage_combobox")
-    //         .selected_text(format!("{:?}%", zoom_percentage))
-    //         .show_ui(ui, |ui| {
-    //             let btns = [50, 100, 200].iter().map(|&i| {
-    //                 ui.selectable_value(&mut selected, (i, true), format!("{}%", i))
-    //                     .rect
-    //             });
-    //             btns.reduce(|acc, e| e.union(acc))
-    //         })
-    //         .inner;
+        let res = egui::ComboBox::from_id_source("zoom_percentage_combobox")
+            .selected_text(format!("{:?}%", zoom_percentage))
+            .show_ui(ui, |ui| {
+                let btns = [50, 100, 200].iter().map(|&i| {
+                    ui.selectable_value(&mut selected, (i, true), format!("{}%", i))
+                        .rect
+                });
+                btns.reduce(|acc, e| e.union(acc))
+            })
+            .inner;
 
-    //     if let Some(Some(r)) = res {
-    //         if r.contains(ui.input(|r| r.pointer.hover_pos().unwrap_or_default())) {
-    //             *skip_frame = true;
-    //         }
-    //     }
-    //     if Button::default().icon(&Icon::ZOOM_OUT).show(ui).clicked() {
-    //         zoom_to_percentage(buffer, zoom_percentage - 10, ui.ctx().screen_rect());
-    //     }
+        if let Some(Some(r)) = res {
+            if r.contains(ui.input(|r| r.pointer.hover_pos().unwrap_or_default())) {
+                *skip_frame = true;
+            }
+        }
+        if Button::default().icon(&Icon::ZOOM_OUT).show(ui).clicked() {
+            // zoom_to_percentage(buffer, zoom_percentage - 10, ui.ctx().screen_rect());
+        }
 
-    //     if selected.1 {
-    //         zoom_to_percentage(buffer, selected.0, ui.ctx().screen_rect());
-    //         selected.1 = false;
-    //     }
+        if selected.1 {
+            // zoom_to_percentage(buffer, selected.0, ui.ctx().screen_rect());
+            selected.1 = false;
+        }
 
-    //     self.right_tab_rect = Some(ui.min_rect());
-    // }
+        self.right_tab_rect = Some(ui.min_rect());
+    }
 }

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -111,7 +111,7 @@ impl Toolbar {
                         ui.add_space(right_bar_width + 10.0);
 
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
-                            self.show_right_toolbar(ui, buffer, &mut false);
+                            // self.show_right_toolbar(ui, buffer, &mut false);
                         });
                     });
                 });

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -339,9 +339,8 @@ impl Toolbar {
         &mut self, ui: &mut egui::Ui, buffer: &mut Buffer, skip_frame: &mut bool,
         inner_rect: egui::Rect,
     ) -> Option<Transform> {
-        let zoom_percentage = ((buffer.master_transform.sx + buffer.master_transform.sy) / 2.0
-            * 100.0)
-            .round() as f32;
+        let zoom_percentage =
+            ((buffer.master_transform.sx + buffer.master_transform.sy) / 2.0 * 100.0).round();
 
         if Button::default().icon(&Icon::ZOOM_IN).show(ui).clicked() {
             return Some(zoom_percentage_to_transform(zoom_percentage + 10., buffer, ui));
@@ -436,7 +435,7 @@ fn calc_elements_bounds(buffer: &mut Buffer) -> egui::Rect {
         elements_bound.max.x = elements_bound.max.x.max(el_rect.max.x);
         elements_bound.max.y = elements_bound.max.y.max(el_rect.max.y);
     }
-    return elements_bound;
+    elements_bound
 }
 
 fn zoom_percentage_to_transform(

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -184,10 +184,6 @@ impl Toolbar {
         ui.add_space(4.0);
 
         self.show_tool_inline_controls(ui);
-
-        ui.add_space(4.0);
-        ui.add(egui::Separator::default().shrink(ui.available_height() * 0.3));
-        ui.add_space(4.0);
     }
 
     fn show_tool_inline_controls(&mut self, ui: &mut egui::Ui) {

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -10,6 +10,7 @@ use crate::{
 use super::{
     history::{self, History},
     parser,
+    selection::Selection,
     util::deserialize_transform,
     zoom::zoom_to_percentage,
     Buffer, Eraser, Pen,
@@ -24,7 +25,7 @@ pub struct Toolbar {
     right_tab_rect: Option<egui::Rect>,
     pub pen: Pen,
     pub eraser: Eraser,
-    // pub selection: Selection,
+    pub selection: Selection,
     pub previous_tool: Option<Tool>,
 }
 
@@ -45,7 +46,7 @@ macro_rules! set_tool {
     ($obj:expr, $new_tool:expr) => {
         if $obj.active_tool != $new_tool {
             if (matches!($new_tool, Tool::Selection)) {
-                // $obj.selection = Selection::default();
+                $obj.selection = Selection::default();
             }
             $obj.previous_tool = Some($obj.active_tool);
             $obj.active_tool = $new_tool;
@@ -75,7 +76,7 @@ impl Toolbar {
             right_tab_rect: None,
             pen: Pen::new(max_id),
             eraser: Eraser::new(),
-            // selection: Selection::default(),
+            selection: Selection::default(),
         }
     }
 

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -214,11 +214,9 @@ impl Toolbar {
                         .size(15.0),
                 );
                 ui.add_space(10.0);
-
                 ui.add(
-                    egui::DragValue::new(&mut self.pen.simplification_tolerance)
-                        .clamp_range(0.1..=5.0)
-                        .speed(0.1),
+                    egui::Slider::new(&mut self.pen.simplification_tolerance, 0.0..=5.0)
+                        .show_value(false),
                 );
 
                 ui.add_space(4.0);
@@ -376,7 +374,7 @@ impl Toolbar {
         if selected.1 {
             selected.1 = false;
 
-            if selected.0 as i32 == FIT_ZOOM {
+            if selected.0 as i32 == FIT_ZOOM && !buffer.elements.is_empty() {
                 let elements_bound = calc_elements_bounds(buffer);
                 let is_width_smaller = elements_bound.width() < elements_bound.height();
 

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 
-use egui::{RichText, ScrollArea, Widget};
+use egui::{RichText, ScrollArea};
 
 use crate::{
     theme::{icons::Icon, palette::ThemePalette},
@@ -8,12 +8,7 @@ use crate::{
 };
 
 use super::{
-    history::{self, History},
-    parser,
-    selection::Selection,
-    util::deserialize_transform,
-    zoom::zoom_to_percentage,
-    Buffer, Eraser, Pen,
+    history::History, parser, selection::Selection, zoom::zoom_to_percentage, Buffer, Eraser, Pen,
 };
 
 const COLOR_SWATCH_BTN_RADIUS: f32 = 9.0;

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 
 use super::{
-    selection::Selection, util::deserialize_transform, zoom::zoom_to_percentage, Buffer, Eraser,
-    Pen,
+    parser, selection::Selection, util::deserialize_transform, zoom::zoom_to_percentage, Buffer,
+    Eraser, Pen,
 };
 
 const COLOR_SWATCH_BTN_RADIUS: f32 = 9.0;
@@ -109,7 +109,8 @@ impl Toolbar {
         }
     }
 
-    pub fn show(&mut self, ui: &mut egui::Ui, buffer: &mut Buffer, skip_frame: &mut bool) {
+    pub fn show(&mut self, ui: &mut egui::Ui, buffer: &mut parser::Buffer, skip_frame: &mut bool) {
+        
         if ui.input_mut(|r| {
             r.consume_key(egui::Modifiers::CTRL | egui::Modifiers::SHIFT, egui::Key::Z)
         }) {

--- a/libs/content/workspace/src/tab/svg_editor/util.rs
+++ b/libs/content/workspace/src/tab/svg_editor/util.rs
@@ -2,7 +2,7 @@ use bezier_rs::{Bezier, Subpath};
 use glam::DVec2;
 use minidom::Element;
 
-use super::{history::ManipulatorGroupId, Buffer};
+use super::parser::{self, ManipulatorGroupId};
 
 pub fn node_by_id(root: &mut Element, id: String) -> Option<&mut Element> {
     root.children_mut().find(
@@ -79,15 +79,12 @@ pub fn serialize_transform(matrix: &[f64]) -> String {
     )
 }
 
-pub fn apply_transform_to_pos(pos: &mut egui::Pos2, buffer: &Buffer) {
-    if let Some(transform) = buffer.current.attr("transform") {
-        let transform = deserialize_transform(transform);
-        pos.x -= transform[4] as f32;
-        pos.y -= transform[5] as f32;
+pub fn apply_transform_to_pos(pos: &mut egui::Pos2, buffer: &mut parser::Buffer) {
+    pos.x -= buffer.master_transform.tx;
+    pos.y -= buffer.master_transform.ty;
 
-        pos.x /= transform[0] as f32;
-        pos.y /= transform[3] as f32;
-    }
+    pos.x /= buffer.master_transform.sx;
+    pos.y /= buffer.master_transform.sy;
 }
 
 pub fn bb_to_rect(bb: [DVec2; 2]) -> egui::Rect {

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 use super::{
     parser,
+    selection::u_transform_to_bezier,
     util::{deserialize_transform, serialize_transform},
 };
 
@@ -55,13 +56,7 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
     }
 
     if pan.is_some() || is_zooming {
-        let transform = glam::DAffine2 {
-            matrix2: glam::DMat2 {
-                x_axis: glam::DVec2 { x: t.sx.into(), y: t.ky.into() },
-                y_axis: glam::DVec2 { x: t.kx.into(), y: t.sy.into() },
-            },
-            translation: glam::DVec2 { x: t.tx.into(), y: t.ty.into() },
-        };
+        let transform = u_transform_to_bezier(&t);
         for el in buffer.elements.values_mut() {
             match el {
                 parser::Element::Path(path) => {

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -54,22 +54,22 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
     }
 }
 
-pub fn zoom_to_percentage(buffer: &mut Buffer, percentage: i32, working_rect: egui::Rect) {
-    let original_matrix =
-        deserialize_transform(buffer.current.attr("transform").unwrap_or_default());
+pub fn zoom_to_percentage(buffer: &mut parser::Buffer, percentage: i32, working_rect: egui::Rect) {
+    // let original_matrix =
+    //     deserialize_transform(buffer.current.attr("transform").unwrap_or_default());
 
-    let [a, b, _, _, _, _] = original_matrix;
+    // let [a, b, _, _, _, _] = original_matrix;
 
-    let scale_x = (a * a + b * b).sqrt();
+    // let scale_x = (a * a + b * b).sqrt();
 
-    let zoom_delta = percentage as f64 / (scale_x * 100.0);
+    // let zoom_delta = percentage as f64 / (scale_x * 100.0);
 
-    let mut scaled_matrix: Vec<f64> = original_matrix.iter().map(|x| zoom_delta * x).collect();
+    // let mut scaled_matrix: Vec<f64> = original_matrix.iter().map(|x| zoom_delta * x).collect();
 
-    scaled_matrix[4] += (1.0 - zoom_delta) * working_rect.center().x as f64;
-    scaled_matrix[5] += (1.0 - zoom_delta) * working_rect.center().y as f64;
-    let new_transform = serialize_transform(scaled_matrix.as_slice());
+    // scaled_matrix[4] += (1.0 - zoom_delta) * working_rect.center().x as f64;
+    // scaled_matrix[5] += (1.0 - zoom_delta) * working_rect.center().y as f64;
+    // let new_transform = serialize_transform(scaled_matrix.as_slice());
 
-    buffer.current.set_attr("transform", new_transform);
-    buffer.needs_path_map_update = true;
+    // buffer.current.set_attr("transform", new_transform);
+    // buffer.needs_path_map_update = true;
 }

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -1,12 +1,6 @@
-use minidom::Element;
 use resvg::usvg::Transform;
-use std::collections::HashSet;
 
-use super::{
-    parser,
-    selection::u_transform_to_bezier,
-    util::{deserialize_transform, serialize_transform},
-};
+use super::{ parser, selection::u_transform_to_bezier};
 
 pub const G_CONTAINER_ID: &str = "lb:zoom_container";
 

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -64,23 +64,3 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
         }
     }
 }
-
-pub fn zoom_to_percentage(buffer: &mut parser::Buffer, percentage: i32, working_rect: egui::Rect) {
-    // let original_matrix =
-    //     deserialize_transform(buffer.current.attr("transform").unwrap_or_default());
-
-    // let [a, b, _, _, _, _] = original_matrix;
-
-    // let scale_x = (a * a + b * b).sqrt();
-
-    // let zoom_delta = percentage as f64 / (scale_x * 100.0);
-
-    // let mut scaled_matrix: Vec<f64> = original_matrix.iter().map(|x| zoom_delta * x).collect();
-
-    // scaled_matrix[4] += (1.0 - zoom_delta) * working_rect.center().x as f64;
-    // scaled_matrix[5] += (1.0 - zoom_delta) * working_rect.center().y as f64;
-    // let new_transform = serialize_transform(scaled_matrix.as_slice());
-
-    // buffer.current.set_attr("transform", new_transform);
-    // buffer.needs_path_map_update = true;
-}

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -2,8 +2,6 @@ use resvg::usvg::Transform;
 
 use super::{parser, selection::u_transform_to_bezier};
 
-pub const G_CONTAINER_ID: &str = "lb:zoom_container";
-
 pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &mut parser::Buffer) {
     let zoom_delta = ui.input(|r| r.zoom_delta());
     let is_zooming = zoom_delta != 1.0;

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -1,6 +1,6 @@
 use resvg::usvg::Transform;
 
-use super::{ parser, selection::u_transform_to_bezier};
+use super::{parser, selection::u_transform_to_bezier};
 
 pub const G_CONTAINER_ID: &str = "lb:zoom_container";
 
@@ -57,11 +57,9 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
                     path.data.apply_transform(transform);
                 }
                 parser::Element::Image(img) => {
-                    if let Some(transformed_view_box) = img.view_box.rect.transform(t) {
-                        img.view_box.rect = transformed_view_box;
-                    }
+                    img.apply_transform(t);
                 }
-                parser::Element::Text(text) => todo!(),
+                parser::Element::Text(_) => todo!(),
             }
         }
     }

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -62,7 +62,11 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
                 parser::Element::Path(path) => {
                     path.data.apply_transform(transform);
                 }
-                parser::Element::Image(img) => todo!(),
+                parser::Element::Image(img) => {
+                    if let Some(transformed_view_box) = img.view_box.rect.transform(t) {
+                        img.view_box.rect = transformed_view_box;
+                    }
+                }
                 parser::Element::Text(text) => todo!(),
             }
         }

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -48,10 +48,13 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
     }
 
     if pan.is_some() || is_zooming {
+        buffer.master_transform = buffer.master_transform.post_concat(t);
+
         let transform = u_transform_to_bezier(&t);
         for el in buffer.elements.values_mut() {
             match el {
                 parser::Element::Path(path) => {
+                    path.transform = path.transform.post_concat(t);
                     path.data.apply_transform(transform);
                 }
                 parser::Element::Image(img) => {

--- a/libs/content/workspace/src/theme/palette.rs
+++ b/libs/content/workspace/src/theme/palette.rs
@@ -49,6 +49,16 @@ impl ThemePalette {
             ("fg".to_string(), if is_dark_mode { palette.white } else { palette.black }),
         ]
     }
+
+    pub fn get_fg_color(is_dark_mode: bool) -> Color32 {
+        let palette = if is_dark_mode { ThemePalette::DARK } else { ThemePalette::LIGHT };
+
+        if is_dark_mode {
+            palette.white
+        } else {
+            palette.black
+        }
+    }
 }
 
 impl std::ops::Index<lb_rs::ColorAlias> for ThemePalette {

--- a/libs/content/workspace/src/theme/visuals.rs
+++ b/libs/content/workspace/src/theme/visuals.rs
@@ -11,6 +11,9 @@ pub fn init(ctx: &egui::Context, dark_mode: bool) {
     style.spacing.menu_margin = egui::Margin::same(10.0);
     style.spacing.combo_width = 50.0;
 
+    style.visuals.menu_rounding = egui::Rounding::same(10.0);
+    style.visuals.window_rounding = egui::Rounding::same(10.0);
+
     style
         .text_styles
         .insert(egui::TextStyle::Body, egui::FontId::new(17.0, egui::FontFamily::Proportional));

--- a/libs/content/workspace/src/theme/visuals.rs
+++ b/libs/content/workspace/src/theme/visuals.rs
@@ -25,11 +25,9 @@ pub fn init(ctx: &egui::Context, dark_mode: bool) {
         .text_styles
         .insert(egui::TextStyle::Monospace, egui::FontId::new(17.0, egui::FontFamily::Monospace));
 
-    let button_font_size = if cfg!(target_os = "ios") { 30.0 } else { 17.0 };
-    style.text_styles.insert(
-        egui::TextStyle::Button,
-        egui::FontId::new(button_font_size, egui::FontFamily::Proportional),
-    );
+    style
+        .text_styles
+        .insert(egui::TextStyle::Button, egui::FontId::new(17.0, egui::FontFamily::Proportional));
     ctx.set_style(style);
 }
 

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -12,7 +12,7 @@ use crate::tab::markdown_editor::Markdown;
 use crate::tab::pdf_viewer::PdfViewer;
 use crate::tab::plain_text::PlainText;
 use crate::tab::svg_editor::SVGEditor;
-use crate::tab::{ClipContent, EventManager, Tab, TabContent, TabFailure};
+use crate::tab::{Tab, TabContent, TabFailure};
 use crate::theme::icons::Icon;
 use crate::widgets::{separator, Button, ToolBarVisibility};
 use lb_rs::{File, FileType, LbError, NameComponents, SyncProgress, SyncStatus, Uuid};
@@ -37,8 +37,6 @@ pub struct Workspace {
     pub last_touch_event: Option<Instant>,
 
     pub pers_status: PersistentWsStatus,
-
-    texture: Option<egui::TextureHandle>,
 }
 
 pub enum WsMsg {
@@ -108,7 +106,6 @@ impl Workspace {
             show_tabs: true,
             focused_parent: None,
             last_touch_event: None,
-            texture: None,
         }
     }
 
@@ -342,36 +339,6 @@ impl Workspace {
                 egui::Stroke { color: ui.visuals().widgets.active.bg_fill, ..Default::default() };
             if Button::default().text("New folder").show(ui).clicked() {
                 out.new_folder_clicked = true;
-            }
-
-            for custom_event in ui.ctx().pop_events() {
-                match custom_event {
-                    crate::Event::Drop { content, position }
-                    | crate::Event::Paste { content, position } => {
-                        for clip in content {
-                            match clip {
-                                ClipContent::Png(data) => {
-                                    // let image_href = format!("lb://{}", file.id);
-
-                                    if self.texture.is_none() {
-                                        println!("alloc texture");
-
-                                        self.texture = Some(ui.ctx().load_texture(
-                                            "test",
-                                            egui::ColorImage::example(),
-                                            egui::TextureOptions::LINEAR,
-                                        ));
-                                    }
-                                }
-                                ClipContent::Files(..) => unimplemented!(), // todo: support file drop & paste
-                            }
-                        }
-                    }
-                    crate::Event::Markdown(..) => {}
-                }
-            }
-            if let Some(texture) = &self.texture {
-                ui.image((texture.id(), texture.size_vec2()));
             }
         });
     }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -12,7 +12,7 @@ use crate::tab::markdown_editor::Markdown;
 use crate::tab::pdf_viewer::PdfViewer;
 use crate::tab::plain_text::PlainText;
 use crate::tab::svg_editor::SVGEditor;
-use crate::tab::{Tab, TabContent, TabFailure};
+use crate::tab::{ClipContent, EventManager, Tab, TabContent, TabFailure};
 use crate::theme::icons::Icon;
 use crate::widgets::{separator, Button, ToolBarVisibility};
 use lb_rs::{File, FileType, LbError, NameComponents, SyncProgress, SyncStatus, Uuid};
@@ -37,6 +37,8 @@ pub struct Workspace {
     pub last_touch_event: Option<Instant>,
 
     pub pers_status: PersistentWsStatus,
+
+    texture: Option<egui::TextureHandle>,
 }
 
 pub enum WsMsg {
@@ -106,6 +108,7 @@ impl Workspace {
             show_tabs: true,
             focused_parent: None,
             last_touch_event: None,
+            texture: None,
         }
     }
 
@@ -339,6 +342,36 @@ impl Workspace {
                 egui::Stroke { color: ui.visuals().widgets.active.bg_fill, ..Default::default() };
             if Button::default().text("New folder").show(ui).clicked() {
                 out.new_folder_clicked = true;
+            }
+
+            for custom_event in ui.ctx().pop_events() {
+                match custom_event {
+                    crate::Event::Drop { content, position }
+                    | crate::Event::Paste { content, position } => {
+                        for clip in content {
+                            match clip {
+                                ClipContent::Png(data) => {
+                                    // let image_href = format!("lb://{}", file.id);
+
+                                    if self.texture.is_none() {
+                                        println!("alloc texture");
+
+                                        self.texture = Some(ui.ctx().load_texture(
+                                            "test",
+                                            egui::ColorImage::example(),
+                                            egui::TextureOptions::LINEAR,
+                                        ));
+                                    }
+                                }
+                                ClipContent::Files(..) => unimplemented!(), // todo: support file drop & paste
+                            }
+                        }
+                    }
+                    crate::Event::Markdown(..) => {}
+                }
+            }
+            if let Some(texture) = &self.texture {
+                ui.image((texture.id(), texture.size_vec2()));
             }
         });
     }


### PR DESCRIPTION
fixes: #2531 #2278 

## Perf gains
x axis is the number of anchors in a drawing
![image](https://github.com/lockbook/lockbook/assets/66345861/681eab61-90f1-4947-8b90-33919a4ee831)
![image](https://github.com/lockbook/lockbook/assets/66345861/fb2b79cf-65dd-45a3-8f41-dbbbbe5bbd44)
![image](https://github.com/lockbook/lockbook/assets/66345861/9427f039-db3b-479f-aff0-612f78d376cd)

### Regressions 
1.  path segments are disjointed on a high zoom level
2. path color doesn't adjust to light/dark mode switch 