### PR TITLE
editor: find in document mvp

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -141,7 +141,7 @@ impl Editor {
         let touch_mode = matches!(ui.ctx().os(), OperatingSystem::Android | OperatingSystem::IOS);
 
         // show find toolbar
-        let find_resp = self.find.show(ui);
+        let find_resp = self.find.show(&self.buffer, ui);
         if let Some(term) = find_resp.term {
             ui.ctx()
                 .push_markdown_event(Event::Find { term, backwards: find_resp.backwards });

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -140,8 +140,14 @@ impl Editor {
 
         let touch_mode = matches!(ui.ctx().os(), OperatingSystem::Android | OperatingSystem::IOS);
 
+        // show find toolbar
+        let find_resp = self.find.show(ui);
+        if let Some(term) = find_resp.term {
+            ui.ctx()
+                .push_markdown_event(Event::Find { term, backwards: find_resp.backwards });
+        }
+
         // show ui
-        self.find.show(ui);
         if touch_mode {
             ui.ctx().style_mut(|style| {
                 style.spacing.scroll = egui::style::ScrollStyle::solid();

--- a/libs/content/workspace/src/tab/markdown_editor/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/find.rs
@@ -41,12 +41,11 @@ impl Find {
             if self.term.is_none() {
                 self.term = Some(String::from(&buffer[buffer.current.selection]));
                 ui.memory_mut(|m| m.request_focus(self.id));
+            }
+            if ui.memory(|m| m.has_focus(self.id)) {
+                self.term = None;
             } else {
-                if ui.memory(|m| m.has_focus(self.id)) {
-                    self.term = None;
-                } else {
-                    ui.memory_mut(|m| m.request_focus(self.id));
-                }
+                ui.memory_mut(|m| m.request_focus(self.id));
             }
         }
         if ui.memory(|m| m.has_focus(self.id)) {
@@ -78,7 +77,7 @@ impl Find {
                     .hint_text("Search")
                     .ui(ui);
                 if term != &before_term {
-                    if term == "" {
+                    if term.is_empty() {
                         self.match_count = 0;
                     } else {
                         self.match_count = text.matches(term.as_str()).count();

--- a/libs/content/workspace/src/tab/markdown_editor/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/find.rs
@@ -41,8 +41,7 @@ impl Find {
             if self.term.is_none() {
                 self.term = Some(String::from(&buffer[buffer.current.selection]));
                 ui.memory_mut(|m| m.request_focus(self.id));
-            }
-            if ui.memory(|m| m.has_focus(self.id)) {
+            } else if ui.memory(|m| m.has_focus(self.id)) {
                 self.term = None;
             } else {
                 ui.memory_mut(|m| m.request_focus(self.id));

--- a/libs/content/workspace/src/tab/markdown_editor/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/find.rs
@@ -1,32 +1,54 @@
-use egui::{EventFilter, Frame, Id, Key, Margin, TextEdit, Ui};
+use egui::{Button, EventFilter, Frame, Id, Key, Margin, TextEdit, Ui, Widget as _};
+use lb_rs::text::offset_types::{DocByteOffset, DocCharOffset, RangeExt};
 
-#[derive(Default)]
+use super::Editor;
+
 pub struct Find {
+    pub id: egui::Id,
     pub term: Option<String>,
 }
 
-pub struct Response {}
+impl Default for Find {
+    fn default() -> Self {
+        Self { id: Id::new("find"), term: None }
+    }
+}
+
+#[derive(Default)]
+pub struct Response {
+    pub term: Option<String>,
+    pub backwards: bool,
+}
 
 impl Find {
     pub fn show(&mut self, ui: &mut Ui) -> Response {
-        let id = Id::new("find-term");
+        let resp = if self.term.is_some() {
+            Frame::default()
+                .inner_margin(Margin::symmetric(10., 10.))
+                .fill(ui.style().visuals.window_fill)
+                .stroke(ui.style().visuals.window_stroke)
+                .show(ui, |ui| self.show_inner(ui))
+                .inner
+        } else {
+            Response::default()
+        };
 
         if ui.input(|i| i.key_pressed(Key::F) && i.modifiers.command) {
             if self.term.is_none() {
                 self.term = Some(String::new());
-                ui.memory_mut(|m| m.request_focus(id));
+                ui.memory_mut(|m| m.request_focus(self.id));
             } else {
-                if ui.memory(|m| m.has_focus(id)) {
+                if ui.memory(|m| m.has_focus(self.id)) {
                     self.term = None;
                 } else {
-                    ui.memory_mut(|m| m.request_focus(id));
+                    ui.memory_mut(|m| m.request_focus(self.id));
                 }
             }
         }
-        if ui.memory(|m| m.has_focus(id)) {
+        if ui.memory(|m| m.has_focus(self.id)) {
             ui.memory_mut(|m| {
                 m.set_focus_lock_filter(
-                    id,
+                    self.id,
                     EventFilter {
                         tab: true,
                         horizontal_arrows: true,
@@ -37,47 +59,69 @@ impl Find {
             })
         }
 
-        if self.term.is_some() {
-            Frame::default()
-                .inner_margin(Margin::symmetric(10., 10.))
-                .fill(ui.style().visuals.window_fill)
-                .stroke(ui.style().visuals.window_stroke)
-                .show(ui, |ui| self.show_inner(ui))
-                .inner
-        } else {
-            Response {}
-        }
+        resp
     }
 
     pub fn show_inner(&mut self, ui: &mut Ui) -> Response {
-        let id = Id::new("find-term");
-
-        let mut search_term_response = None;
+        let mut resp = Response::default();
         ui.horizontal(|ui| {
             let resp = if let Some(term) = &mut self.term {
-                ui.add(
-                    TextEdit::singleline(term)
-                        .id(id)
-                        .desired_width(ui.available_width())
-                        .hint_text("Search"),
-                )
+                if Button::new("<").small().ui(ui).clicked()
+                    || ui.input(|i| i.key_pressed(Key::Enter) && i.modifiers.shift)
+                {
+                    resp.term = Some(term.clone());
+                    resp.backwards = true;
+                }
+                ui.add_space(5.);
+                if Button::new(">").small().ui(ui).clicked()
+                    || ui.input(|i| i.key_pressed(Key::Enter) && !i.modifiers.shift)
+                {
+                    resp.term = Some(term.clone());
+                }
+                ui.add_space(5.);
+
+                let resp = TextEdit::singleline(term)
+                    .return_key(None)
+                    .id(self.id)
+                    .desired_width(ui.available_width())
+                    .hint_text("Search")
+                    .ui(ui);
+
+                resp
             } else {
                 unreachable!()
             };
-            if ui.input(|i| i.key_pressed(Key::Enter) && !i.modifiers.shift) {
-                println!("find next");
-            }
-            if ui.input(|i| i.key_pressed(Key::Enter) && i.modifiers.shift) {
-                println!("find previous");
-            }
             if ui.input(|i| i.key_pressed(Key::Escape)) && resp.has_focus() {
                 self.term = None;
                 ui.ctx().request_repaint();
             }
-
-            search_term_response = Some(resp);
         });
+        resp
+    }
+}
 
-        Response {}
+impl Editor {
+    pub fn find(&self, term: String, backwards: bool) -> Option<(DocCharOffset, DocCharOffset)> {
+        let buffer = &self.buffer.current;
+        let result_start = if !backwards {
+            let mut start = buffer.selection.start();
+            if start != buffer.segs.last_cursor_position() {
+                start += 1;
+            }
+            let byte_start = buffer.segs.offset_to_byte(start);
+            let slice_result = &buffer.text[byte_start.0..].find(&term)?;
+            slice_result + byte_start.0
+        } else {
+            let mut end = buffer.selection.end();
+            if end != 0 {
+                end -= 1;
+            }
+            buffer.text[..buffer.segs.offset_to_byte(end).0].rfind(&term)?
+        };
+        let result_end = result_start + term.len();
+        Some((
+            buffer.segs.offset_to_char(DocByteOffset(result_start)),
+            buffer.segs.offset_to_char(DocByteOffset(result_end)),
+        ))
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/find.rs
@@ -1,0 +1,83 @@
+use egui::{EventFilter, Frame, Id, Key, Margin, TextEdit, Ui};
+
+#[derive(Default)]
+pub struct Find {
+    pub term: Option<String>,
+}
+
+pub struct Response {}
+
+impl Find {
+    pub fn show(&mut self, ui: &mut Ui) -> Response {
+        let id = Id::new("find-term");
+
+        if ui.input(|i| i.key_pressed(Key::F) && i.modifiers.command) {
+            if self.term.is_none() {
+                self.term = Some(String::new());
+                ui.memory_mut(|m| m.request_focus(id));
+            } else {
+                if ui.memory(|m| m.has_focus(id)) {
+                    self.term = None;
+                } else {
+                    ui.memory_mut(|m| m.request_focus(id));
+                }
+            }
+        }
+        if ui.memory(|m| m.has_focus(id)) {
+            ui.memory_mut(|m| {
+                m.set_focus_lock_filter(
+                    id,
+                    EventFilter {
+                        tab: true,
+                        horizontal_arrows: true,
+                        vertical_arrows: true,
+                        escape: true,
+                    },
+                )
+            })
+        }
+
+        if self.term.is_some() {
+            Frame::default()
+                .inner_margin(Margin::symmetric(10., 10.))
+                .fill(ui.style().visuals.window_fill)
+                .stroke(ui.style().visuals.window_stroke)
+                .show(ui, |ui| self.show_inner(ui))
+                .inner
+        } else {
+            Response {}
+        }
+    }
+
+    pub fn show_inner(&mut self, ui: &mut Ui) -> Response {
+        let id = Id::new("find-term");
+
+        let mut search_term_response = None;
+        ui.horizontal(|ui| {
+            let resp = if let Some(term) = &mut self.term {
+                ui.add(
+                    TextEdit::singleline(term)
+                        .id(id)
+                        .desired_width(ui.available_width())
+                        .hint_text("Search"),
+                )
+            } else {
+                unreachable!()
+            };
+            if ui.input(|i| i.key_pressed(Key::Enter) && !i.modifiers.shift) {
+                println!("find next");
+            }
+            if ui.input(|i| i.key_pressed(Key::Enter) && i.modifiers.shift) {
+                println!("find previous");
+            }
+            if ui.input(|i| i.key_pressed(Key::Escape)) && resp.has_focus() {
+                self.term = None;
+                ui.ctx().request_repaint();
+            }
+
+            search_term_response = Some(resp);
+        });
+
+        Response {}
+    }
+}

--- a/libs/content/workspace/src/tab/markdown_editor/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/find.rs
@@ -79,7 +79,10 @@ impl Find {
                     if term.is_empty() {
                         self.match_count = 0;
                     } else {
-                        self.match_count = text.matches(term.as_str()).count();
+                        self.match_count = text
+                            .to_lowercase()
+                            .matches(term.to_lowercase().as_str())
+                            .count();
                     }
                 }
                 ui.add_space(5.);
@@ -125,14 +128,18 @@ impl Editor {
                 start += 1;
             }
             let byte_start = buffer.segs.offset_to_byte(start);
-            let slice_result = &buffer.text[byte_start.0..].find(&term)?;
+            let slice_result = &buffer.text[byte_start.0..]
+                .to_lowercase()
+                .find(&term.to_lowercase())?;
             slice_result + byte_start.0
         } else {
             let mut end = buffer.selection.end();
             if end != 0 {
                 end -= 1;
             }
-            buffer.text[..buffer.segs.offset_to_byte(end).0].rfind(&term)?
+            buffer.text[..buffer.segs.offset_to_byte(end).0]
+                .to_lowercase()
+                .rfind(&term.to_lowercase())?
         };
         let result_end = result_start + term.len();
         Some((

--- a/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
@@ -94,6 +94,7 @@ pub enum Event {
     Newline { advance_cursor: bool }, // distinct from replace because it triggers auto-bullet, etc
     Delete { region: Region }, // distinct from replace because it triggers numbered list renumber, etc
     Indent { deindent: bool },
+    Find { term: String, backwards: bool },
     Undo,
     Redo,
     Cut,

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -612,6 +612,11 @@ impl Editor {
                     }));
                 }
             }
+            Event::Find { term, backwards } => {
+                if let Some(result) = self.find(term, backwards) {
+                    operations.push(Operation::Select(result));
+                }
+            }
             Event::Undo => {
                 response |= self.buffer.undo();
             }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -9,6 +9,7 @@ pub mod bounds;
 pub mod debug;
 pub mod draw;
 pub mod editor;
+pub mod find;
 pub mod galleys;
 pub mod images;
 pub mod input;

--- a/libs/content/workspace/src/widgets/toolbar.rs
+++ b/libs/content/workspace/src/widgets/toolbar.rs
@@ -93,7 +93,7 @@ impl ToolBar {
                         spread: ui.visuals().window_shadow.spread,
                         color: ui.visuals().window_shadow.color.gamma_multiply(0.3),
                     })
-                    .rounding(egui::Rounding::same(20.0))
+                    .rounding(ui.style().visuals.menu_rounding)
                     .show(ui, |ui| self.map_buttons(ui, editor, res, false))
             });
         }
@@ -174,7 +174,7 @@ impl ToolBar {
         };
         let how_on = ui.ctx().animate_bool(egui::Id::from("toolbar_animate"), on);
 
-        let editor_rect = editor.scroll_area_rect;
+        let editor_rect = editor.rect;
 
         let maximized_min_x = (editor_rect.width() - self.width()) / 2.0 + editor_rect.left();
         let minimized_min_x = editor_rect.max.x - (self.width() / self.buttons.len() as f32) - 40.0;

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -931,7 +931,7 @@ fn tab_label(
                 .inner;
 
             if !res.has_focus() && !res.lost_focus() {
-                // request focus on the first frame
+                // request focus on the first frame (todo: wrong but works)
                 res.request_focus();
             }
             if res.has_focus() {


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/2186

It's not the prettiest or most full-featured, but it has enough to get us started:
* focus
  * cmd+f opens the toolbar using the selected text as the initial search term
  * cmd+f focuses the toolbar if it was already open without modifying the search term
  * cmd+f while toolbar is focused closes it (focus returns to editor)
  * esc while toolbar is focused also closes it
  * tab while toolbar is focused does nothing
* search
  * match count updated when search term updated (not when text updated)
  * enter (or button) advances cursor to next match after current cursor (shift+enter/other button for previous)
* things that are missing
  * highlight search results (enter advances selection to next result which is sort of fine)
  * indicator of which result number you're on
  * obvious indicator you are at the last search result
  * wrap from last to first result
  * buttons to open/close search toolbar (cmd+f only for now)
  * case insensitive/whole word/regex search

https://github.com/user-attachments/assets/4584db9f-6572-4423-8039-427b2178fb0b

