### PR TITLE
editor: spell checking POC with spellbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,6 +3175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "hassle-rs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6737,6 +6743,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "spellbook"
+version = "0.1.0"
+dependencies = [
+ "ahash 0.8.11",
+ "hashbrown 0.15.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8768,6 +8782,7 @@ dependencies = [
  "reqwest",
  "resvg",
  "serde",
+ "spellbook",
  "svgtypes 0.13.0",
  "tld",
  "tldextract",

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8.5"
 rayon = "1.10.0"
 resvg = "0.41.0"
 serde = { version = "1.0.171", features = ["derive"] }
+spellbook = { path = "../../../../../spellbook" }
 svgtypes = "0.13.0"
 unicode-segmentation = "1.10.0"
 usvg-parser = "0.36.0"

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -29,6 +29,8 @@ use markdown_editor::{ast, bounds, galleys, images};
 use serde::Serialize;
 use std::time::{Duration, Instant};
 
+use super::spelling::Spelling;
+
 #[derive(Debug, Serialize, Default)]
 pub struct Response {
     // state changes
@@ -64,6 +66,7 @@ pub struct Editor {
     pub toolbar: Toolbar,
     pub find: Find,
     pub event: EventState,
+    pub spelling: Spelling,
 
     pub virtual_keyboard_shown: bool,
     pub started_scrolling: Option<Instant>,
@@ -95,6 +98,7 @@ impl Editor {
             toolbar: Default::default(),
             find: Default::default(),
             event: Default::default(),
+            spelling: Spelling::new(), // todo: initialize once for all instances
 
             virtual_keyboard_shown: false,
             started_scrolling: None,
@@ -280,6 +284,7 @@ impl Editor {
             self.bounds.words =
                 bounds::calc_words(&self.buffer, &self.ast, &self.bounds.ast, &self.appearance);
             self.bounds.paragraphs = bounds::calc_paragraphs(&self.buffer);
+            self.spelling.check(&self.bounds.words, &self.buffer);
         }
         if text_updated || selection_updated || self.capture.mark_changes_processed() {
             self.bounds.text = bounds::calc_text(
@@ -303,6 +308,7 @@ impl Editor {
             &self.bounds,
             &self.images,
             &self.appearance,
+            &self.spelling,
             touch_mode,
             ui,
         );

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -1,7 +1,9 @@
 use crate::tab::markdown_editor::bounds::{BoundCase, BoundExt as _, RangesExt as _};
 use crate::tab::markdown_editor::input::Location;
 use crate::tab::{self, markdown_editor, ClipContent, ExtendedInput as _, ExtendedOutput as _};
-use egui::{Context, EventFilter, Pos2};
+use egui::{
+    Button, Context, EventFilter, FontFamily, FontId, Pos2, Stroke, TextStyle, TextWrapMode,
+};
 use lb_rs::text::buffer;
 use lb_rs::text::offset_types::{DocCharOffset, RangeExt as _, RangeIterExt as _};
 use markdown_editor::input::{Event, Region};
@@ -103,11 +105,77 @@ impl Editor {
         }
     }
 
-    fn get_pointer_events(&self, ctx: &Context) -> Vec<Event> {
+    fn get_pointer_events(&mut self, ctx: &Context) -> Vec<Event> {
         for i in 0..self.galleys.galleys.len() {
             let galley = &self.galleys.galleys[i];
             if let Some(response) = ctx.read_response(galley.response.id) {
                 let modifiers = ctx.input(|i| i.modifiers);
+
+                ctx.style_mut(|s| s.spacing.menu_margin = egui::vec2(10., 5.).into());
+                ctx.style_mut(|s| s.visuals.menu_rounding = (2.).into());
+                ctx.style_mut(|s| s.visuals.window_fill = s.visuals.extreme_bg_color);
+                ctx.style_mut(|s| s.visuals.window_stroke = Stroke::NONE);
+                ctx.style_mut(|s| {
+                    s.text_styles
+                        .insert(TextStyle::Button, FontId::new(16.0, FontFamily::Proportional));
+                });
+
+                if !cfg!(target_os = "ios") && !cfg!(target_os = "android") {
+                    let mut context_menu_events = Vec::new();
+                    response.context_menu(|ui| {
+                        let offset = pos_to_char_offset(
+                            self.event.prev_click_pos,
+                            &self.galleys,
+                            &self.buffer.current.segs,
+                            &self.bounds.text,
+                        );
+                        if let Some(spelling_error_range) = self
+                            .spelling
+                            .errors
+                            .iter()
+                            .find(|error| error.contains(offset, true, true))
+                        {
+                            let spelling_error_range = *spelling_error_range;
+                            let spelling_error_text = &self.buffer[spelling_error_range];
+
+                            let max_suggestions = 5;
+                            let mut suggestions = Vec::new();
+                            self.spelling
+                                .dict
+                                .suggest(spelling_error_text, &mut suggestions);
+                            for (i, suggestion) in suggestions.into_iter().enumerate() {
+                                if i >= max_suggestions {
+                                    break;
+                                }
+                                let msg = format!(
+                                    "Replace ‘{}’ with ‘{}’",
+                                    spelling_error_text, suggestion
+                                );
+
+                                if ui
+                                    .add(Button::new(msg).wrap_mode(TextWrapMode::Extend))
+                                    .clicked()
+                                {
+                                    context_menu_events.push(Event::Replace {
+                                        region: Region::BetweenLocations {
+                                            start: Location::DocCharOffset(
+                                                spelling_error_range.start(),
+                                            ),
+                                            end: Location::DocCharOffset(
+                                                spelling_error_range.end(),
+                                            ),
+                                        },
+                                        text: suggestion,
+                                    });
+                                    ui.close_menu();
+                                }
+                            }
+                        }
+                    });
+                    if !context_menu_events.is_empty() {
+                        return context_menu_events;
+                    }
+                }
 
                 // hover-based cursor icons
                 let hovering_clickable = ctx
@@ -130,8 +198,10 @@ impl Editor {
                     ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::Text);
                 }
 
+                // note: early continue here unless response has a pointer interaction
                 let pos =
                     if let Some(pos) = response.interact_pointer_pos() { pos } else { continue };
+                self.event.prev_click_pos = pos;
                 let location = Location::Pos(pos);
 
                 let maybe_clicked_link = if modifiers.command

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -27,6 +27,7 @@ use super::Bound;
 #[derive(Default)]
 pub struct EventState {
     prev_event: Option<Event>,
+    pub prev_click_pos: Pos2,
 }
 
 impl Editor {

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -12,6 +12,7 @@ pub mod images;
 pub mod input;
 pub mod layouts;
 pub mod output;
+pub mod spelling;
 pub mod style;
 pub mod test_input;
 pub mod widgets;

--- a/libs/content/workspace/src/tab/markdown_editor/spelling.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/spelling.rs
@@ -1,0 +1,43 @@
+use lb_rs::text::buffer::Buffer;
+use spellbook::Dictionary;
+
+use super::bounds::Words;
+
+pub struct Spelling {
+    pub dict: Dictionary,
+    pub errors: Words,
+}
+
+impl Spelling {
+    pub fn new() -> Self {
+        let aff = std::fs::read_to_string("/Users/travis/downloads/index.aff").unwrap();
+        let dic = std::fs::read_to_string("/Users/travis/downloads/index.dic").unwrap();
+        let dict = Dictionary::new(&aff, &dic).unwrap();
+
+        Self { dict, errors: Vec::new() }
+    }
+
+    pub fn check(&mut self, words: &Words, buffer: &Buffer) {
+        let start = std::time::Instant::now();
+
+        self.errors.clear();
+        for &word in words.iter() {
+            let word_text = &buffer[word];
+
+            if !word_text.chars().any(|c| c.is_alphabetic()) {
+                // words must contain a letter
+                continue;
+            }
+            if word_text.chars().any(|c| c.is_numeric()) {
+                // words must not contain a number
+                continue;
+            }
+
+            if !self.dict.check(&buffer[word]) {
+                self.errors.push(word);
+            }
+        }
+
+        println!("Spelling check took: {:?}", start.elapsed());
+    }
+}

--- a/libs/content/workspace/src/tab/markdown_editor/style.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/style.rs
@@ -1,5 +1,5 @@
 use crate::tab::markdown_editor::appearance::Appearance;
-use egui::{FontFamily, Stroke, TextFormat, Visuals};
+use egui::{Color32, FontFamily, Stroke, TextFormat, Visuals};
 use pulldown_cmark::{HeadingLevel, LinkType};
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
@@ -114,6 +114,7 @@ pub enum RenderStyle {
     Selection,
     PlaintextLink,
     Syntax,
+    Grammar,
     Markdown(MarkdownNode),
 }
 
@@ -318,6 +319,7 @@ impl RenderStyle {
                     text_format.underline = Stroke { width: 1.5, color: vis.link() };
                 }
                 RenderStyle::Syntax => {}
+                RenderStyle::Grammar => {}
                 RenderStyle::Markdown(MarkdownNode::Document) => {
                     text_format.font_id.family = FontFamily::Monospace;
                     text_format.font_id.size = vis.font_size();
@@ -336,6 +338,9 @@ impl RenderStyle {
                 }
                 RenderStyle::Syntax => {
                     text_format.color = vis.syntax();
+                }
+                RenderStyle::Grammar => {
+                    text_format.underline = Stroke { width: 1., color: Color32::RED };
                 }
                 RenderStyle::Markdown(MarkdownNode::Document) => {
                     text_format.font_id.size = vis.font_size();


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/753

Demo:
<details>

https://github.com/user-attachments/assets/afcfdf4b-9d85-452e-a927-adcb83a47c5a
</details>

notes:
* result quality depends on choice of dictionary (open format Hunspell)
* performs well (~1ms for a ~35kb markdown document)

todo:
* [ ] integrate with system dictionary
* [ ] ignore parts of the document as mentioned in #753

branch reproduces some changes from https://github.com/lockbook/lockbook/pull/3031