### PR TITLE
editor: support windows-style line endings

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/ast.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/ast.rs
@@ -87,19 +87,17 @@ impl Ast {
         let mut skipped = 0;
         while let Some((event, mut range)) = iter.next() {
             // correct for windows-style line endings by keeping \r and \n together
-            if buffer.text[range.clone()].starts_with('\n') {
-                if range.start > 0 {
-                    if &buffer.text[range.start - 1..range.start] == "\r" {
-                        range.start -= 1;
-                    }
-                }
+            if buffer.text[range.clone()].starts_with('\n')
+                && range.start > 0
+                && &buffer.text[range.start - 1..range.start] == "\r"
+            {
+                range.start -= 1;
             }
-            if buffer.text[range.clone()].ends_with('\r') {
-                if range.end < buffer.text.len() {
-                    if &buffer.text[range.end..range.end + 1] == "\n" {
-                        range.end += 1;
-                    }
-                }
+            if buffer.text[range.clone()].ends_with('\r')
+                && range.end < buffer.text.len()
+                && &buffer.text[range.end..range.end + 1] == "\n"
+            {
+                range.end += 1;
             }
 
             let range = buffer

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -271,8 +271,7 @@ impl Editor {
                 &self.bounds.ast,
                 &self.appearance,
             );
-            self.bounds.paragraphs =
-                bounds::calc_paragraphs(&self.buffer.current, &self.bounds.ast);
+            self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer.current);
         }
         if text_updated || selection_updated || self.capture.mark_changes_processed() {
             self.bounds.text = bounds::calc_text(


### PR DESCRIPTION
...also present in XCode log output. Pasting any multi-line content from XCode logs crashed the editor before this change.