### PR TITLE
egui: don't close settings when changging toolbar vis

### DIFF
--- a/clients/egui/src/account/modals/mod.rs
+++ b/clients/egui/src/account/modals/mod.rs
@@ -85,7 +85,6 @@ impl super::AccountScreen {
                 match inner {
                     SuccessfullyUpgraded => self.workspace.refresh_sync_status(),
                     ToggleToolbarVisibility(new_change) => {
-                        self.modals.settings = None;
                         self.refresh_toolbar_visibilities(new_change);
                         ctx.request_repaint();
                     }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -101,7 +101,9 @@ impl Markdown {
             } else {
                 self.editor.show(ui)
             };
-            if !self.editor.appearance.plaintext_mode {
+            if !self.editor.appearance.plaintext_mode
+                && self.toolbar.visibility != ToolBarVisibility::Disabled
+            {
                 self.toolbar.show(ui, &mut self.editor, &mut res);
             }
             res


### PR DESCRIPTION
requested by @BuriedInTheGround
what this pr accomplishes: 
- don't abruptly close settings if you change toolbar settings 
- don't render the toolbar if it's disabled. 

what's missing:
- persist toolbar visibility state across sessions.  #2936
