### PR TITLE
editor: rework syntax hover reveal

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/appearance.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/appearance.rs
@@ -81,7 +81,6 @@ pub struct Appearance {
 
     // capture of markdown syntax characters
     pub markdown_capture: Option<HashSet<MarkdownNodeType>>,
-    pub markdown_capture_disabled_for_cursor_paragraph: bool,
 }
 
 impl Appearance {

--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -3,6 +3,7 @@ use crate::tab::markdown_editor::ast::{Ast, AstTextRange, AstTextRangeType};
 use crate::tab::markdown_editor::buffer::SubBuffer;
 use crate::tab::markdown_editor::galleys::Galleys;
 use crate::tab::markdown_editor::input::canonical::Bound;
+use crate::tab::markdown_editor::input::capture::CaptureState;
 use crate::tab::markdown_editor::input::cursor::Cursor;
 use crate::tab::markdown_editor::offset_types::{
     DocByteOffset, DocCharOffset, RangeExt, RelByteOffset,
@@ -15,8 +16,6 @@ use linkify::LinkFinder;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use unicode_segmentation::UnicodeSegmentation;
-
-use super::input::capture::CaptureState;
 
 pub type AstTextRanges = Vec<AstTextRange>;
 pub type Words = Vec<(DocCharOffset, DocCharOffset)>;
@@ -184,13 +183,12 @@ pub fn calc_paragraphs(buffer: &SubBuffer, ast: &AstTextRanges) -> Paragraphs {
 
 pub fn calc_text(
     ast: &Ast, ast_ranges: &AstTextRanges, paragraphs: &Paragraphs, appearance: &Appearance,
-    segs: &UnicodeSegs, cursor: Cursor, hover_reveal_state: &CaptureState,
+    segs: &UnicodeSegs, cursor: Cursor, capture: &CaptureState,
 ) -> Text {
     let mut result = vec![];
     let mut last_range_pushed = false;
     for (i, text_range) in ast_ranges.iter().enumerate() {
-        let captured =
-            hover_reveal_state.captured(cursor, paragraphs, ast, ast_ranges, i, appearance);
+        let captured = capture.captured(cursor, paragraphs, ast, ast_ranges, i, appearance);
 
         let this_range_pushed = if !captured {
             // text range or uncaptured syntax range

--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::time::{Duration, Instant};
 use unicode_segmentation::UnicodeSegmentation;
 
-pub const HOVER_SYNTAX_REVEAL_DEBOUNCE: Duration = Duration::from_millis(200);
+pub const HOVER_SYNTAX_REVEAL_DEBOUNCE: Duration = Duration::from_millis(300);
 
 pub type AstTextRanges = Vec<AstTextRange>;
 pub type Words = Vec<(DocCharOffset, DocCharOffset)>;

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -121,7 +121,7 @@ impl Editor {
             selection_updated: Default::default(),
             maybe_menu_location: Default::default(),
 
-            capture: CaptureState::new(),
+            capture: Default::default(),
 
             scroll_area_rect: Rect { min: Default::default(), max: Default::default() },
             scroll_area_offset: Default::default(),

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -6,24 +6,22 @@ use egui::{Color32, Context, Event, FontDefinitions, Frame, Pos2, Rect, Sense, U
 use lb_rs::Uuid;
 use serde::Serialize;
 
-use crate::tab::markdown_editor;
-use crate::tab::EventManager;
-
-use markdown_editor::appearance::Appearance;
-use markdown_editor::ast::Ast;
-use markdown_editor::bounds::{BoundCase, Bounds};
-use markdown_editor::buffer::Buffer;
-use markdown_editor::debug::DebugInfo;
-use markdown_editor::galleys::Galleys;
-use markdown_editor::images::ImageCache;
-use markdown_editor::input::canonical::{Bound, Modification, Offset, Region};
-use markdown_editor::input::capture::CaptureState;
-use markdown_editor::input::click_checker::{ClickChecker, EditorClickChecker};
-use markdown_editor::input::cursor::{Cursor, PointerState};
-use markdown_editor::input::events;
-use markdown_editor::offset_types::{DocCharOffset, RangeExt as _};
-use markdown_editor::style::{BlockNode, InlineNode, ListItem, MarkdownNode};
-use markdown_editor::{ast, bounds, galleys, images, register_fonts};
+use crate::tab::markdown_editor::appearance::Appearance;
+use crate::tab::markdown_editor::ast::Ast;
+use crate::tab::markdown_editor::bounds::{BoundCase, Bounds};
+use crate::tab::markdown_editor::buffer::Buffer;
+use crate::tab::markdown_editor::debug::DebugInfo;
+use crate::tab::markdown_editor::galleys::Galleys;
+use crate::tab::markdown_editor::images::ImageCache;
+use crate::tab::markdown_editor::input::canonical::{Bound, Modification, Offset, Region};
+use crate::tab::markdown_editor::input::capture::CaptureState;
+use crate::tab::markdown_editor::input::click_checker::{ClickChecker, EditorClickChecker};
+use crate::tab::markdown_editor::input::cursor::{Cursor, PointerState};
+use crate::tab::markdown_editor::input::events;
+use crate::tab::markdown_editor::offset_types::{DocCharOffset, RangeExt as _};
+use crate::tab::markdown_editor::style::{BlockNode, InlineNode, ListItem, MarkdownNode};
+use crate::tab::markdown_editor::{ast, bounds, galleys, images, register_fonts};
+use crate::tab::EventManager as _;
 
 #[derive(Debug, Serialize, Default)]
 pub struct EditorResponse {
@@ -304,7 +302,6 @@ impl Editor {
             );
             self.bounds.links =
                 bounds::calc_links(&self.buffer.current, &self.bounds.text, &self.ast);
-            self.capture.mark_changes_processed();
         }
         if text_updated || selection_updated || theme_updated {
             self.images = images::calc(&self.ast, &self.images, &self.client, &self.core, ui);

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -287,24 +287,11 @@ impl Editor {
 
             (true, true, true)
         };
-        let appearance_updated = {
-            let capture_already_disabled = self
-                .appearance
-                .markdown_capture_disabled_for_cursor_paragraph;
-            self.appearance
-                .markdown_capture_disabled_for_cursor_paragraph = ui.input(|i| i.modifiers.command); // command key disables capture for current paragraph
-            capture_already_disabled
-                != self
-                    .appearance
-                    .markdown_capture_disabled_for_cursor_paragraph
-        };
 
         // recalculate dependent state
         if text_updated {
             self.ast = ast::calc(&self.buffer.current);
             self.bounds.ast = bounds::calc_ast(&self.ast);
-        }
-        if text_updated || appearance_updated {
             self.bounds.words = bounds::calc_words(
                 &self.buffer.current,
                 &self.ast,
@@ -314,7 +301,7 @@ impl Editor {
             self.bounds.paragraphs =
                 bounds::calc_paragraphs(&self.buffer.current, &self.bounds.ast);
         }
-        if text_updated || selection_updated || appearance_updated || pointer_offset_updated {
+        if text_updated || selection_updated || pointer_offset_updated {
             self.bounds.text = bounds::calc_text(
                 &self.ast,
                 &self.bounds.ast,

--- a/libs/content/workspace/src/tab/markdown_editor/galleys.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/galleys.rs
@@ -1,8 +1,7 @@
 use crate::tab::markdown_editor::appearance::Appearance;
 use crate::tab::markdown_editor::ast::{Ast, AstTextRangeType};
-use crate::tab::markdown_editor::bounds::{self, Bounds, RangesExt, Text};
+use crate::tab::markdown_editor::bounds::{self, Bounds, Text};
 use crate::tab::markdown_editor::buffer::SubBuffer;
-use crate::tab::markdown_editor::editor::HoverSyntaxRevealDebounceState;
 use crate::tab::markdown_editor::images::{ImageCache, ImageState};
 use crate::tab::markdown_editor::layouts::{Annotation, LayoutJobInfo};
 use crate::tab::markdown_editor::offset_types::{DocCharOffset, RangeExt, RelCharOffset};
@@ -45,12 +44,8 @@ pub struct ImageInfo {
 
 pub fn calc(
     ast: &Ast, buffer: &SubBuffer, bounds: &Bounds, images: &ImageCache, appearance: &Appearance,
-    hover_syntax_reveal_debounce_state: HoverSyntaxRevealDebounceState, ui: &mut Ui,
+    ui: &mut Ui,
 ) -> Galleys {
-    let cursor_paragraphs = bounds
-        .paragraphs
-        .find_intersecting(buffer.cursor.selection, true);
-
     let mut result: Galleys = Default::default();
 
     let mut head_size: RelCharOffset = 0.into();
@@ -58,21 +53,20 @@ pub fn calc(
     let mut annotation_text_format = Default::default();
     let mut layout: LayoutJob = Default::default();
 
-    // join ast text ranges, paragraphs, plaintext links, selection, and whole document (to ensure everything is captured)
+    // join all bounds that affect rendering
     // emit one galley per paragraph; other data is used to determine style
     let ast_ranges = bounds
         .ast
         .iter()
         .map(|range| range.range)
         .collect::<Vec<_>>();
-    let doc_range = (0.into(), buffer.segs.last_cursor_position());
-    for ([ast_idx, paragraph_idx, link_idx, selection_idx, _], text_range_portion) in
+    for ([ast_idx, paragraph_idx, link_idx, selection_idx, text_idx], text_range_portion) in
         bounds::join([
             &ast_ranges,
             &bounds.paragraphs,
             &bounds.links,
             &[buffer.cursor.selection],
-            &[doc_range],
+            &bounds.text,
         ])
     {
         // paragraphs cover all text; will always have at least one possibly-empty paragraph
@@ -88,15 +82,7 @@ pub fn calc(
             let maybe_link_range = link_idx.map(|link_idx| bounds.links[link_idx]);
             let in_selection = selection_idx.is_some() && !buffer.cursor.selection.is_empty();
 
-            let captured = bounds::captured(
-                buffer.cursor,
-                &bounds.paragraphs,
-                ast,
-                text_range,
-                hover_syntax_reveal_debounce_state,
-                appearance,
-                cursor_paragraphs,
-            );
+            let captured = text_idx.is_none();
 
             // construct text format using styles for all ancestor nodes
             let mut text_format = TextFormat::default();

--- a/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
@@ -309,7 +309,7 @@ pub fn calc(
         Event::PointerButton { pos, button: PointerButton::Primary, pressed: true, modifiers }
             if click_checker.ui(*pos) =>
         {
-            pointer_state.press(now, *pos, click_checker.pos_to_char_offset(*pos), *modifiers);
+            pointer_state.press(now, *pos, *modifiers);
             None
         }
         Event::PointerMoved(pos) if click_checker.ui(*pos) => {
@@ -317,10 +317,10 @@ pub fn calc(
             if pointer_state.click_dragged.unwrap_or_default() && !touch_mode {
                 if pointer_state.click_mods.unwrap_or_default().shift {
                     Some(Modification::Select { region: Region::ToLocation(Location::Pos(*pos)) })
-                } else if let Some(click_offset) = pointer_state.click_offset {
+                } else if let Some(click_pos) = pointer_state.click_pos {
                     Some(Modification::Select {
                         region: Region::BetweenLocations {
-                            start: Location::DocCharOffset(click_offset),
+                            start: Location::Pos(click_pos),
                             end: Location::Pos(*pos),
                         },
                     })
@@ -333,7 +333,7 @@ pub fn calc(
         }
         Event::PointerButton { pos, button: PointerButton::Primary, pressed: false, .. } => {
             let click_type = pointer_state.click_type.unwrap_or_default();
-            let click_offset = pointer_state.click_offset.unwrap_or_default();
+            let click_pos = pointer_state.click_pos.unwrap_or_default();
             let click_mods = pointer_state.click_mods.unwrap_or_default();
             let click_dragged = pointer_state.click_dragged.unwrap_or_default();
             pointer_state.release();
@@ -366,7 +366,7 @@ pub fn calc(
                                         }
                                     } else {
                                         Region::BetweenLocations {
-                                            start: Location::DocCharOffset(click_offset),
+                                            start: Location::Pos(click_pos),
                                             end: location,
                                         }
                                     }

--- a/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
@@ -24,6 +24,12 @@ pub struct CaptureState {
     hovered_at_by_ast_text_range: HashMap<usize, Instant>,
 }
 
+impl Default for CaptureState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CaptureState {
     pub fn new() -> Self {
         Self {
@@ -90,12 +96,9 @@ impl CaptureState {
                     continue; // only head and tail ranges are ever captured
                 }
 
-                if !self
-                    .hovered_at_by_ast_text_range
-                    .contains_key(&ast_range_idx)
-                {
-                    self.hovered_at_by_ast_text_range.insert(ast_range_idx, now);
-                }
+                self.hovered_at_by_ast_text_range
+                    .entry(ast_range_idx)
+                    .or_insert(now);
             }
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
@@ -1,0 +1,158 @@
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
+
+use crate::tab::markdown_editor::{
+    appearance::{Appearance, CaptureCondition},
+    ast::{Ast, AstTextRangeType},
+    bounds::{AstTextRanges, Bounds, Paragraphs, RangesExt as _},
+    galleys::Galleys,
+    input::{
+        cursor::{Cursor, PointerState},
+        mutation,
+    },
+    offset_types::{RangeExt as _, RangeIterExt},
+    unicode_segs::UnicodeSegs,
+};
+
+pub const HOVER_REVEAL_DEBOUNCE: Duration = Duration::from_millis(300);
+
+pub struct CaptureState {
+    unprocessed_changes: bool,
+    now: Instant,
+    hovered_at_by_ast_text_range: HashMap<usize, Instant>,
+}
+
+impl CaptureState {
+    pub fn new() -> Self {
+        Self {
+            unprocessed_changes: false,
+            now: Instant::now(),
+            hovered_at_by_ast_text_range: HashMap::new(),
+        }
+    }
+
+    /// Updates the state of the hover reveal mechanism. Call this every frame after text layout so that the galleys
+    /// are synchronized with other parameters.
+    pub fn update(
+        &mut self, now: Instant, pointer_state: &PointerState, galleys: &Galleys,
+        segs: &UnicodeSegs, bounds: &Bounds, ast: &Ast,
+    ) {
+        if self
+            .hovered_at_by_ast_text_range
+            .iter()
+            .any(|(_, &hovered_at)| {
+                let reveal_at = hovered_at + HOVER_REVEAL_DEBOUNCE;
+                self.now < reveal_at && reveal_at <= now
+            })
+        {
+            self.unprocessed_changes |= true;
+        }
+        self.now = now;
+
+        if let Some(pos) = pointer_state.pointer_pos {
+            let pointer = mutation::pos_to_char_offset(pos, galleys, segs, &bounds.text);
+
+            // revealed ranges are those whose ast nodes are hovered
+            let mut revealed_ranges = HashSet::new();
+            for ast_range_idx in bounds.ast.find_containing(pointer, true, true).iter() {
+                let ast_text_range = &bounds.ast[ast_range_idx];
+                for &ancestor_ast_node_idx in ast_text_range.ancestors.iter() {
+                    let ast_node = &ast.nodes[ancestor_ast_node_idx];
+
+                    if !ast_node.head_range().is_empty() {
+                        let head_range_idx =
+                            bounds.ast.find_containing(ast_node.range.0, true, false).0;
+                        revealed_ranges.insert(head_range_idx);
+                    }
+                    if !ast_node.tail_range().is_empty() {
+                        let tail_range_idx =
+                            bounds.ast.find_containing(ast_node.range.1, false, true).0;
+                        revealed_ranges.insert(tail_range_idx);
+                    }
+                }
+            }
+            revealed_ranges.retain(|&range| bounds.ast[range].range_type != AstTextRangeType::Text);
+
+            // remove ranges that are no longer hovered
+            let pre_count = self.hovered_at_by_ast_text_range.len();
+            self.hovered_at_by_ast_text_range
+                .retain(|ast_range_idx, _| revealed_ranges.contains(ast_range_idx));
+            if pre_count != self.hovered_at_by_ast_text_range.len() {
+                self.unprocessed_changes |= true;
+            }
+
+            // add ranges that are newly hovered
+            for ast_range_idx in revealed_ranges {
+                let ast_text_range = &bounds.ast[ast_range_idx];
+                if ast_text_range.range_type == AstTextRangeType::Text {
+                    continue; // only head and tail ranges are ever captured
+                }
+
+                if !self
+                    .hovered_at_by_ast_text_range
+                    .contains_key(&ast_range_idx)
+                {
+                    self.hovered_at_by_ast_text_range.insert(ast_range_idx, now);
+                }
+            }
+        }
+    }
+
+    pub fn mark_changes_processed(&mut self) -> bool {
+        let unprocessed_changes = self.unprocessed_changes;
+        self.unprocessed_changes = false;
+        unprocessed_changes
+    }
+
+    /// Returns true if the given AST text range should be captured for any reason, including cursor selection or hover
+    /// reveal. Debounce is evaluated using the time of last update rather than the current time.
+    pub fn captured(
+        &self, cursor: Cursor, paragraphs: &Paragraphs, ast: &Ast, ast_ranges: &AstTextRanges,
+        ast_range_idx: usize, appearance: &Appearance,
+    ) -> bool {
+        let ast_text_range = &ast_ranges[ast_range_idx];
+        if ast_text_range.range_type == AstTextRangeType::Text {
+            return false;
+        }
+
+        // check if this text range intersects any paragraph with selected text
+        let selection_paragraphs = paragraphs.find_intersecting(cursor.selection, true);
+        let text_range_paragraphs = paragraphs.find_intersecting(ast_text_range.range, true);
+        let intersects_selected_paragraph =
+            selection_paragraphs.intersects(&text_range_paragraphs, false);
+
+        // check if the pointer is hovering this text range with a satisfied debounce
+        let hovered = self
+            .hovered_at_by_ast_text_range
+            .get(&ast_range_idx)
+            .map(|hovered_at| *hovered_at + HOVER_REVEAL_DEBOUNCE <= self.now)
+            .unwrap_or(false);
+
+        match appearance.markdown_capture(ast_text_range.node(ast).node_type()) {
+            CaptureCondition::Always => true,
+            CaptureCondition::NoCursor => !(intersects_selected_paragraph || hovered),
+            CaptureCondition::Never => false,
+        }
+    }
+
+    /// Returns the duration until hover reveal should be recalculated, if any. This is the minimum time until debounce
+    /// is newly satisfied for a hovered AST range or zero if an AST range has been un-hovered since the last call to
+    /// `clear`. Call this when determining when to repaint (after calling `update`, which affects the result).
+    pub fn recalc_after(&self) -> Option<Duration> {
+        if self.unprocessed_changes {
+            return Some(Duration::ZERO);
+        }
+
+        let mut reveals = Vec::new();
+        for &hovered_at in self.hovered_at_by_ast_text_range.values() {
+            let reveal_at = hovered_at + HOVER_REVEAL_DEBOUNCE;
+            if reveal_at > self.now {
+                reveals.push(reveal_at - self.now);
+            }
+        }
+
+        reveals.iter().min().copied()
+    }
+}

--- a/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
@@ -100,6 +100,7 @@ impl CaptureState {
         }
     }
 
+    /// Marks changes to capture state as processed. Returns true if there were unprocessed changes.
     pub fn mark_changes_processed(&mut self) -> bool {
         let unprocessed_changes = self.unprocessed_changes;
         self.unprocessed_changes = false;
@@ -107,7 +108,8 @@ impl CaptureState {
     }
 
     /// Returns true if the given AST text range should be captured for any reason, including cursor selection or hover
-    /// reveal. Debounce is evaluated using the time of last update rather than the current time.
+    /// reveal. Debounce is evaluated using the time of last update rather than the current time to facilitate change
+    /// detection.
     pub fn captured(
         &self, cursor: Cursor, paragraphs: &Paragraphs, ast: &Ast, ast_ranges: &AstTextRanges,
         ast_range_idx: usize, appearance: &Appearance,

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -150,7 +150,6 @@ pub struct PointerState {
     /// Type, position, modifiers, and drag status of current click, recorded on press and processed on release
     pub click_type: Option<ClickType>,
     pub click_pos: Option<Pos2>,
-    pub click_offset: Option<DocCharOffset>,
     pub click_mods: Option<Modifiers>,
     pub click_dragged: Option<bool>,
     pub pointer_pos: Option<Pos2>,
@@ -171,7 +170,7 @@ pub enum ClickType {
 }
 
 impl PointerState {
-    pub fn press(&mut self, t: Instant, pos: Pos2, offset: DocCharOffset, modifiers: Modifiers) {
+    pub fn press(&mut self, t: Instant, pos: Pos2, modifiers: Modifiers) {
         self.last_click_times.3 = self.last_click_times.2;
         self.last_click_times.2 = self.last_click_times.1;
         self.last_click_times.1 = self.last_click_times.0;
@@ -191,7 +190,6 @@ impl PointerState {
             _ => ClickType::Quadruple,
         });
         self.click_pos = Some(pos);
-        self.click_offset = Some(offset);
         self.click_mods = Some(modifiers);
         self.click_dragged = Some(false);
         self.pointer_pos = Some(pos)
@@ -214,7 +212,6 @@ impl PointerState {
     pub fn release(&mut self) {
         self.click_type = None;
         self.click_pos = None;
-        self.click_offset = None;
         self.click_mods = None;
         self.click_dragged = None;
     }

--- a/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
@@ -1,5 +1,6 @@
 pub mod advance;
 pub mod canonical;
+pub mod capture;
 pub mod click_checker;
 pub mod cursor;
 pub mod events;


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2236
Changes behavior to process hover reveal debounce per-ast-text-range for the head/tail ranges of all ast node ancestors of the hovered ast node. The result is that you can smoothly reveal and un-reveal syntax for nested ast nodes. Also fixed a bunch of bugs.


https://github.com/lockbook/lockbook/assets/6198756/5a6d4ca4-e50d-47d5-bce3-5d9ea5fe0453

