### PR TITLE
egui: improve keyboard shortcuts on macos

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -281,7 +281,7 @@ impl AccountScreen {
     /// See also workspace::process_keys
     fn process_keys(&mut self, ctx: &egui::Context) {
         const ALT: egui::Modifiers = egui::Modifiers::ALT;
-        const CTRL: egui::Modifiers = egui::Modifiers::CTRL;
+        const COMMAND: egui::Modifiers = egui::Modifiers::COMMAND;
 
         // Escape (without modifiers) to close something such as an open modal.
         // We don't want to consume it unless something is closed.
@@ -293,7 +293,7 @@ impl AccountScreen {
         }
 
         // Ctrl-E toggle zen mode
-        if ctx.input_mut(|i| i.consume_key(CTRL, egui::Key::E)) {
+        if ctx.input_mut(|i| i.consume_key(COMMAND, egui::Key::E)) {
             let mut zen_mode = false;
             if let Ok(settings) = &self.settings.read() {
                 zen_mode = !settings.zen_mode;
@@ -303,7 +303,7 @@ impl AccountScreen {
 
         // Ctrl-Space or Ctrl-L pressed while search modal is not open.
         let is_search_open = ctx.input_mut(|i| {
-            i.consume_key(CTRL, egui::Key::Space) || i.consume_key(CTRL, egui::Key::L)
+            i.consume_key(COMMAND, egui::Key::Space) || i.consume_key(COMMAND, egui::Key::L)
         });
         if is_search_open {
             if let Some(search) = &mut self.modals.search {
@@ -315,7 +315,7 @@ impl AccountScreen {
 
         // Ctrl-, to open settings modal.
         if self.modals.settings.is_none()
-            && ctx.input_mut(|i| i.consume_key(CTRL, egui::Key::Comma))
+            && ctx.input_mut(|i| i.consume_key(COMMAND, egui::Key::Comma))
         {
             self.modals.settings = Some(SettingsModal::new(&self.core, &self.settings));
         }

--- a/clients/egui/src/account/modals/help.rs
+++ b/clients/egui/src/account/modals/help.rs
@@ -6,6 +6,7 @@ pub struct HelpModal;
 
 impl HelpModal {
     pub fn show(&mut self, ui: &mut egui::Ui) {
+        let is_mac = ui.ctx().os() == egui::os::OperatingSystem::Mac;
         TableBuilder::new(ui)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
             .striped(true)
@@ -20,20 +21,21 @@ impl HelpModal {
                 });
             })
             .body(|mut body| {
-                for (k, v) in [
-                    ("Ctrl-N", "Open the New File prompt"),
-                    ("Ctrl-Space, Ctrl-L", "Open the search prompt"),
-                    ("Ctrl-S", "Save the active document"),
-                    ("Ctrl-W", "Close an opened document"),
-                    ("Alt-{1-9}", "Navigate tabs (9 will always go to the last one)"),
-                    ("Alt-H", "Toggle this help window"),
+                for (shortcut, shortcut_mac, description) in [
+                    ("Ctrl-N", "Cmd-N", "Open the New File prompt"),
+                    ("Ctrl-Space, Ctrl-L", "Cmd-Space, Cmd-L", "Open the search prompt"),
+                    ("Ctrl-S", "Cmd-S", "Save the active document"),
+                    ("Ctrl-W", "Cmd-W", "Close an opened document"),
+                    ("Alt-{1-9}", "Alt-{1-9}", "Navigate tabs (9 will always go to the last one)"),
+                    ("Alt-H", "Alt-H", "Toggle this help window"),
                 ] {
                     body.row(30.0, |mut row| {
                         row.col(|ui| {
-                            ui.label(k);
+                            let shortcut = if is_mac { shortcut_mac } else { shortcut };
+                            ui.label(shortcut);
                         });
                         row.col(|ui| {
-                            ui.label(v);
+                            ui.label(description);
                         });
                     });
                 }

--- a/clients/egui/src/account/modals/search.rs
+++ b/clients/egui/src/account/modals/search.rs
@@ -277,7 +277,7 @@ impl super::Modal for SearchModal {
                         if self.draw_search_result(ui, res, index).clicked() {
                             let keep_open = {
                                 let m = ui.input(|i| i.modifiers);
-                                m.ctrl && !m.alt && !m.shift
+                                m.command && !m.alt && !m.shift
                             };
                             resp = Some(SearchItemSelection { id: res.id, close: !keep_open });
                             self.field_needs_focus = true;

--- a/clients/egui/src/account/tree/node.rs
+++ b/clients/egui/src/account/tree/node.rs
@@ -129,7 +129,7 @@ impl TreeNode {
         {
             self.primary_press = ui.input(|i| i.pointer.press_origin());
 
-            if ui.input(|i| i.modifiers.ctrl) {
+            if ui.input(|i| i.modifiers.command) {
                 state.toggle_selected(self.file.id);
             } else if !state.selected.contains(&self.file.id) {
                 state.selected.clear();
@@ -142,7 +142,7 @@ impl TreeNode {
                     && resp.rect.contains(pos)
                     && state.selected.len() > 1
                     && state.selected.contains(&self.file.id)
-                    && !ui.input(|i| i.modifiers.ctrl)
+                    && !ui.input(|i| i.modifiers.command)
                 {
                     state.selected.retain(|id| *id == self.file.id);
                 }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -632,19 +632,19 @@ impl Workspace {
     }
 
     fn process_keys(&mut self, output: &mut WsOutput) {
-        const CTRL: egui::Modifiers = egui::Modifiers::COMMAND;
+        const COMMAND: egui::Modifiers = egui::Modifiers::COMMAND;
         // Ctrl-N pressed while new file modal is not open.
-        if self.ctx.input_mut(|i| i.consume_key(CTRL, egui::Key::N)) {
+        if self.ctx.input_mut(|i| i.consume_key(COMMAND, egui::Key::N)) {
             self.create_file(false);
         }
 
         // Ctrl-S to save current tab.
-        if self.ctx.input_mut(|i| i.consume_key(CTRL, egui::Key::S)) {
+        if self.ctx.input_mut(|i| i.consume_key(COMMAND, egui::Key::S)) {
             self.save_tab(self.active_tab);
         }
 
         // Ctrl-W to close current tab.
-        if self.ctx.input_mut(|i| i.consume_key(CTRL, egui::Key::W)) && !self.is_empty() {
+        if self.ctx.input_mut(|i| i.consume_key(COMMAND, egui::Key::W)) && !self.is_empty() {
             self.close_tab(self.active_tab);
             output.window_title = Some(
                 self.current_tab()
@@ -659,7 +659,7 @@ impl Workspace {
         // Ctrl-{1-9} to easily navigate tabs (9 will always go to the last tab).
         self.ctx.clone().input_mut(|input| {
             for i in 1..10 {
-                if input.consume_key_exact(CTRL, NUM_KEYS[i - 1]) {
+                if input.consume_key_exact(COMMAND, NUM_KEYS[i - 1]) {
                     self.goto_tab(i);
                     // Remove any text event that's also present this frame so that it doesn't show up
                     // in the editor.


### PR DESCRIPTION
macos quality is not super important here because we don't release it, but launching the egui app on macos is the easiest way for me to iterate on the editor and mac-friendly shortcuts make that nicer

qa on macos:
- [x] cmd+e toggle zen mode
- [ ] cmd+space open file search
  - this opens spotlight/alfred instead, seems just a bad choice of shortcut for mac (that's what cmd+l is for)
- [x] cmd+l open file search
- [x] cmd+, open settings
- [ ] help menu looks correct
  - alt+h does not open the help menu (not a regression)
- [x] cmd+click a search result to open it without closing search
- [ ] cmd+click a file to add it to selection
  - not working (not a regression)

qa on linux or windows:
- [x] ctrl+e toggle zen mode
- [x] ctrl+space open file search
- [x] ctrl+l open file search
- [x] ctrl+, open settings
- [ ] help menu looks correct
  - alt+h does not open the help menu (not a regression)
- [x] ctrl+click a search result to open it without closing search
- [ ] ctrl+click a file to add it to selection
  - not working (not a regression)
  
opened these issues:
- https://github.com/lockbook/lockbook/issues/2692
- https://github.com/lockbook/lockbook/issues/2693