### PR TITLE
core, server: upgrade db-rs to use flocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,19 +1820,20 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "db-rs"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b737c8e3b8018c03926390a42e78ece1d1455f42ae2f8a1d9e16ee0a2fda10"
+checksum = "0184bbfa5fc69ef7d6b53cc0f3eeaf9f728c3e1e7f2e2be06cb60a333f71d08d"
 dependencies = [
  "bincode",
+ "fs2",
  "serde",
 ]
 
 [[package]]
 name = "db-rs-derive"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0961c29b9ddc2809adc993e3386aaba512a7beb7c5b856895d683288dcd4ad13"
+checksum = "635c914a3ba843700b4d8dc9ff024682b54c48795cb435cee1a842ed6738a32a"
 dependencies = [
  "db-rs",
  "quote",
@@ -2547,6 +2548,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding 2.3.1",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -39,8 +39,8 @@ sublime_fuzzy = "0.7.0"
 crossbeam = "0.8.1"
 lockbook-shared = { version = "0.9.1", path = "libs/shared" }
 qrcode-generator = "4.1.6"
-db-rs = "0.2.1"
-db-rs-derive = "0.2.1"
+db-rs = "0.3.1"
+db-rs-derive = "0.3.1"
 
 lockbook-server = { version = "0.9.1", path = "../../../server/server", optional = true }
 tokio = { version = "1.5.0", optional = true }

--- a/libs/lb/lb-rs/libs/shared/Cargo.toml
+++ b/libs/lb/lb-rs/libs/shared/Cargo.toml
@@ -18,7 +18,7 @@ aes-gcm = "0.9.3"
 bincode = "1.2.1"
 sha2 = "0.9.9"
 hmac = "0.11.0"
-db-rs = "0.2.1"
+db-rs = "0.3.1"
 tracing = "0.1.5"
 flate2 = "1.0"
 

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -46,8 +46,8 @@ itertools = "0.10.1"
 reqwest = { version = "0.11", features = ["json"] }
 jsonwebtoken = "8.2.0"
 x509-parser = { version = "0.15.0", features = ["verify", "validate"]}
-db-rs = "0.2.1"
-db-rs-derive = "0.2.1"
+db-rs = "0.3.1"
+db-rs-derive = "0.3.1"
 semver = "1.0.17"
 async-trait = "0.1.68"
 


### PR DESCRIPTION
meat and potatoes of this work can be found here: https://github.com/lockbook/db-rs/pull/21

will eliminate data corruption issues for 
- egui devs
- corner cases on desktop where multiple windows can be spawned
- cli users

pre-requisite to: #2207 
pre-requisite to: multiple cores on one machine (clis and desktop apps) not duplicating their data
and ultimately: #2207