### PR TITLE
workspace: image refinements

### DIFF
--- a/clients/egui/src/model.rs
+++ b/clients/egui/src/model.rs
@@ -42,9 +42,11 @@ impl DocType {
             "draw" | "svg" => Self::Drawing,
             "md" => Self::Markdown,
             "txt" => Self::PlainText,
-            "png" | "jpeg" | "jpg" | "gif" | "webp" | "bmp" | "ico" => Self::Image(ext.to_string()),
             "cr2" => Self::ImageUnsupported(ext.to_string()),
             "go" => Self::Code(ext.to_string()),
+            _ if workspace_rs::tab::image_viewer::is_supported_image_fmt(ext) => {
+                Self::Image(ext.to_string())
+            }
             _ => Self::Unknown,
         }
     }

--- a/clients/linux/src/input/clipboard_paste.rs
+++ b/clients/linux/src/input/clipboard_paste.rs
@@ -225,7 +225,7 @@ impl<'a> Ctx<'a> {
                 .push(egui::Event::Paste(text.to_string()));
         } else if format == atoms.ImagePng {
             app.context.push_event(workspace_rs::Event::Paste {
-                content: vec![ClipContent::Png(data)],
+                content: vec![ClipContent::Image(data)],
                 position: egui::Pos2::ZERO,
             });
         } else {

--- a/clients/windows/src/input/clipboard_paste.rs
+++ b/clients/windows/src/input/clipboard_paste.rs
@@ -17,7 +17,7 @@ pub fn handle(app: &mut WgpuLockbook) {
             .expect("png encode pasted image");
 
         app.context.push_event(workspace_rs::Event::Paste {
-            content: vec![ClipContent::Png(png_bytes)],
+            content: vec![ClipContent::Image(png_bytes)],
             position: Pos2::ZERO, // todo: support position
         });
     }

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
@@ -201,7 +201,8 @@ public class MacMTK: MTKView, MTKViewDelegate {
         } else if !isPaste {
             if let data = pasteBoard.data(forType: .fileURL) {
                 if let url = URL(dataRepresentation: data, relativeTo: nil) {
-                    if url.pathExtension.lowercased() == "png" {
+                    print("url.pathExtension.lowercased(): \(url.pathExtension.lowercased())")
+                    if isSupportedImageFormat(ext: url.pathExtension.lowercased()) {
                         guard let data = try? Data(contentsOf: url) else {
                             return false
                         }
@@ -229,6 +230,17 @@ public class MacMTK: MTKView, MTKViewDelegate {
         }
         
         clipboard_send_image(wsHandle, imgPtr, UInt(img.count), isPaste)
+    }
+    
+    // copy of workspace::tab::image_viewer::is_supported_image_fmt() because ffi seems like overkill
+    func isSupportedImageFormat(ext: String) -> Bool {
+        // Complete list derived from which features are enabled on image crate according to image-rs default features:
+        // https://github.com/image-rs/image/blob/main/Cargo.toml#L70
+        let imgFormats: Set<String> = [
+            "avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "jpg", "png", "pnm", "qoi", "tga",
+            "tiff", "webp"
+        ]
+        return imgFormats.contains(ext)
     }
 
     func viewCoordinates(_ event: NSEvent) -> NSPoint {

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
@@ -201,7 +201,6 @@ public class MacMTK: MTKView, MTKViewDelegate {
         } else if !isPaste {
             if let data = pasteBoard.data(forType: .fileURL) {
                 if let url = URL(dataRepresentation: data, relativeTo: nil) {
-                    print("url.pathExtension.lowercased(): \(url.pathExtension.lowercased())")
                     if isSupportedImageFormat(ext: url.pathExtension.lowercased()) {
                         guard let data = try? Data(contentsOf: url) else {
                             return false

--- a/libs/content/workspace-ffi/src/apple/common_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/common_ffi.rs
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn clipboard_send_image(
 ) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let img = std::slice::from_raw_parts(content, length).to_vec();
-    let content = vec![ClipContent::Png(img)];
+    let content = vec![ClipContent::Image(img)];
     let position = egui::Pos2::ZERO; // todo: cursor position
 
     if is_paste {

--- a/libs/content/workspace/src/tab/image_viewer.rs
+++ b/libs/content/workspace/src/tab/image_viewer.rs
@@ -21,7 +21,11 @@ impl ImageViewer {
 }
 
 pub fn is_supported_image_fmt(ext: &str) -> bool {
-    // todo see if this list is incomplete
-    const IMG_FORMATS: [&str; 7] = ["png", "jpeg", "jpg", "gif", "webp", "bmp", "ico"];
+    // complete list derived from which features are enabled on image crate according to image-rs default features:
+    // https://github.com/image-rs/image/blob/main/Cargo.toml#L70
+    const IMG_FORMATS: [&str; 15] = [
+        "avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga",
+        "tiff", "webp",
+    ];
     IMG_FORMATS.contains(&ext)
 }

--- a/libs/content/workspace/src/tab/image_viewer.rs
+++ b/libs/content/workspace/src/tab/image_viewer.rs
@@ -20,12 +20,13 @@ impl ImageViewer {
     }
 }
 
+// a copy of this fn exists in Swift as isSupportedImageFormat()
 pub fn is_supported_image_fmt(ext: &str) -> bool {
     // complete list derived from which features are enabled on image crate according to image-rs default features:
     // https://github.com/image-rs/image/blob/main/Cargo.toml#L70
-    const IMG_FORMATS: [&str; 15] = [
-        "avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga",
-        "tiff", "webp",
+    const IMG_FORMATS: [&str; 16] = [
+        "avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "jpg", "png", "pnm", "qoi",
+        "tga", "tiff", "webp",
     ];
     IMG_FORMATS.contains(&ext)
 }

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -310,7 +310,8 @@ impl Editor {
                 bounds::calc_links(&self.buffer.current, &self.bounds.text, &self.ast);
         }
         if text_updated || selection_updated || theme_updated {
-            self.images = images::calc(&self.ast, &self.images, &self.client, &self.core, ui);
+            self.images =
+                images::calc(&self.ast, &self.images, &self.client, &self.core, self.open_file, ui);
         }
         self.galleys = galleys::calc(
             &self.ast,

--- a/libs/content/workspace/src/tab/markdown_editor/images.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/images.rs
@@ -61,16 +61,13 @@ pub fn calc(
                         // use core for lb:// urls and relative paths
                         let maybe_lb_id = match url.strip_prefix("lb://") {
                             Some(id) => Some(Uuid::parse_str(id).map_err(|e| e.to_string())?),
-                            None => match PathBuf::try_from(&url) {
-                                // not an id
-                                Ok(path) => Some(
-                                    tab::core_get_by_relative_path(&core, open_file, &path)?.id,
-                                ),
-                                Err(_) => {
-                                    // not a path either
-                                    None
-                                }
-                            },
+                            None => tab::core_get_by_relative_path(
+                                &core,
+                                open_file,
+                                &PathBuf::from(&url),
+                            )
+                            .map(|f| f.id)
+                            .ok(),
                         };
 
                         let image_bytes = if let Some(id) = maybe_lb_id {

--- a/libs/content/workspace/src/tab/markdown_editor/images.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/images.rs
@@ -1,3 +1,4 @@
+use crate::tab;
 use crate::tab::markdown_editor::ast::Ast;
 use crate::tab::markdown_editor::style::{InlineNode, MarkdownNode, Url};
 use egui::{ColorImage, TextureId, Ui};
@@ -6,6 +7,7 @@ use resvg::tiny_skia::Pixmap;
 use resvg::usvg::{self, Transform};
 use std::collections::HashMap;
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -24,7 +26,7 @@ pub enum ImageState {
 
 pub fn calc(
     ast: &Ast, prior_cache: &ImageCache, client: &reqwest::blocking::Client, core: &lb_rs::Core,
-    ui: &Ui,
+    open_file: Uuid, ui: &Ui,
 ) -> ImageCache {
     let mut result = ImageCache::default();
 
@@ -56,11 +58,19 @@ pub fn calc(
                     let texture_manager = ctx.tex_manager();
 
                     let texture_result = (|| -> Result<TextureId, String> {
-                        // use core for lb:// urls
-                        // todo: also handle relative paths
+                        // use core for lb:// urls and relative paths
                         let maybe_lb_id = match url.strip_prefix("lb://") {
                             Some(id) => Some(Uuid::parse_str(id).map_err(|e| e.to_string())?),
-                            None => None,
+                            None => match PathBuf::try_from(&url) {
+                                // not an id
+                                Ok(path) => Some(
+                                    tab::core_get_by_relative_path(&core, open_file, &path)?.id,
+                                ),
+                                Err(_) => {
+                                    // not a path either
+                                    None
+                                }
+                            },
                         };
 
                         let image_bytes = if let Some(id) = maybe_lb_id {

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -86,7 +86,8 @@ fn handle_custom_event(
                 match clip {
                     ClipContent::Image(data) => {
                         let file = tab::import_image(core, open_file, &data);
-                        let markdown_image_link = format!("![{}](lb://{})", file.name, file.id);
+                        let rel_path = tab::core_get_relative_path(core, open_file, file.id);
+                        let markdown_image_link = format!("![{}]({})", file.name, rel_path);
 
                         modifications.push(Modification::Replace {
                             region: Region::Selection, // todo: more thoughtful location

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -84,7 +84,7 @@ fn handle_custom_event(
             let mut modifications = Vec::new();
             for clip in content {
                 match clip {
-                    ClipContent::Png(data) => {
+                    ClipContent::Image(data) => {
                         let file = tab::import_image(core, open_file, &data);
                         let markdown_image_link = format!("![{}](lb://{})", file.name, file.id);
 

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -93,7 +93,10 @@ fn handle_custom_event(
                             text: markdown_image_link,
                         });
                     }
-                    ClipContent::Files(..) => unimplemented!(), // todo: support file drop & paste
+                    ClipContent::Files(..) => {
+                        // todo: support file drop & paste
+                        println!("unimplemented: editor file drop & paste");
+                    }
                 }
             }
             modifications

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -7,7 +7,7 @@ use chrono::DateTime;
 use egui::Id;
 use lb_rs::{File, FileType, Uuid};
 use markdown_editor::input::canonical::Modification;
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 pub mod image_viewer;
@@ -236,7 +236,7 @@ pub fn canonicalize_path(path: &str) -> String {
 }
 
 pub fn core_get_by_relative_path(
-    core: &lb_rs::Core, from: Uuid, path: &PathBuf,
+    core: &lb_rs::Core, from: Uuid, path: &Path,
 ) -> Result<File, String> {
     let target_path = if path.is_relative() {
         let mut open_file_path =

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -126,7 +126,6 @@ impl EventManager for egui::Context {
     }
 }
 
-// todo: use relative path (caller responsibilty?)
 // todo: use background thread
 // todo: refresh file tree view
 pub fn import_image(core: &lb_rs::Core, open_file: Uuid, data: &[u8]) -> File {

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -1,6 +1,6 @@
 use resvg::usvg::{AspectRatio, NonZeroRect, Transform, ViewBox};
 
-use crate::tab::{self, ClipContent, EventManager as _};
+use crate::tab::{ClipContent, EventManager as _};
 
 use super::SVGEditor;
 

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -11,7 +11,7 @@ impl SVGEditor {
                 crate::Event::Drop { content, .. } | crate::Event::Paste { content, .. } => {
                     for clip in content {
                         match clip {
-                            ClipContent::Png(data) => {
+                            ClipContent::Image(data) => {
                                 let file =
                                     crate::tab::import_image(&self.core, self.open_file, &data);
 

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -14,7 +14,11 @@ impl SVGEditor {
                             ClipContent::Image(data) => {
                                 let file =
                                     crate::tab::import_image(&self.core, self.open_file, &data);
-
+                                let href = crate::tab::core_get_relative_path(
+                                    &self.core,
+                                    self.open_file,
+                                    file.id,
+                                );
                                 let img = image::load_from_memory(&data).unwrap();
 
                                 let position = ui.input(|r| {
@@ -38,7 +42,7 @@ impl SVGEditor {
                                                 aspect: AspectRatio::default(),
                                             },
                                             texture: None,
-                                            href: Some(file.id),
+                                            href: Some(href),
                                             opacity: 1.0,
                                         },
                                     ),

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -1,6 +1,6 @@
 use resvg::usvg::{AspectRatio, NonZeroRect, Transform, ViewBox};
 
-use crate::tab::{ClipContent, EventManager as _};
+use crate::tab::{self, ClipContent, EventManager as _};
 
 use super::SVGEditor;
 

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -44,7 +44,7 @@ impl SVGEditor {
     pub fn new(bytes: &[u8], core: lb_rs::Core, open_file: Uuid) -> Self {
         let content = std::str::from_utf8(bytes).unwrap();
 
-        let buffer = parser::Buffer::new(content, &core);
+        let buffer = parser::Buffer::new(content, &core, open_file);
         let max_id = buffer
             .elements
             .keys()

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -154,13 +154,10 @@ fn parse_child(u_el: &usvg::Node, buffer: &mut Buffer, i: usize) {
 }
 
 fn lb_local_resolver(core: &lb_rs::Core, open_file: Uuid) -> ImageHrefStringResolverFn {
-    let lb_link_prefix = "lb://";
     let core = core.clone();
     Box::new(move |href: &str, _opts: &Options, _db: &Database| {
-        let id = if href.starts_with(lb_link_prefix) {
-            let id = &href[lb_link_prefix.len()..];
-            let id = lb_rs::Uuid::from_str(id).ok()?;
-            id
+        let id = if let Some(id) = href.strip_prefix("lb://") {
+            lb_rs::Uuid::from_str(id).ok()?
         } else {
             crate::tab::core_get_by_relative_path(&core, open_file, &PathBuf::from(&href))
                 .ok()?


### PR DESCRIPTION
* fixes https://github.com/lockbook/lockbook/issues/2694
* fixes https://github.com/lockbook/lockbook/issues/2480
* fixes an issue where all images were imported with .png extensions
* fixes an issue where non-png images weren't imported as images
* fixes an issue where the editor crashes when you drop an unsupported file (now it just does nothing)
* updates supported image file extensions to include all the supported image file extensions

https://github.com/lockbook/lockbook/assets/6198756/806d3a3e-7a98-43f6-8ef5-28ee0ae42884

