### PR TITLE
editor: b&w emoji support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,10 +3875,6 @@ dependencies = [
 [[package]]
 name = "lb-fonts"
 version = "0.1.5"
-
-[[package]]
-name = "lb-fonts"
-version = "0.1.5"
 source = "git+https://github.com/lockbook/lb-fonts#b2718aad58a7ff1c7bbe85f03cb37cec14517b56"
 
 [[package]]
@@ -4184,7 +4180,7 @@ dependencies = [
  "egui_wgpu_backend",
  "env_logger",
  "image 0.24.9",
- "lb-fonts 0.1.5 (git+https://github.com/lockbook/lb-fonts)",
+ "lb-fonts",
  "lb-rs",
  "minidom",
  "pdfium-render",
@@ -7398,12 +7394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twemoji-assets"
-version = "1.3.0+15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d025c23299766dbecaea9047ddf23e51ab324a42d8b1662aaa3347ff58161c"
-
-[[package]]
 name = "type-map"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8731,7 +8721,7 @@ dependencies = [
  "image 0.24.9",
  "indexmap 2.5.0",
  "jni",
- "lb-fonts 0.1.5",
+ "lb-fonts",
  "lb-pdf",
  "lb-rs",
  "linkify",
@@ -8750,7 +8740,6 @@ dependencies = [
  "tldextract",
  "tracing",
  "tracing-test",
- "twemoji-assets",
  "unicode-segmentation",
  "usvg-parser",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "lb-fonts"
 version = "0.1.5"
-source = "git+https://github.com/lockbook/lb-fonts#b2718aad58a7ff1c7bbe85f03cb37cec14517b56"
+source = "git+https://github.com/lockbook/lb-fonts#42ce8132e5770002242982c77c29826ec14061c5"
 
 [[package]]
 name = "lb-fs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,6 +3875,10 @@ dependencies = [
 [[package]]
 name = "lb-fonts"
 version = "0.1.5"
+
+[[package]]
+name = "lb-fonts"
+version = "0.1.5"
 source = "git+https://github.com/lockbook/lb-fonts#b2718aad58a7ff1c7bbe85f03cb37cec14517b56"
 
 [[package]]
@@ -4180,7 +4184,7 @@ dependencies = [
  "egui_wgpu_backend",
  "env_logger",
  "image 0.24.9",
- "lb-fonts",
+ "lb-fonts 0.1.5 (git+https://github.com/lockbook/lb-fonts)",
  "lb-rs",
  "minidom",
  "pdfium-render",
@@ -7394,6 +7398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twemoji-assets"
+version = "1.3.0+15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d025c23299766dbecaea9047ddf23e51ab324a42d8b1662aaa3347ff58161c"
+
+[[package]]
 name = "type-map"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8721,7 +8731,7 @@ dependencies = [
  "image 0.24.9",
  "indexmap 2.5.0",
  "jni",
- "lb-fonts",
+ "lb-fonts 0.1.5",
  "lb-pdf",
  "lb-rs",
  "linkify",
@@ -8740,6 +8750,7 @@ dependencies = [
  "tldextract",
  "tracing",
  "tracing-test",
+ "twemoji-assets",
  "unicode-segmentation",
  "usvg-parser",
 ]

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -8,12 +8,15 @@ name = "workspace_rs"
 
 [dependencies]
 bezier-rs = "0.2.0"
+chrono = "0.4"
 egui = "0.28.1"
 egui_animation = "0.5.0"
 epaint = "0.28.1"
 glam = "0.22.0"
 image = "0.24"
-lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
+indexmap = { version = "2.5.0", features = ["rayon"] }
+lb-fonts = { path = "../../../../lb-fonts" }
+# lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
 lb-pdf = { git = "https://github.com/lockbook/lb-pdf" }
 linkify = "0.10.0"
 lyon = "1.0.1"
@@ -23,14 +26,13 @@ rayon = "1.10.0"
 resvg = "0.41.0"
 serde = { version = "1.0.171", features = ["derive"] }
 svgtypes = "0.13.0"
-unicode-segmentation = "1.10.0"
-usvg-parser = "0.36.0"
-chrono = "0.4"
 tld = "2.35.0"
 tldextract = "0.6.0"
 tracing = "0.1.5"
 tracing-test = "0.2.5"
-indexmap = { version = "2.5.0", features = ["rayon"] }
+twemoji-assets = { version = "1.0", features = ["svg", "names"] }
+unicode-segmentation = "1.10.0"
+usvg-parser = "0.36.0"
 
 # todo: maybe move this switch into lb itself
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -8,15 +8,12 @@ name = "workspace_rs"
 
 [dependencies]
 bezier-rs = "0.2.0"
-chrono = "0.4"
 egui = "0.28.1"
 egui_animation = "0.5.0"
 epaint = "0.28.1"
 glam = "0.22.0"
 image = "0.24"
-indexmap = { version = "2.5.0", features = ["rayon"] }
-lb-fonts = { path = "../../../../lb-fonts" }
-# lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
+lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
 lb-pdf = { git = "https://github.com/lockbook/lb-pdf" }
 linkify = "0.10.0"
 lyon = "1.0.1"
@@ -26,13 +23,14 @@ rayon = "1.10.0"
 resvg = "0.41.0"
 serde = { version = "1.0.171", features = ["derive"] }
 svgtypes = "0.13.0"
+unicode-segmentation = "1.10.0"
+usvg-parser = "0.36.0"
+chrono = "0.4"
 tld = "2.35.0"
 tldextract = "0.6.0"
 tracing = "0.1.5"
 tracing-test = "0.2.5"
-twemoji-assets = { version = "1.0", features = ["svg", "names"] }
-unicode-segmentation = "1.10.0"
-usvg-parser = "0.36.0"
+indexmap = { version = "2.5.0", features = ["rayon"] }
 
 # todo: maybe move this switch into lb itself
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -42,6 +42,10 @@ pub fn register_fonts(fonts: &mut FontDefinitions) {
         font.tweak.y_offset_factor = -0.1;
         font
     });
+    fonts.font_data.insert(
+        "twitter_emoji".to_owned(),
+        FontData::from_static(lb_fonts::TWITTER_COLOR_EMOJI_15_1),
+    );
 
     fonts
         .families
@@ -61,7 +65,25 @@ pub fn register_fonts(fonts: &mut FontDefinitions) {
 
     fonts
         .families
+        .get_mut(&egui::FontFamily::Proportional)
+        .unwrap()
+        .push("material_icons".to_owned());
+
+    fonts
+        .families
         .get_mut(&egui::FontFamily::Monospace)
         .unwrap()
         .push("material_icons".to_owned());
+
+    fonts
+        .families
+        .get_mut(&egui::FontFamily::Proportional)
+        .unwrap()
+        .insert(0, "twitter_emoji".to_owned());
+
+    fonts
+        .families
+        .get_mut(&egui::FontFamily::Monospace)
+        .unwrap()
+        .insert(0, "twitter_emoji".to_owned());
 }


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/1788 (in black & white)

todo
- [x] release lb-fonts (https://github.com/lockbook/lb-fonts/pull/2)
- [ ] stability issues with extended emojis (skin tones etc)