### PR TITLE
infra: address cbindgen warnings

### DIFF
--- a/libs/content/workspace-ffi/cbindgen.toml
+++ b/libs/content/workspace-ffi/cbindgen.toml
@@ -1,0 +1,14 @@
+# A list of substitutions for converting cfg's to ifdefs. cfgs which aren't
+# defined here will just be discarded.
+#
+# e.g.
+# `#[cfg(target = "freebsd")] ...`
+# becomes
+# `#if defined(DEFINE_FREEBSD) ... #endif`
+#
+# Values chosen to match standard variables defined for the C preprocessor on respective platforms according to:
+# https://github.com/cpredef/predef/blob/master/OperatingSystems.md
+[defines]
+"target_vendor = apple" = "__APPLE__"
+"target_os = ios" = "__APPLE__"
+"target_os = android" = "__ANDROID__"

--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -8,9 +8,11 @@ use workspace_rs::workspace::Workspace;
 #[cfg(target_vendor = "apple")]
 pub mod apple;
 
+/// cbindgen:ignore
 #[cfg(target_os = "android")]
 pub mod android;
 
+/// cbindgen:ignore
 #[cfg(target_os = "android")]
 pub use android::resp::*;
 


### PR DESCRIPTION
[cbindgen](https://github.com/mozilla/cbindgen) is configured using `cbindgen.toml` and needs help deciding how to translate conditionally compiled code. Instead of supporting filters like "only generate C bindings for apple" it maps cfg's to C preprocessor define's so someone on the C side can use a flag to enable/disable compilation. Basically, cbindgen needs help translating the conditions for compiling Rust functions into conditions for compiling C functions.

In C, this is done by defining variables for the preprocessor and checking if those are defined. I'm not sure exactly the mechanism but there are variables that are defined based on the target platform and [references](https://github.com/cpredef/predef/blob/master/OperatingSystems.md) are available.

This PR adds a config to translate platform-dependent compilation flags into their equivalents for the C preprocessor. It also excludes android-only modules from cbindgen processing because they were emitting warnings and we only use cbindgen for Apple clients. Android uses the JNI.

Tested by building and running lockbook for macos and ios.