### PR TITLE
editor: suggested filename refinements

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::time::{Duration, Instant};
 
 use egui::os::OperatingSystem;
@@ -7,7 +6,7 @@ use lb_rs::Uuid;
 use serde::Serialize;
 
 use crate::tab::markdown_editor::appearance::Appearance;
-use crate::tab::markdown_editor::ast::Ast;
+use crate::tab::markdown_editor::ast::{Ast, AstTextRangeType};
 use crate::tab::markdown_editor::bounds::{BoundCase, Bounds};
 use crate::tab::markdown_editor::buffer::Buffer;
 use crate::tab::markdown_editor::debug::DebugInfo;
@@ -16,7 +15,7 @@ use crate::tab::markdown_editor::images::ImageCache;
 use crate::tab::markdown_editor::input::canonical::{Bound, Modification, Offset, Region};
 use crate::tab::markdown_editor::input::capture::CaptureState;
 use crate::tab::markdown_editor::input::click_checker::{ClickChecker, EditorClickChecker};
-use crate::tab::markdown_editor::input::cursor::{Cursor, PointerState};
+use crate::tab::markdown_editor::input::cursor::PointerState;
 use crate::tab::markdown_editor::input::events;
 use crate::tab::markdown_editor::offset_types::{DocCharOffset, RangeExt as _};
 use crate::tab::markdown_editor::style::{BlockNode, InlineNode, ListItem, MarkdownNode};
@@ -26,8 +25,7 @@ use crate::tab::EventManager as _;
 #[derive(Debug, Serialize, Default)]
 pub struct EditorResponse {
     pub text_updated: bool,
-    pub potential_title: Option<String>,
-    pub document_renamed: Option<String>,
+    pub suggested_rename: Option<String>,
 
     pub scroll_updated: bool,
 
@@ -250,6 +248,9 @@ impl Editor {
             ui.set_max_width(ui.max_rect().width() - 15.);
         }
 
+        // remember state for change detection
+        let prior_suggested_title = self.get_suggested_title();
+
         // process events
         let (text_updated, selection_updated) = if self.initialized {
             if ui.memory(|m| m.has_focus(id))
@@ -373,21 +374,12 @@ impl Editor {
             ui.scroll_to_rect(rect, None);
         }
 
-        let potential_title = self.get_potential_text_title();
-        let document_renamed = if self.needs_name {
-            if let Some(title) = &potential_title {
-                Some(title.clone())
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
+        let suggested_title = self.get_suggested_title();
+        let suggested_rename =
+            if suggested_title != prior_suggested_title { suggested_title } else { None };
         let mut result = EditorResponse {
             text_updated,
-            potential_title,
-            document_renamed,
+            suggested_rename,
 
             show_edit_menu: self.maybe_menu_location.is_some(),
             has_selection: self.buffer.current.cursor.selection().is_some(),
@@ -596,27 +588,35 @@ impl Editor {
         ctx.set_fonts(fonts);
     }
 
-    pub fn get_potential_text_title(&self) -> Option<String> {
-        let mut maybe_chosen: Option<(DocCharOffset, DocCharOffset)> = None;
-
-        for text_range in &self.bounds.text {
-            if !text_range.is_empty() {
-                maybe_chosen = Some(*text_range);
-                break;
-            }
+    pub fn get_suggested_title(&self) -> Option<String> {
+        if !self.needs_name {
+            return None;
         }
 
-        maybe_chosen.map(|chosen: (DocCharOffset, DocCharOffset)| {
-            let ast_idx = self.ast.ast_node_at_char(chosen.start());
-            let ast = &self.ast.nodes[ast_idx];
+        let ast_ranges = self
+            .bounds
+            .ast
+            .iter()
+            .map(|range| range.range)
+            .collect::<Vec<_>>();
+        for ([ast_idx, paragraph_idx], text_range_portion) in
+            bounds::join([&ast_ranges, &self.bounds.paragraphs])
+        {
+            if let Some(ast_idx) = ast_idx {
+                let ast_text_range = &self.bounds.ast[ast_idx];
+                if ast_text_range.range_type != AstTextRangeType::Text {
+                    continue; // no syntax characters in suggested title
+                }
+                if ast_text_range.is_empty() {
+                    continue; // no empty text in suggested title
+                }
+            }
+            if paragraph_idx > Some(0) {
+                break; // suggested title must be from first paragraph
+            }
 
-            let cursor: Cursor = (
-                ast.text_range.start(),
-                cmp::min(ast.text_range.end(), ast.text_range.start() + 30),
-            )
-                .into();
-
-            String::from(cursor.selection_text(&self.buffer.current)) + ".md"
-        })
+            return Some(String::from(&self.buffer.current[text_range_portion]) + ".md");
+        }
+        None
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/images.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/images.rs
@@ -26,7 +26,7 @@ pub enum ImageState {
 
 pub fn calc(
     ast: &Ast, prior_cache: &ImageCache, client: &reqwest::blocking::Client, core: &lb_rs::Core,
-    open_file: Uuid, ui: &Ui,
+    file_id: Uuid, ui: &Ui,
 ) -> ImageCache {
     let mut result = ImageCache::default();
 
@@ -61,13 +61,11 @@ pub fn calc(
                         // use core for lb:// urls and relative paths
                         let maybe_lb_id = match url.strip_prefix("lb://") {
                             Some(id) => Some(Uuid::parse_str(id).map_err(|e| e.to_string())?),
-                            None => tab::core_get_by_relative_path(
-                                &core,
-                                open_file,
-                                &PathBuf::from(&url),
-                            )
-                            .map(|f| f.id)
-                            .ok(),
+                            None => {
+                                tab::core_get_by_relative_path(&core, file_id, &PathBuf::from(&url))
+                                    .map(|f| f.id)
+                                    .ok()
+                            }
                         };
 
                         let image_bytes = if let Some(id) = maybe_lb_id {

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -20,7 +20,7 @@ use super::canonical::Region;
 pub fn combine(
     events: &[Event], custom_events: &[crate::Event], click_checker: impl ClickChecker + Copy,
     touch_mode: bool, appearance: &Appearance, pointer_state: &mut PointerState,
-    core: &mut lb_rs::Core, open_file: Uuid,
+    core: &mut lb_rs::Core, file_id: Uuid,
 ) -> Vec<Modification> {
     let canonical_egui_events = events.iter().filter_map(|e| {
         input::canonical::calc(
@@ -36,7 +36,7 @@ pub fn combine(
     custom_events
         .iter()
         .cloned()
-        .flat_map(|event| handle_custom_event(event, core, open_file))
+        .flat_map(|event| handle_custom_event(event, core, file_id))
         .chain(canonical_egui_events)
         .collect()
 }
@@ -76,7 +76,7 @@ pub fn process(
 }
 
 fn handle_custom_event(
-    event: crate::Event, core: &mut lb_rs::Core, open_file: Uuid,
+    event: crate::Event, core: &mut lb_rs::Core, file_id: Uuid,
 ) -> Vec<Modification> {
     match event {
         crate::Event::Markdown(modification) => vec![modification],
@@ -85,8 +85,8 @@ fn handle_custom_event(
             for clip in content {
                 match clip {
                     ClipContent::Image(data) => {
-                        let file = tab::import_image(core, open_file, &data);
-                        let rel_path = tab::core_get_relative_path(core, open_file, file.id);
+                        let file = tab::import_image(core, file_id, &data);
+                        let rel_path = tab::core_get_relative_path(core, file_id, file.id);
                         let markdown_image_link = format!("![{}]({})", file.name, rel_path);
 
                         modifications.push(Modification::Replace {

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -128,9 +128,9 @@ impl EventManager for egui::Context {
 
 // todo: use background thread
 // todo: refresh file tree view
-pub fn import_image(core: &lb_rs::Core, open_file: Uuid, data: &[u8]) -> File {
+pub fn import_image(core: &lb_rs::Core, file_id: Uuid, data: &[u8]) -> File {
     let file = core
-        .get_file_by_id(open_file)
+        .get_file_by_id(file_id)
         .expect("get lockbook file for image");
     let siblings = core
         .get_children(file.parent)

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -494,7 +494,7 @@ impl Workspace {
                                     let id = self.current_tab().unwrap().id;
                                     if let Some(tab) = self.get_mut_tab_by_id(id) {
                                         if let Some(TabContent::Markdown(md)) = &mut tab.content {
-                                            md.needs_name = false;
+                                            md.editor.needs_name = false;
                                         }
                                     }
                                     self.rename_file((id, name.clone()));

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -389,7 +389,7 @@ impl Workspace {
                                     tab.last_changed = Instant::now();
                                 }
 
-                                if let Some(new_name) = resp.document_renamed {
+                                if let Some(new_name) = resp.suggested_rename {
                                     rename_req = Some((tab.id, new_name))
                                 }
 


### PR DESCRIPTION
The first time a new document was opened, it was sending suggested file names every frame, and workspace spawned a thread to handle each rename asynchronously (and not necessarily in order). Not sure how to measure all the performance benefits of not spawning a thread each frame, but it could only fix performance issues that occur after creating markdown documents.

Also did some data model cleanup because some fields had been duplicated and had inconsistent/poor names.

before:

https://github.com/lockbook/lockbook/assets/6198756/fe696d44-ca96-4c0b-9063-20691cd90987

after:

https://github.com/lockbook/lockbook/assets/6198756/b3b67d71-6527-4b40-b71b-f9af20b5737c
