### PR TITLE
android: update google play billing to version 7

### DIFF
--- a/clients/android/build.gradle
+++ b/clients/android/build.gradle
@@ -31,9 +31,8 @@ buildscript {
         sliding_pane_layout_version = '1.2.0'
         recyclical_version = '1.1.0'
         safe_args_gradle_plugin = '2.4.2'
-        billing_version = '4.1.0'
         fab_speed_dial = '3.3.0'
-        billing_version = '5.0.0'
+        billing_version = '7.0.0'
         donut_chart_version = '2.2.2'
     }
 


### PR DESCRIPTION
Google Play requires that we upgrade our google play billing version (previously `5.0.0`), to a version above `6.0.1`. I took the liberty of updating to the newest version, and since our usage is minimal, we didn't need to change much. I sanity checked billing.

fixes #2743