### PR TITLE
workspace tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,8 +8508,6 @@ dependencies = [
  "tld",
  "tldextract",
  "tracing",
- "tracing-appender",
- "tracing-subscriber",
  "unicode-segmentation",
  "usvg-parser",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8507,6 +8507,9 @@ dependencies = [
  "svgtypes 0.13.0",
  "tld",
  "tldextract",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "unicode-segmentation",
  "usvg-parser",
 ]
@@ -8526,6 +8529,7 @@ dependencies = [
  "raw-window-handle 0.6.2",
  "serde",
  "serde_json",
+ "tracing",
  "workspace",
 ]
 

--- a/libs/content/workspace-ffi/Cargo.toml
+++ b/libs/content/workspace-ffi/Cargo.toml
@@ -18,6 +18,7 @@ lb_external_interface = { path = "../../lb/lb_external_interface" }
 raw-window-handle = "0.6"
 jni = "0.21.0"
 pollster = "0.2"
+tracing="0.1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -2,6 +2,7 @@ use egui::{Event, Key, Modifiers, PointerButton, Pos2, TouchDeviceId, TouchId, T
 use std::cmp;
 use std::ffi::{c_char, c_void, CStr, CString};
 use std::ptr::null;
+use tracing::{span, Level};
 use workspace_rs::tab::markdown_editor::input::canonical::{
     Bound, Increment, Modification, Offset, Region,
 };
@@ -16,12 +17,23 @@ use workspace_rs::tab::TabContent;
 use super::super::response::*;
 use super::response::*;
 use crate::apple::keyboard::UIKeys;
-use crate::WgpuWorkspace;
+use crate::{ExtendedInput, WgpuWorkspace};
 
 #[no_mangle]
 pub extern "C" fn ios_frame(obj: *mut c_void) -> IOSResponse {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
-    obj.frame().into()
+
+    let frame = obj.context.frame_nr();
+    let span = span!(target: "svg_editor", Level::TRACE, "request ios frame", frame);
+    let _ = span.enter();
+
+    let res = obj.frame().into();
+
+    let span_clone = span.clone();
+    drop(span);
+    obj.context.push_span(span_clone);
+
+    res
 }
 
 /// # Safety
@@ -275,6 +287,12 @@ pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
 #[no_mangle]
 pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    let frame = obj.context.frame_nr();
+    let pos = egui::pos2(x, y);
+    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch start", ?pos, frame);
+    let _ = span.enter();
+
     let force = if force == 0.0 { None } else { Some(force) };
     obj.raw_input.events.push(Event::Touch {
         device_id: TouchDeviceId(0),
@@ -290,6 +308,10 @@ pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32
         pressed: true,
         modifiers: Default::default(),
     });
+
+    let span_clone = span.clone();
+    drop(span);
+    obj.context.push_span(span_clone);
 }
 
 /// # Safety
@@ -297,6 +319,12 @@ pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32
 #[no_mangle]
 pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    let frame = obj.context.frame_nr();
+    let pos = egui::pos2(x, y);
+    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch move", ?pos, frame);
+    let _ = span.enter();
+
     let force = if force == 0.0 { None } else { Some(force) };
 
     obj.raw_input.events.push(Event::Touch {
@@ -310,6 +338,10 @@ pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32
     obj.raw_input
         .events
         .push(Event::PointerMoved(Pos2 { x, y }));
+
+    let span_clone = span.clone();
+    drop(span);
+    obj.context.push_span(span_clone);
 }
 
 /// # Safety
@@ -319,6 +351,12 @@ pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32
 #[no_mangle]
 pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    let pos = egui::pos2(x, y);
+    let frame = obj.context.frame_nr();
+    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch end", ?pos, frame);
+    let _ = span.enter();
+
     let force = if force == 0.0 { None } else { Some(force) };
 
     obj.raw_input.events.push(Event::Touch {
@@ -337,6 +375,10 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
     });
 
     obj.raw_input.events.push(Event::PointerGone);
+
+    let span_clone = span.clone();
+    drop(span);
+    obj.context.push_span(span_clone);
 }
 
 /// # Safety
@@ -345,6 +387,10 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
 /// https://developer.apple.com/documentation/uikit/uiresponder/1621142-touchesbegan
 #[no_mangle]
 pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
+    let pos = egui::pos2(x, y);
+    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch canceled", ?pos);
+    let _ = span.enter();
+
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let force = if force == 0.0 { None } else { Some(force) };
 
@@ -357,6 +403,10 @@ pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y:
     });
 
     obj.raw_input.events.push(Event::PointerGone);
+
+    let span_clone = span.clone();
+    drop(span);
+    obj.context.push_span(span_clone);
 }
 
 /// # Safety

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -29,9 +29,7 @@ pub extern "C" fn ios_frame(obj: *mut c_void) -> IOSResponse {
 
     let res = obj.frame().into();
 
-    let span_clone = span.clone();
-    drop(span);
-    obj.context.push_span(span_clone);
+    obj.context.push_span(span);
 
     res
 }
@@ -290,7 +288,7 @@ pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32
 
     let frame = obj.context.frame_nr();
     let pos = egui::pos2(x, y);
-    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch start", ?pos, frame);
+    let span = span!(target: "svg_editor", Level::TRACE, "UIEvent touch start", ?pos, frame);
     let _ = span.enter();
 
     let force = if force == 0.0 { None } else { Some(force) };
@@ -309,9 +307,7 @@ pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32
         modifiers: Default::default(),
     });
 
-    let span_clone = span.clone();
-    drop(span);
-    obj.context.push_span(span_clone);
+    obj.context.push_span(span);
 }
 
 /// # Safety
@@ -322,7 +318,7 @@ pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32
 
     let frame = obj.context.frame_nr();
     let pos = egui::pos2(x, y);
-    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch move", ?pos, frame);
+    let span = span!(target: "svg_editor", Level::DEBUG, "UIEvent touch move", ?pos, frame);
     let _ = span.enter();
 
     let force = if force == 0.0 { None } else { Some(force) };
@@ -339,9 +335,7 @@ pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32
         .events
         .push(Event::PointerMoved(Pos2 { x, y }));
 
-    let span_clone = span.clone();
-    drop(span);
-    obj.context.push_span(span_clone);
+    obj.context.push_span(span);
 }
 
 /// # Safety
@@ -354,7 +348,7 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
 
     let pos = egui::pos2(x, y);
     let frame = obj.context.frame_nr();
-    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch end", ?pos, frame);
+    let span = span!(target: "svg_editor", Level::TRACE, "UIEvent touch end", ?pos, frame);
     let _ = span.enter();
 
     let force = if force == 0.0 { None } else { Some(force) };
@@ -376,9 +370,7 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
 
     obj.raw_input.events.push(Event::PointerGone);
 
-    let span_clone = span.clone();
-    drop(span);
-    obj.context.push_span(span_clone);
+    obj.context.push_span(span);
 }
 
 /// # Safety
@@ -388,7 +380,7 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
 #[no_mangle]
 pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let pos = egui::pos2(x, y);
-    let span = span!(target: "svg_editor", Level::TRACE, "NSEevent touch canceled", ?pos);
+    let span = span!(target: "svg_editor", Level::TRACE, "UIEvent touch canceled", ?pos);
     let _ = span.enter();
 
     let obj = &mut *(obj as *mut WgpuWorkspace);
@@ -404,9 +396,7 @@ pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y:
 
     obj.raw_input.events.push(Event::PointerGone);
 
-    let span_clone = span.clone();
-    drop(span);
-    obj.context.push_span(span_clone);
+    obj.context.push_span(span);
 }
 
 /// # Safety

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -20,13 +20,11 @@ use crate::apple::keyboard::UIKeys;
 use crate::WgpuWorkspace;
 
 #[no_mangle]
-#[instrument(level="trace", skip(obj) fields(frame = (&mut *(obj as *mut WgpuWorkspace)).context.frame_nr()))]
+#[instrument(level="trace", skip(obj) fields(frame = (*(obj as *mut WgpuWorkspace)).context.frame_nr()))]
 pub unsafe extern "C" fn ios_frame(obj: *mut c_void) -> IOSResponse {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
 
-    let res = obj.frame().into();
-
-    res
+    obj.frame().into()
 }
 
 /// # Safety
@@ -278,7 +276,7 @@ pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
-#[instrument(level="trace", skip(obj) fields(frame = (&mut *(obj as *mut WgpuWorkspace)).context.frame_nr()))]
+#[instrument(level="trace", skip(obj) fields(frame = (*(obj as *mut WgpuWorkspace)).context.frame_nr()))]
 pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
@@ -302,7 +300,7 @@ pub unsafe extern "C" fn touches_began(obj: *mut c_void, id: u64, x: f32, y: f32
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
-#[instrument(level="trace", skip(obj) fields(frame = (&mut *(obj as *mut WgpuWorkspace)).context.frame_nr()))]
+#[instrument(level="trace", skip(obj) fields(frame = (*(obj as *mut WgpuWorkspace)).context.frame_nr()))]
 pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
@@ -326,7 +324,7 @@ pub unsafe extern "C" fn touches_moved(obj: *mut c_void, id: u64, x: f32, y: f32
 ///
 /// https://developer.apple.com/documentation/uikit/uiresponder/1621142-touchesbegan
 #[no_mangle]
-#[instrument(level="trace", skip(obj) fields(frame = (&mut *(obj as *mut WgpuWorkspace)).context.frame_nr()))]
+#[instrument(level="trace", skip(obj) fields(frame = (*(obj as *mut WgpuWorkspace)).context.frame_nr()))]
 pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
@@ -355,7 +353,7 @@ pub unsafe extern "C" fn touches_ended(obj: *mut c_void, id: u64, x: f32, y: f32
 ///
 /// https://developer.apple.com/documentation/uikit/uiresponder/1621142-touchesbegan
 #[no_mangle]
-#[instrument(level="trace", skip(obj) fields(frame = (&mut *(obj as *mut WgpuWorkspace)).context.frame_nr()))]
+#[instrument(level="trace", skip(obj) fields(frame = (*(obj as *mut WgpuWorkspace)).context.frame_nr()))]
 pub unsafe extern "C" fn touches_cancelled(obj: *mut c_void, id: u64, x: f32, y: f32, force: f32) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let force = if force == 0.0 { None } else { Some(force) };

--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -1,8 +1,6 @@
-use egui::Id;
 use egui_wgpu_backend::wgpu;
 use std::iter;
 use std::time::Instant;
-use tracing::Span;
 use workspace_rs::workspace::Workspace;
 
 /// cbindgen:ignore
@@ -36,8 +34,6 @@ pub struct WgpuWorkspace<'window> {
 
 impl<'window> WgpuWorkspace<'window> {
     pub fn frame(&mut self) -> Response {
-        self.context.pop_spans();
-
         self.configure_surface();
         let output_frame = match self.surface.get_current_texture() {
             Ok(frame) => frame,
@@ -158,35 +154,5 @@ impl<'window> WgpuWorkspace<'window> {
             self.surface_width = self.screen.physical_width;
             self.surface_height = self.screen.physical_height;
         }
-    }
-}
-
-pub trait ExtendedInput {
-    fn push_span(&self, event: Span);
-    fn pop_spans(&self) -> Vec<Span>;
-}
-
-impl ExtendedInput for egui::Context {
-    fn push_span(&self, event: Span) {
-        self.memory_mut(|m| {
-            let mut events: Vec<Span> = m
-                .data
-                .get_temp(Id::new("tracing_event"))
-                .unwrap_or_default();
-            events.push(event);
-            m.data.insert_temp(Id::new("tracing_event"), events);
-        })
-    }
-
-    fn pop_spans(&self) -> Vec<Span> {
-        self.memory_mut(|m| {
-            let events: Vec<Span> = m
-                .data
-                .get_temp(Id::new("tracing_event"))
-                .unwrap_or_default();
-            m.data
-                .insert_temp(Id::new("tracing_event"), Vec::<Span>::new());
-            events
-        })
     }
 }

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -28,6 +28,10 @@ chrono = "0.4"
 similar = { version = "2.6.0", features = ["unicode"] }
 tld = "2.35.0"
 tldextract = "0.6.0"
+tracing = "0.1.5"
+tracing-subscriber = "0.3.9"
+tracing-appender = "0.2"
+
 
 # todo: maybe move this switch into lb itself
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -29,8 +29,6 @@ similar = { version = "2.6.0", features = ["unicode"] }
 tld = "2.35.0"
 tldextract = "0.6.0"
 tracing = "0.1.5"
-tracing-subscriber = "0.3.9"
-tracing-appender = "0.2"
 
 
 # todo: maybe move this switch into lb itself

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -25,6 +25,8 @@ pub use pen::Pen;
 use renderer::Renderer;
 use resvg::usvg::ImageKind;
 pub use toolbar::Tool;
+use tracing::span;
+use tracing::Level;
 use usvg_parser::Options;
 
 /// A shorthand for [ImageHrefResolver]'s string function.
@@ -73,6 +75,10 @@ impl SVGEditor {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
+        let frame = ui.ctx().frame_nr();
+        let span = span!(Level::TRACE, "showing canvas widget", frame);
+        let _ = span.enter();
+
         if ui.input(|r| r.key_down(egui::Key::D)) {
             self.show_debug_info(ui);
         }

--- a/libs/content/workspace/src/tab/svg_editor/renderer.rs
+++ b/libs/content/workspace/src/tab/svg_editor/renderer.rs
@@ -10,7 +10,7 @@ use lyon::tessellation::{
 
 use rayon::prelude::*;
 use resvg::usvg::{ImageKind, Transform};
-use tracing::{event, span, Level};
+use tracing::{span, Level};
 
 use super::parser::{self, DiffState};
 use super::Buffer;

--- a/libs/content/workspace/src/tab/svg_editor/renderer.rs
+++ b/libs/content/workspace/src/tab/svg_editor/renderer.rs
@@ -10,6 +10,7 @@ use lyon::tessellation::{
 
 use rayon::prelude::*;
 use resvg::usvg::{ImageKind, Transform};
+use tracing::{event, span, Level};
 
 use super::parser::{self, DiffState};
 use super::Buffer;
@@ -51,13 +52,17 @@ impl Renderer {
     }
 
     pub fn render_svg(&mut self, ui: &mut egui::Ui, buffer: &mut Buffer, painter: egui::Painter) {
+        let frame = ui.ctx().frame_nr();
+        let span = span!(Level::TRACE, "rendering svg", frame);
+        let _ = span.enter();
+
         let mut elements = buffer.elements.clone();
 
         self.painter = Some(painter.clone());
         let dark_mode_changed = ui.visuals().dark_mode != self.dark_mode;
         self.dark_mode = ui.visuals().dark_mode;
 
-        // todo: should avoid runing this on every frame, because the images are allocated once
+        // todo: should avoid running this on every frame, because the images are allocated once
         load_image_textures(buffer, ui);
 
         let paint_ops: Vec<(String, RenderOp)> = elements
@@ -81,7 +86,7 @@ impl Renderer {
                     return Some((id.clone(), RenderOp::Transform(transform)));
                 }
 
-                tesselate_element(el, id, ui.visuals().dark_mode, buffer.master_transform)
+                tesselate_element(el, id, ui.visuals().dark_mode, frame, buffer.master_transform)
             })
             .collect();
 
@@ -153,13 +158,16 @@ fn load_image_textures(buffer: &mut Buffer, ui: &mut egui::Ui) {
 
 // todo: maybe impl this on element struct
 fn tesselate_element(
-    el: &mut parser::Element, id: &String, dark_mode: bool, master_transform: Transform,
+    el: &mut parser::Element, id: &String, dark_mode: bool, frame: u64, master_transform: Transform,
 ) -> Option<(String, RenderOp)> {
     let mut mesh: VertexBuffers<_, u32> = VertexBuffers::new();
     let mut stroke_tess = StrokeTessellator::new();
 
     match el {
         parser::Element::Path(p) => {
+            let span = span!(Level::TRACE, "tessellating path", frame = frame);
+            let _ = span.enter();
+
             if let Some(stroke) = p.stroke {
                 if p.data.is_empty() {
                     return None;

--- a/libs/lb/lb-rs/src/service/log_service.rs
+++ b/libs/lb/lb-rs/src/service/log_service.rs
@@ -12,7 +12,7 @@ pub fn init(config: &Config) -> LbResult<()> {
         let lockbook_log_level = env::var("LOG_LEVEL")
             .ok()
             .and_then(|s| s.as_str().parse().ok())
-            .unwrap_or(LevelFilter::TRACE);
+            .unwrap_or(LevelFilter::DEBUG);
 
         let subscriber = tracing_subscriber::Registry::default()
             .with(
@@ -25,7 +25,7 @@ pub fn init(config: &Config) -> LbResult<()> {
                     .with_filter(filter::filter_fn(|metadata| {
                         metadata.target().starts_with("lb_rs")
                             || metadata.target().starts_with("dbrs")
-                            || metadata.target().contains("svg_editor")
+                            || metadata.target().starts_with("workspace")
                     })),
             )
             .with(
@@ -33,16 +33,8 @@ pub fn init(config: &Config) -> LbResult<()> {
                     .pretty()
                     .with_target(false)
                     .with_filter(filter::filter_fn(|metadata| {
-                        metadata.target().starts_with("lb_fs")
-                    })),
-            )
-            .with(
-                fmt::Layer::new()
-                    .with_span_events(FmtSpan::ACTIVE)
-                    .pretty()
-                    .with_target(false)
-                    .with_filter(filter::filter_fn(|metadata| {
-                        metadata.target().contains("svg_editor")
+                        metadata.target().starts_with("workspace")
+                            || metadata.target().starts_with("lb_fs")
                     })),
             );
 

--- a/libs/lb/lb-rs/src/service/log_service.rs
+++ b/libs/lb/lb-rs/src/service/log_service.rs
@@ -14,26 +14,28 @@ pub fn init(config: &Config) -> LbResult<()> {
             .and_then(|s| s.as_str().parse().ok())
             .unwrap_or(LevelFilter::DEBUG);
 
-        let subscriber =
-            tracing_subscriber::Registry::default()
-                .with(
-                    fmt::Layer::new()
-                        .with_span_events(FmtSpan::ACTIVE)
-                        .with_ansi(config.colored_logs)
-                        .with_target(true)
-                        .with_writer(tracing_appender::rolling::never(
-                            &config.writeable_path,
-                            LOG_FILE,
-                        ))
-                        .with_filter(lockbook_log_level)
-                        .with_filter(filter::filter_fn(|metadata| {
-                            metadata.target().starts_with("lb_rs")
-                                || metadata.target().starts_with("dbrs")
-                        })),
-                )
-                .with(fmt::Layer::new().pretty().with_target(false).with_filter(
-                    filter::filter_fn(|metadata| metadata.target().starts_with("lb_fs")),
-                ));
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(
+                fmt::Layer::new()
+                    .with_span_events(FmtSpan::ACTIVE)
+                    .with_ansi(config.colored_logs)
+                    .with_target(true)
+                    .with_writer(tracing_appender::rolling::never(&config.writeable_path, LOG_FILE))
+                    .with_filter(lockbook_log_level)
+                    .with_filter(filter::filter_fn(|metadata| {
+                        metadata.target().starts_with("lb_rs")
+                            || metadata.target().starts_with("dbrs")
+                    })),
+            )
+            .with(
+                fmt::Layer::new()
+                    .with_ansi(false)
+                    .with_span_events(FmtSpan::CLOSE)
+                    .with_filter(filter::filter_fn(|metadata| {
+                        metadata.target().starts_with("lb_fs")
+                            || metadata.target().contains("svg_editor")
+                    })),
+            );
 
         tracing::subscriber::set_global_default(subscriber).map_err(core_err_unexpected)?;
         panic_capture();

--- a/libs/lb/lb-rs/src/service/log_service.rs
+++ b/libs/lb/lb-rs/src/service/log_service.rs
@@ -14,28 +14,27 @@ pub fn init(config: &Config) -> LbResult<()> {
             .and_then(|s| s.as_str().parse().ok())
             .unwrap_or(LevelFilter::DEBUG);
 
-        let subscriber = tracing_subscriber::Registry::default()
-            .with(
-                fmt::Layer::new()
-                    .with_span_events(FmtSpan::ACTIVE)
-                    .with_ansi(config.colored_logs)
-                    .with_target(true)
-                    .with_writer(tracing_appender::rolling::never(&config.writeable_path, LOG_FILE))
-                    .with_filter(lockbook_log_level)
-                    .with_filter(filter::filter_fn(|metadata| {
-                        metadata.target().starts_with("lb_rs")
-                            || metadata.target().starts_with("dbrs")
-                    })),
-            )
-            .with(
-                fmt::Layer::new()
-                    .with_ansi(false)
-                    .with_span_events(FmtSpan::CLOSE)
-                    .with_filter(filter::filter_fn(|metadata| {
-                        metadata.target().starts_with("lb_fs")
-                            || metadata.target().contains("svg_editor")
-                    })),
-            );
+        let subscriber =
+            tracing_subscriber::Registry::default()
+                .with(
+                    fmt::Layer::new()
+                        .with_span_events(FmtSpan::ACTIVE)
+                        .with_ansi(config.colored_logs)
+                        .with_target(true)
+                        .with_writer(tracing_appender::rolling::never(
+                            &config.writeable_path,
+                            LOG_FILE,
+                        ))
+                        .with_filter(lockbook_log_level)
+                        .with_filter(filter::filter_fn(|metadata| {
+                            metadata.target().starts_with("lb_rs")
+                                || metadata.target().starts_with("dbrs")
+                                || metadata.target().contains("svg_editor")
+                        })),
+                )
+                .with(fmt::Layer::new().pretty().with_target(false).with_filter(
+                    filter::filter_fn(|metadata| metadata.target().starts_with("lb_fs")),
+                ));
 
         tracing::subscriber::set_global_default(subscriber).map_err(core_err_unexpected)?;
         panic_capture();

--- a/libs/lb/lb-rs/src/service/log_service.rs
+++ b/libs/lb/lb-rs/src/service/log_service.rs
@@ -12,29 +12,39 @@ pub fn init(config: &Config) -> LbResult<()> {
         let lockbook_log_level = env::var("LOG_LEVEL")
             .ok()
             .and_then(|s| s.as_str().parse().ok())
-            .unwrap_or(LevelFilter::DEBUG);
+            .unwrap_or(LevelFilter::TRACE);
 
-        let subscriber =
-            tracing_subscriber::Registry::default()
-                .with(
-                    fmt::Layer::new()
-                        .with_span_events(FmtSpan::ACTIVE)
-                        .with_ansi(config.colored_logs)
-                        .with_target(true)
-                        .with_writer(tracing_appender::rolling::never(
-                            &config.writeable_path,
-                            LOG_FILE,
-                        ))
-                        .with_filter(lockbook_log_level)
-                        .with_filter(filter::filter_fn(|metadata| {
-                            metadata.target().starts_with("lb_rs")
-                                || metadata.target().starts_with("dbrs")
-                                || metadata.target().contains("svg_editor")
-                        })),
-                )
-                .with(fmt::Layer::new().pretty().with_target(false).with_filter(
-                    filter::filter_fn(|metadata| metadata.target().starts_with("lb_fs")),
-                ));
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(
+                fmt::Layer::new()
+                    .with_span_events(FmtSpan::ACTIVE)
+                    .with_ansi(config.colored_logs)
+                    .with_target(true)
+                    .with_writer(tracing_appender::rolling::never(&config.writeable_path, LOG_FILE))
+                    .with_filter(lockbook_log_level)
+                    .with_filter(filter::filter_fn(|metadata| {
+                        metadata.target().starts_with("lb_rs")
+                            || metadata.target().starts_with("dbrs")
+                            || metadata.target().contains("svg_editor")
+                    })),
+            )
+            .with(
+                fmt::Layer::new()
+                    .pretty()
+                    .with_target(false)
+                    .with_filter(filter::filter_fn(|metadata| {
+                        metadata.target().starts_with("lb_fs")
+                    })),
+            )
+            .with(
+                fmt::Layer::new()
+                    .with_span_events(FmtSpan::ACTIVE)
+                    .pretty()
+                    .with_target(false)
+                    .with_filter(filter::filter_fn(|metadata| {
+                        metadata.target().contains("svg_editor")
+                    })),
+            );
 
         tracing::subscriber::set_global_default(subscriber).map_err(core_err_unexpected)?;
         panic_capture();


### PR DESCRIPTION
fixes #2790
better observability for canvas. currently most of the added spans are traces that can be added to your lockbook.log if you ran the app with a trace log level env variable.   