### PR TITLE
core: fix safe_writes race condition

### DIFF
--- a/libs/lb/lb-rs/src/service/document_service.rs
+++ b/libs/lb/lb-rs/src/service/document_service.rs
@@ -84,7 +84,7 @@ impl<Client: Requester, Docs: DocumentService> CoreState<Client, Docs> {
         self.docs.insert(&id, Some(&hmac), &encrypted_document)?;
         self.add_doc_event(activity_service::DocEvent::Write(id, get_time().0))?;
 
-        self.docs.delete(&id, old_hmac.as_ref())?;
+        self.cleanup()?;
 
         Ok(hmac)
     }


### PR DESCRIPTION
After encountering a 2nd `FileNonexistent` error this week, I found this in my logs:
```
2024-10-04T13:57:54.959856Z DEBUG write_document{id=f6a7ad3d-ffc3-44d1-9d6a-ce4cd9b32bf7}: lb_rs::service::document_service: skipping doc cleanup due to active sync
```

This indicates the importance of using [`cleanup()`](https://github.com/lockbook/lockbook/blob/master/libs/lb/lb-rs/src/service/document_service.rs#L92-L104), which accounts for whether we're actively syncing, to clean up old file versions as we did before merging the safe-writes branch (collaborative editing).