### PR TITLE
editor: fix windows-style newline corrections crash

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/ast.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/ast.rs
@@ -87,17 +87,19 @@ impl Ast {
         let mut skipped = 0;
         while let Some((event, mut range)) = iter.next() {
             // correct for windows-style line endings by keeping \r and \n together
-            if buffer.text[range.clone()].starts_with('\n')
-                && range.start > 0
-                && &buffer.text[range.start - 1..range.start] == "\r"
-            {
-                range.start -= 1;
+            if buffer.text[range.clone()].starts_with('\n') {
+                if let Some(prev_char) = buffer.text[..range.start].chars().next_back() {
+                    if prev_char == '\r' {
+                        range.start -= 1;
+                    }
+                }
             }
-            if buffer.text[range.clone()].ends_with('\r')
-                && range.end < buffer.text.len()
-                && &buffer.text[range.end..range.end + 1] == "\n"
-            {
-                range.end += 1;
+            if buffer.text[range.clone()].ends_with('\r') {
+                if let Some(next_char) = buffer.text[range.end..].chars().next() {
+                    if next_char == '\n' {
+                        range.end += 1;
+                    }
+                }
             }
 
             let range = buffer


### PR DESCRIPTION
sample crashing doc:
```
Ø
x
```