### PR TITLE
lbrs: reduce log volume by 99%

### DIFF
--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -266,7 +266,7 @@ impl<Client: Requester, Docs: DocumentService> CoreLib<Client, Docs> {
             .expected_errs(&[CoreError::FileNonexistent, CoreError::FileNotFolder])
     }
 
-    #[instrument(level = "debug", skip(self), err(Debug))]
+    #[instrument(level = "trace", skip(self), err(Debug))]
     pub fn get_file_by_id(&self, id: Uuid) -> Result<File, LbError> {
         self.in_tx(|s| s.get_file_by_id(&id))
             .expected_errs(&[CoreError::FileNonexistent])


### PR DESCRIPTION
Looking at my own logs for the egui client, only 1% of characters remain after removing lines containing "DEBUG get":
```
~/.lockbook/egui ❯ cat uncolored-2024-10-23.log | wc -c
 59965612
~/.lockbook/egui ❯ grep -v -E "DEBUG get" uncolored-2024-10-23.log | wc -c
  697974
```

More analysis is required to demonstrate the bold claim of the PR title. I don't even see a fn `get` in lb-rs/lib.rs though I've been using other branches while developing recently.