### PR TITLE
canvas: perf improvements and more phantom strokes detection 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8548,6 +8548,7 @@ name = "workspace"
 version = "0.9.8"
 dependencies = [
  "bezier-rs",
+ "bincode",
  "chrono",
  "egui",
  "epaint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,6 +4325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5813,7 +5822,16 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5830,8 +5848,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7225,12 +7249,37 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -8524,6 +8573,7 @@ dependencies = [
  "tld",
  "tldextract",
  "tracing",
+ "tracing-test",
  "unicode-segmentation",
  "usvg-parser",
 ]

--- a/clients/apple/lockbook.xcodeproj/xcshareddata/xcschemes/Lockbook (iOS).xcscheme
+++ b/clients/apple/lockbook.xcodeproj/xcshareddata/xcschemes/Lockbook (iOS).xcscheme
@@ -76,7 +76,7 @@
          <EnvironmentVariable
             key = "LOG_LEVEL"
             value = "5"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/clients/apple/lockbook.xcodeproj/xcshareddata/xcschemes/Lockbook (iOS).xcscheme
+++ b/clients/apple/lockbook.xcodeproj/xcshareddata/xcschemes/Lockbook (iOS).xcscheme
@@ -73,6 +73,11 @@
             value = "1"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "LOG_LEVEL"
+            value = "5"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1038,7 +1038,7 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         
         let rustNanoseconds = rustEndTime.uptimeNanoseconds - rustStartTime.uptimeNanoseconds
         let rustSeconds = Double(rustNanoseconds) / 1_000_000.0
-        print("Swift time: \(swiftSeconds) ms | Rust time: \(rustSeconds)")
+        // print("Swift time: \(swiftSeconds) ms | Rust time: \(rustSeconds)")
         
     }
 

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1056,6 +1056,13 @@ public class iOSMTK: MTKView, MTKViewDelegate {
                 
                 touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
             }
+            
+            for touch in event!.predictedTouches(for: touch)! {
+                let location = touch.location(in: self)
+                let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
+                
+                touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
+            }
         }
 
         self.setNeedsDisplay(self.frame)

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1073,15 +1073,15 @@ public class iOSMTK: MTKView, MTKViewDelegate {
 //                
 //                touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
 //            }
+//            
+//            for touch in event!.predictedTouches(for: touch)! {
+//                let location = touch.preciseLocation(in: self)
+//                let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
+//                
+//                touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
+//            }
             
-            for touch in event!.predictedTouches(for: touch)! {
-                let location = touch.location(in: self)
-                let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
-                
-                touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
-            }
-            
-            let location = touch.location(in: self)
+            let location = touch.preciseLocation(in: self)
             let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
             touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
 
@@ -1095,12 +1095,12 @@ public class iOSMTK: MTKView, MTKViewDelegate {
             let point = Unmanaged.passUnretained(touch).toOpaque()
             let value = UInt64(UInt(bitPattern: point))
 
-            for touch in event!.coalescedTouches(for: touch)! {
+//            for touch in event!.coalescedTouches(for: touch)! {
                 let location = touch.location(in: self)
                 let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
                 
                 touches_ended(wsHandle, value, Float(location.x), Float(location.y), Float(force))
-            }
+//            }
         }
 
         self.setNeedsDisplay(self.frame)

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1066,19 +1066,12 @@ public class iOSMTK: MTKView, MTKViewDelegate {
         for touch in touches {
             let point = Unmanaged.passUnretained(touch).toOpaque()
             let value = UInt64(UInt(bitPattern: point))
-
+            
 //            for touch in event!.coalescedTouches(for: touch)! {
 //                let location = touch.location(in: self)
 //                let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
 //                
-//                touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
-//            }
-//            
-//            for touch in event!.predictedTouches(for: touch)! {
-//                let location = touch.preciseLocation(in: self)
-//                let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
-//                
-//                touches_moved(wsHandle, value, Float(location.x), Float(location.y), Float(force))
+//                touches_ended(wsHandle, value, Float(location.x), Float(location.y), Float(force))
 //            }
             
             let location = touch.preciseLocation(in: self)
@@ -1095,12 +1088,12 @@ public class iOSMTK: MTKView, MTKViewDelegate {
             let point = Unmanaged.passUnretained(touch).toOpaque()
             let value = UInt64(UInt(bitPattern: point))
 
-//            for touch in event!.coalescedTouches(for: touch)! {
+            for touch in event!.coalescedTouches(for: touch)! {
                 let location = touch.location(in: self)
                 let force = touch.force != 0 ? touch.force / touch.maximumPossibleForce : 0
                 
                 touches_ended(wsHandle, value, Float(location.x), Float(location.y), Float(force))
-//            }
+            }
         }
 
         self.setNeedsDisplay(self.frame)

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -29,7 +29,7 @@ similar = { version = "2.6.0", features = ["unicode"] }
 tld = "2.35.0"
 tldextract = "0.6.0"
 tracing = "0.1.5"
-
+tracing-test = "0.2.5"
 
 # todo: maybe move this switch into lb itself
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -8,6 +8,7 @@ name = "workspace_rs"
 
 [dependencies]
 bezier-rs = "0.2.0"
+bincode = "1.3.3"
 egui = "0.26.2"
 epaint = "0.26.2"
 glam = "0.22.0"

--- a/libs/content/workspace/src/tab/svg_editor/clip.rs
+++ b/libs/content/workspace/src/tab/svg_editor/clip.rs
@@ -1,3 +1,4 @@
+use lb_rs::Uuid;
 use resvg::usvg::{AspectRatio, NonZeroRect, Transform, ViewBox};
 
 use crate::tab::{ClipContent, ExtendedInput as _};
@@ -25,7 +26,7 @@ impl SVGEditor {
                                     r.pointer.hover_pos().unwrap_or(self.inner_rect.center())
                                 });
                                 self.buffer.elements.insert(
-                                    self.toolbar.pen.current_id.to_string(),
+                                    Uuid::new_v4(),
                                     crate::tab::svg_editor::parser::Element::Image(
                                         crate::tab::svg_editor::parser::Image {
                                             data: resvg::usvg::ImageKind::PNG(data.into()),
@@ -49,7 +50,6 @@ impl SVGEditor {
                                         },
                                     ),
                                 );
-                                self.toolbar.pen.current_id += 1;
                             }
                             ClipContent::Files(..) => unimplemented!(), // todo: support file drop & paste
                         }

--- a/libs/content/workspace/src/tab/svg_editor/eraser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/eraser.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
+use lb_rs::Uuid;
+
 use super::history::History;
 use super::{util::pointer_intersects_element, Buffer, DeleteElement};
 
 pub struct Eraser {
     pub radius: f32,
-    delete_candidates: HashMap<String, bool>,
+    delete_candidates: HashMap<Uuid, bool>,
     last_pos: Option<egui::Pos2>,
 }
 
@@ -51,7 +53,7 @@ impl Eraser {
                                 self.last_pos,
                                 self.radius as f64,
                             ) {
-                                self.delete_candidates.insert(id.clone(), false);
+                                self.delete_candidates.insert(*id, false);
                             }
                         });
 
@@ -103,11 +105,11 @@ impl Eraser {
                     let event = super::Event::Delete(
                         self.delete_candidates
                             .keys()
-                            .map(|id| DeleteElement { id: id.to_owned() })
+                            .map(|id| DeleteElement { id: *id })
                             .collect(),
                     );
 
-                    history.save(event.clone());
+                    history.save(event);
 
                     self.delete_candidates.clear();
                 }

--- a/libs/content/workspace/src/tab/svg_editor/eraser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/eraser.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use lb_rs::Uuid;
 
 use super::toolbar::ToolContext;
+use super::util::is_multi_touch;
 use super::{util::pointer_intersects_element, DeleteElement};
 
 pub struct Eraser {
@@ -33,18 +34,16 @@ impl Eraser {
     }
 
     pub fn handle_input(&mut self, ui: &mut egui::Ui, eraser_ctx: ToolContext) {
-        let maybe_event = if eraser_ctx.is_multi_touch || eraser_ctx.is_touch_start {
-            Some(EraseEvent::End)
-        } else {
-            self.setup_events(ui, eraser_ctx.painter, eraser_ctx.painter.clip_rect())
-        };
+        if is_multi_touch(ui) {
+            *eraser_ctx.allow_viewport_changes = true;
+            return;
+        }
 
-        if let Some(event) = maybe_event {
+        if let Some(event) =
+            self.setup_events(ui, eraser_ctx.painter, eraser_ctx.painter.clip_rect())
+        {
             match event {
                 EraseEvent::Start(pos) => {
-                    if eraser_ctx.is_panning_or_zooming {
-                        return;
-                    }
                     eraser_ctx
                         .buffer
                         .elements

--- a/libs/content/workspace/src/tab/svg_editor/history.rs
+++ b/libs/content/workspace/src/tab/svg_editor/history.rs
@@ -1,5 +1,6 @@
 use std::{collections::VecDeque, fmt::Debug};
 
+use lb_rs::Uuid;
 use resvg::usvg::Transform;
 
 use super::parser;
@@ -10,26 +11,26 @@ pub struct History {
     redo: Vec<Event>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Event {
     Insert(Vec<InsertElement>),
     Delete(Vec<DeleteElement>),
     Transform(Vec<TransformElement>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct DeleteElement {
-    pub id: String,
+    pub id: Uuid,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct InsertElement {
-    pub id: String,
+    pub id: Uuid,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct TransformElement {
-    pub id: String,
+    pub id: Uuid,
     pub transform: Transform,
 }
 
@@ -93,7 +94,7 @@ impl History {
             return;
         }
 
-        if let Some(undo_event) = self.undo.pop_back().to_owned() {
+        if let Some(undo_event) = self.undo.pop_back() {
             let undo_event = self.swap_event(undo_event);
             self.apply_event(&undo_event, buffer);
             self.redo.push(undo_event);
@@ -109,7 +110,7 @@ impl History {
             return;
         }
 
-        if let Some(redo_event) = self.redo.pop().to_owned() {
+        if let Some(redo_event) = self.redo.pop() {
             let redo_event = self.swap_event(redo_event);
             self.apply_event(&redo_event, buffer);
             self.undo.push_back(redo_event);
@@ -122,7 +123,7 @@ impl History {
                 source = Event::Delete(
                     payload
                         .iter()
-                        .map(|insert_payload| DeleteElement { id: insert_payload.id.clone() })
+                        .map(|insert_payload| DeleteElement { id: insert_payload.id })
                         .collect(),
                 );
             }
@@ -130,7 +131,7 @@ impl History {
                 source = Event::Insert(
                     payload
                         .iter()
-                        .map(|delete_payload| InsertElement { id: delete_payload.id.clone() })
+                        .map(|delete_payload| InsertElement { id: delete_payload.id })
                         .collect(),
                 );
             }
@@ -139,7 +140,7 @@ impl History {
                     payload
                         .iter_mut()
                         .map(|transform_payload| TransformElement {
-                            id: transform_payload.id.clone(),
+                            id: transform_payload.id,
                             transform: transform_payload
                                 .transform
                                 .invert()

--- a/libs/content/workspace/src/tab/svg_editor/history.rs
+++ b/libs/content/workspace/src/tab/svg_editor/history.rs
@@ -5,7 +5,7 @@ use resvg::usvg::Transform;
 
 use super::parser;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct History {
     undo: VecDeque<Event>,
     redo: Vec<Event>,

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -30,7 +30,6 @@ use toolbar::ToolContext;
 use tracing::span;
 use tracing::Level;
 use usvg_parser::Options;
-use util::is_multi_touch;
 
 /// A shorthand for [ImageHrefResolver]'s string function.
 pub type ImageHrefStringResolverFn = Box<dyn Fn(&str, &Options) -> Option<ImageKind> + Send + Sync>;
@@ -165,6 +164,7 @@ impl SVGEditor {
             history: &mut self.history,
             allow_viewport_changes: &mut self.allow_viewport_changes,
             is_viewport_changing: &mut self.is_viewport_changing,
+            is_touch_frame: &mut false,
         };
 
         match self.toolbar.active_tool {

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -144,10 +144,7 @@ impl SVGEditor {
     }
 
     fn process_events(&mut self, ui: &mut egui::Ui) {
-        // todo: toggle debug print before merge
-        // if ui.input(|r| r.key_down(egui::Key::D)) {
-        self.show_debug_info(ui);
-        // }
+        // self.show_debug_info(ui);
 
         if !ui.is_enabled() {
             return;
@@ -164,7 +161,14 @@ impl SVGEditor {
             history: &mut self.history,
             allow_viewport_changes: &mut self.allow_viewport_changes,
             is_viewport_changing: &mut self.is_viewport_changing,
-            is_touch_frame: &mut false,
+            is_touch_frame: ui.input(|r| {
+                r.events.iter().any(|e| {
+                    matches!(
+                        e,
+                        egui::Event::Touch { device_id: _, id: _, phase: _, pos: _, force: _ }
+                    )
+                })
+            }),
         };
 
         match self.toolbar.active_tool {

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -42,7 +42,7 @@ pub struct SVGEditor {
     core: lb_rs::Core,
     open_file: Uuid,
     skip_frame: bool,
-    last_render: Instant,
+    // last_render: Instant,
     renderer: Renderer,
     painter: egui::Painter,
     has_queued_save_request: bool,
@@ -79,7 +79,7 @@ impl SVGEditor {
             core,
             open_file,
             skip_frame: false,
-            last_render: Instant::now(),
+            // last_render: Instant::now(),
             painter: egui::Painter::new(
                 ctx.to_owned(),
                 egui::LayerId::new(egui::Order::Background, "canvas_painter".into()),
@@ -214,29 +214,29 @@ impl SVGEditor {
         });
     }
 
-    fn show_debug_info(&mut self, ui: &mut egui::Ui) {
-        let frame_cost = Instant::now() - self.last_render;
-        self.last_render = Instant::now();
-        let mut anchor_count = 0;
-        self.buffer
-            .elements
-            .iter()
-            .filter(|(_, el)| !el.deleted())
-            .for_each(|(_, el)| {
-                if let parser::Element::Path(p) = el {
-                    anchor_count += p.data.len()
-                }
-            });
+    // fn show_debug_info(&mut self, ui: &mut egui::Ui) {
+    //     let frame_cost = Instant::now() - self.last_render;
+    //     self.last_render = Instant::now();
+    //     let mut anchor_count = 0;
+    //     self.buffer
+    //         .elements
+    //         .iter()
+    //         .filter(|(_, el)| !el.deleted())
+    //         .for_each(|(_, el)| {
+    //             if let parser::Element::Path(p) = el {
+    //                 anchor_count += p.data.len()
+    //             }
+    //         });
 
-        let mut top = self.inner_rect.right_top();
-        top.x -= 150.0;
-        if frame_cost.as_millis() != 0 {
-            ui.painter().debug_text(
-                top,
-                egui::Align2::LEFT_TOP,
-                egui::Color32::RED,
-                format!("{} anchor | {}fps", anchor_count, 1000 / frame_cost.as_millis()),
-            );
-        }
-    }
+    //     let mut top = self.inner_rect.right_top();
+    //     top.x -= 150.0;
+    //     if frame_cost.as_millis() != 0 {
+    //         ui.painter().debug_text(
+    //             top,
+    //             egui::Align2::LEFT_TOP,
+    //             egui::Color32::RED,
+    //             format!("{} anchor | {}fps", anchor_count, 1000 / frame_cost.as_millis()),
+    //         );
+    //     }
+    // }
 }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -179,13 +179,8 @@ impl SVGEditor {
             }
         }
 
-        self.is_viewport_changing = if self.allow_viewport_changes
-            && handle_zoom_input(ui, self.inner_rect, &mut self.buffer)
-        {
-            true
-        } else {
-            false
-        };
+        self.is_viewport_changing =
+            self.allow_viewport_changes && handle_zoom_input(ui, self.inner_rect, &mut self.buffer);
 
         self.handle_clip_input(ui);
     }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -61,15 +61,8 @@ impl SVGEditor {
         let content = std::str::from_utf8(bytes).unwrap();
 
         let buffer = parser::Buffer::new(content, &core, open_file);
-        let max_id = buffer
-            .elements
-            .keys()
-            .filter_map(|key_str| key_str.parse::<usize>().ok())
-            .max()
-            .unwrap_or_default()
-            + 1;
 
-        let toolbar = Toolbar::new(max_id);
+        let toolbar = Toolbar::new();
 
         let elements_count = buffer.elements.len();
 

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -9,7 +9,6 @@ mod toolbar;
 mod util;
 mod zoom;
 
-use std::collections::HashSet;
 use std::time::Instant;
 
 use self::history::History;

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -83,8 +83,6 @@ impl SVGEditor {
             self.show_debug_info(ui);
         }
 
-        self.show_canvas(ui);
-
         if !ui.is_enabled() {
             return;
         }
@@ -139,32 +137,28 @@ impl SVGEditor {
         }
 
         self.handle_clip_input(ui);
+
+        self.show_canvas(ui);
     }
 
     fn show_canvas(&mut self, ui: &mut egui::Ui) {
         ui.vertical(|ui| {
-            egui::Frame::default()
-                .fill(if ui.visuals().dark_mode {
-                    egui::Color32::BLACK
-                } else {
-                    egui::Color32::WHITE
-                })
-                .show(ui, |ui| {
-                    self.toolbar.show(
-                        ui,
-                        &mut self.buffer,
-                        &mut self.history,
-                        &mut self.skip_frame,
-                        self.inner_rect,
-                    );
+            egui::Frame::default().show(ui, |ui| {
+                self.toolbar.show(
+                    ui,
+                    &mut self.buffer,
+                    &mut self.history,
+                    &mut self.skip_frame,
+                    self.inner_rect,
+                );
 
-                    self.inner_rect = ui.available_rect_before_wrap();
-                    let painter = ui
-                        .allocate_painter(self.inner_rect.size(), egui::Sense::click_and_drag())
-                        .1;
+                self.inner_rect = ui.available_rect_before_wrap();
+                let painter = ui
+                    .allocate_painter(self.inner_rect.size(), egui::Sense::click_and_drag())
+                    .1;
 
-                    self.renderer.render_svg(ui, &mut self.buffer, painter);
-                });
+                self.renderer.render_svg(ui, &mut self.buffer, painter);
+            });
         });
     }
 

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -179,7 +179,7 @@ impl SVGEditor {
         //     self.skip_frame = false;
         // }
 
-        let tool_context = ToolContext {
+        let mut tool_context = ToolContext {
             painter: &self.painter,
             buffer: &mut self.buffer,
             history: &mut self.history,
@@ -190,7 +190,7 @@ impl SVGEditor {
 
         match self.toolbar.active_tool {
             Tool::Pen => {
-                let is_path_being_built = self.toolbar.pen.handle_input(ui, tool_context);
+                let is_path_being_built = self.toolbar.pen.handle_input(ui, &mut tool_context);
                 if is_path_being_built {
                     res = Some(CanvasEvent::BuildingPath);
                 }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -9,8 +9,6 @@ mod toolbar;
 mod util;
 mod zoom;
 
-use std::time::Instant;
-
 use self::history::History;
 use self::zoom::handle_zoom_input;
 use crate::tab::svg_editor::toolbar::Toolbar;

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -219,7 +219,10 @@ impl SVGEditor {
 
                 self.inner_rect = ui.available_rect_before_wrap();
                 self.painter = ui
-                    .allocate_painter(self.inner_rect.size(), egui::Sense::click_and_drag())
+                    .allocate_painter(
+                        ui.available_rect_before_wrap().size(),
+                        egui::Sense::click_and_drag(),
+                    )
                     .1;
 
                 self.renderer

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -145,12 +145,6 @@ impl SVGEditor {
     }
 
     fn process_events(&mut self, ui: &mut egui::Ui) {
-        ui.input(|r| {
-            r.events.iter().for_each(move |event| {
-                println!("{:#?}", event);
-            })
-        });
-        println!("---");
         // todo: toggle debug print before merge
         // if ui.input(|r| r.key_down(egui::Key::D)) {
         self.show_debug_info(ui);
@@ -170,11 +164,11 @@ impl SVGEditor {
             buffer: &mut self.buffer,
             history: &mut self.history,
             allow_viewport_changes: &mut self.allow_viewport_changes,
-            is_viewport_changing: self.is_viewport_changing,
+            is_viewport_changing: &mut self.is_viewport_changing,
         };
 
         match self.toolbar.active_tool {
-            Tool::Pen => {
+            Tool::Pen | Tool::Brush | Tool::Highlighter => {
                 self.toolbar.pen.handle_input(ui, &mut tool_context);
             }
             Tool::Eraser => {

--- a/libs/content/workspace/src/tab/svg_editor/parser.rs
+++ b/libs/content/workspace/src/tab/svg_editor/parser.rs
@@ -64,6 +64,15 @@ pub struct DiffState {
     pub data_changed: bool,
 }
 
+impl DiffState {
+    /// is state dirty and require an i/o save
+    pub fn is_dirty(&self) -> bool {
+        self.data_changed
+            || self.delete_changed
+            || self.opacity_changed
+            || self.transformed.is_some()
+    }
+}
 #[derive(Clone, Copy, Debug)]
 pub struct Stroke {
     pub color: (egui::Color32, egui::Color32),

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -669,7 +669,7 @@ fn cancel_touch_ui_event() {
         is_touch_frame: &mut false,
     };
 
-    let mut input_state = PenPointerInput {
+    let input_state = PenPointerInput {
         is_pointer_released: false,
         pointer_press_origin: Some(pen_ctx.painter.clip_rect().center()),
         is_multi_touch: false,

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -16,9 +16,11 @@ use super::{
     Buffer, InsertElement,
 };
 
+pub const DEFAULT_PEN_STROKE_WIDTH: f32 = 3.0;
+
 pub struct Pen {
     pub active_color: Option<(egui::Color32, egui::Color32)>,
-    pub active_stroke_width: u32,
+    pub active_stroke_width: f32,
     pub active_opacity: f32,
     path_builder: CubicBezBuilder,
     pub current_id: Uuid, // todo: this should be at a higher component state, maybe in buffer
@@ -27,11 +29,9 @@ pub struct Pen {
 
 impl Pen {
     pub fn new() -> Self {
-        let default_stroke_width = 3;
-
         Pen {
             active_color: None,
-            active_stroke_width: default_stroke_width,
+            active_stroke_width: DEFAULT_PEN_STROKE_WIDTH,
             current_id: Uuid::new_v4(),
             path_builder: CubicBezBuilder::new(),
             maybe_snap_started: None,

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -65,7 +65,7 @@ impl Pen {
                     // for some reason in ipad there are  two draw events on the same pos which results in a knot.
                     if let Some(last_pos) = self.path_builder.original_points.last() {
                         if last_pos.eq(&payload.pos) && self.path_builder.path.len() > 1 {
-                            event!(Level::DEBUG, ?payload.pos, "draw event canceled because it's pos is equal to the last pos on the path");
+                            event!(Level::TRACE, ?payload.pos, "draw event canceled because it's pos is equal to the last pos on the path");
                             return;
                         }
                     }

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -280,7 +280,6 @@ impl Pen {
         *pen_ctx.allow_viewport_changes = false;
 
         if let egui::Event::Touch { device_id: _, id, phase, pos, force } = *e {
-            *pen_ctx.is_touch_frame = true;
             // let (should_end_path, should_draw) = self.decide_event(pen_ctx, pos, input_state);
 
             if phase == TouchPhase::Cancel {
@@ -318,11 +317,10 @@ impl Pen {
                 }
                 *pen_ctx.is_viewport_changing = false;
 
-                trace!("sending draw path ");
                 return Some(PathEvent::Draw(DrawPayload { pos, force, id: Some(id) }));
             }
         }
-        if *pen_ctx.is_touch_frame {
+        if pen_ctx.is_touch_frame {
             return None;
         }
 
@@ -613,7 +611,7 @@ fn correct_start_of_path() {
         history: &mut crate::tab::svg_editor::history::History::default(),
         allow_viewport_changes: &mut false,
         is_viewport_changing: &mut false,
-        is_touch_frame: &mut false,
+        is_touch_frame: true,
     };
 
     let start_pos = egui::pos2(10.0, 10.0);
@@ -666,7 +664,7 @@ fn cancel_touch_ui_event() {
         history: &mut crate::tab::svg_editor::history::History::default(),
         allow_viewport_changes: &mut false,
         is_viewport_changing: &mut false,
-        is_touch_frame: &mut false,
+        is_touch_frame: true,
     };
 
     let input_state = PenPointerInput {

--- a/libs/content/workspace/src/tab/svg_editor/pen.rs
+++ b/libs/content/workspace/src/tab/svg_editor/pen.rs
@@ -20,6 +20,7 @@ use super::{
 
 pub const DEFAULT_PEN_STROKE_WIDTH: f32 = 3.0;
 
+#[derive(Default)]
 pub struct Pen {
     pub active_color: Option<(egui::Color32, egui::Color32)>,
     pub active_stroke_width: f32,
@@ -177,7 +178,7 @@ impl Pen {
                         stroke.color = c;
                     }
 
-                    stroke.width = self.active_stroke_width as f32;
+                    stroke.width = self.active_stroke_width;
 
                     let pressure =
                         if self.supports_pressure { payload.force.map(|f| vec![f]) } else { None };
@@ -214,7 +215,6 @@ impl Pen {
                 self.end_path(pen_ctx, false);
 
                 self.maybe_snap_started = None;
-                return;
             }
             PathEvent::CancelStroke() => {
                 trace!("canceling stroke");
@@ -676,7 +676,7 @@ fn cancel_touch_ui_event() {
     };
 
     events.iter().for_each(|e| {
-        if let Some(path_event) = pen.map_ui_event(e, &mut pen_ctx, &mut input_state) {
+        if let Some(path_event) = pen.map_ui_event(e, &mut pen_ctx, &input_state) {
             pen.handle_path_event(path_event, &mut pen_ctx);
         }
     });
@@ -706,7 +706,7 @@ fn cancel_touch_ui_event() {
     ];
 
     events.iter().for_each(|e| {
-        if let Some(path_event) = pen.map_ui_event(e, &mut pen_ctx, &mut input_state) {
+        if let Some(path_event) = pen.map_ui_event(e, &mut pen_ctx, &input_state) {
             pen.handle_path_event(path_event, &mut pen_ctx);
         }
     });

--- a/libs/content/workspace/src/tab/svg_editor/renderer.rs
+++ b/libs/content/workspace/src/tab/svg_editor/renderer.rs
@@ -81,7 +81,7 @@ impl Renderer {
                 {
                     return None;
                 }
-                
+
                 if let Some(transform) = el.transformed() {
                     return Some((*id, RenderOp::Transform(transform)));
                 }

--- a/libs/content/workspace/src/tab/svg_editor/renderer.rs
+++ b/libs/content/workspace/src/tab/svg_editor/renderer.rs
@@ -81,7 +81,7 @@ impl Renderer {
                 {
                     return None;
                 }
-
+                
                 if let Some(transform) = el.transformed() {
                     return Some((*id, RenderOp::Transform(transform)));
                 }
@@ -110,7 +110,6 @@ impl Renderer {
         }
 
         if !self.mesh_cache.is_empty() {
-            ui.ctx().graphics(reader)
             painter.extend(self.mesh_cache.clone().into_values().filter(|shape| {
                 if let egui::Shape::Mesh(m) = shape {
                     !m.vertices.is_empty() && !m.indices.is_empty()

--- a/libs/content/workspace/src/tab/svg_editor/renderer.rs
+++ b/libs/content/workspace/src/tab/svg_editor/renderer.rs
@@ -62,7 +62,7 @@ impl Renderer {
         self.dark_mode = ui.visuals().dark_mode;
 
         // todo: should avoid running this on every frame, because the images are allocated once
-        // load_image_textures(buffer, ui);
+        load_image_textures(buffer, ui);
 
         let paint_ops: Vec<(Uuid, RenderOp)> = buffer
             .elements

--- a/libs/content/workspace/src/tab/svg_editor/renderer.rs
+++ b/libs/content/workspace/src/tab/svg_editor/renderer.rs
@@ -185,7 +185,7 @@ fn tesselate_element(
                     };
 
                     let normalized_pressure =
-                        if let Some(prsr) = pressure { *prsr * 2.5 + 0.2 } else { 1.0 };
+                        if let Some(prsr) = pressure { *prsr * 2.0 + 0.5 } else { 1.0 };
 
                     let thickness = stroke.width * master_transform.sx * normalized_pressure;
 

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -16,7 +16,11 @@ use self::{
 };
 
 use super::{
-    history::History, parser, toolbar::ToolContext, util::bb_to_rect, Buffer, DeleteElement,
+    history::History,
+    parser,
+    toolbar::ToolContext,
+    util::{bb_to_rect, is_multi_touch},
+    Buffer, DeleteElement,
 };
 
 #[derive(Default)]
@@ -51,7 +55,7 @@ impl Selection {
 
         let working_rect = selection_ctx.painter.clip_rect();
 
-        if selection_ctx.is_multi_touch {
+        if is_multi_touch(ui) {
             self.selection_rect =
                 SelectionRectContainer::new(&self.selected_elements, selection_ctx.buffer);
             if let Some(s) = &self.selection_rect {

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -66,7 +66,6 @@ impl Selection {
                 ui.output_mut(|r| r.cursor_icon = egui::CursorIcon::Grab);
             }
         }
-        println!("{:#?}", maybe_selected_el);
 
         // build up selected elements
         let should_rebuild = if cfg!(target_os = "ios") {
@@ -133,7 +132,7 @@ impl Selection {
                     self.candidate_selected_elements.clear();
 
                     self.laso_rect = Some(rect);
-                    ui.painter().rect_filled(
+                    painter.rect_filled(
                         rect,
                         egui::Rounding::ZERO,
                         ui.visuals().hyperlink_color.gamma_multiply(0.1),

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -16,11 +16,7 @@ use self::{
 };
 
 use super::{
-    history::History,
-    parser,
-    toolbar::ToolContext,
-    util::{bb_to_rect, is_multi_touch},
-    Buffer, DeleteElement,
+    history::History, parser, toolbar::ToolContext, util::is_multi_touch, Buffer, DeleteElement,
 };
 
 #[derive(Default)]

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -52,6 +52,8 @@ impl Selection {
         let working_rect = selection_ctx.painter.clip_rect();
 
         if is_multi_touch(ui) {
+            *selection_ctx.allow_viewport_changes = true;
+
             self.selection_rect =
                 SelectionRectContainer::new(&self.selected_elements, selection_ctx.buffer);
             if let Some(s) = &self.selection_rect {

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -4,6 +4,7 @@ mod translate;
 
 use bezier_rs::Subpath;
 use glam::{DAffine2, DMat2, DVec2};
+use lb_rs::Uuid;
 use resvg::usvg::Transform;
 
 use crate::tab::svg_editor::selection::scale::snap_scale;
@@ -29,7 +30,7 @@ pub struct Selection {
 
 #[derive(Clone, Debug)]
 struct SelectedElement {
-    id: String,
+    id: Uuid,
     prev_pos: egui::Pos2,
     transform: Transform,
 }
@@ -177,7 +178,7 @@ impl Selection {
 
                         if el_intersects_laso {
                             self.candidate_selected_elements.push(SelectedElement {
-                                id: id.to_owned(),
+                                id: *id,
                                 prev_pos: pos,
                                 transform: Transform::identity(),
                             });
@@ -319,8 +320,8 @@ impl Selection {
                 buffer
                     .elements
                     .iter()
-                    .find(|(id, _el)| id.to_owned().eq(&selection.id));
-                DeleteElement { id: selection.id.clone() }
+                    .find(|(&id, _el)| id.eq(&selection.id));
+                DeleteElement { id: selection.id }
             })
             .collect();
 

--- a/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/mod.rs
@@ -260,6 +260,9 @@ impl Selection {
                                     p.y - selection.prev_pos.y,
                                 );
                                 selection.transform = selection.transform.post_concat(transform);
+                                selection.transform.sx = 1.0;
+                                selection.transform.sy = 1.0;
+
                                 el.transform(transform);
                             }
 

--- a/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
@@ -86,38 +86,44 @@ impl SelectionRectContainer {
 
     pub fn show_delete_btn(&self, ui: &mut egui::Ui, painter: &egui::Painter) -> bool {
         let delete_toolbar_dim = egui::pos2(20.0, 20.0);
-        let gap = 15.0;
+        let gap_between_btn_and_rect = 15.0;
         let icon_size = 19.0;
 
         let delete_toolbar_rect = egui::Rect {
             min: egui::pos2(
                 self.container.raw.min.x,
-                self.container.raw.min.y - delete_toolbar_dim.y - gap,
+                self.container.raw.min.y - delete_toolbar_dim.y - gap_between_btn_and_rect,
             ),
             max: egui::pos2(
                 self.container.raw.min.x + delete_toolbar_dim.x,
-                self.container.raw.min.y - gap,
+                self.container.raw.min.y - gap_between_btn_and_rect,
             ),
         };
-        ui.allocate_ui_at_rect(delete_toolbar_rect, |ui| {
-            ui.vertical_centered(|ui| {
-                let res = Icon::DELETE
-                    .size(icon_size)
-                    .color(ui.style().visuals.hyperlink_color)
-                    .paint(ui, painter);
-                let rect = res.rect.expand(10.0);
-                painter.circle_filled(
-                    rect.center(),
-                    (rect.left() - rect.center().x).abs(),
-                    ui.style().visuals.hyperlink_color.gamma_multiply(0.1),
-                );
 
-                rect.contains(ui.input(|r| r.pointer.hover_pos().unwrap_or_default()))
-                    && ui.input(|r| r.pointer.primary_clicked())
-            })
-            .inner
-        })
-        .inner
+        if ui.is_rect_visible(delete_toolbar_rect) {
+            // let text_color = ui.style().interact(&res).text_color();
+            let wrap_width = ui.available_width();
+
+            let icon_pos = egui::pos2(
+                delete_toolbar_rect.min.x,
+                delete_toolbar_rect.center().y - icon_size / 2.0,
+            );
+
+            let icon: egui::WidgetText = (&Icon::DELETE).into();
+            let icon = icon.into_galley(ui, Some(false), wrap_width, egui::TextStyle::Body);
+
+            painter.galley(icon_pos, icon, ui.style().visuals.hyperlink_color);
+
+            let circle_padding = 7.0;
+            painter.circle_filled(
+                delete_toolbar_rect.center(),
+                (delete_toolbar_rect.left() - delete_toolbar_rect.center().x).abs()
+                    + circle_padding,
+                ui.style().visuals.hyperlink_color.gamma_multiply(0.1),
+            );
+        }
+        delete_toolbar_rect.contains(ui.input(|r| r.pointer.hover_pos().unwrap_or_default()))
+            && ui.input(|r| r.pointer.primary_clicked())
     }
 }
 

--- a/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
@@ -20,6 +20,9 @@ pub struct SelectionRectContainer {
 }
 impl SelectionRectContainer {
     pub fn new(els: &[SelectedElement], buffer: &mut Buffer) -> Option<Self> {
+        if els.is_empty() {
+            return None;
+        }
         let mut container_bb = [DVec2::new(f64::MAX, f64::MAX), DVec2::new(f64::MIN, f64::MIN)];
         let mut children = vec![];
         for el in els.iter() {

--- a/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/rect.rs
@@ -5,7 +5,7 @@ use super::{SelectedElement, SelectionOperation, SelectionResponse};
 use crate::{
     tab::svg_editor::{
         parser::ManipulatorGroupId,
-        util::{bb_to_rect, pointer_intersects_outline},
+        util::{bb_to_rect, pointer_intersects_outline, rect_to_bb},
         Buffer,
     },
     theme::icons::Icon,
@@ -26,22 +26,11 @@ impl SelectionRectContainer {
         let mut container_bb = [DVec2::new(f64::MAX, f64::MAX), DVec2::new(f64::MIN, f64::MIN)];
         let mut children = vec![];
         for el in els.iter() {
-            let bb = match buffer.elements.get(&el.id) {
-                Some(el) => match el {
-                    crate::tab::svg_editor::parser::Element::Path(p) => {
-                        p.data.bounding_box().unwrap()
-                    }
-                    crate::tab::svg_editor::parser::Element::Image(img) => {
-                        let rect = img.bounding_box();
-                        [
-                            DVec2 { x: rect.left().into(), y: rect.top().into() },
-                            DVec2 { x: rect.right().into(), y: rect.bottom().into() },
-                        ]
-                    }
-                    crate::tab::svg_editor::parser::Element::Text(_) => todo!(),
-                },
+            let rect = match buffer.elements.get(&el.id) {
+                Some(el) => el.bounding_box(),
                 None => continue,
             };
+            let bb = rect_to_bb(rect);
 
             if let Some(clipped_rect) = SelectionRect::new(bb) {
                 children.push(clipped_rect);

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -30,7 +30,11 @@ pub fn scale_from_center(
         },
     );
 
-    let bb = path.bounding_box().unwrap();
+    let bb = match path.bounding_box() {
+        Some(val) => val,
+        None => return,
+    };
+
     let element_rect = egui::Rect {
         min: egui::pos2(bb[0].x as f32, bb[0].y as f32),
         max: egui::pos2(bb[1].x as f32, bb[1].y as f32),

--- a/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/scale.rs
@@ -16,7 +16,7 @@ pub fn scale_group_from_center(
 }
 
 pub fn scale_from_center(
-    factor: f32, el: &mut SelectedElement, selected_rect: &SelectionRectContainer,
+    factor: f32, selection: &mut SelectedElement, selected_rect: &SelectionRectContainer,
     buffer: &mut Buffer,
 ) {
     let path: Subpath<ManipulatorGroupId> = Subpath::new_rect(
@@ -36,14 +36,15 @@ pub fn scale_from_center(
         max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
     };
 
-    if let Some(node) = buffer.elements.get_mut(&el.id) {
-        el.transform = Transform::identity()
+    if let Some(el) = buffer.elements.get_mut(&selection.id) {
+        let transform = Transform::identity()
             .post_scale(factor, factor)
             .post_translate(
                 -(1. - factor) * (element_rect.width() / 2. - element_rect.right()),
                 -(1. - factor) * (element_rect.height() / 2. - element_rect.bottom()),
             );
-        node.transform(el.transform)
+        selection.transform = selection.transform.post_concat(transform);
+        el.transform(transform)
     }
 }
 

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -41,7 +41,7 @@ pub fn detect_translation(
         }
         if pointer_intersects_element(el, current_pos, last_pos, 10.0) {
             return Some(SelectedElement {
-                id: id.clone(),
+                id: *id,
                 prev_pos: current_pos,
                 transform: Transform::identity(),
             });

--- a/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
+++ b/libs/content/workspace/src/tab/svg_editor/selection/translate.rs
@@ -17,7 +17,7 @@ pub fn end_translation(
         .filter_map(|el| {
             el.prev_pos = pos;
             if buffer.elements.get_mut(&el.id).is_some() {
-                if save_event {
+                if save_event && !el.transform.is_identity() {
                     Some(TransformElement { id: el.id.to_owned(), transform: el.transform })
                 } else {
                     None

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -43,7 +43,7 @@ pub struct ToolContext<'a> {
     pub history: &'a mut History,
     pub allow_viewport_changes: &'a mut bool,
     pub is_viewport_changing: &'a mut bool,
-    pub is_touch_frame: &'a mut bool,
+    pub is_touch_frame: bool,
 }
 #[derive(Clone)]
 pub struct ColorSwatch {

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -33,6 +33,14 @@ pub enum Tool {
     Selection,
 }
 
+pub struct ToolContext<'a> {
+    pub painter: &'a egui::Painter,
+    pub buffer: &'a mut Buffer,
+    pub history: &'a mut History,
+    pub is_panning_or_zooming: bool,
+    pub is_multi_touch: bool,
+    pub is_touch_start: bool,
+}
 #[derive(Clone)]
 pub struct ColorSwatch {
     pub id: Option<String>,

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -37,9 +37,8 @@ pub struct ToolContext<'a> {
     pub painter: &'a egui::Painter,
     pub buffer: &'a mut Buffer,
     pub history: &'a mut History,
-    pub is_panning_or_zooming: bool,
-    pub is_multi_touch: bool,
-    pub is_touch_start: bool,
+    pub allow_viewport_changes: &'a mut bool,
+    pub is_viewport_changing: bool,
 }
 #[derive(Clone)]
 pub struct ColorSwatch {

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -68,12 +68,12 @@ impl Toolbar {
         self.set_tool(new_tool);
     }
 
-    pub fn new(max_id: usize) -> Self {
+    pub fn new() -> Self {
         Toolbar {
             active_tool: Tool::Pen,
             previous_tool: None,
             right_tab_rect: None,
-            pen: Pen::new(max_id),
+            pen: Pen::new(),
             eraser: Eraser::new(),
             selection: Selection::default(),
         }
@@ -244,7 +244,6 @@ impl Toolbar {
         let theme_colors = ThemePalette::as_array();
 
         theme_colors.iter().for_each(|theme_color| {
-            // let color = ColorSwatch { id: theme_color.0.clone(), color: theme_color.1 };
             let color = ThemePalette::resolve_dynamic_color(*theme_color, ui);
             if self.show_color_btn(ui, color).clicked() {
                 self.pen.active_color = Some(*theme_color);

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -17,6 +17,7 @@ const COLOR_SWATCH_BTN_RADIUS: f32 = 9.0;
 const THICKNESS_BTN_X_MARGIN: f32 = 5.0;
 const THICKNESS_BTN_WIDTH: f32 = 30.0;
 
+#[derive(Default)]
 pub struct Toolbar {
     pub active_tool: Tool,
     right_tab_rect: Option<egui::Rect>,
@@ -26,8 +27,9 @@ pub struct Toolbar {
     pub previous_tool: Option<Tool>,
 }
 
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Default)]
 pub enum Tool {
+    #[default]
     Pen,
     Eraser,
     Selection,
@@ -244,7 +246,7 @@ impl Toolbar {
             Tool::Pen | Tool::Brush => {
                 if let Some(thickness) = self.show_thickness_pickers(
                     ui,
-                    self.pen.active_stroke_width as f32,
+                    self.pen.active_stroke_width,
                     vec![DEFAULT_PEN_STROKE_WIDTH, 4.0, 6.0],
                 ) {
                     self.pen.active_stroke_width = thickness;
@@ -269,7 +271,7 @@ impl Toolbar {
             Tool::Highlighter => {
                 if let Some(thickness) = self.show_thickness_pickers(
                     ui,
-                    self.pen.active_stroke_width as f32,
+                    self.pen.active_stroke_width,
                     vec![DEFAULT_PEN_STROKE_WIDTH * 2.0, 4.0 * 2.0, 6.0 * 2.0],
                 ) {
                     self.pen.active_stroke_width = thickness;

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -41,6 +41,7 @@ pub struct ToolContext<'a> {
     pub history: &'a mut History,
     pub allow_viewport_changes: &'a mut bool,
     pub is_viewport_changing: &'a mut bool,
+    pub is_touch_frame: &'a mut bool,
 }
 #[derive(Clone)]
 pub struct ColorSwatch {

--- a/libs/content/workspace/src/tab/svg_editor/toolbar.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 use super::{
-    eraser::DEFAULT_ERASER_RADIUS, history::History, parser, selection::Selection,
-    zoom::zoom_percentage_to_transform, Buffer, Eraser, Pen,
+    eraser::DEFAULT_ERASER_RADIUS, history::History, parser, pen::DEFAULT_PEN_STROKE_WIDTH,
+    selection::Selection, zoom::zoom_percentage_to_transform, Buffer, Eraser, Pen,
 };
 
 const COLOR_SWATCH_BTN_RADIUS: f32 = 9.0;
@@ -206,9 +206,9 @@ impl Toolbar {
                 if let Some(thickness) = self.show_thickness_pickers(
                     ui,
                     self.pen.active_stroke_width as f32,
-                    vec![2.0, 4.0, 6.0],
+                    vec![DEFAULT_PEN_STROKE_WIDTH, 4.0, 6.0],
                 ) {
-                    self.pen.active_stroke_width = thickness as u32;
+                    self.pen.active_stroke_width = thickness;
                 }
 
                 ui.add_space(4.0);

--- a/libs/content/workspace/src/tab/svg_editor/util.rs
+++ b/libs/content/workspace/src/tab/svg_editor/util.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use bezier_rs::{Bezier, Subpath};
 use glam::DVec2;
 
@@ -90,4 +92,25 @@ pub fn get_current_touch_id(ui: &mut egui::Ui) -> Option<egui::TouchId> {
             }
         })
     })
+}
+
+pub fn is_multi_touch(ui: &mut egui::Ui) -> bool {
+    let mut custom_multi_touch = false;
+    ui.input(|r| {
+        if r.multi_touch().is_some() {
+            custom_multi_touch = true;
+            return;
+        }
+        let mut touch_ids = HashSet::new();
+        for e in r.events.iter() {
+            if let egui::Event::Touch { device_id: _, id, phase: _, pos: _, force: _ } = e {
+                touch_ids.insert(id.0);
+                if touch_ids.len() > 1 {
+                    custom_multi_touch = true;
+                    break;
+                }
+            }
+        }
+    });
+    custom_multi_touch
 }

--- a/libs/content/workspace/src/tab/svg_editor/util.rs
+++ b/libs/content/workspace/src/tab/svg_editor/util.rs
@@ -82,16 +82,29 @@ pub fn bb_to_rect(bb: [DVec2; 2]) -> egui::Rect {
     }
 }
 
-pub fn get_current_touch_id(ui: &mut egui::Ui) -> Option<egui::TouchId> {
-    ui.input(|r| {
+pub fn get_event_touch_id(event: &egui::Event) -> Option<egui::TouchId> {
+    if let egui::Event::Touch { device_id: _, id, phase: _, pos: _, force: _ } = event {
+        Some(*id)
+    } else {
+        None
+    }
+}
+
+pub fn get_is_pointer_released(ui: &mut egui::Ui) -> (bool, Option<egui::Pos2>) {
+    let released_pointer_id = ui.input(|r| {
         r.events.iter().find_map(move |event| {
-            if let egui::Event::Touch { device_id: _, id, phase: _, pos: _, force: _ } = event {
-                Some(*id)
+            if let egui::Event::Touch { device_id: _, id, phase, pos, force: _ } = event {
+                if phase == &egui::TouchPhase::End {
+                    Some(*pos)
+                } else {
+                    None
+                }
             } else {
                 None
             }
         })
-    })
+    });
+    (ui.input(|r| r.pointer.any_released()), released_pointer_id)
 }
 
 pub fn is_multi_touch(ui: &mut egui::Ui) -> bool {

--- a/libs/content/workspace/src/tab/svg_editor/util.rs
+++ b/libs/content/workspace/src/tab/svg_editor/util.rs
@@ -96,23 +96,6 @@ pub fn get_event_touch_id(event: &egui::Event) -> Option<egui::TouchId> {
     }
 }
 
-pub fn get_is_pointer_released(ui: &mut egui::Ui) -> (bool, Option<egui::Pos2>) {
-    let released_pointer_id = ui.input(|r| {
-        r.events.iter().find_map(move |event| {
-            if let egui::Event::Touch { device_id: _, id, phase, pos, force: _ } = event {
-                if phase == &egui::TouchPhase::End {
-                    Some(*pos)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-    });
-    (ui.input(|r| r.pointer.any_released()), released_pointer_id)
-}
-
 pub fn is_multi_touch(ui: &mut egui::Ui) -> bool {
     let mut custom_multi_touch = false;
     ui.input(|r| {

--- a/libs/content/workspace/src/tab/svg_editor/util.rs
+++ b/libs/content/workspace/src/tab/svg_editor/util.rs
@@ -81,6 +81,12 @@ pub fn bb_to_rect(bb: [DVec2; 2]) -> egui::Rect {
         max: egui::pos2(bb[1].x as f32, bb[1].y as f32),
     }
 }
+pub fn rect_to_bb(rect: egui::Rect) -> [DVec2; 2] {
+    [
+        DVec2 { x: rect.left().into(), y: rect.top().into() },
+        DVec2 { x: rect.right().into(), y: rect.bottom().into() },
+    ]
+}
 
 pub fn get_event_touch_id(event: &egui::Event) -> Option<egui::TouchId> {
     if let egui::Event::Touch { device_id: _, id, phase: _, pos: _, force: _ } = event {

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -57,7 +57,7 @@ pub fn handle_zoom_input(
         }
         return true;
     }
-    return false;
+    false
 }
 
 pub fn zoom_percentage_to_transform(

--- a/libs/content/workspace/src/tab/svg_editor/zoom.rs
+++ b/libs/content/workspace/src/tab/svg_editor/zoom.rs
@@ -2,7 +2,9 @@ use resvg::usvg::Transform;
 
 use super::{parser, Buffer};
 
-pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &mut parser::Buffer) {
+pub fn handle_zoom_input(
+    ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &mut parser::Buffer,
+) -> bool {
     let zoom_delta = ui.input(|r| r.zoom_delta());
     let is_zooming = zoom_delta != 1.0;
 
@@ -27,7 +29,7 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
             if working_rect.contains(cp) {
                 cp
             } else {
-                return; // todo: check this doesn't break zoom on touch devices
+                return false; // todo: check this doesn't break zoom on touch devices
             }
         }
         None => egui::Pos2::ZERO,
@@ -53,7 +55,9 @@ pub fn handle_zoom_input(ui: &mut egui::Ui, working_rect: egui::Rect, buffer: &m
         for el in buffer.elements.values_mut() {
             el.transform(t);
         }
+        return true;
     }
+    return false;
 }
 
 pub fn zoom_percentage_to_transform(

--- a/libs/content/workspace/src/theme/icons.rs
+++ b/libs/content/workspace/src/theme/icons.rs
@@ -14,7 +14,7 @@ const fn ic(c: &'static str) -> Icon {
 impl Icon {
     pub const ACCOUNT: Self = ic("\u{e7ff}"); // Person Outline
     pub const ARROW_CIRCLE_DOWN: Self = ic("\u{f181}"); // Arrow Circle Down
-    pub const BRUSH: Self = ic("\u{e3ae}"); // Bold Text
+    pub const BRUSH: Self = ic("\u{e3ae}"); // Brush
     pub const BOLD: Self = ic("\u{e238}"); // Bold Text
     pub const CHECK_CIRCLE: Self = ic("\u{e86c}"); // Check Circle
     pub const CANCEL: Self = ic("\u{e5c9}"); // Cancel
@@ -35,6 +35,7 @@ impl Icon {
     pub const FOLDER_OPEN: Self = ic("\u{e2c8}"); // Folder Open
     pub const GROUP: Self = ic("\u{e7ef}"); // Group
     pub const HISTORY: Self = ic("\u{e889}"); // History
+    pub const HIGHLIGHTER: Self = ic("\u{e6d1}");
     pub const HIGHLIGHT_OFF: Self = ic("\u{e888}"); // Highlight Off
     pub const HEADER_1: Self = ic("\u{e262}"); // Header 11
     pub const TOGGLE_SIDEBAR: Self = ic("\u{f7e4}");
@@ -47,6 +48,7 @@ impl Icon {
     pub const MONEY: Self = ic("\u{e263}"); // Monetization On
     pub const NUMBER_LIST: Self = ic("\u{e242}"); // Number List
     pub const PLACE_ITEM: Self = ic("\u{f1f0}"); // Place Item
+    pub const PEN: Self = ic("\u{e150}"); // Pencil
     pub const PREVIEW: Self = ic("\u{f1c5}"); // Preview
     pub const SETTINGS: Self = ic("\u{e8b8}"); // Settings
     pub const SPARKLE: Self = ic("\u{e65f}"); // Auto Awesome

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -398,7 +398,7 @@ impl Workspace {
                             TabContent::Pdf(pdf) => pdf.show(ui),
                             TabContent::Svg(svg) => {
                                 let res = svg.show(ui);
-                                if res.needs_save {
+                                if res.request_save {
                                     tab.last_changed = Instant::now();
                                 }
                             }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -397,8 +397,10 @@ impl Workspace {
                             TabContent::Image(img) => img.show(ui),
                             TabContent::Pdf(pdf) => pdf.show(ui),
                             TabContent::Svg(svg) => {
-                                svg.show(ui);
-                                tab.last_changed = Instant::now();
+                                let res = svg.show(ui);
+                                if res.needs_save {
+                                    tab.last_changed = Instant::now();
+                                }
                             }
                         };
                     } else {
@@ -610,7 +612,7 @@ impl Workspace {
                             is_mobile_viewport,
                         ))
                     } else if ext == "svg" {
-                        TabContent::Svg(SVGEditor::new(&bytes, core.clone(), id))
+                        TabContent::Svg(SVGEditor::new(&bytes, &ctx, core.clone(), id))
                     } else {
                         TabContent::Markdown(Markdown::new(
                             core.clone(),

--- a/libs/lb/lb-rs/src/service/log_service.rs
+++ b/libs/lb/lb-rs/src/service/log_service.rs
@@ -32,6 +32,7 @@ pub fn init(config: &Config) -> LbResult<()> {
                 fmt::Layer::new()
                     .pretty()
                     .with_target(false)
+                    .with_filter(lockbook_log_level)
                     .with_filter(filter::filter_fn(|metadata| {
                         metadata.target().starts_with("workspace")
                             || metadata.target().starts_with("lb_fs")


### PR DESCRIPTION
## features:
- performance optimizations and better input events processing that minimize input latency. fixes #2791 
- procreate like handling of canceled touch events to avoid phantom strokes fixes #2689 
- remove crashes in selections.  fixes #2792 
- lock viewport changes when drawing a path
- experimental highlighter tool
- brush tool (pen tool with non svg compliant pressure support)
- pen tool refactor that isolates event processing logic allowing unit tests. 



## canceled paths demo

https://github.com/user-attachments/assets/de3daf49-b46d-4abc-b013-bb6f07c743d0



<details>
<summary>work history</summary>

- [x] explore precise location 
- [x] unfuck selection
- [x] save at a correct frequency by correctly modeling dirty state 
- [x] process events before drawing
- [x] use predicted touch
- [ ] reduce heap allocations
    - [x] ids
    - [x] pen tool
    - [ ] renderer => persist meshes across renders to avoid cloning  
- [x] fix history bugs

</details>


## future work 

optimizations done in this pr bring a low latency pen tool, but more can be done to decrease latency:
- [ ] incorporate predicted touches into the pen tool.
- [ ] explore other perf optimizations to achieve 120fps instead of 100-110fps 

