### PR TITLE
iOS, android: hide keyboard and insert link toolbar buttons

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/WorkspaceView.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/WorkspaceView.swift
@@ -172,10 +172,11 @@ public class iOSMTKInputManager: UIView, UIGestureRecognizerDelegate {
                 
                 switch inputManager.currentTab {
                 case .Welcome, .Pdf, .Loading, .Image:
-                    print("wrapper not needed")
+                    inputManager.mtkView.currentWrapper = nil
                 case .Svg:
                     let drawingWrapper = iOSMTKDrawingWrapper(mtkView: inputManager.mtkView)
                     inputManager.currentWrapper = drawingWrapper
+                    inputManager.mtkView.currentWrapper = drawingWrapper
                                     
                     drawingWrapper.translatesAutoresizingMaskIntoConstraints = false
                     inputManager.addSubview(drawingWrapper)
@@ -188,6 +189,7 @@ public class iOSMTKInputManager: UIView, UIGestureRecognizerDelegate {
                 case .PlainText, .Markdown:
                     let textWrapper = iOSMTKTextInputWrapper(mtkView: inputManager.mtkView)
                     inputManager.currentWrapper = textWrapper
+                    inputManager.mtkView.currentWrapper = textWrapper
                     
                     textWrapper.translatesAutoresizingMaskIntoConstraints = false
                     inputManager.addSubview(textWrapper)

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
@@ -8,8 +8,6 @@ import UniformTypeIdentifiers
 
 import GameController
 
-// i removed UIEditMenuInteractionDelegate
-
 public class iOSMTKTextInputWrapper: UIView, UITextInput, UIDropInteractionDelegate {
     public static let TOOL_BAR_HEIGHT: CGFloat = 42
     
@@ -723,18 +721,6 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         dark_mode(wsHandle, isDarkMode())
         set_scale(wsHandle, Float(self.contentScaleFactor))
         let output = draw_editor(wsHandle)
-                
-        if(output.workspace_resp.hide_keyboard) {
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-        }
-
-        if output.workspace_resp.selection_updated {
-            onSelectionChanged?()
-        }
-        
-        if output.workspace_resp.text_updated {
-            onTextChanged?()
-        }
         
         workspaceState?.syncing = output.workspace_resp.syncing
         workspaceState?.statusMsg = textFromPtr(s: output.workspace_resp.msg)
@@ -771,6 +757,18 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         }
         
         if(currentTab == .Markdown) {
+            if(output.workspace_resp.hide_virtual_keyboard) {
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+            }
+            
+            if output.workspace_resp.selection_updated {
+                onSelectionChanged?()
+            }
+            
+            if output.workspace_resp.text_updated {
+                onTextChanged?()
+            }
+
             let keyboard_shown = currentWrapper?.isFirstResponder ?? false && GCKeyboard.coalesced == nil;
             update_virtual_keyboard(wsHandle, keyboard_shown)
         }

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
@@ -719,6 +719,10 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         dark_mode(wsHandle, isDarkMode())
         set_scale(wsHandle, Float(self.contentScaleFactor))
         let output = draw_editor(wsHandle)
+        
+        if(output.workspace_resp.hide_keyboard) {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
 
         if output.workspace_resp.selection_updated {
             onSelectionChanged?()

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
@@ -6,6 +6,8 @@ import SwiftUI
 import MobileCoreServices
 import UniformTypeIdentifiers
 
+import GameController
+
 // i removed UIEditMenuInteractionDelegate
 
 public class iOSMTKTextInputWrapper: UIView, UITextInput, UIDropInteractionDelegate {
@@ -648,6 +650,8 @@ public class iOSMTK: MTKView, MTKViewDelegate {
     var tabSwitchTask: (() -> Void)? = nil
     var onSelectionChanged: (() -> Void)? = nil
     var onTextChanged: (() -> Void)? = nil
+    
+    weak var currentWrapper: UIView? = nil
         
     var showTabs = true
     var overrideDefaultKeyboardBehavior = false
@@ -719,7 +723,7 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         dark_mode(wsHandle, isDarkMode())
         set_scale(wsHandle, Float(self.contentScaleFactor))
         let output = draw_editor(wsHandle)
-        
+                
         if(output.workspace_resp.hide_keyboard) {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
@@ -764,6 +768,11 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         if currentTab == .Welcome && currentOpenDoc != nil {
             currentOpenDoc = nil
             self.workspaceState?.openDoc = nil
+        }
+        
+        if(currentTab == .Markdown) {
+            let keyboard_shown = currentWrapper?.isFirstResponder ?? false && GCKeyboard.coalesced == nil;
+            update_virtual_keyboard(wsHandle, keyboard_shown)
         }
         
         if output.workspace_resp.tab_title_clicked {

--- a/libs/content/workspace-ffi/src/apple/ios_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/ios_ffi.rs
@@ -665,6 +665,21 @@ pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPos
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
+pub unsafe extern "C" fn update_virtual_keyboard(
+    obj: *mut c_void, showing: bool,
+) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+    let markdown = match obj.workspace.current_tab_markdown_mut() {
+        Some(markdown) => markdown,
+        None => return,
+    };
+
+    markdown.editor.is_virtual_keyboard_showing = showing;
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
 pub unsafe extern "C" fn selection_rects(
     obj: *mut c_void, range: CTextRange,
 ) -> UITextSelectionRects {

--- a/libs/content/workspace-ffi/src/apple/ios_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/ios_ffi.rs
@@ -665,9 +665,7 @@ pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPos
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
-pub unsafe extern "C" fn update_virtual_keyboard(
-    obj: *mut c_void, showing: bool,
-) {
+pub unsafe extern "C" fn update_virtual_keyboard(obj: *mut c_void, showing: bool) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,

--- a/libs/content/workspace-ffi/src/resp.rs
+++ b/libs/content/workspace-ffi/src/resp.rs
@@ -40,9 +40,13 @@ pub struct FfiWorkspaceResp {
     new_folder_btn_pressed: bool,
 
     #[cfg(target_os = "ios")]
+    pub hide_keyboard: bool,
+
+    #[cfg(target_os = "ios")]
     pub text_updated: bool,
     #[cfg(target_os = "ios")]
     pub selection_updated: bool,
+
     #[cfg(target_os = "ios")]
     pub tab_title_clicked: bool,
 }
@@ -56,6 +60,8 @@ impl Default for FfiWorkspaceResp {
             syncing: Default::default(),
             refresh_files: Default::default(),
             new_folder_btn_pressed: Default::default(),
+            #[cfg(target_os = "ios")]
+            hide_keyboard: false,
             #[cfg(target_os = "ios")]
             text_updated: Default::default(),
             #[cfg(target_os = "ios")]
@@ -86,6 +92,9 @@ impl From<WsOutput> for FfiWorkspaceResp {
                 _ => Uuid::nil().into(),
             },
             new_folder_btn_pressed: value.new_folder_clicked,
+
+            #[cfg(target_os = "ios")]
+            hide_keyboard: value.hide_keyboard,
             #[cfg(target_os = "ios")]
             text_updated: false,
             #[cfg(target_os = "ios")]

--- a/libs/content/workspace-ffi/src/resp.rs
+++ b/libs/content/workspace-ffi/src/resp.rs
@@ -40,7 +40,7 @@ pub struct FfiWorkspaceResp {
     new_folder_btn_pressed: bool,
 
     #[cfg(target_os = "ios")]
-    pub hide_keyboard: bool,
+    pub hide_virtual_keyboard: bool,
 
     #[cfg(target_os = "ios")]
     pub text_updated: bool,
@@ -61,7 +61,7 @@ impl Default for FfiWorkspaceResp {
             refresh_files: Default::default(),
             new_folder_btn_pressed: Default::default(),
             #[cfg(target_os = "ios")]
-            hide_keyboard: false,
+            hide_virtual_keyboard: false,
             #[cfg(target_os = "ios")]
             text_updated: Default::default(),
             #[cfg(target_os = "ios")]
@@ -94,7 +94,7 @@ impl From<WsOutput> for FfiWorkspaceResp {
             new_folder_btn_pressed: value.new_folder_clicked,
 
             #[cfg(target_os = "ios")]
-            hide_keyboard: value.hide_keyboard,
+            hide_virtual_keyboard: value.hide_virtual_keyboard,
             #[cfg(target_os = "ios")]
             text_updated: false,
             #[cfg(target_os = "ios")]

--- a/libs/content/workspace/src/output.rs
+++ b/libs/content/workspace/src/output.rs
@@ -14,6 +14,8 @@ pub struct WsOutput {
     pub new_folder_clicked: bool,
     pub tab_title_clicked: bool,
 
+    pub hide_keyboard: bool,
+
     pub file_created: Option<Result<File, String>>,
 
     pub error: Option<String>,

--- a/libs/content/workspace/src/output.rs
+++ b/libs/content/workspace/src/output.rs
@@ -14,7 +14,7 @@ pub struct WsOutput {
     pub new_folder_clicked: bool,
     pub tab_title_clicked: bool,
 
-    pub hide_keyboard: bool,
+    pub hide_virtual_keyboard: bool,
 
     pub file_created: Option<Result<File, String>>,
 

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -36,6 +36,8 @@ pub struct EditorResponse {
     pub edit_menu_x: f32,
     pub edit_menu_y: f32,
 
+    pub hide_keyboard: bool,
+
     pub cursor_in_heading: bool,
     pub cursor_in_bullet_list: bool,
     pub cursor_in_number_list: bool,

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -98,6 +98,8 @@ pub struct Editor {
     pub scroll_area_offset: Vec2,
 
     pub old_scroll_area_offset: Vec2,
+
+    pub is_virtual_keyboard_showing: bool,
 }
 
 impl Editor {
@@ -139,6 +141,8 @@ impl Editor {
             scroll_area_rect: Rect { min: Default::default(), max: Default::default() },
             scroll_area_offset: Default::default(),
             old_scroll_area_offset: Default::default(),
+
+            is_virtual_keyboard_showing: Default::default(),
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -36,7 +36,7 @@ pub struct EditorResponse {
     pub edit_menu_x: f32,
     pub edit_menu_y: f32,
 
-    pub hide_keyboard: bool,
+    pub hide_virtual_keyboard: bool,
 
     pub cursor_in_heading: bool,
     pub cursor_in_bullet_list: bool,

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -95,7 +95,7 @@ impl Markdown {
     pub fn show(&mut self, ui: &mut egui::Ui) -> EditorResponse {
         ui.vertical(|ui| {
             let mut res = if cfg!(target_os = "ios") || cfg!(target_os = "android") {
-                let res = ui
+                let mut res = ui
                     .allocate_ui(
                         egui::vec2(
                             ui.available_width(),
@@ -104,12 +104,12 @@ impl Markdown {
                         |ui| self.editor.scroll_ui(ui),
                     )
                     .inner;
-                self.toolbar.show(ui, &mut self.editor);
+                self.toolbar.show(ui, &mut self.editor, &mut res);
 
                 res
             } else {
-                let res = self.editor.scroll_ui(ui);
-                self.toolbar.show(ui, &mut self.editor);
+                let mut res = self.editor.scroll_ui(ui);
+                self.toolbar.show(ui, &mut self.editor, &mut res);
 
                 res
             };

--- a/libs/content/workspace/src/theme/icons.rs
+++ b/libs/content/workspace/src/theme/icons.rs
@@ -42,6 +42,8 @@ impl Icon {
     pub const IMAGE: Self = ic("\u{e3f4}"); // Image
     pub const INFO: Self = ic("\u{e88e}");
     pub const ITALIC: Self = ic("\u{e23f}");
+    pub const KEYBOARD_HIDE: Self = ic("\u{e31a}");
+    pub const LINK: Self = ic("\u{e157}");
     pub const MONEY: Self = ic("\u{e263}"); // Monetization On
     pub const NUMBER_LIST: Self = ic("\u{e242}"); // Number List
     pub const PLACE_ITEM: Self = ic("\u{f1f0}"); // Place Item

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -392,6 +392,10 @@ impl Workspace {
                                 if let Some(new_name) = resp.document_renamed {
                                     rename_req = Some((tab.id, new_name))
                                 }
+
+                                if resp.hide_keyboard {
+                                    output.hide_keyboard = resp.hide_keyboard;
+                                }
                             }
                             TabContent::PlainText(txt) => txt.show(ui),
                             TabContent::Image(img) => img.show(ui),

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -393,8 +393,8 @@ impl Workspace {
                                     rename_req = Some((tab.id, new_name))
                                 }
 
-                                if resp.hide_keyboard {
-                                    output.hide_keyboard = resp.hide_keyboard;
+                                if resp.hide_virtual_keyboard {
+                                    output.hide_virtual_keyboard = resp.hide_virtual_keyboard;
                                 }
                             }
                             TabContent::PlainText(txt) => txt.show(ui),


### PR DESCRIPTION
I added a "hide keyboard" button and "create link" button. The "hide keyboard" button will only be shown when the keyboard is shown. The "create link" button is straightforward, and will simply insert the link markdown syntax around what's selected.

note: the hide keyboard button won't be on Android devices, since Android (the OS itself) already allows the user to hide their keyboard

fixes #2682
fixes #2089