### PR TITLE
editor: fix image size

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/galleys.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/galleys.rs
@@ -321,9 +321,9 @@ impl GalleyInfo {
         last_galley: bool, max_rect: Rect, ui: &mut Ui,
     ) -> Self {
         let mut offset = annotation_offset(&job.annotation, appearance);
-        let text_width = ui.available_width().min(700.);
-        let padding_width = (ui.available_width() - text_width) / 2.;
-        job.job.wrap.max_width = text_width - (offset.min.x + offset.max.x);
+        let content_width = ui.available_width().min(700.);
+        let padding_width = (ui.available_width() - content_width) / 2.;
+        job.job.wrap.max_width = content_width - (offset.min.x + offset.max.x);
 
         // allocate space for image
         let image = if let Some(Annotation::Image(_, url, _)) = &job.annotation {
@@ -333,12 +333,8 @@ impl GalleyInfo {
                     let [image_width, image_height] =
                         ui.ctx().tex_manager().read().meta(texture).unwrap().size;
                     let [image_width, image_height] = [image_width as f32, image_height as f32];
-                    let width = f32::min(
-                        ui.available_width() - appearance.image_padding() * 2.0,
-                        image_width,
-                    );
-                    let height =
-                        image_height * width / image_width + appearance.image_padding() * 2.0;
+                    let width = image_width.min(content_width);
+                    let height = image_height * (width / image_width);
                     ui.allocate_exact_size(Vec2::new(width, height), Sense::hover())
                 } else {
                     ui.allocate_exact_size(Vec2::new(200.0, 200.0), Sense::hover())


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/3026
also fixes an issue where images were slightly stretched because they filled their 'padding'

<details>

<img width="1012" alt="Screenshot 2024-10-28 at 1 02 06 PM" src="https://github.com/user-attachments/assets/d0cf5fca-32de-4127-8174-9988b136dfc1">
</details>