### PR TITLE
apple: delete confirmation

### DIFF
--- a/clients/apple/Shared/Views/DeleteConfirmationButtons.swift
+++ b/clients/apple/Shared/Views/DeleteConfirmationButtons.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import Foundation
+import SwiftLockbookCore
+
+struct DeleteConfirmationButtons: View {
+    
+    var meta: File
+    
+    var body: some View {
+        Group {
+            Button("Delete \"\(meta.name)\"", role: .destructive) {
+                DI.files.deleteFile(id: meta.id)
+            }
+            
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+}

--- a/clients/apple/Shared/Views/ListFileCell.swift
+++ b/clients/apple/Shared/Views/ListFileCell.swift
@@ -24,12 +24,6 @@ struct FileCell: View {
                 })
                 
                 Button(action: {
-                    DI.files.deleteFile(id: meta.id)
-                }) {
-                    Label("Delete", systemImage: "trash.fill")
-                }
-                
-                Button(action: {
                     DI.sheets.sharingFileInfo = meta
                 }, label: {
                     Label("Share", systemImage: "person.wave.2.fill")
@@ -47,6 +41,12 @@ struct FileCell: View {
                     }) {
                         Label("Copy file link", systemImage: "link")
                     }
+                }
+                
+                Button(role: .destructive, action: {
+                    DI.sheets.deleteConfirmationInfo = meta
+                }) {
+                    Label("Delete", systemImage: "trash.fill")
                 }
             })
     }

--- a/clients/apple/Shared/Views/ListFileCell.swift
+++ b/clients/apple/Shared/Views/ListFileCell.swift
@@ -23,6 +23,8 @@ struct FileCell: View {
                     Label("Move", systemImage: "arrow.up.and.down.and.arrow.left.and.right")
                 })
                 
+                Divider()
+                
                 Button(action: {
                     DI.sheets.sharingFileInfo = meta
                 }, label: {
@@ -42,6 +44,8 @@ struct FileCell: View {
                         Label("Copy file link", systemImage: "link")
                     }
                 }
+                
+                Divider()
                 
                 Button(role: .destructive, action: {
                     DI.sheets.deleteConfirmationInfo = meta

--- a/clients/apple/Shared/Views/PlatformView.swift
+++ b/clients/apple/Shared/Views/PlatformView.swift
@@ -52,7 +52,7 @@ struct PlatformView: View {
                 }
             }
     }
-
+    
     #if os(iOS)
     var platform: some View {
         Group {

--- a/clients/apple/Shared/Views/PlatformView.swift
+++ b/clients/apple/Shared/Views/PlatformView.swift
@@ -52,7 +52,7 @@ struct PlatformView: View {
                 }
             }
     }
-    
+
     #if os(iOS)
     var platform: some View {
         Group {
@@ -77,6 +77,15 @@ struct PlatformView: View {
     
     var iOS: some View {
         ConstrainedHomeViewWrapper()
+            .confirmationDialog(
+                "Are you sure? This action cannot be undone.",
+                isPresented: $sheets.deleteConfirmation,
+                titleVisibility: .visible,
+                actions: {
+                    if let meta = sheets.deleteConfirmationInfo {
+                        DeleteConfirmationButtons(meta: meta)
+                    }
+                })
     }
         
     var iPad: some View {
@@ -88,6 +97,15 @@ struct PlatformView: View {
     var platform: some View {
         ZStack {
             DesktopHomeView()
+                .confirmationDialog(
+                    "Are you sure? This action cannot be undone.",
+                    isPresented: $sheets.deleteConfirmation,
+                    titleVisibility: .visible,
+                    actions: {
+                        if let meta = sheets.deleteConfirmationInfo {
+                            DeleteConfirmationButtons(meta: meta)
+                        }
+                    })
             
             if search.isPathSearching {
                 PathSearchActionBar()

--- a/clients/apple/Shared/Views/PlatformView.swift
+++ b/clients/apple/Shared/Views/PlatformView.swift
@@ -97,15 +97,17 @@ struct PlatformView: View {
     var platform: some View {
         ZStack {
             DesktopHomeView()
-                .confirmationDialog(
-                    "Are you sure? This action cannot be undone.",
-                    isPresented: $sheets.deleteConfirmation,
-                    titleVisibility: .visible,
-                    actions: {
-                        if let meta = sheets.deleteConfirmationInfo {
-                            DeleteConfirmationButtons(meta: meta)
-                        }
-                    })
+                .alert(
+                    "Are you sure?",
+                    isPresented: $sheets.deleteConfirmation
+                ) {
+                    if let meta = sheets.deleteConfirmationInfo {
+                        DeleteConfirmationButtons(meta: meta)
+                    }
+                } message: {
+                    Text("This action cannot be undone.")
+                }
+
             
             if search.isPathSearching {
                 PathSearchActionBar()

--- a/clients/apple/iOS/OutlineView/OutlineBranch.swift
+++ b/clients/apple/iOS/OutlineView/OutlineBranch.swift
@@ -62,12 +62,11 @@ struct OutlineBranch: View {
             .contextMenu(menuItems: {
                 OutlineContextMenu(meta: file, branchState: state)
             })
-        }
-    }
-    
-    func handleDelete(meta: File) -> () -> Void {
-        {
-            files.deleteFile(id: meta.id)
+            .confirmationDialog("Are you sure? This action cannot be undone.", isPresented: Binding(get: { sheets.deleteConfirmationInfo?.id == file.id }, set: { sheets.deleteConfirmation = $0 }), titleVisibility: .visible, actions: {
+                if let meta = sheets.deleteConfirmationInfo {
+                    DeleteConfirmationButtons(meta: meta)
+                }
+            })
         }
     }
 }

--- a/clients/apple/iOS/OutlineView/OutlineContextMenu.swift
+++ b/clients/apple/iOS/OutlineView/OutlineContextMenu.swift
@@ -49,6 +49,8 @@ struct OutlineContextMenu: View {
                     Label("Move", systemImage: "arrow.up.and.down.and.arrow.left.and.right")
                 }
                 
+                Divider()
+                
                 Button(action: { DI.sheets.sharingFileInfo = meta}) {
                     Label("Share", systemImage: "person.wave.2.fill")
                 }
@@ -64,6 +66,8 @@ struct OutlineContextMenu: View {
                         Label("Copy file link", systemImage: "link")
                     }
                 }
+                
+                Divider()
                 
                 Button(role: .destructive, action: {
                     DI.sheets.deleteConfirmationInfo = meta

--- a/clients/apple/iOS/OutlineView/OutlineContextMenu.swift
+++ b/clients/apple/iOS/OutlineView/OutlineContextMenu.swift
@@ -49,10 +49,6 @@ struct OutlineContextMenu: View {
                     Label("Move", systemImage: "arrow.up.and.down.and.arrow.left.and.right")
                 }
                 
-                Button(action: { DI.files.deleteFile(id: meta.id) }) {
-                    Label("Delete", systemImage: "trash.fill")
-                }
-
                 Button(action: { DI.sheets.sharingFileInfo = meta}) {
                     Label("Share", systemImage: "person.wave.2.fill")
                 }
@@ -60,13 +56,19 @@ struct OutlineContextMenu: View {
                 Button(action: { exportFileAndShowShareSheet(meta: meta) }) {
                     Label("Share externally to...", systemImage: "square.and.arrow.up.fill")
                 }
-            }
-            
-            if meta.fileType == .Document {
-                Button(action: {
-                    DI.files.copyFileLink(id: meta.id)
+                
+                if meta.fileType == .Document {
+                    Button(action: {
+                        DI.files.copyFileLink(id: meta.id)
+                    }) {
+                        Label("Copy file link", systemImage: "link")
+                    }
+                }
+                
+                Button(role: .destructive, action: {
+                    DI.sheets.deleteConfirmationInfo = meta
                 }) {
-                    Label("Copy file link", systemImage: "link")
+                    Label("Delete", systemImage: "trash.fill")
                 }
             }
         }

--- a/clients/apple/iOS/OutlineView/OutlineRow.swift
+++ b/clients/apple/iOS/OutlineView/OutlineRow.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 import SwiftLockbookCore
+import SwiftWorkspace
 
-/// This view handles displaying the contents of each row for its object. Clicking its arrow image also toggles a node's open state./
 struct OutlineRow: View {
     
     @EnvironmentObject var files: FileService
+    @EnvironmentObject var workspace: WorkspaceState
     
     var file: File
     var level: CGFloat
@@ -26,7 +27,7 @@ struct OutlineRow: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 16, height: 16)
-                .foregroundColor(file.fileType == .Folder ? .accentColor : .secondary)
+                .foregroundColor(file.fileType == .Folder ? .accentColor : (workspace.openDoc == file.id ? .white : .secondary ))
             
             Text(file.name)
                 .lineLimit(1) // If lineLimit is not specified, non-leaf names will wrap

--- a/clients/apple/iOS/OutlineView/SheetState.swift
+++ b/clients/apple/iOS/OutlineView/SheetState.swift
@@ -93,7 +93,6 @@ class SheetState: ObservableObject {
     }
     @Published var deleteConfirmationInfo: File? {
         didSet {
-            print("was set!")
             deleteConfirmation = deleteConfirmationInfo != nil
         }
     }

--- a/clients/apple/iOS/OutlineView/SheetState.swift
+++ b/clients/apple/iOS/OutlineView/SheetState.swift
@@ -84,6 +84,20 @@ class SheetState: ObservableObject {
         }
     }
     
+    @Published var deleteConfirmation: Bool = false {
+        didSet {
+            if !deleteConfirmation && deleteConfirmationInfo != nil {
+                deleteConfirmationInfo = nil
+            }
+        }
+    }
+    @Published var deleteConfirmationInfo: File? {
+        didSet {
+            print("was set!")
+            deleteConfirmation = deleteConfirmationInfo != nil
+        }
+    }
+    
     private var cancellables: Set<AnyCancellable> = []
     
     init() {

--- a/clients/apple/lockbook.xcodeproj/project.pbxproj
+++ b/clients/apple/lockbook.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		4779C62E2AB8C09E007C0100 /* PathSearchActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779C62C2AB8C09E007C0100 /* PathSearchActionBar.swift */; };
 		477CC4902967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
 		477CC4912967A53C00714456 /* ShareFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477CC48F2967A53C00714456 /* ShareFileSheet.swift */; };
+		4782F83B2C49B4E700D55923 /* DeleteConfirmationButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4782F83A2C49B4E700D55923 /* DeleteConfirmationButtons.swift */; };
+		4782F83C2C49B4E700D55923 /* DeleteConfirmationButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4782F83A2C49B4E700D55923 /* DeleteConfirmationButtons.swift */; };
 		47837E292A72EA7500863FA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B273394C26C8A4B400303EAE /* Assets.xcassets */; };
 		47A45FBB2969047B00573044 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A45FBA2969047B00573044 /* ShareService.swift */; };
 		47A45FBC2969047B00573044 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A45FBA2969047B00573044 /* ShareService.swift */; };
@@ -144,6 +146,7 @@
 		476436CB29B7DE4E00FBDC59 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchService.swift; path = "Shared/Stateful Logic/SearchService.swift"; sourceTree = SOURCE_ROOT; };
 		4779C62C2AB8C09E007C0100 /* PathSearchActionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathSearchActionBar.swift; sourceTree = "<group>"; };
 		477CC48F2967A53C00714456 /* ShareFileSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFileSheet.swift; sourceTree = "<group>"; };
+		4782F83A2C49B4E700D55923 /* DeleteConfirmationButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteConfirmationButtons.swift; sourceTree = "<group>"; };
 		47A45FBA2969047B00573044 /* ShareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
 		47B53837290EFE150012E542 /* BillingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingService.swift; sourceTree = "<group>"; };
 		47B67288295F977C00DB0D8E /* ManageSubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionView.swift; sourceTree = "<group>"; };
@@ -398,6 +401,7 @@
 				4779C62C2AB8C09E007C0100 /* PathSearchActionBar.swift */,
 				DFE4E3702B847F6000AC8A15 /* LogoutConfirmation.swift */,
 				47FC8F5E2C24B6580023069E /* PlatformView.swift */,
+				4782F83A2C49B4E700D55923 /* DeleteConfirmationButtons.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -555,6 +559,7 @@
 				47E208562C387A60002A356B /* Util.swift in Sources */,
 				EA9079C32569960A00E04F5D /* ListFileCell.swift in Sources */,
 				87F78F7A27094A040001E159 /* BeforeYouStart.swift in Sources */,
+				4782F83B2C49B4E700D55923 /* DeleteConfirmationButtons.swift in Sources */,
 				8741E8E425AAA524005B7B01 /* BottomBar.swift in Sources */,
 				B249B9E8282AF6B1004F5300 /* OutlineBranch.swift in Sources */,
 				473A3DCE29AC354B0017BC6A /* FilePathBreadcrumb.swift in Sources */,
@@ -627,6 +632,7 @@
 				47E208572C387A62002A356B /* Util.swift in Sources */,
 				B2459BEE28DBB43100756D71 /* ColorProgressBar.swift in Sources */,
 				EAF96D0D252E8ED000AA1A14 /* ConfigHelper.swift in Sources */,
+				4782F83C2C49B4E700D55923 /* DeleteConfirmationButtons.swift in Sources */,
 				B2ADC2472833FA8200DB8D3D /* FileCell.swift in Sources */,
 				877FB55A26D18EC80008AB3F /* FileService.swift in Sources */,
 				6581A7EF74307EAE69426206 /* SheetState.swift in Sources */,

--- a/clients/apple/macOS/TreeView/DataSource.swift
+++ b/clients/apple/macOS/TreeView/DataSource.swift
@@ -124,12 +124,10 @@ class TreeDelegate: NSObject, MenuOutlineViewDelegate {
 
         if parent.id != parent.parent {
             menu.addItem(RenameFile(file: parent))
-            menu.addItem(Delete(file: parent))
             menu.addItem(Share(file: parent))
             menu.addItem(ShareExternallyMenu(file: parent, fileTree: outlineView))
+            menu.addItem(Delete(file: parent))
         }
-        
-        
         
         return menu
     }

--- a/clients/apple/macOS/TreeView/MenuItems.swift
+++ b/clients/apple/macOS/TreeView/MenuItems.swift
@@ -82,7 +82,7 @@ class Delete: NSMenuItem {
     }
 
     @objc func delete(_ sender: AnyObject) {
-        DI.files.deleteFile(id: file.id)
+        DI.sheets.deleteConfirmationInfo = file
     }
 }
 


### PR DESCRIPTION
I added delete confirmation dialogs for all platforms. On iOS and iPadOS, I moved the delete buttons to the bottom of the context menus and made them red.

iOS:
<img  width="300" src="https://github.com/user-attachments/assets/bb03b7e8-c2df-4102-a808-2cc5f4b8ce05"/>

iPadOS:
![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-07-18 at 16 53 26](https://github.com/user-attachments/assets/c5b14f2e-c640-4009-bfe0-f2921de38b63)

macOS:
<img width="1306" alt="Screenshot 2024-07-18 at 5 32 57 PM" src="https://github.com/user-attachments/assets/31b22471-3c17-45ca-be68-8f5bdc2ddd86">

fixes #2360