### PR TITLE
ios: auto-scroll breadcrumb on folder open

### DIFF
--- a/clients/apple/iOS/FilePathBreadcrumb.swift
+++ b/clients/apple/iOS/FilePathBreadcrumb.swift
@@ -17,7 +17,7 @@ struct FilePathBreadcrumb: View {
                 .onChange(of: files.path.count) { count in
                     if count > 0 {
                         withAnimation {
-                            scrollHelper.scrollTo(files.path.count - 2, anchor: .trailing)
+                            scrollHelper.scrollTo(files.path.count - 1, anchor: .trailing)
                         }
                     }
                 }


### PR DESCRIPTION
fixes #2748 