### PR TITLE
editor: fix hover syntax reveal

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -15,10 +15,7 @@ use egui::epaint::text::cursor::RCursor;
 use linkify::LinkFinder;
 use std::cmp::Ordering;
 use std::collections::HashSet;
-use std::time::{Duration, Instant};
 use unicode_segmentation::UnicodeSegmentation;
-
-pub const HOVER_SYNTAX_REVEAL_DEBOUNCE: Duration = Duration::from_millis(500);
 
 pub type AstTextRanges = Vec<AstTextRange>;
 pub type Words = Vec<(DocCharOffset, DocCharOffset)>;
@@ -272,16 +269,10 @@ pub fn captured(
 ) -> bool {
     let ast_node_range = ast.nodes[*text_range.ancestors.last().unwrap()].range;
     let intersects_selection = ast_node_range.intersects_allow_empty(&cursor.selection);
-
-    let debounce_satisfied = hover_syntax_reveal_debounce_state.pointer_offset_updated_at
-        < Instant::now() - HOVER_SYNTAX_REVEAL_DEBOUNCE;
-    let intersects_pointer = debounce_satisfied
-        && hover_syntax_reveal_debounce_state
-            .pointer_offset
-            .map(|pointer_offset| {
-                ast_node_range.intersects(&(pointer_offset, pointer_offset), true)
-            })
-            .unwrap_or(false);
+    let intersects_pointer = hover_syntax_reveal_debounce_state
+        .pointer_offset
+        .map(|pointer_offset| ast_node_range.intersects(&(pointer_offset, pointer_offset), true))
+        .unwrap_or(false);
 
     let text_range_paragraphs = paragraphs.find_intersecting(text_range.range, true);
     let in_capture_disabled_paragraph = appearance.markdown_capture_disabled_for_cursor_paragraph

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -1,5 +1,5 @@
 use std::cmp;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use egui::os::OperatingSystem;
 use egui::{Color32, Context, Event, FontDefinitions, Frame, Pos2, Rect, Sense, Ui, Vec2};
@@ -50,7 +50,6 @@ pub struct EditorResponse {
 #[derive(Clone, Copy)]
 pub struct HoverSyntaxRevealDebounceState {
     pub pointer_offset: Option<DocCharOffset>,
-    pub pointer_offset_updated_at: Instant,
 }
 
 pub struct Editor {
@@ -130,7 +129,6 @@ impl Editor {
 
             hover_syntax_reveal_debounce_state: HoverSyntaxRevealDebounceState {
                 pointer_offset: None,
-                pointer_offset_updated_at: Instant::now(),
             },
             pointer_offset_updated: Default::default(),
 
@@ -329,12 +327,7 @@ impl Editor {
         self.bounds.lines = bounds::calc_lines(&self.galleys, &self.bounds.ast, &self.bounds.text);
         self.initialized = true;
 
-        if self.images.any_loading()
-            || self
-                .hover_syntax_reveal_debounce_state
-                .pointer_offset_updated_at
-                > Instant::now() - bounds::HOVER_SYNTAX_REVEAL_DEBOUNCE
-        {
+        if self.images.any_loading() {
             ui.ctx().request_repaint_after(Duration::from_millis(50));
         }
 
@@ -578,13 +571,6 @@ impl Editor {
         self.selection_updated = self.buffer.current.cursor.selection != prior_selection;
         self.hover_syntax_reveal_debounce_state.pointer_offset = pointer_offset;
         self.pointer_offset_updated = pointer_offset != prior_pointer_offset;
-        self.hover_syntax_reveal_debounce_state
-            .pointer_offset_updated_at = if self.pointer_offset_updated {
-            Instant::now()
-        } else {
-            self.hover_syntax_reveal_debounce_state
-                .pointer_offset_updated_at
-        };
     }
 
     pub fn set_font(&self, ctx: &Context) {

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -287,24 +287,11 @@ impl Editor {
 
             (true, true, true)
         };
-        let appearance_updated = {
-            let capture_already_disabled = self
-                .appearance
-                .markdown_capture_disabled_for_cursor_paragraph;
-            self.appearance
-                .markdown_capture_disabled_for_cursor_paragraph = ui.input(|i| i.modifiers.command); // command key disables capture for current paragraph
-            capture_already_disabled
-                != self
-                    .appearance
-                    .markdown_capture_disabled_for_cursor_paragraph
-        };
 
         // recalculate dependent state
         if text_updated {
             self.ast = ast::calc(&self.buffer.current);
             self.bounds.ast = bounds::calc_ast(&self.ast);
-        }
-        if text_updated || appearance_updated {
             self.bounds.words = bounds::calc_words(
                 &self.buffer.current,
                 &self.ast,
@@ -314,7 +301,7 @@ impl Editor {
             self.bounds.paragraphs =
                 bounds::calc_paragraphs(&self.buffer.current, &self.bounds.ast);
         }
-        if text_updated || selection_updated || appearance_updated || pointer_offset_updated {
+        if text_updated || selection_updated || pointer_offset_updated {
             self.bounds.text = bounds::calc_text(
                 &self.ast,
                 &self.bounds.ast,


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2236 (by removing the debounce)

PR is in draft because I haven't totally decided if this is the right direction (alternative: https://github.com/lockbook/lockbook/pull/2683)


https://github.com/lockbook/lockbook/assets/6198756/35af929b-022b-4e1d-b35c-32cba776d3c5

