### PR TITLE
editor: capture refinements

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -206,12 +206,12 @@ pub fn calc_paragraphs(buffer: &Buffer) -> Paragraphs {
 
 pub fn calc_text(
     ast: &Ast, ast_ranges: &AstTextRanges, appearance: &Appearance, segs: &UnicodeSegs,
-    selection: (DocCharOffset, DocCharOffset), capture: &CaptureState,
+    selection: (DocCharOffset, DocCharOffset), selecting: bool, capture: &CaptureState,
 ) -> Text {
     let mut result = vec![];
     let mut last_range_pushed = false;
     for (i, text_range) in ast_ranges.iter().enumerate() {
-        let captured = capture.captured(selection, ast, ast_ranges, i, appearance);
+        let captured = capture.captured(selection, ast, ast_ranges, i, selecting, appearance);
 
         let this_range_pushed = if !captured {
             // text range or uncaptured syntax range

--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -211,7 +211,7 @@ pub fn calc_text(
     let mut result = vec![];
     let mut last_range_pushed = false;
     for (i, text_range) in ast_ranges.iter().enumerate() {
-        let captured = capture.captured(selection, paragraphs, ast, ast_ranges, i, appearance);
+        let captured = capture.captured(selection, ast, ast_ranges, i, appearance);
 
         let this_range_pushed = if !captured {
             // text range or uncaptured syntax range

--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -205,8 +205,8 @@ pub fn calc_paragraphs(buffer: &Buffer) -> Paragraphs {
 }
 
 pub fn calc_text(
-    ast: &Ast, ast_ranges: &AstTextRanges, paragraphs: &Paragraphs, appearance: &Appearance,
-    segs: &UnicodeSegs, selection: (DocCharOffset, DocCharOffset), capture: &CaptureState,
+    ast: &Ast, ast_ranges: &AstTextRanges, appearance: &Appearance, segs: &UnicodeSegs,
+    selection: (DocCharOffset, DocCharOffset), capture: &CaptureState,
 ) -> Text {
     let mut result = vec![];
     let mut last_range_pushed = false;

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -254,7 +254,6 @@ impl Editor {
             self.bounds.text = bounds::calc_text(
                 &self.ast,
                 &self.bounds.ast,
-                &self.bounds.paragraphs,
                 &self.appearance,
                 &self.buffer.current.segs,
                 self.buffer.current.selection,

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -257,6 +257,7 @@ impl Editor {
                 &self.appearance,
                 &self.buffer.current.segs,
                 self.buffer.current.selection,
+                ui.ctx().input(|i| i.pointer.primary_down()),
                 &self.capture,
             );
             self.bounds.links = bounds::calc_links(&self.buffer, &self.bounds.text, &self.ast);

--- a/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
@@ -109,7 +109,7 @@ impl CaptureState {
     /// detection.
     pub fn captured(
         &self, selection: (DocCharOffset, DocCharOffset), ast: &Ast, ast_ranges: &AstTextRanges,
-        ast_range_idx: usize, appearance: &Appearance,
+        ast_range_idx: usize, selecting: bool, appearance: &Appearance,
     ) -> bool {
         let ast_text_range = &ast_ranges[ast_range_idx];
         if ast_text_range.range_type == AstTextRangeType::Text {
@@ -118,7 +118,7 @@ impl CaptureState {
 
         // check if the ast node for this range intersects the selection
         let ast_node = &ast.nodes[ast_text_range.ancestors.last().copied().unwrap_or_default()];
-        let node_intersects_selection = ast_node.range.intersects(&selection, true);
+        let node_intersects_selection = ast_node.range.intersects(&selection, true) && !selecting;
 
         // check if the pointer is hovering this text range with a satisfied debounce
         let hovered = self

--- a/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/capture.rs
@@ -108,19 +108,13 @@ impl CaptureState {
     /// reveal. Debounce is evaluated using the time of last update rather than the current time to facilitate change
     /// detection.
     pub fn captured(
-        &self, selection: (DocCharOffset, DocCharOffset), paragraphs: &Paragraphs, ast: &Ast,
-        ast_ranges: &AstTextRanges, ast_range_idx: usize, appearance: &Appearance,
+        &self, selection: (DocCharOffset, DocCharOffset), ast: &Ast, ast_ranges: &AstTextRanges,
+        ast_range_idx: usize, appearance: &Appearance,
     ) -> bool {
         let ast_text_range = &ast_ranges[ast_range_idx];
         if ast_text_range.range_type == AstTextRangeType::Text {
             return false;
         }
-
-        // check if this text range intersects any paragraph with selected text
-        let selection_paragraphs = paragraphs.find_intersecting(selection, true);
-        let text_range_paragraphs = paragraphs.find_intersecting(ast_text_range.range, true);
-        let intersects_selected_paragraph =
-            selection_paragraphs.intersects(&text_range_paragraphs, false);
 
         // check if the pointer is hovering this text range with a satisfied debounce
         let hovered = self
@@ -131,7 +125,9 @@ impl CaptureState {
 
         match appearance.markdown_capture(ast_text_range.node(ast).node_type()) {
             CaptureCondition::Always => true,
-            CaptureCondition::NoCursor => !(intersects_selected_paragraph || hovered),
+            CaptureCondition::NoCursor => {
+                !(ast_text_range.range.intersects(&selection, true) || hovered)
+            }
             CaptureCondition::Never => false,
         }
     }


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2724
- removes paragraph-based capture
- does not un-capture line when command is held because that makes no sense for cmd+v and most others
- does have problem where cmd+right does not necessarily leave you at end of line if capture changes (same as obsidian)
- capture updates for selection applied on release instead of on click (same as obsidian)
- hover mechanism still works while drag-selecting
- hovering an image reveals syntax without flicker (not demo'd)

https://github.com/user-attachments/assets/ae451098-b1c9-4d31-92ae-6c8abb20f43d

