### PR TITLE
editor: cleanup state and output

### DIFF
--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -114,16 +114,6 @@ impl<'window> WgpuWorkspace<'window> {
 
         #[cfg(not(target_os = "android"))]
         {
-            #[cfg(target_os = "ios")]
-            {
-                if let Some(markdown) = self.workspace.current_tab_markdown() {
-                    out.workspace_resp.text_updated = markdown.editor.text_updated;
-                    out.workspace_resp.selection_updated = (markdown.editor.scroll_area_offset
-                        != markdown.editor.old_scroll_area_offset)
-                        || markdown.editor.selection_updated;
-                }
-            }
-
             if !full_output.platform_output.copied_text.is_empty() {
                 // todo: can this go in output?
                 out.copied_text = CString::new(full_output.platform_output.copied_text)

--- a/libs/content/workspace-ffi/src/resp.rs
+++ b/libs/content/workspace-ffi/src/resp.rs
@@ -96,9 +96,9 @@ impl From<WsOutput> for FfiWorkspaceResp {
             #[cfg(target_os = "ios")]
             hide_virtual_keyboard: value.hide_virtual_keyboard,
             #[cfg(target_os = "ios")]
-            text_updated: false,
+            text_updated: value.markdown_editor_text_updated,
             #[cfg(target_os = "ios")]
-            selection_updated: false,
+            selection_updated: value.markdown_editor_selection_updated,
             #[cfg(target_os = "ios")]
             tab_title_clicked: value.tab_title_clicked,
         }

--- a/libs/content/workspace/src/output.rs
+++ b/libs/content/workspace/src/output.rs
@@ -27,6 +27,13 @@ pub struct WsOutput {
     // todo see below comment about this anti-patern I've created. Only one place should be updating this, we'll refactor
     // this more thoroughly in 0.8.6
     pub status: PersistentWsStatus,
+
+    // first of all, love the above commitment to refactor something in 0.8.6 (we're now on 0.9.4). it do be like that.
+    // next up, acknowledging the need for a better pattern here, but there are some editor-specific outputs that need
+    // to make their way across FFI and it's cleaner to put them in this transient data structure than to maintain them
+    // as persistent editor state
+    pub markdown_editor_text_updated: bool,
+    pub markdown_editor_selection_updated: bool,
 }
 
 // todo: this should probably not be included in output

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use egui::os::OperatingSystem;
-use egui::{Color32, Context, Event, FontDefinitions, Frame, Pos2, Rect, Sense, Ui, Vec2};
+use egui::{Color32, Context, Event, FontDefinitions, Frame, Rect, Sense, Ui, Vec2};
 use lb_rs::Uuid;
 use serde::Serialize;
 
@@ -18,79 +18,50 @@ use crate::tab::markdown_editor::input::click_checker::{ClickChecker, EditorClic
 use crate::tab::markdown_editor::input::cursor::PointerState;
 use crate::tab::markdown_editor::input::events;
 use crate::tab::markdown_editor::offset_types::{DocCharOffset, RangeExt as _};
-use crate::tab::markdown_editor::style::{BlockNode, InlineNode, ListItem, MarkdownNode};
 use crate::tab::markdown_editor::{ast, bounds, galleys, images, register_fonts};
 use crate::tab::EventManager as _;
 
 #[derive(Debug, Serialize, Default)]
 pub struct EditorResponse {
+    // state changes
     pub text_updated: bool,
-    pub suggested_rename: Option<String>,
-
+    pub selection_updated: bool,
     pub scroll_updated: bool,
 
-    pub show_edit_menu: bool,
-    pub has_selection: bool,
-    pub selection_updated: bool,
-    pub edit_menu_x: f32,
-    pub edit_menu_y: f32,
-
+    // actions taken
+    pub suggested_rename: Option<String>,
     pub hide_virtual_keyboard: bool,
-
-    pub cursor_in_heading: bool,
-    pub cursor_in_bullet_list: bool,
-    pub cursor_in_number_list: bool,
-    pub cursor_in_todo_list: bool,
-    pub cursor_in_bold: bool,
-    pub cursor_in_italic: bool,
-    pub cursor_in_inline_code: bool,
-    pub cursor_in_strikethrough: bool,
 }
 
 pub struct Editor {
-    pub id: egui::Id,
-    pub file_id: Uuid,
-    pub needs_name: bool,
-    pub initialized: bool,
-
     // dependencies
     pub core: lb_rs::Core,
     pub client: reqwest::blocking::Client,
 
-    // config
+    // input
+    pub id: egui::Id,
+    pub file_id: Uuid,
+    pub needs_name: bool,
+    pub initialized: bool,
     pub appearance: Appearance,
 
     // state
     pub buffer: Buffer,
-    pub pointer_state: PointerState, // state of cursor not subject to undo history
+    pub pointer_state: PointerState,
     pub debug: DebugInfo,
     pub images: ImageCache,
     pub has_focus: bool,
-
-    // cached intermediate state
     pub ast: Ast,
     pub bounds: Bounds,
     pub galleys: Galleys,
-
-    // computed state from last frame
-    pub ui_rect: Rect,
-
-    // state computed from processing events as client feedback
-    pub maybe_to_clipboard: Option<String>,
-    pub maybe_opened_url: Option<String>,
-    pub text_updated: bool,
-    pub selection_updated: bool,
-    pub maybe_menu_location: Option<Pos2>,
-
-    // additional state for hover reveal etc
     pub capture: CaptureState,
 
-    // state for detecting clicks and converting global to local coordinates
+    // state from last frame for focus & change detection
+    pub ui_rect: Rect,
     pub scroll_area_rect: Rect,
     pub scroll_area_offset: Vec2,
 
-    pub old_scroll_area_offset: Vec2,
-
+    // referenced by toolbar for keyboard toggle (todo: cleanup)
     pub is_virtual_keyboard_showing: bool,
 }
 
@@ -99,14 +70,13 @@ impl Editor {
         core: lb_rs::Core, content: &str, file_id: Uuid, needs_name: bool, plaintext_mode: bool,
     ) -> Self {
         Self {
-            id: egui::Id::new(file_id),
-            file_id,
-            needs_name,
-            initialized: Default::default(),
-
             core,
             client: Default::default(),
 
+            id: egui::Id::new(file_id),
+            file_id,
+            needs_name,
+            initialized: false,
             appearance: Appearance { plaintext_mode, ..Default::default() },
 
             buffer: content.into(),
@@ -114,26 +84,16 @@ impl Editor {
             debug: Default::default(),
             images: Default::default(),
             has_focus: true,
-
             ast: Default::default(),
             bounds: Default::default(),
             galleys: Default::default(),
-
-            ui_rect: Rect { min: Default::default(), max: Default::default() },
-
-            maybe_to_clipboard: Default::default(),
-            maybe_opened_url: Default::default(),
-            text_updated: Default::default(),
-            selection_updated: Default::default(),
-            maybe_menu_location: Default::default(),
-
             capture: Default::default(),
 
+            ui_rect: Rect { min: Default::default(), max: Default::default() },
             scroll_area_rect: Rect { min: Default::default(), max: Default::default() },
             scroll_area_offset: Default::default(),
-            old_scroll_area_offset: Default::default(),
 
-            is_virtual_keyboard_showing: Default::default(),
+            is_virtual_keyboard_showing: false,
         }
     }
 
@@ -226,12 +186,16 @@ impl Editor {
             });
         }
 
+        let mut resp = sao.inner.inner.inner;
+        resp.scroll_updated = self.scroll_area_offset != sao.state.offset;
+
         // remember scroll area rect for focus next frame
         self.scroll_area_rect = sao.inner_rect;
-        self.old_scroll_area_offset = self.scroll_area_offset;
+
+        // remember scroll area offset for change detection
         self.scroll_area_offset = sao.state.offset;
 
-        sao.inner.inner.inner
+        resp
     }
 
     fn ui(
@@ -260,16 +224,17 @@ impl Editor {
                 || cfg!(target_os = "android")
             {
                 let custom_events = ui.ctx().pop_events();
-                self.process_events(events, &custom_events, touch_mode);
-                if let Some(to_clipboard) = &self.maybe_to_clipboard {
-                    ui.output_mut(|o| o.copied_text = to_clipboard.clone());
+                let (maybe_to_clipboard, maybe_opened_url, text_updated, selection_updated) =
+                    self.process_events(events, &custom_events, touch_mode);
+                if let Some(to_clipboard) = maybe_to_clipboard {
+                    ui.output_mut(|o| o.copied_text = to_clipboard);
                 }
-                if let Some(opened_url) = &self.maybe_opened_url {
+                if let Some(opened_url) = maybe_opened_url {
                     ui.output_mut(|o| {
                         o.open_url = Some(egui::output::OpenUrl::new_tab(opened_url))
                     });
                 }
-                (self.text_updated, self.selection_updated)
+                (text_updated, selection_updated)
             } else {
                 (false, false)
             }
@@ -379,49 +344,6 @@ impl Editor {
         let suggested_title = self.get_suggested_title();
         let suggested_rename =
             if suggested_title != prior_suggested_title { suggested_title } else { None };
-        let mut result = EditorResponse {
-            text_updated,
-            suggested_rename,
-
-            show_edit_menu: self.maybe_menu_location.is_some(),
-            has_selection: self.buffer.current.cursor.selection().is_some(),
-            selection_updated,
-            edit_menu_x: self.maybe_menu_location.map(|p| p.x).unwrap_or_default(),
-            edit_menu_y: self.maybe_menu_location.map(|p| p.y).unwrap_or_default(),
-
-            scroll_updated: self.scroll_area_offset != self.old_scroll_area_offset,
-
-            ..Default::default()
-        };
-
-        // determine styles at cursor location
-        // todo: check for styles in selection
-        if self.buffer.current.cursor.selection.is_empty() {
-            for style in self
-                .ast
-                .styles_at_offset(self.buffer.current.cursor.selection.start(), &self.bounds.ast)
-            {
-                match style {
-                    MarkdownNode::Inline(InlineNode::Bold) => result.cursor_in_bold = true,
-                    MarkdownNode::Inline(InlineNode::Italic) => result.cursor_in_italic = true,
-                    MarkdownNode::Inline(InlineNode::Code) => result.cursor_in_inline_code = true,
-                    MarkdownNode::Inline(InlineNode::Strikethrough) => {
-                        result.cursor_in_strikethrough = true
-                    }
-                    MarkdownNode::Block(BlockNode::Heading(..)) => result.cursor_in_heading = true,
-                    MarkdownNode::Block(BlockNode::ListItem(ListItem::Bulleted, ..)) => {
-                        result.cursor_in_bullet_list = true
-                    }
-                    MarkdownNode::Block(BlockNode::ListItem(ListItem::Numbered(..), ..)) => {
-                        result.cursor_in_number_list = true
-                    }
-                    MarkdownNode::Block(BlockNode::ListItem(ListItem::Todo(..), ..)) => {
-                        result.cursor_in_todo_list = true
-                    }
-                    _ => {}
-                }
-            }
-        }
 
         // set cursor style
         {
@@ -449,12 +371,18 @@ impl Editor {
             }
         }
 
-        result
+        EditorResponse {
+            text_updated,
+            suggested_rename,
+            hide_virtual_keyboard: false, // set by toolbar callback (todo: cleanup)
+            selection_updated,
+            scroll_updated: false, // set by scroll_ui
+        }
     }
 
     pub fn process_events(
         &mut self, events: &[Event], custom_events: &[crate::Event], touch_mode: bool,
-    ) {
+    ) -> (Option<String>, Option<String>, bool, bool) {
         // if the cursor is in an invalid location, move it to the next valid location
         if let BoundCase::BetweenRanges { range_after, .. } = self
             .buffer
@@ -506,68 +434,6 @@ impl Editor {
             &mut self.appearance,
         );
 
-        // in touch mode, check if we should open the menu
-        let click_checker = EditorClickChecker {
-            ui_rect: self.ui_rect,
-            galleys: &self.galleys,
-            buffer: &self.buffer,
-            ast: &self.ast,
-            appearance: &self.appearance,
-            bounds: &self.bounds,
-        };
-        if touch_mode {
-            let current_cursor = self.buffer.current.cursor;
-            let current_selection = current_cursor.selection;
-
-            let touched_a_galley = events.iter().any(|e| {
-                if let Event::Touch { pos, .. } | Event::PointerButton { pos, .. } = e {
-                    (&click_checker).text(*pos).is_some()
-                } else {
-                    false
-                }
-            });
-
-            let touched_cursor = current_selection.is_empty()
-                && prior_selection == current_selection
-                && touched_a_galley
-                && combined_events
-                    .iter()
-                    .any(|e| matches!(e, Modification::Select { region: Region::Location(..) }));
-
-            let touched_selection = current_selection.is_empty()
-                && prior_selection.contains_inclusive(current_selection.1)
-                && touched_a_galley
-                && combined_events
-                    .iter()
-                    .any(|e| matches!(e, Modification::Select { region: Region::Location(..) }));
-
-            let double_touched_for_selection = !current_selection.is_empty()
-                && touched_a_galley
-                && combined_events.iter().any(|e| {
-                    matches!(
-                        e,
-                        Modification::Select { region: Region::BoundAt { bound: Bound::Word, .. } }
-                    )
-                });
-
-            if touched_cursor || touched_selection || double_touched_for_selection {
-                // set menu location
-                self.maybe_menu_location = Some(
-                    self.buffer.current.cursor.end_line(
-                        &self.galleys,
-                        &self.bounds.text,
-                        &self.appearance,
-                    )[0],
-                );
-            } else {
-                self.maybe_menu_location = None;
-            }
-            if touched_cursor || touched_selection {
-                // put the cursor back the way it was
-                self.buffer.current.cursor.selection = prior_selection;
-            }
-        }
-
         // assume https for urls without a scheme
         let maybe_opened_url = maybe_opened_url.map(|url| {
             if !url.contains("://") {
@@ -577,11 +443,12 @@ impl Editor {
             }
         });
 
-        // update editor output
-        self.maybe_to_clipboard = maybe_to_clipboard;
-        self.maybe_opened_url = maybe_opened_url;
-        self.text_updated = text_updated;
-        self.selection_updated = self.buffer.current.cursor.selection != prior_selection;
+        (
+            maybe_to_clipboard,
+            maybe_opened_url,
+            text_updated,
+            self.buffer.current.cursor.selection != prior_selection,
+        )
     }
 
     pub fn set_font(&self, ctx: &Context) {

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -395,6 +395,13 @@ impl Workspace {
                                 if resp.hide_virtual_keyboard {
                                     output.hide_virtual_keyboard = resp.hide_virtual_keyboard;
                                 }
+                                if resp.text_updated {
+                                    output.markdown_editor_text_updated = true;
+                                }
+                                if resp.selection_updated || resp.scroll_updated {
+                                    // not sure what scroll has to do with it but I'm just moving code written by smail
+                                    output.markdown_editor_selection_updated = true;
+                                }
                             }
                             TabContent::Image(img) => img.show(ui),
                             TabContent::Pdf(pdf) => pdf.show(ui),

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -399,7 +399,8 @@ impl Workspace {
                                     output.markdown_editor_text_updated = true;
                                 }
                                 if resp.selection_updated || resp.scroll_updated {
-                                    // not sure what scroll has to do with it but I'm just moving code written by smail
+                                    // markdown_editor_selection_updated represents a change to the screen position of
+                                    // the cursor, which is also updated when scrolling
                                     output.markdown_editor_selection_updated = true;
                                 }
                             }


### PR DESCRIPTION
QA:
- [x] add text should redraw
- [x] change selection should redraw
- [x] fling scroll should redraw continuously until coming to rest
- [x] toolbar style buttons should still work
- [x] ios menu should still appear at correct times and places
- [x] android should still build