### PR TITLE
ws: reduce sync aggression

### DIFF
--- a/libs/content/workspace/src/background.rs
+++ b/libs/content/workspace/src/background.rs
@@ -10,7 +10,7 @@ pub enum BwIncomingMsg {
 }
 
 pub enum Signal {
-    Sync,
+    MaybeSync,
     SaveAll,
     UpdateStatus,
     BwDone,
@@ -71,7 +71,7 @@ impl BackgroundWorker {
 
         if now.duration_since(self.worker_state.last_auto_sync) > Duration::from_secs(1) {
             self.worker_state.last_auto_sync = now;
-            self.updates.send(WsMsg::BgSignal(Signal::Sync)).unwrap();
+            self.updates.send(WsMsg::BgSignal(Signal::MaybeSync)).unwrap();
             self.ctx.request_repaint();
         }
 

--- a/libs/content/workspace/src/background.rs
+++ b/libs/content/workspace/src/background.rs
@@ -71,7 +71,9 @@ impl BackgroundWorker {
 
         if now.duration_since(self.worker_state.last_auto_sync) > Duration::from_secs(1) {
             self.worker_state.last_auto_sync = now;
-            self.updates.send(WsMsg::BgSignal(Signal::MaybeSync)).unwrap();
+            self.updates
+                .send(WsMsg::BgSignal(Signal::MaybeSync))
+                .unwrap();
             self.ctx.request_repaint();
         }
 


### PR DESCRIPTION
In the foreground we determine that a user is active if they've done something within the last 10s. If they're active we sync every 5 seconds.

If its been more than 5 seconds or the app is in the background we sync every hour.

Obviously we don't sync automatically if it's disabled.

fixes #3018 