### PR TITLE
apple: send modifiers with scroll wheel

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -215,9 +215,9 @@ public class iOSMTKTextInputWrapper: UIView, UITextInput, UIDropInteractionDeleg
         let y = point.y - self.floatingCursorNewStartY
 
         if y >= bounds.height - 5 {
-            scroll_wheel(wsHandle, 0, -20)
+            scroll_wheel(wsHandle, 0, -20, false, false, false, false)
         } else if y <= 5 {
-            scroll_wheel(wsHandle, 0, 20)
+            scroll_wheel(wsHandle, 0, 20, false, false, false, false)
         }
 
         if animate {
@@ -863,7 +863,7 @@ public class iOSMTK: MTKView, MTKViewDelegate, UIPointerInteractionDelegate {
                 if !cursorTracked {
                     mouse_moved(wsHandle, Float(bounds.width / 2), Float(bounds.height / 2))
                 }
-                scroll_wheel(self.wsHandle, Float(velocity.x), Float(velocity.y))
+                scroll_wheel(self.wsHandle, Float(velocity.x), Float(velocity.y), false, false, false, false)
                 if !cursorTracked {
                     mouse_gone(wsHandle)
                 }
@@ -874,7 +874,7 @@ public class iOSMTK: MTKView, MTKViewDelegate, UIPointerInteractionDelegate {
             if !cursorTracked {
                 mouse_moved(wsHandle, Float(bounds.width / 2), Float(bounds.height / 2))
             }
-            scroll_wheel(wsHandle, Float(velocity.x), Float(velocity.y))
+            scroll_wheel(wsHandle, Float(velocity.x), Float(velocity.y), false, false, false, false)
             if !cursorTracked {
                 mouse_gone(wsHandle)
             }

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
@@ -147,9 +147,9 @@ public class MacMTK: MTKView, MTKViewDelegate {
 
     public override func scrollWheel(with event: NSEvent) {
         if event.hasPreciseScrollingDeltas {
-            scroll_wheel(wsHandle, Float(event.scrollingDeltaX), Float(event.scrollingDeltaY))
+            scroll_wheel(wsHandle, Float(event.scrollingDeltaX), Float(event.scrollingDeltaY), event.modifierFlags.contains(.shift), event.modifierFlags.contains(.control), event.modifierFlags.contains(.option), event.modifierFlags.contains(.command))
         } else {
-            scroll_wheel(wsHandle, Float(event.scrollingDeltaX * 10), Float(event.scrollingDeltaY * 10))
+            scroll_wheel(wsHandle, Float(event.scrollingDeltaX * 10), Float(event.scrollingDeltaY * 10), event.modifierFlags.contains(.shift), event.modifierFlags.contains(.control), event.modifierFlags.contains(.option), event.modifierFlags.contains(.command))
         }
         setNeedsDisplay(self.frame)
     }

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -51,8 +51,14 @@ pub unsafe extern "C" fn dark_mode(obj: *mut c_void, dark: bool) {
 
 /// # Safety
 #[no_mangle]
-pub unsafe extern "C" fn scroll_wheel(obj: *mut c_void, scroll_x: f32, scroll_y: f32) {
+pub unsafe extern "C" fn scroll_wheel(
+    obj: *mut c_void, scroll_x: f32, scroll_y: f32, shift: bool, ctrl: bool, option: bool,
+    command: bool,
+) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    let modifiers = egui::Modifiers { alt: option, ctrl, shift, mac_cmd: command, command };
+    obj.raw_input.modifiers = modifiers;
 
     if obj.raw_input.modifiers.command || obj.raw_input.modifiers.ctrl {
         let factor = (scroll_y / 50.).exp();


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2726 which happens because, when the app is left while holding cmd (as in cmd+tab'ing or cmd+click'ing a link), the message that the command key was released is never sent to workspace. Then, scroll events start being interpreted as zoom events until a key press is sent (which updates the modifiers).