### PR TITLE
apple: fix the energy consumption problem

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/iOSMTK.swift
@@ -720,7 +720,7 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         
         dark_mode(wsHandle, isDarkMode())
         set_scale(wsHandle, Float(self.contentScaleFactor))
-        let output = draw_editor(wsHandle)
+        let output = draw_workspace(wsHandle)
         
         workspaceState?.syncing = output.workspace_resp.syncing
         workspaceState?.statusMsg = textFromPtr(s: output.workspace_resp.msg)
@@ -804,7 +804,7 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         }
 
         redrawTask?.cancel()
-        self.isPaused = output.redraw_in > 100
+        self.isPaused = output.redraw_in > 50
         if self.isPaused {
             let redrawIn = UInt64(truncatingIfNeeded: output.redraw_in)
             let redrawInInterval = DispatchTimeInterval.milliseconds(Int(truncatingIfNeeded: min(500, redrawIn)));

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
@@ -309,7 +309,7 @@ public class MacMTK: MTKView, MTKViewDelegate {
 
         redrawTask?.cancel()
         redrawTask = nil
-        self.isPaused = output.redraw_in > 100
+        self.isPaused = output.redraw_in > 50
         if self.isPaused {
             let redrawIn = UInt64(truncatingIfNeeded: output.redraw_in)
             let redrawInInterval = DispatchTimeInterval.milliseconds(Int(truncatingIfNeeded: min(500, redrawIn)));

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Editor/macMTK.swift
@@ -270,7 +270,7 @@ public class MacMTK: MTKView, MTKViewDelegate {
         let scale = Float(self.window?.backingScaleFactor ?? 1.0)
         dark_mode(wsHandle, isDarkMode())
         set_scale(wsHandle, scale)
-        let output = draw_editor(wsHandle)
+        let output = draw_workspace(wsHandle)
 
         workspaceState?.syncing = output.workspace_resp.syncing
         workspaceState?.statusMsg = textFromPtr(s: output.workspace_resp.msg)

--- a/libs/content/workspace-ffi/src/apple/common_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/common_ffi.rs
@@ -100,7 +100,7 @@ pub extern "C" fn request_sync(obj: *mut c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn draw_editor(obj: *mut c_void) -> IntegrationOutput {
+pub extern "C" fn draw_workspace(obj: *mut c_void) -> IntegrationOutput {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
     obj.frame()
 }

--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -149,6 +149,19 @@ impl<'window> WgpuWorkspace<'window> {
             }
         }
 
+        out.redraw_in = match full_output
+            .viewport_output
+            .values()
+            .next()
+            .map(|v| v.repaint_delay)
+        {
+            Some(d) => d.as_millis() as u64,
+            None => {
+                eprintln!("VIEWPORT Missing, not requesting redraw");
+                u64::max_value()
+            }
+        };
+
         out
     }
 


### PR DESCRIPTION
we stopped return repaint_after and the integration fell back to continuous redraws

https://discord.com/channels/1014184997751619664/1026208854280777789/1253746606855950428