### PR TITLE
editor: toolbar and find refinements

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -146,15 +146,15 @@ impl Editor {
     pub fn show(&mut self, ui: &mut Ui) -> Response {
         let touch_mode = matches!(ui.ctx().os(), OperatingSystem::Android | OperatingSystem::IOS);
         ui.vertical(|ui| {
-            // show find toolbar
-            let find_resp = self.find.show(&self.buffer, ui);
-            if let Some(term) = find_resp.term {
-                ui.ctx()
-                    .push_markdown_event(Event::Find { term, backwards: find_resp.backwards });
-            }
-
             if touch_mode {
-                // touch devices: show toolbar at the bottom
+                // touch devices: show find...
+                let find_resp = self.find.show(&self.buffer, ui);
+                if let Some(term) = find_resp.term {
+                    ui.ctx()
+                        .push_markdown_event(Event::Find { term, backwards: find_resp.backwards });
+                }
+
+                // ...then show editor content...
                 let resp = ui
                     .allocate_ui(
                         egui::vec2(
@@ -164,6 +164,8 @@ impl Editor {
                         |ui| self.show_inner(touch_mode, ui),
                     )
                     .inner;
+
+                // ...then show toolbar at the bottom
                 self.toolbar.show(
                     &self.ast,
                     &self.bounds,
@@ -173,7 +175,7 @@ impl Editor {
                 );
                 resp
             } else {
-                // non-touch devices: show toolbar at the top
+                // non-touch devices: show toolbar...
                 self.toolbar.show(
                     &self.ast,
                     &self.bounds,
@@ -181,6 +183,15 @@ impl Editor {
                     self.virtual_keyboard_shown,
                     ui,
                 );
+
+                // ...then show find...
+                let find_resp = self.find.show(&self.buffer, ui);
+                if let Some(term) = find_resp.term {
+                    ui.ctx()
+                        .push_markdown_event(Event::Find { term, backwards: find_resp.backwards });
+                }
+
+                // ...then show editor content
                 self.show_inner(touch_mode, ui)
             }
         })

--- a/libs/content/workspace/src/tab/markdown_editor/style.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/style.rs
@@ -1,6 +1,7 @@
 use crate::tab::markdown_editor::appearance::Appearance;
 use egui::{FontFamily, Stroke, TextFormat, Visuals};
 use pulldown_cmark::{HeadingLevel, LinkType};
+use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -405,6 +406,44 @@ impl MarkdownNode {
             "\t".repeat(*indent as usize) + type_head
         } else {
             type_head.to_string()
+        }
+    }
+}
+
+impl Display for MarkdownNode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Document => write!(f, "Document"),
+            Self::Paragraph => write!(f, "Paragraph"),
+            Self::Inline(inline_node) => write!(f, "{}", inline_node),
+            Self::Block(block_node) => write!(f, "{}", block_node),
+        }
+    }
+}
+
+impl Display for InlineNode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Code => write!(f, "Code"),
+            Self::Bold => write!(f, "Bold"),
+            Self::Italic => write!(f, "Italic"),
+            Self::Strikethrough => write!(f, "Strikethrough"),
+            Self::Link(..) => write!(f, "Link"),
+            Self::Image(..) => write!(f, "Image"),
+        }
+    }
+}
+
+impl Display for BlockNode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Heading(..) => write!(f, "Heading"),
+            Self::Quote => write!(f, "Quote"),
+            Self::Code => write!(f, "Code"),
+            Self::ListItem(ListItem::Bulleted, ..) => write!(f, "Bulleted List"),
+            Self::ListItem(ListItem::Numbered(..), ..) => write!(f, "Numbered List"),
+            Self::ListItem(ListItem::Todo(..), ..) => write!(f, "Todo List"),
+            Self::Rule => write!(f, "Rule"),
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widgets/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widgets/find.rs
@@ -94,14 +94,20 @@ impl Find {
             }
             ui.add_space(5.);
 
-            if IconButton::new(&Icon::CHEVRON_LEFT).show(ui).clicked()
+            if IconButton::new(&Icon::CHEVRON_LEFT)
+                .tooltip("Previous")
+                .show(ui)
+                .clicked()
                 || ui.input(|i| i.key_pressed(Key::Enter) && i.modifiers.shift)
             {
                 result.term = Some(term.clone());
                 result.backwards = true;
             }
             ui.add_space(5.);
-            if IconButton::new(&Icon::CHEVRON_RIGHT).show(ui).clicked()
+            if IconButton::new(&Icon::CHEVRON_RIGHT)
+                .tooltip("Next")
+                .show(ui)
+                .clicked()
                 || ui.input(|i| i.key_pressed(Key::Enter) && !i.modifiers.shift)
             {
                 result.term = Some(term.clone());

--- a/libs/content/workspace/src/tab/markdown_editor/widgets/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widgets/find.rs
@@ -1,8 +1,10 @@
-use egui::{Button, EventFilter, Frame, Id, Key, Label, Margin, Stroke, TextEdit, Ui, Widget as _};
+use egui::{EventFilter, Frame, Id, Key, Label, Margin, Stroke, TextEdit, Ui, Widget as _};
 use lb_rs::text::{
     buffer::Buffer,
     offset_types::{DocByteOffset, DocCharOffset, RangeExt as _},
 };
+
+use crate::{theme::icons::Icon, widgets::IconButton};
 
 use super::super::Editor;
 
@@ -64,57 +66,62 @@ impl Find {
     }
 
     pub fn show_inner(&mut self, text: &str, ui: &mut Ui) -> Response {
-        let mut result = Response::default();
         ui.horizontal(|ui| {
-            let resp = if let Some(term) = &mut self.term {
-                let before_term = term.clone();
-                let resp = TextEdit::singleline(term)
-                    .return_key(None)
-                    .id(self.id)
-                    .desired_width(300.)
-                    .hint_text("Search")
-                    .ui(ui);
-                if term != &before_term {
-                    if term.is_empty() {
-                        self.match_count = 0;
-                    } else {
-                        self.match_count = text
-                            .to_lowercase()
-                            .matches(term.to_lowercase().as_str())
-                            .count();
-                    }
-                }
-                ui.add_space(5.);
-
-                if Button::new("↑").small().ui(ui).clicked()
-                    || ui.input(|i| i.key_pressed(Key::Enter) && i.modifiers.shift)
-                {
-                    result.term = Some(term.clone());
-                    result.backwards = true;
-                }
-                ui.add_space(5.);
-                if Button::new("↓").small().ui(ui).clicked()
-                    || ui.input(|i| i.key_pressed(Key::Enter) && !i.modifiers.shift)
-                {
-                    result.term = Some(term.clone());
-                }
-                ui.add_space(5.);
-
-                Label::new(format!("Matches: {:?}", self.match_count))
-                    .selectable(false)
-                    .ui(ui);
-                ui.add_space(ui.available_width());
-
-                resp
-            } else {
-                unreachable!()
+            let mut result = Response::default();
+            let Some(term) = &mut self.term else {
+                return result;
             };
+
+            ui.spacing_mut().button_padding = egui::vec2(5., 5.);
+            ui.set_min_height(30.);
+
+            let before_term = term.clone();
+            let resp = TextEdit::singleline(term)
+                .return_key(None)
+                .id(self.id)
+                .desired_width(300.)
+                .hint_text("Search")
+                .ui(ui);
+            if term != &before_term {
+                if term.is_empty() {
+                    self.match_count = 0;
+                } else {
+                    self.match_count = text
+                        .to_lowercase()
+                        .matches(term.to_lowercase().as_str())
+                        .count();
+                }
+            }
+            ui.add_space(5.);
+
+            if IconButton::new(&Icon::CHEVRON_LEFT).show(ui).clicked()
+                || ui.input(|i| i.key_pressed(Key::Enter) && i.modifiers.shift)
+            {
+                result.term = Some(term.clone());
+                result.backwards = true;
+            }
+            ui.add_space(5.);
+            if IconButton::new(&Icon::CHEVRON_RIGHT).show(ui).clicked()
+                || ui.input(|i| i.key_pressed(Key::Enter) && !i.modifiers.shift)
+            {
+                result.term = Some(term.clone());
+            }
+            ui.add_space(5.);
+
+            Label::new(format!("{:?} matches", self.match_count))
+                .selectable(false)
+                .ui(ui);
+
+            ui.add_space(ui.available_width());
+
             if ui.input(|i| i.key_pressed(Key::Escape)) && resp.has_focus() {
                 self.term = None;
                 ui.ctx().request_repaint();
             }
-        });
-        result
+
+            result
+        })
+        .inner
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widgets/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widgets/toolbar.rs
@@ -7,7 +7,7 @@ use pulldown_cmark::LinkType;
 
 use crate::tab::{ExtendedInput as _, ExtendedOutput as _};
 use crate::theme::icons::Icon;
-use crate::widgets::Button;
+use crate::widgets::IconButton;
 
 use crate::tab::markdown_editor;
 use markdown_editor::ast::Ast;
@@ -50,47 +50,54 @@ impl Toolbar {
                 let is_mobile = cfg!(target_os = "ios") || cfg!(target_os = "android");
                 let s = ast.styles_at_offset(selection.1, &bounds.ast);
 
-                ui.spacing_mut().button_padding = egui::vec2(10., 5.);
+                ui.spacing_mut().button_padding = egui::vec2(5., 5.);
 
                 let mut events = Vec::new();
 
                 if is_mobile && virtual_keyboard_shown {
-                    let resp = Button::default().icon(&Icon::KEYBOARD_HIDE).show(ui);
+                    let resp = IconButton::new(&Icon::KEYBOARD_HIDE).show(ui);
                     if resp.clicked() {
                         ui.ctx().set_virtual_keyboard_shown(false);
                     }
                     add_seperator(ui);
                 }
 
-                if Button::default().icon(&Icon::UNDO).show(ui).clicked() {
+                if IconButton::new(&Icon::UNDO).show(ui).clicked() {
                     events.push(Event::Undo);
                 }
-                if Button::default().icon(&Icon::REDO).show(ui).clicked() {
+                ui.add_space(5.);
+                if IconButton::new(&Icon::REDO).show(ui).clicked() {
                     events.push(Event::Redo);
                 }
 
                 add_seperator(ui);
 
                 self.heading_button(&s, ui).map(|e| events.push(e));
-                inline_btn(Icon::BOLD, InlineNode::Bold, &s, ui).map(|e| events.push(e));
-                inline_btn(Icon::ITALIC, InlineNode::Italic, &s, ui).map(|e| events.push(e));
-                inline_btn(Icon::CODE, InlineNode::Code, &s, ui).map(|e| events.push(e));
-                inline_btn(Icon::STRIKETHROUGH, InlineNode::Strikethrough, &s, ui)
+                ui.add_space(5.);
+                inline(&Icon::BOLD, InlineNode::Bold, &s, ui).map(|e| events.push(e));
+                ui.add_space(5.);
+                inline(&Icon::ITALIC, InlineNode::Italic, &s, ui).map(|e| events.push(e));
+                ui.add_space(5.);
+                inline(&Icon::CODE, InlineNode::Code, &s, ui).map(|e| events.push(e));
+                ui.add_space(5.);
+                inline(&Icon::STRIKETHROUGH, InlineNode::Strikethrough, &s, ui)
                     .map(|e| events.push(e));
 
                 add_seperator(ui);
 
-                block_btn(Icon::NUMBER_LIST, BlockNode::ListItem(ListItem::Numbered(1), 0), &s, ui)
+                block(&Icon::NUMBER_LIST, BlockNode::ListItem(ListItem::Numbered(1), 0), &s, ui)
                     .map(|e| events.push(e));
-                block_btn(Icon::BULLET_LIST, BlockNode::ListItem(ListItem::Bulleted, 0), &s, ui)
+                ui.add_space(5.);
+                block(&Icon::BULLET_LIST, BlockNode::ListItem(ListItem::Bulleted, 0), &s, ui)
                     .map(|e| events.push(e));
-                block_btn(Icon::TODO_LIST, BlockNode::ListItem(ListItem::Todo(false), 0), &s, ui)
+                ui.add_space(5.);
+                block(&Icon::TODO_LIST, BlockNode::ListItem(ListItem::Todo(false), 0), &s, ui)
                     .map(|e| events.push(e));
 
                 add_seperator(ui);
 
-                inline_btn(
-                    Icon::LINK,
+                inline(
+                    &Icon::LINK,
                     InlineNode::Link(LinkType::Inline, "".into(), "".into()),
                     &s,
                     ui,
@@ -99,10 +106,11 @@ impl Toolbar {
 
                 add_seperator(ui);
 
-                if Button::default().icon(&Icon::INDENT).show(ui).clicked() {
+                if IconButton::new(&Icon::INDENT).show(ui).clicked() {
                     events.push(Event::Indent { deindent: false });
                 }
-                if Button::default().icon(&Icon::DEINDENT).show(ui).clicked() {
+                ui.add_space(5.);
+                if IconButton::new(&Icon::DEINDENT).show(ui).clicked() {
                     events.push(Event::Indent { deindent: true });
                 }
 
@@ -129,12 +137,8 @@ impl Toolbar {
                 break;
             }
         }
-        let mut icon = Icon::HEADER_1;
-        if applied {
-            icon = icon.color(ui.visuals().widgets.active.bg_fill)
-        }
 
-        let resp = Button::default().icon(&icon).show(ui);
+        let resp = IconButton::new(&Icon::HEADER_1).colored(applied).show(ui);
         if resp.clicked() {
             if mem::replace(&mut self.heading_last_click_at, Instant::now()).elapsed()
                 > Duration::from_secs(1)
@@ -150,26 +154,23 @@ impl Toolbar {
     }
 }
 
-fn inline_btn(
-    icon: Icon, style: InlineNode, styles_at_cursor: &[MarkdownNode], ui: &mut Ui,
+fn inline(
+    icon: &'static Icon, style: InlineNode, styles_at_cursor: &[MarkdownNode], ui: &mut Ui,
 ) -> Option<Event> {
     button(icon, MarkdownNode::Inline(style), styles_at_cursor, ui)
 }
 
-fn block_btn(
-    icon: Icon, style: BlockNode, styles_at_cursor: &[MarkdownNode], ui: &mut Ui,
+fn block(
+    icon: &'static Icon, style: BlockNode, styles_at_cursor: &[MarkdownNode], ui: &mut Ui,
 ) -> Option<Event> {
     button(icon, MarkdownNode::Block(style), styles_at_cursor, ui)
 }
 
 fn button(
-    mut icon: Icon, style: MarkdownNode, styles_at_cursor: &[MarkdownNode], ui: &mut Ui,
+    icon: &'static Icon, style: MarkdownNode, styles_at_cursor: &[MarkdownNode], ui: &mut Ui,
 ) -> Option<Event> {
     let applied = styles_at_cursor.iter().any(|s| s == &style);
-    if applied {
-        icon = icon.color(ui.visuals().widgets.active.bg_fill)
-    }
-    let resp = Button::default().icon(&icon).show(ui);
+    let resp = IconButton::new(&icon).colored(applied).show(ui);
     if resp.clicked() {
         Some(Event::ToggleStyle { region: Region::Selection, style })
     } else {

--- a/libs/content/workspace/src/tab/markdown_editor/widgets/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widgets/toolbar.rs
@@ -191,7 +191,7 @@ fn button(
     icon: &'static Icon, style: MarkdownNode, styles_at_cursor: &[MarkdownNode], ui: &mut Ui,
 ) -> Option<Event> {
     let applied = styles_at_cursor.iter().any(|s| s == &style);
-    let resp = IconButton::new(&icon)
+    let resp = IconButton::new(icon)
         .colored(applied)
         .tooltip(format!("{}", style))
         .show(ui);

--- a/libs/content/workspace/src/theme/icons.rs
+++ b/libs/content/workspace/src/theme/icons.rs
@@ -16,8 +16,8 @@ const fn ic(c: &'static str) -> Icon {
 impl Icon {
     pub const ACCOUNT: Self = ic("\u{e7ff}"); // Person Outline
     pub const ARROW_CIRCLE_DOWN: Self = ic("\u{f181}"); // Arrow Circle Down
-    pub const ARROW_DOWN: Self = ic("\u{e5c5}"); // Arrow Circle Down
-    pub const ARROW_UP: Self = ic("\u{e5c7}"); // Arrow Circle Down
+    pub const ARROW_DOWN: Self = ic("\u{e5c5}"); // Arrow Down
+    pub const ARROW_UP: Self = ic("\u{e5c7}"); // Arrow Up
     pub const BRING_BACK: Self = ic("\u{e5cb}");
     pub const BRING_TO_BACK: Self = ic("\u{e5dc}");
     pub const BRING_TO_FRONT: Self = ic("\u{e5dd}");
@@ -28,6 +28,8 @@ impl Icon {
     pub const CANCEL: Self = ic("\u{e5c9}"); // Cancel
     pub const CANCEL_PRESENTATION: Self = ic("\u{e0e9}"); // Cancel Presentation
     pub const CIRCLE: Self = ic("\u{ef4a}"); // Circle
+    pub const CHEVRON_LEFT: Self = ic("\u{e5cb}"); // Chevron Left
+    pub const CHEVRON_RIGHT: Self = ic("\u{e5cc}"); // Chevron Right
     pub const CLOSE: Self = ic("\u{e5cd}"); // Close
     pub const CODE: Self = ic("\u{e86f}"); // Code
     pub const CONTENT_COPY: Self = ic("\u{e14d}"); // Content Copy

--- a/libs/content/workspace/src/widgets/icon_button.rs
+++ b/libs/content/workspace/src/widgets/icon_button.rs
@@ -1,0 +1,73 @@
+use egui::{Response, Sense, TextStyle, TextWrapMode, Ui, WidgetText};
+
+use crate::theme::icons::Icon;
+
+/// A button with only an icon. Has a background when hovered. Colored when clicked.
+/// Supports an optional tooltip.
+pub struct IconButton {
+    icon: &'static Icon,
+    tooltip: Option<String>,
+    colored: bool,
+}
+
+impl IconButton {
+    /// Create an icon button with the given icon.
+    pub fn new(icon: &'static Icon) -> Self {
+        Self { icon, tooltip: None, colored: false }
+    }
+
+    /// Add a tooltip for the button. Default: `None`.
+    pub fn tooltip(self, tooltip: impl Into<String>) -> Self {
+        Self { tooltip: Some(tooltip.into()), ..self }
+    }
+
+    /// Make the button colored even if it's not clicked. Default: `false`.
+    pub fn colored(self, colored: bool) -> Self {
+        Self { colored, ..self }
+    }
+
+    pub fn show(self, ui: &mut Ui) -> Response {
+        let padding = ui.spacing().button_padding;
+        let wrap_width = ui.available_width();
+
+        let icon_text: WidgetText = self.icon.into();
+        let galley =
+            icon_text.into_galley(ui, Some(TextWrapMode::Extend), wrap_width, TextStyle::Body);
+
+        let desired_size = egui::Vec2::splat(self.icon.size) + padding * 2.;
+        let (rect, mut resp) = ui.allocate_at_least(desired_size, Sense::click());
+
+        if resp.hovered() {
+            ui.painter()
+                .rect(rect, 2., ui.visuals().code_bg_color, egui::Stroke::NONE);
+            ui.output_mut(|o: &mut egui::PlatformOutput| {
+                o.cursor_icon = egui::CursorIcon::PointingHand
+            });
+        }
+
+        let draw_pos = rect.center() - egui::Vec2::splat(self.icon.size) / 2. + egui::vec2(0., 1.5);
+        let icon_color = if self.colored || resp.is_pointer_button_down_on() {
+            ui.visuals().widgets.active.bg_fill
+        } else {
+            ui.visuals().text_color()
+        };
+        ui.painter().galley(draw_pos, galley, icon_color);
+
+        if let Some(tooltip) = &self.tooltip {
+            ui.ctx()
+                .style_mut(|s| s.visuals.menu_rounding = (2.).into());
+            resp = resp.on_hover_ui(|ui| {
+                let text: WidgetText = (tooltip).into();
+                let text = text.clone().into_galley(
+                    ui,
+                    Some(TextWrapMode::Extend),
+                    ui.available_width(),
+                    egui::TextStyle::Small,
+                );
+                ui.add(egui::Label::new(text));
+            });
+        }
+
+        resp
+    }
+}

--- a/libs/content/workspace/src/widgets/mod.rs
+++ b/libs/content/workspace/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod button;
 pub mod button_group;
+pub mod icon_button;
 pub mod progress_bar;
 pub mod separator;
 pub mod subscription;
@@ -7,6 +8,7 @@ pub mod switch;
 
 pub use button::Button;
 pub use button_group::ButtonGroup;
+pub use icon_button::IconButton;
 pub use progress_bar::ProgressBar;
 pub use separator::separator;
 pub use subscription::subscription;

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -1056,7 +1056,6 @@ fn tab_label(
 
         // draw close button icon
         if show_close_button {
-            // todo: use galley size of icon instead of icon.size for a more accurate reading.
             let icon_draw_pos = egui::pos2(
                 close_button_rect.center().x - x_icon.size / 2.,
                 close_button_rect.center().y - x_icon.size / 2.2,


### PR DESCRIPTION
* fixes https://github.com/lockbook/lockbook/issues/2978
* moves find below toolbar on desktop
* fixes find layout (elements were inconsistently vertically aligned)
* gives toolbar & find buttons visual indicators for being hovered and pressed
* gives toolbar & find buttons tooltips
* toolbar & find buttons set an appropriate cursor icon when hovering

<details>

![image](https://github.com/user-attachments/assets/30ea0c4c-1ba9-482a-8814-a6e9e363c62e)
![image](https://github.com/user-attachments/assets/4d5c3873-3aab-41ae-accf-1d6fe1eef3cb)

</details>