### PR TITLE
ios/editor: fix end of line cursor placement

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/ios_ffi.rs
@@ -25,6 +25,8 @@ pub unsafe extern "C" fn insert_text(obj: *mut c_void, content: *const c_char) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let content = CStr::from_ptr(content).to_str().unwrap().into();
 
+    println!("insert_text: {:?}", content);
+
     if content == "\n" {
         obj.context
             .push_markdown_event(Modification::Newline { advance_cursor: true });
@@ -44,6 +46,8 @@ pub unsafe extern "C" fn insert_text(obj: *mut c_void, content: *const c_char) {
 pub unsafe extern "C" fn backspace(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
+    println!("backspace");
+
     obj.raw_input.events.push(Event::Key {
         key: Key::Backspace,
         physical_key: None,
@@ -60,6 +64,9 @@ pub unsafe extern "C" fn backspace(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn has_text(obj: *mut c_void) -> bool {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("has_text");
+
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return false,
@@ -76,6 +83,9 @@ pub unsafe extern "C" fn has_text(obj: *mut c_void) -> bool {
 pub unsafe extern "C" fn replace_text(obj: *mut c_void, range: CTextRange, text: *const c_char) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let text = CStr::from_ptr(text).to_str().unwrap().into();
+
+    println!("replace_text: {:?}, {:?}", range, text);
+
     if !range.none {
         obj.context
             .push_markdown_event(Modification::Replace { region: range.into(), text });
@@ -87,6 +97,9 @@ pub unsafe extern "C" fn replace_text(obj: *mut c_void, range: CTextRange, text:
 #[no_mangle]
 pub unsafe extern "C" fn copy_selection(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("copy_selection");
+
     obj.context.push_markdown_event(Modification::Copy);
 }
 
@@ -95,6 +108,9 @@ pub unsafe extern "C" fn copy_selection(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn cut_selection(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("cut_selection");
+
     obj.context.push_markdown_event(Modification::Cut);
 }
 
@@ -105,6 +121,9 @@ pub unsafe extern "C" fn cut_selection(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *const c_char {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("text_in_range: {:?}", range);
+
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return null(),
@@ -128,6 +147,9 @@ pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *
 #[no_mangle]
 pub unsafe extern "C" fn get_selected(obj: *mut c_void) -> CTextRange {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("get_selected");
+
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextRange::default(),
@@ -149,6 +171,9 @@ pub unsafe extern "C" fn get_selected(obj: *mut c_void) -> CTextRange {
 #[no_mangle]
 pub unsafe extern "C" fn set_selected(obj: *mut c_void, range: CTextRange) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("set_selected: {:?}", range);
+
     if !range.none {
         obj.context
             .push_markdown_event(Modification::Select { region: range.into() });
@@ -160,6 +185,9 @@ pub unsafe extern "C" fn set_selected(obj: *mut c_void, range: CTextRange) {
 #[no_mangle]
 pub unsafe extern "C" fn select_current_word(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("select_current_word");
+
     obj.context.push_markdown_event(Modification::Select {
         region: Region::Bound { bound: Bound::Word, backwards: true },
     });
@@ -170,6 +198,9 @@ pub unsafe extern "C" fn select_current_word(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn select_all(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("select_all");
+
     obj.context.push_markdown_event(Modification::Select {
         region: Region::Bound { bound: Bound::Doc, backwards: true },
     });
@@ -182,6 +213,9 @@ pub unsafe extern "C" fn select_all(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn get_marked(obj: *mut c_void) -> CTextRange {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("get_marked");
+
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextRange::default(),
@@ -207,6 +241,8 @@ pub unsafe extern "C" fn set_marked(obj: *mut c_void, range: CTextRange, text: *
     let text =
         if text.is_null() { None } else { Some(CStr::from_ptr(text).to_str().unwrap().into()) };
 
+    println!("set_marked: {:?} {:?}", range, text);
+
     obj.context.push_markdown_event(Modification::StageMarked {
         highlighted: range.into(),
         text: text.unwrap_or_default(),
@@ -220,6 +256,9 @@ pub unsafe extern "C" fn set_marked(obj: *mut c_void, range: CTextRange, text: *
 #[no_mangle]
 pub unsafe extern "C" fn unmark_text(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("unmark_text");
+
     obj.context.push_markdown_event(Modification::CommitMarked);
 }
 
@@ -231,6 +270,8 @@ pub unsafe extern "C" fn unmark_text(obj: *mut c_void) {
 /// should we be returning a subset of the document? https://stackoverflow.com/questions/12676851/uitextinput-is-it-ok-to-return-incorrect-beginningofdocument-endofdocumen
 #[no_mangle]
 pub unsafe extern "C" fn beginning_of_document(_obj: *mut c_void) -> CTextPosition {
+    println!("beginning_of_document");
+
     CTextPosition { ..Default::default() }
 }
 
@@ -242,6 +283,9 @@ pub unsafe extern "C" fn beginning_of_document(_obj: *mut c_void) -> CTextPositi
 #[no_mangle]
 pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("end_of_document");
+
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextPosition::default(),
@@ -258,6 +302,9 @@ pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
 #[no_mangle]
 pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("touches_began: {:?} {:?} {:?} {:?}", id, x, y, force);
+
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -280,6 +327,8 @@ pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32
 pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
+    println!("touches_moved: {:?} {:?} {:?} {:?}", id, x, y, force);
+
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -300,6 +349,9 @@ pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32
 #[no_mangle]
 pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("touches_ended: {:?} {:?} {:?} {:?}", id, x, y, force);
+
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -325,6 +377,9 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
 #[no_mangle]
 pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("touches_cancelled: {:?} {:?} {:?} {:?}", id, x, y, force);
+
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -339,6 +394,8 @@ pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y:
 /// https://developer.apple.com/documentation/uikit/uiresponder/1621142-touchesbegan
 #[no_mangle]
 pub extern "C" fn text_range(start: CTextPosition, end: CTextPosition) -> CTextRange {
+    println!("text_range: {:?} {:?}", start, end);
+
     if start.pos < end.pos {
         CTextRange { none: false, start, end }
     } else {
@@ -355,6 +412,9 @@ pub unsafe extern "C" fn position_offset(
     obj: *mut c_void, mut start: CTextPosition, offset: i32,
 ) -> CTextPosition {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    println!("position_offset: {:?} {:?}", start, offset);
+
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextPosition::default(),
@@ -384,6 +444,8 @@ pub unsafe extern "C" fn position_offset(
 pub unsafe extern "C" fn position_offset_in_direction(
     obj: *mut c_void, start: CTextPosition, direction: CTextLayoutDirection, offset: i32,
 ) -> CTextPosition {
+    println!("position_offset_in_direction: {:?} {:?} {:?}", start, direction, offset);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -416,6 +478,8 @@ pub unsafe extern "C" fn position_offset_in_direction(
 pub unsafe extern "C" fn is_position_at_bound(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> bool {
+    println!("is_position_at_bound: {:?} {:?} {:?}", pos, granularity, backwards);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -433,10 +497,14 @@ pub unsafe extern "C" fn is_position_at_bound(
     if let Some(range) =
         DocCharOffset(pos.pos).range_bound(bound, backwards, false, &markdown.editor.bounds)
     {
-        if !backwards && pos.pos == range.0 || backwards && pos.pos == range.1 {
+        // forwards: the provided position is at the end of the enclosing range
+        // backwards: the provided position is at the start of the enclosing range
+        if !backwards && pos.pos == range.end() || backwards && pos.pos == range.start() {
+            println!("-> true");
             return true;
         }
     }
+    println!("-> false");
     false
 }
 
@@ -448,6 +516,8 @@ pub unsafe extern "C" fn is_position_at_bound(
 pub unsafe extern "C" fn is_position_within_bound(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> bool {
+    println!("is_position_within_bound: {:?} {:?} {:?}", pos, granularity, backwards);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -467,9 +537,11 @@ pub unsafe extern "C" fn is_position_within_bound(
     if let Some(range) = pos.range_bound(bound, backwards, false, &markdown.editor.bounds) {
         // this implementation doesn't meet the specification in apple's docs, but the implementation that does creates word jumping bugs
         if range.contains_inclusive(pos) {
+            println!("-> true");
             return true;
         }
     }
+    println!("-> false");
     false
 }
 
@@ -481,6 +553,8 @@ pub unsafe extern "C" fn is_position_within_bound(
 pub unsafe extern "C" fn bound_from_position(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> CTextPosition {
+    println!("bound_from_position: {:?} {:?} {:?}", pos, granularity, backwards);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -501,7 +575,9 @@ pub unsafe extern "C" fn bound_from_position(
     };
     cursor.advance(Offset::Next(bound), backwards, buffer, galleys, &markdown.editor.bounds);
 
-    CTextPosition { none: false, pos: cursor.selection.1 .0 }
+    let result = CTextPosition { none: false, pos: cursor.selection.1 .0 };
+    println!("-> {:?}", result);
+    result
 }
 
 /// # Safety
@@ -512,6 +588,8 @@ pub unsafe extern "C" fn bound_from_position(
 pub unsafe extern "C" fn bound_at_position(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> CTextRange {
+    println!("bound_at_position: {:?} {:?} {:?}", pos, granularity, backwards);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -537,11 +615,13 @@ pub unsafe extern "C" fn bound_at_position(
         &markdown.editor.bounds,
     );
 
-    CTextRange {
+    let result = CTextRange {
         none: false,
         start: CTextPosition { none: false, pos: cursor.selection.start().0 },
         end: CTextPosition { none: false, pos: cursor.selection.end().0 },
-    }
+    };
+    println!("-> {:?}", result);
+    result
 }
 
 /// # Safety
@@ -550,6 +630,8 @@ pub unsafe extern "C" fn bound_at_position(
 /// https://developer.apple.com/documentation/uikit/uitextinput/1614570-firstrect
 #[no_mangle]
 pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRect {
+    println!("first_rect: {:?}", range);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -586,6 +668,8 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn clipboard_cut(obj: *mut c_void) {
+    println!("clipboard_cut");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.context.push_markdown_event(Modification::Cut);
 }
@@ -594,6 +678,8 @@ pub unsafe extern "C" fn clipboard_cut(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn clipboard_copy(obj: *mut c_void) {
+    println!("clipboard_copy");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.context.push_markdown_event(Modification::Copy);
 }
@@ -602,6 +688,8 @@ pub unsafe extern "C" fn clipboard_copy(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> CTextPosition {
+    println!("position_at_point: {:?}", point);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -624,6 +712,8 @@ pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> C
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn get_text(obj: *mut c_void) -> *const c_char {
+    println!("get_text");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -641,6 +731,8 @@ pub unsafe extern "C" fn get_text(obj: *mut c_void) -> *const c_char {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPosition) -> CRect {
+    println!("cursor_rect_at_position: {:?}", pos);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -666,6 +758,8 @@ pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPos
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn update_virtual_keyboard(obj: *mut c_void, showing: bool) {
+    println!("update_virtual_keyboard: {:?}", showing);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -681,6 +775,8 @@ pub unsafe extern "C" fn update_virtual_keyboard(obj: *mut c_void, showing: bool
 pub unsafe extern "C" fn selection_rects(
     obj: *mut c_void, range: CTextRange,
 ) -> UITextSelectionRects {
+    println!("selection_rects: {:?}", range);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -729,6 +825,8 @@ pub unsafe extern "C" fn selection_rects(
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn free_selection_rects(rects: UITextSelectionRects) {
+    println!("free_selection_rects");
+
     let _ = Box::from_raw(std::slice::from_raw_parts_mut(
         rects.rects as *mut CRect,
         rects.size as usize,
@@ -739,6 +837,8 @@ pub unsafe extern "C" fn free_selection_rects(rects: UITextSelectionRects) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
+    println!("indent_at_cursor: {:?}", deindent);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.context
         .push_markdown_event(Modification::Indent { deindent });
@@ -748,6 +848,8 @@ pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn undo_redo(obj: *mut c_void, redo: bool) {
+    println!("undo_redo: {:?}", redo);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     if redo {
         obj.context.push_markdown_event(Modification::Redo);
@@ -760,6 +862,8 @@ pub unsafe extern "C" fn undo_redo(obj: *mut c_void, redo: bool) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn can_undo(obj: *mut c_void) -> bool {
+    println!("can_undo");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -773,6 +877,8 @@ pub unsafe extern "C" fn can_undo(obj: *mut c_void) -> bool {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn can_redo(obj: *mut c_void) -> bool {
+    println!("can_redo");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -788,6 +894,8 @@ pub unsafe extern "C" fn can_redo(obj: *mut c_void) -> bool {
 /// https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
 #[no_mangle]
 pub unsafe extern "C" fn delete_word(obj: *mut c_void) {
+    println!("delete_word");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     obj.raw_input.events.push(Event::Key {
@@ -803,6 +911,8 @@ pub unsafe extern "C" fn delete_word(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn current_tab(obj: *mut c_void) -> i64 {
+    println!("current_tab");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     match obj.workspace.current_tab() {
@@ -824,6 +934,8 @@ pub unsafe extern "C" fn current_tab(obj: *mut c_void) -> i64 {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn toggle_drawing_tool(obj: *mut c_void) {
+    println!("toggle_drawing_tool");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if let Some(svg) = obj.workspace.current_tab_svg_mut() {
@@ -836,6 +948,8 @@ pub unsafe extern "C" fn toggle_drawing_tool(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn toggle_drawing_tool_between_eraser(obj: *mut c_void) {
+    println!("toggle_drawing_tool_between_eraser");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if let Some(svg) = obj.workspace.current_tab_svg_mut() {
@@ -847,6 +961,8 @@ pub unsafe extern "C" fn toggle_drawing_tool_between_eraser(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn unfocus_title(obj: *mut c_void) {
+    println!("unfocus_title");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if let Some(tab) = obj.workspace.current_tab_mut() {
@@ -858,6 +974,8 @@ pub unsafe extern "C" fn unfocus_title(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn show_hide_tabs(obj: *mut c_void, show: bool) {
+    println!("show_hide_tabs: {:?}", show);
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     obj.workspace.show_tabs = show;
@@ -867,6 +985,8 @@ pub unsafe extern "C" fn show_hide_tabs(obj: *mut c_void, show: bool) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn close_active_tab(obj: *mut c_void) {
+    println!("close_active_tab");
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if !obj.workspace.tabs.is_empty() {
@@ -881,6 +1001,11 @@ pub unsafe extern "C" fn ios_key_event(
     obj: *mut c_void, key_code: isize, shift: bool, ctrl: bool, option: bool, command: bool,
     pressed: bool,
 ) {
+    println!(
+        "ios_key_event: {:?}, shift: {:?}, ctrl: {:?}, option: {:?}, command: {:?}, pressed: {:?}",
+        key_code, shift, ctrl, option, command, pressed
+    );
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     let modifiers = egui::Modifiers { alt: option, ctrl, shift, mac_cmd: command, command };

--- a/libs/content/workspace-ffi/src/apple/ios_ffi.rs
+++ b/libs/content/workspace-ffi/src/apple/ios_ffi.rs
@@ -25,8 +25,6 @@ pub unsafe extern "C" fn insert_text(obj: *mut c_void, content: *const c_char) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let content = CStr::from_ptr(content).to_str().unwrap().into();
 
-    println!("insert_text: {:?}", content);
-
     if content == "\n" {
         obj.context
             .push_markdown_event(Modification::Newline { advance_cursor: true });
@@ -46,8 +44,6 @@ pub unsafe extern "C" fn insert_text(obj: *mut c_void, content: *const c_char) {
 pub unsafe extern "C" fn backspace(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    println!("backspace");
-
     obj.raw_input.events.push(Event::Key {
         key: Key::Backspace,
         physical_key: None,
@@ -64,9 +60,6 @@ pub unsafe extern "C" fn backspace(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn has_text(obj: *mut c_void) -> bool {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("has_text");
-
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return false,
@@ -83,9 +76,6 @@ pub unsafe extern "C" fn has_text(obj: *mut c_void) -> bool {
 pub unsafe extern "C" fn replace_text(obj: *mut c_void, range: CTextRange, text: *const c_char) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let text = CStr::from_ptr(text).to_str().unwrap().into();
-
-    println!("replace_text: {:?}, {:?}", range, text);
-
     if !range.none {
         obj.context
             .push_markdown_event(Modification::Replace { region: range.into(), text });
@@ -97,9 +87,6 @@ pub unsafe extern "C" fn replace_text(obj: *mut c_void, range: CTextRange, text:
 #[no_mangle]
 pub unsafe extern "C" fn copy_selection(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("copy_selection");
-
     obj.context.push_markdown_event(Modification::Copy);
 }
 
@@ -108,9 +95,6 @@ pub unsafe extern "C" fn copy_selection(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn cut_selection(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("cut_selection");
-
     obj.context.push_markdown_event(Modification::Cut);
 }
 
@@ -121,9 +105,6 @@ pub unsafe extern "C" fn cut_selection(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *const c_char {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("text_in_range: {:?}", range);
-
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return null(),
@@ -147,9 +128,6 @@ pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *
 #[no_mangle]
 pub unsafe extern "C" fn get_selected(obj: *mut c_void) -> CTextRange {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("get_selected");
-
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextRange::default(),
@@ -171,9 +149,6 @@ pub unsafe extern "C" fn get_selected(obj: *mut c_void) -> CTextRange {
 #[no_mangle]
 pub unsafe extern "C" fn set_selected(obj: *mut c_void, range: CTextRange) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("set_selected: {:?}", range);
-
     if !range.none {
         obj.context
             .push_markdown_event(Modification::Select { region: range.into() });
@@ -185,9 +160,6 @@ pub unsafe extern "C" fn set_selected(obj: *mut c_void, range: CTextRange) {
 #[no_mangle]
 pub unsafe extern "C" fn select_current_word(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("select_current_word");
-
     obj.context.push_markdown_event(Modification::Select {
         region: Region::Bound { bound: Bound::Word, backwards: true },
     });
@@ -198,9 +170,6 @@ pub unsafe extern "C" fn select_current_word(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn select_all(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("select_all");
-
     obj.context.push_markdown_event(Modification::Select {
         region: Region::Bound { bound: Bound::Doc, backwards: true },
     });
@@ -213,9 +182,6 @@ pub unsafe extern "C" fn select_all(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn get_marked(obj: *mut c_void) -> CTextRange {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("get_marked");
-
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextRange::default(),
@@ -241,8 +207,6 @@ pub unsafe extern "C" fn set_marked(obj: *mut c_void, range: CTextRange, text: *
     let text =
         if text.is_null() { None } else { Some(CStr::from_ptr(text).to_str().unwrap().into()) };
 
-    println!("set_marked: {:?} {:?}", range, text);
-
     obj.context.push_markdown_event(Modification::StageMarked {
         highlighted: range.into(),
         text: text.unwrap_or_default(),
@@ -256,9 +220,6 @@ pub unsafe extern "C" fn set_marked(obj: *mut c_void, range: CTextRange, text: *
 #[no_mangle]
 pub unsafe extern "C" fn unmark_text(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("unmark_text");
-
     obj.context.push_markdown_event(Modification::CommitMarked);
 }
 
@@ -270,8 +231,6 @@ pub unsafe extern "C" fn unmark_text(obj: *mut c_void) {
 /// should we be returning a subset of the document? https://stackoverflow.com/questions/12676851/uitextinput-is-it-ok-to-return-incorrect-beginningofdocument-endofdocumen
 #[no_mangle]
 pub unsafe extern "C" fn beginning_of_document(_obj: *mut c_void) -> CTextPosition {
-    println!("beginning_of_document");
-
     CTextPosition { ..Default::default() }
 }
 
@@ -283,9 +242,6 @@ pub unsafe extern "C" fn beginning_of_document(_obj: *mut c_void) -> CTextPositi
 #[no_mangle]
 pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("end_of_document");
-
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextPosition::default(),
@@ -302,9 +258,6 @@ pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
 #[no_mangle]
 pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("touches_began: {:?} {:?} {:?} {:?}", id, x, y, force);
-
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -327,8 +280,6 @@ pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32
 pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    println!("touches_moved: {:?} {:?} {:?} {:?}", id, x, y, force);
-
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -349,9 +300,6 @@ pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32
 #[no_mangle]
 pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("touches_ended: {:?} {:?} {:?} {:?}", id, x, y, force);
-
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -377,9 +325,6 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
 #[no_mangle]
 pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("touches_cancelled: {:?} {:?} {:?} {:?}", id, x, y, force);
-
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
         id: TouchId(id),
@@ -394,8 +339,6 @@ pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y:
 /// https://developer.apple.com/documentation/uikit/uiresponder/1621142-touchesbegan
 #[no_mangle]
 pub extern "C" fn text_range(start: CTextPosition, end: CTextPosition) -> CTextRange {
-    println!("text_range: {:?} {:?}", start, end);
-
     if start.pos < end.pos {
         CTextRange { none: false, start, end }
     } else {
@@ -412,9 +355,6 @@ pub unsafe extern "C" fn position_offset(
     obj: *mut c_void, mut start: CTextPosition, offset: i32,
 ) -> CTextPosition {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    println!("position_offset: {:?} {:?}", start, offset);
-
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
         None => return CTextPosition::default(),
@@ -444,8 +384,6 @@ pub unsafe extern "C" fn position_offset(
 pub unsafe extern "C" fn position_offset_in_direction(
     obj: *mut c_void, start: CTextPosition, direction: CTextLayoutDirection, offset: i32,
 ) -> CTextPosition {
-    println!("position_offset_in_direction: {:?} {:?} {:?}", start, direction, offset);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -478,8 +416,6 @@ pub unsafe extern "C" fn position_offset_in_direction(
 pub unsafe extern "C" fn is_position_at_bound(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> bool {
-    println!("is_position_at_bound: {:?} {:?} {:?}", pos, granularity, backwards);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -500,11 +436,9 @@ pub unsafe extern "C" fn is_position_at_bound(
         // forwards: the provided position is at the end of the enclosing range
         // backwards: the provided position is at the start of the enclosing range
         if !backwards && pos.pos == range.end() || backwards && pos.pos == range.start() {
-            println!("-> true");
             return true;
         }
     }
-    println!("-> false");
     false
 }
 
@@ -516,8 +450,6 @@ pub unsafe extern "C" fn is_position_at_bound(
 pub unsafe extern "C" fn is_position_within_bound(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> bool {
-    println!("is_position_within_bound: {:?} {:?} {:?}", pos, granularity, backwards);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -537,11 +469,9 @@ pub unsafe extern "C" fn is_position_within_bound(
     if let Some(range) = pos.range_bound(bound, backwards, false, &markdown.editor.bounds) {
         // this implementation doesn't meet the specification in apple's docs, but the implementation that does creates word jumping bugs
         if range.contains_inclusive(pos) {
-            println!("-> true");
             return true;
         }
     }
-    println!("-> false");
     false
 }
 
@@ -553,8 +483,6 @@ pub unsafe extern "C" fn is_position_within_bound(
 pub unsafe extern "C" fn bound_from_position(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> CTextPosition {
-    println!("bound_from_position: {:?} {:?} {:?}", pos, granularity, backwards);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -575,9 +503,7 @@ pub unsafe extern "C" fn bound_from_position(
     };
     cursor.advance(Offset::Next(bound), backwards, buffer, galleys, &markdown.editor.bounds);
 
-    let result = CTextPosition { none: false, pos: cursor.selection.1 .0 };
-    println!("-> {:?}", result);
-    result
+    CTextPosition { none: false, pos: cursor.selection.1 .0 }
 }
 
 /// # Safety
@@ -588,8 +514,6 @@ pub unsafe extern "C" fn bound_from_position(
 pub unsafe extern "C" fn bound_at_position(
     obj: *mut c_void, pos: CTextPosition, granularity: CTextGranularity, backwards: bool,
 ) -> CTextRange {
-    println!("bound_at_position: {:?} {:?} {:?}", pos, granularity, backwards);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -615,13 +539,11 @@ pub unsafe extern "C" fn bound_at_position(
         &markdown.editor.bounds,
     );
 
-    let result = CTextRange {
+    CTextRange {
         none: false,
         start: CTextPosition { none: false, pos: cursor.selection.start().0 },
         end: CTextPosition { none: false, pos: cursor.selection.end().0 },
-    };
-    println!("-> {:?}", result);
-    result
+    }
 }
 
 /// # Safety
@@ -630,8 +552,6 @@ pub unsafe extern "C" fn bound_at_position(
 /// https://developer.apple.com/documentation/uikit/uitextinput/1614570-firstrect
 #[no_mangle]
 pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRect {
-    println!("first_rect: {:?}", range);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -668,8 +588,6 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn clipboard_cut(obj: *mut c_void) {
-    println!("clipboard_cut");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.context.push_markdown_event(Modification::Cut);
 }
@@ -678,8 +596,6 @@ pub unsafe extern "C" fn clipboard_cut(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn clipboard_copy(obj: *mut c_void) {
-    println!("clipboard_copy");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.context.push_markdown_event(Modification::Copy);
 }
@@ -688,8 +604,6 @@ pub unsafe extern "C" fn clipboard_copy(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> CTextPosition {
-    println!("position_at_point: {:?}", point);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -712,8 +626,6 @@ pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> C
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn get_text(obj: *mut c_void) -> *const c_char {
-    println!("get_text");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -731,8 +643,6 @@ pub unsafe extern "C" fn get_text(obj: *mut c_void) -> *const c_char {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPosition) -> CRect {
-    println!("cursor_rect_at_position: {:?}", pos);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -758,8 +668,6 @@ pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPos
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn update_virtual_keyboard(obj: *mut c_void, showing: bool) {
-    println!("update_virtual_keyboard: {:?}", showing);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -775,8 +683,6 @@ pub unsafe extern "C" fn update_virtual_keyboard(obj: *mut c_void, showing: bool
 pub unsafe extern "C" fn selection_rects(
     obj: *mut c_void, range: CTextRange,
 ) -> UITextSelectionRects {
-    println!("selection_rects: {:?}", range);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -825,8 +731,6 @@ pub unsafe extern "C" fn selection_rects(
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn free_selection_rects(rects: UITextSelectionRects) {
-    println!("free_selection_rects");
-
     let _ = Box::from_raw(std::slice::from_raw_parts_mut(
         rects.rects as *mut CRect,
         rects.size as usize,
@@ -837,8 +741,6 @@ pub unsafe extern "C" fn free_selection_rects(rects: UITextSelectionRects) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
-    println!("indent_at_cursor: {:?}", deindent);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.context
         .push_markdown_event(Modification::Indent { deindent });
@@ -848,8 +750,6 @@ pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn undo_redo(obj: *mut c_void, redo: bool) {
-    println!("undo_redo: {:?}", redo);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     if redo {
         obj.context.push_markdown_event(Modification::Redo);
@@ -862,8 +762,6 @@ pub unsafe extern "C" fn undo_redo(obj: *mut c_void, redo: bool) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn can_undo(obj: *mut c_void) -> bool {
-    println!("can_undo");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -877,8 +775,6 @@ pub unsafe extern "C" fn can_undo(obj: *mut c_void) -> bool {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn can_redo(obj: *mut c_void) -> bool {
-    println!("can_redo");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let markdown = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => markdown,
@@ -894,8 +790,6 @@ pub unsafe extern "C" fn can_redo(obj: *mut c_void) -> bool {
 /// https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
 #[no_mangle]
 pub unsafe extern "C" fn delete_word(obj: *mut c_void) {
-    println!("delete_word");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     obj.raw_input.events.push(Event::Key {
@@ -911,8 +805,6 @@ pub unsafe extern "C" fn delete_word(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn current_tab(obj: *mut c_void) -> i64 {
-    println!("current_tab");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     match obj.workspace.current_tab() {
@@ -934,8 +826,6 @@ pub unsafe extern "C" fn current_tab(obj: *mut c_void) -> i64 {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn toggle_drawing_tool(obj: *mut c_void) {
-    println!("toggle_drawing_tool");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if let Some(svg) = obj.workspace.current_tab_svg_mut() {
@@ -948,8 +838,6 @@ pub unsafe extern "C" fn toggle_drawing_tool(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn toggle_drawing_tool_between_eraser(obj: *mut c_void) {
-    println!("toggle_drawing_tool_between_eraser");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if let Some(svg) = obj.workspace.current_tab_svg_mut() {
@@ -961,8 +849,6 @@ pub unsafe extern "C" fn toggle_drawing_tool_between_eraser(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn unfocus_title(obj: *mut c_void) {
-    println!("unfocus_title");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if let Some(tab) = obj.workspace.current_tab_mut() {
@@ -974,8 +860,6 @@ pub unsafe extern "C" fn unfocus_title(obj: *mut c_void) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn show_hide_tabs(obj: *mut c_void, show: bool) {
-    println!("show_hide_tabs: {:?}", show);
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     obj.workspace.show_tabs = show;
@@ -985,8 +869,6 @@ pub unsafe extern "C" fn show_hide_tabs(obj: *mut c_void, show: bool) {
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
 pub unsafe extern "C" fn close_active_tab(obj: *mut c_void) {
-    println!("close_active_tab");
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if !obj.workspace.tabs.is_empty() {
@@ -1001,11 +883,6 @@ pub unsafe extern "C" fn ios_key_event(
     obj: *mut c_void, key_code: isize, shift: bool, ctrl: bool, option: bool, command: bool,
     pressed: bool,
 ) {
-    println!(
-        "ios_key_event: {:?}, shift: {:?}, ctrl: {:?}, option: {:?}, command: {:?}, pressed: {:?}",
-        key_code, shift, ctrl, option, command, pressed
-    );
-
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     let modifiers = egui::Modifiers { alt: option, ctrl, shift, mac_cmd: command, command };

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -1054,7 +1054,7 @@ pub fn region_to_cursor(
                 &bounds.text,
             );
             let range = offset
-                .range_bound(bound, backwards, false, bounds)
+                .range_bound(bound, backwards, true, bounds)
                 .unwrap_or((offset, offset));
             range.into()
         }


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2528

To debug this, I started by tediously adding print statements to everything in ios_ffi.rs to indicate what was being called. I also printed the results of those calls (with an '->' arrow) just for the functions that were interesting to me during the process.

For the following logs, I reproduced the bug using a sample document containing only a single character 'X', then clicked after it and observed the cursor being placed before it. Before the changes here, a sample log looked like this:
```
touches_began: 4436965872 51.33333 59.333332 0.0
current_tab
update_virtual_keyboard: false
current_tab
update_virtual_keyboard: false
...
current_tab
update_virtual_keyboard: false
get_selected
position_at_point: CPoint { x: 51.33332824707031, y: 59.33333333333334 }
position_at_point: CPoint { x: 0.0, y: 50.0 }
get_marked
has_text
get_selected
get_selected
position_offset: CTextPosition { none: false, pos: 0 } -1
position_offset: CTextPosition { none: false, pos: 1 } 1
text_range: CTextPosition { none: false, pos: 1 } CTextPosition { none: false, pos: 1 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 1 }, end: CTextPosition { none: false, pos: 1 } }
beginning_of_document
end_of_document
get_marked
get_marked
get_marked
get_selected
get_selected
position_offset: CTextPosition { none: false, pos: 0 } -1
position_offset: CTextPosition { none: false, pos: 1 } 1
text_range: CTextPosition { none: false, pos: 1 } CTextPosition { none: false, pos: 1 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 1 }, end: CTextPosition { none: false, pos: 1 } }
get_marked
get_marked
get_marked
has_text
get_selected
get_marked
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_at_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
is_position_at_bound: CTextPosition { none: false, pos: 0 } Sentence true
-> false
is_position_at_bound: CTextPosition { none: false, pos: 0 } Sentence false
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 0 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 0 } }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence false
-> CTextPosition { none: false, pos: 1 }
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 1 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
has_text
has_text
beginning_of_document
end_of_document
get_marked
get_selected
get_marked
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence false
-> CTextPosition { none: false, pos: 1 }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 1 } Sentence false
-> CTextPosition { none: false, pos: 1 }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 1 } Sentence false
-> CTextPosition { none: false, pos: 1 }
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 0 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 0 } }
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 0 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 0 } }
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 1 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
has_text
get_marked
get_selected
cursor_rect_at_position: CTextPosition { none: false, pos: 0 }
get_selected
cursor_rect_at_position: CTextPosition { none: false, pos: 0 }
beginning_of_document
get_selected
get_selected
get_selected
cursor_rect_at_position: CTextPosition { none: false, pos: 0 }
get_selected
get_selected
position_at_point: CPoint { x: 51.33332824707031, y: 59.33333333333334 }
text_range: CTextPosition { none: false, pos: 1 } CTextPosition { none: false, pos: 1 }
bound_at_position: CTextPosition { none: false, pos: 1 } Word true
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
get_selected
position_at_point: CPoint { x: 51.33332824707031, y: 59.33333333333334 }
get_marked
is_position_at_bound: CTextPosition { none: false, pos: 1 } Line false
-> false
is_position_within_bound: CTextPosition { none: false, pos: 1 } Word false
-> true
bound_at_position: CTextPosition { none: false, pos: 1 } Word false
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 0 }
get_selected
beginning_of_document
end_of_document
get_selected
get_marked
has_text
get_selected
get_selected
get_selected
has_text
has_text
beginning_of_document
end_of_document
get_marked
get_marked
set_selected: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 0 } }
position_at_point: CPoint { x: 0.0, y: 50.0 }
get_selected
position_at_point: CPoint { x: 0.0, y: 50.0 }
Error for queryMetaDataSync: 2
Error for queryMetaDataSync: 2
current_tab
update_virtual_keyboard: false
beginning_of_document
end_of_document
beginning_of_document
end_of_document
...
beginning_of_document
end_of_document
current_tab
update_virtual_keyboard: false
selection_rects: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 0 } }
free_selection_rects
cursor_rect_at_position: CTextPosition { none: false, pos: 0 }
current_tab
update_virtual_keyboard: false
current_tab
update_virtual_keyboard: false
...
current_tab
update_virtual_keyboard: false
touches_ended: 4436965872 51.33333 59.333332 0.0
```
Isn't that a lot of function calls to place a cursor? What is apple's keyboard trying to do exactly? I played around in Apple Notes to find out: when you tap a word, it places the cursor at the end of the word. It must be aiming for that sort of experience.

Next I looked at the single instance of `set_selected` in the logs and traced up the final moments leading to that selection. Sure enough, it places the selection at the start of the document:
```
set_selected: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 0 } }
```
It got that `CTextRange` from invoking `text_range` with two `CTextPosition`s a few lines before:
```
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 0 }
```
Well why did it assemble this text range? One clue is that the last question it asked before doing that was, "what word is after position 1" (the `false` in the log line represents the `backwards` parameter to the ffi function) to which we replied with (0, 1), the range encapsulating the only word in the document ('X')
```
bound_at_position: CTextPosition { none: false, pos: 1 } Word false
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
```
This looked wrong especially considering the previous call to `bound_at_position` asked, "what word is before position 1" and we replied with the same word:
```
bound_at_position: CTextPosition { none: false, pos: 1 } Word true
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
```
So I fixed `region_to_cursor`, the function that handles this, to give the expected answer (1, 1) when asked for the next word ("there isn't any"). This fixed the bug as far as I could tell, but things still weren't making much sense - why was Apple's keyboard trying to put the cursor at the start of the next word? I found a new test document to confirm that behavior: in the document `X\nY` ('\n' representing an actual newline), tapping after the 'X' placed the cursor at the start of the next line before the 'Y'.

A sample log looked like this:
```
touches_began: 4405224528 57.666656 55.333332 0.0
current_tab
update_virtual_keyboard: false
...
current_tab
update_virtual_keyboard: false
current_tab
update_virtual_keyboard: false
get_selected
position_at_point: CPoint { x: 57.666656494140625, y: 55.33333333333334 }
position_at_point: CPoint { x: 0.0, y: 50.0 }
get_selected
cursor_rect_at_position: CTextPosition { none: false, pos: 1 }
get_selected
get_selected
position_at_point: CPoint { x: 57.666656494140625, y: 55.33333333333334 }
text_range: CTextPosition { none: false, pos: 1 } CTextPosition { none: false, pos: 1 }
bound_at_position: CTextPosition { none: false, pos: 1 } Word true
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
get_selected
position_at_point: CPoint { x: 57.666656494140625, y: 55.33333333333334 }
get_marked
is_position_at_bound: CTextPosition { none: false, pos: 1 } Line false
-> false
is_position_within_bound: CTextPosition { none: false, pos: 1 } Word false
-> true
bound_at_position: CTextPosition { none: false, pos: 1 } Word false
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 3 } }
text_range: CTextPosition { none: false, pos: 2 } CTextPosition { none: false, pos: 2 }
get_selected
set_selected: CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 2 } }
position_at_point: CPoint { x: 0.0, y: 50.0 }
get_selected
position_at_point: CPoint { x: 0.0, y: 50.0 }
cursor_rect_at_position: CTextPosition { none: false, pos: 2 }
current_tab
has_text
get_marked
get_marked
has_text
beginning_of_document
end_of_document
beginning_of_document
end_of_document
get_selected
get_marked
bound_from_position: CTextPosition { none: false, pos: 2 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_at_position: CTextPosition { none: false, pos: 2 } Word true
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Word true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
is_position_at_bound: CTextPosition { none: false, pos: 0 } Sentence true
-> false
is_position_at_bound: CTextPosition { none: false, pos: 0 } Sentence false
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 2 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 2 } }
bound_from_position: CTextPosition { none: false, pos: 2 } Sentence false
-> CTextPosition { none: false, pos: 3 }
text_range: CTextPosition { none: false, pos: 2 } CTextPosition { none: false, pos: 3 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 3 } }
has_text
has_text
beginning_of_document
end_of_document
beginning_of_document
end_of_document
get_selected
get_marked
has_text
get_selected
get_selected
get_selected
get_marked
get_marked
get_selected
get_marked
bound_from_position: CTextPosition { none: false, pos: 2 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 2 } Sentence false
-> CTextPosition { none: false, pos: 3 }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 3 } Sentence false
-> CTextPosition { none: false, pos: 3 }
bound_from_position: CTextPosition { none: false, pos: 0 } Sentence true
-> CTextPosition { none: false, pos: 0 }
bound_from_position: CTextPosition { none: false, pos: 3 } Sentence false
-> CTextPosition { none: false, pos: 3 }
text_range: CTextPosition { none: false, pos: 0 } CTextPosition { none: false, pos: 2 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 2 } }
text_range: CTextPosition { none: false, pos: 2 } CTextPosition { none: false, pos: 2 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 2 } }
text_range: CTextPosition { none: false, pos: 2 } CTextPosition { none: false, pos: 3 }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 3 } }
has_text
get_marked
get_selected
cursor_rect_at_position: CTextPosition { none: false, pos: 2 }
get_selected
cursor_rect_at_position: CTextPosition { none: false, pos: 2 }
beginning_of_document
get_selected
get_selected
update_virtual_keyboard: false
selection_rects: CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 2 } }
free_selection_rects
cursor_rect_at_position: CTextPosition { none: false, pos: 2 }
beginning_of_document
end_of_document
get_marked
get_marked
get_marked
has_text
has_text
beginning_of_document
end_of_document
current_tab
update_virtual_keyboard: false
beginning_of_document
end_of_document
beginning_of_document
end_of_document
beginning_of_document
end_of_document
beginning_of_document
end_of_document
current_tab
update_virtual_keyboard: false
current_tab
update_virtual_keyboard: false
current_tab
...
current_tab
update_virtual_keyboard: false
get_selected
current_tab
update_virtual_keyboard: false
current_tab
...
current_tab
update_virtual_keyboard: false
touches_ended: 4405224528 57.666656 55.333332 0.0
```
Whew, still a lot to read. This time right before our only call to `set_selected`, we see a correct answer (2, 3) for what the next word after position 1 is:
```
bound_at_position: CTextPosition { none: false, pos: 1 } Word false
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 3 } }
text_range: CTextPosition { none: false, pos: 2 } CTextPosition { none: false, pos: 2 }
get_selected
set_selected: CTextRange { none: false, start: CTextPosition { none: false, pos: 2 }, end: CTextPosition { none: false, pos: 2 } }
```
But why is it asking for the next word? Well, not long before that, it asks if position 1 is at the end of a line and we reply that it isn't, even though it really is:
```
is_position_at_bound: CTextPosition { none: false, pos: 1 } Line false
-> false
```
So I went ahead and fixed that too.

Finally, the sample log looked like this:
```
touches_began: 4692477232 59.0 60.66666 0.0
current_tab
update_virtual_keyboard: false
current_tab
update_virtual_keyboard: false
...
current_tab
update_virtual_keyboard: false
get_selected
position_at_point: CPoint { x: 59.0, y: 60.666661580403655 }
position_at_point: CPoint { x: 0.0, y: 50.0 }
cursor_rect_at_position: CTextPosition { none: false, pos: 0 }
get_selected
get_selected
position_at_point: CPoint { x: 59.0, y: 60.666661580403655 }
text_range: CTextPosition { none: false, pos: 1 } CTextPosition { none: false, pos: 1 }
bound_at_position: CTextPosition { none: false, pos: 1 } Word true
-> CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
text_in_range: CTextRange { none: false, start: CTextPosition { none: false, pos: 0 }, end: CTextPosition { none: false, pos: 1 } }
get_selected
position_at_point: CPoint { x: 59.0, y: 60.666661580403655 }
get_marked
is_position_at_bound: CTextPosition { none: false, pos: 1 } Line false
-> true
text_range: CTextPosition { none: false, pos: 1 } CTextPosition { none: false, pos: 1 }
get_selected
set_selected: CTextRange { none: false, start: CTextPosition { none: false, pos: 1 }, end: CTextPosition { none: false, pos: 1 } }
position_at_point: CPoint { x: 0.0, y: 50.0 }
get_selected
position_at_point: CPoint { x: 0.0, y: 50.0 }
cursor_rect_at_position: CTextPosition { none: false, pos: 1 }
current_tab
get_selected
update_virtual_keyboard: false
selection_rects: CTextRange { none: false, start: CTextPosition { none: false, pos: 1 }, end: CTextPosition { none: false, pos: 1 } }
free_selection_rects
cursor_rect_at_position: CTextPosition { none: false, pos: 1 }
current_tab
update_virtual_keyboard: false
current_tab
update_virtual_keyboard: false
...
current_tab
update_virtual_keyboard: false
touches_ended: 4692477232 59.0 60.66666 0.0
```
After discovering we're at the end of a line, Apple's keyboard just puts the cursor there:
```
is_position_at_bound: CTextPosition { none: false, pos: 1 } Line false
-> true
text_range: CTextPosition { none: false, pos: 1 } CTextPosition { none: false, pos: 1 }
get_selected
set_selected: CTextRange { none: false, start: CTextPosition { none: false, pos: 1 }, end: CTextPosition { none: false, pos: 1 } }
```
And that's that! Placing the cursor at the end of the line is working now. Does everything here make total sense to me? No. Am I sure there are no more bugs? No. But this experience will be a helpful guide next time we find one.