### PR TITLE
workspace: prevent a tab from saving and loading concurrently

### DIFF
--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -24,6 +24,10 @@ pub struct Tab {
     pub is_new_file: bool,
     pub last_changed: Instant,
     pub last_saved: Instant,
+
+    /// ...with lb-rs. Different from lb-rs's syncing, which is with the server.
+    /// This is used to prevent saves and loads of this tab from happening concurrently.
+    pub is_syncing: bool,
 }
 
 #[derive(Debug, Default)]

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -27,7 +27,7 @@ pub struct Tab {
 
     /// ...with lb-rs. Different from lb-rs's syncing, which is with the server.
     /// This is used to prevent saves and loads of this tab from happening concurrently.
-    pub is_syncing: bool,
+    pub is_saving_or_loading: bool,
 }
 
 #[derive(Debug, Default)]

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -20,9 +20,10 @@ use crate::tab::{SaveRequest, Tab, TabContent, TabFailure};
 use crate::theme::icons::Icon;
 use crate::widgets::Button;
 use lb_rs::{
-    CoreError, DecryptedDocument, DocumentHmac, Duration, File, FileType, LbError, NameComponents,
+    CoreError, DecryptedDocument, DocumentHmac, File, FileType, LbError, NameComponents,
     SyncProgress, SyncStatus, Uuid,
 };
+use std::time::Duration;
 
 pub struct Workspace {
     pub cfg: WsConfig,
@@ -194,6 +195,7 @@ impl Workspace {
             last_changed: now,
             is_new_file,
             last_saved: now,
+            is_syncing: false,
         };
         self.tabs.push(new_tab);
         if make_active {
@@ -312,7 +314,7 @@ impl Workspace {
         }
 
         if let Some(last_touch_event) = self.last_touch_event {
-            if Instant::now() - last_touch_event > Duration::seconds(5) {
+            if Instant::now() - last_touch_event > Duration::from_secs(5) {
                 self.ctx
                     .style_mut(|style| style.interaction.tooltip_delay = 0.0);
                 self.last_touch_event = None;
@@ -599,10 +601,16 @@ impl Workspace {
         }
     }
 
-    pub fn save_tab(&self, i: usize) {
-        if let Some(tab) = self.tabs.get(i) {
+    pub fn save_tab(&mut self, i: usize) {
+        if let Some(tab) = self.tabs.get_mut(i) {
             if tab.is_dirty() {
                 if let Some(save_req) = tab.make_save_request() {
+                    if tab.is_syncing {
+                        // we'll just try again next tick
+                        return;
+                    }
+                    tab.is_syncing = true;
+
                     let core = self.core.clone();
                     let update_tx = self.updates_tx.clone();
                     let ctx = self.ctx.clone();
@@ -680,6 +688,15 @@ impl Workspace {
         let fpath = self.core.get_path_by_id(id).unwrap(); // TODO
 
         let tab_created = self.upsert_tab(id, &fname, &fpath, is_new_file, make_active);
+        let Some(tab) = self.get_mut_tab_by_id(id) else {
+            unreachable!("could not find a tab we just created")
+        };
+        if tab.is_syncing {
+            // either we're already being opened or we're in the process of saving
+            // a save will always reload when it's done
+            return;
+        }
+        tab.is_syncing = true;
 
         let core = self.core.clone();
         let ctx = self.ctx.clone();
@@ -865,6 +882,8 @@ impl Workspace {
                             )));
                         };
 
+                        tab.is_syncing = false;
+
                         Some(tab.name.clone())
                     } else {
                         println!("failed to load file: tab not found");
@@ -878,7 +897,7 @@ impl Workspace {
                     }
                 }
                 WsMsg::SaveResult(id, result) => {
-                    let mut reopen = false;
+                    let mut sync = false;
                     if let Some(tab) = self.get_mut_tab_by_id(id) {
                         match result {
                             Ok(SaveResult {
@@ -892,18 +911,21 @@ impl Workspace {
                                     md.hmac = hmac;
                                     md.buffer.saved(seq, content);
                                 }
-                                self.perform_sync(); // todo: sync once when saving multiple tabs
+                                sync = true; // todo: sync once when saving multiple tabs
                             }
                             Err(err) => {
-                                if err.kind == CoreError::ReReadRequired {
-                                    reopen = true;
+                                if err.kind != CoreError::ReReadRequired {
+                                    tab.failure = Some(TabFailure::Unexpected(format!("{:?}", err)))
                                 }
-                                tab.failure = Some(TabFailure::Unexpected(format!("{:?}", err)))
                             }
                         }
-                    }
-                    if reopen {
+                        tab.is_syncing = false;
+
+                        // always reload an open file after saving in case a reload was skipped while we were saving
                         self.open_file(id, false, false);
+                    }
+                    if sync {
+                        self.perform_sync();
                     }
                 }
                 WsMsg::BgSignal(Signal::BwDone) => {
@@ -921,15 +943,15 @@ impl Workspace {
 
                     let focused = self.ctx.input(|i| i.focused);
 
-                    if self.user_last_seen.elapsed() < Duration::seconds(10)
+                    if self.user_last_seen.elapsed() < Duration::from_secs(10)
                         && focused
-                        && self.last_sync.elapsed() > Duration::seconds(5)
+                        && self.last_sync.elapsed() > Duration::from_secs(5)
                     {
                         // the user is active if the app is in the foreground and they've done
                         // something in the last 10 seconds.
                         // during this time sync every 5 seconds
                         self.perform_sync();
-                    } else if self.last_sync.elapsed() > Duration::hours(1) {
+                    } else if self.last_sync.elapsed() > Duration::from_secs(60 * 60) {
                         // sync every hour while the user is inactive
                         self.perform_sync()
                     }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -195,7 +195,7 @@ impl Workspace {
             last_changed: now,
             is_new_file,
             last_saved: now,
-            is_syncing: false,
+            is_saving_or_loading: false,
         };
         self.tabs.push(new_tab);
         if make_active {
@@ -605,11 +605,11 @@ impl Workspace {
         if let Some(tab) = self.tabs.get_mut(i) {
             if tab.is_dirty() {
                 if let Some(save_req) = tab.make_save_request() {
-                    if tab.is_syncing {
+                    if tab.is_saving_or_loading {
                         // we'll just try again next tick
                         return;
                     }
-                    tab.is_syncing = true;
+                    tab.is_saving_or_loading = true;
 
                     let core = self.core.clone();
                     let update_tx = self.updates_tx.clone();
@@ -691,12 +691,12 @@ impl Workspace {
         let Some(tab) = self.get_mut_tab_by_id(id) else {
             unreachable!("could not find a tab we just created")
         };
-        if tab.is_syncing {
+        if tab.is_saving_or_loading {
             // either we're already being opened or we're in the process of saving
             // a save will always reload when it's done
             return;
         }
-        tab.is_syncing = true;
+        tab.is_saving_or_loading = true;
 
         let core = self.core.clone();
         let ctx = self.ctx.clone();
@@ -882,7 +882,7 @@ impl Workspace {
                             )));
                         };
 
-                        tab.is_syncing = false;
+                        tab.is_saving_or_loading = false;
 
                         Some(tab.name.clone())
                     } else {
@@ -919,7 +919,7 @@ impl Workspace {
                                 }
                             }
                         }
-                        tab.is_syncing = false;
+                        tab.is_saving_or_loading = false;
 
                         // always reload an open file after saving in case a reload was skipped while we were saving
                         self.open_file(id, false, false);


### PR DESCRIPTION
Maha [reported](https://discord.com/channels/1014184997751619664/1026211549678936214/1301582912746946631) a bug where text she was writing before randomly appeared in a second instance as if it was a remote change.

How could this happen? I added instrumentation and `thread::sleep()`'s to saves and loads to find out. Here's annotated output from my instrumentation. Numbers indicate content length and I did nothing but append to the file during the test:
```
┌── load began (0)
└── load completed:	0
    text "a" x2
  ┌ save began:		2
  │ text "a" x5
 ┌┼ save began:		7
 │└ save completed:	2
 │  text "a" x5
 │┌ save began:		12
 └┼ save completed: re-read required (7)
┌─┼ load began 		(2 or 12)
│ │ text "a" x6
│┌┼ save began:		18
││└ save completed:	12
└┼─ load completed:	12
 │  text "a" x2
 │  text " "
 │  text "a" x2
 │┌ save began:		23
 └┼ save completed: re-read required (18)
┌─┼ load began 		(12 or 23)
│ │ text "a" x6
│┌┼ save began:		29
│││ text "a"
││└ save completed:	23
└┼─ load completed:	23
 │  text "a" x4
 │┌ save began:		34
 └┼ save completed: re-read required (29)
┌─┼ load began 		(23 or 34)
│ │ text "a" x5
│┌┼ save began:		39
│││ text "a" x2
││└ save completed:	34
└┼─ load completed:	34
 │  text "a"
 │┌ save began:		42
 └┼ save completed: re-read required (39)
┌─┼ load began 		(34 or 42)
│ │ text "a"
│┌┼ save began:		43
└┼┼ load completed:	42 <- this load adds 9 characters (spurious conflict)
 │└ save completed:	42
 └─ save completed: re-read required (43)
┌── load began 		(42)
│ ┌ save began:		51 <- 8 chars added since text last typed
│┌┼ save began:		51
└┼┼ load completed:	42
 │└ save completed:	51
 └─ save completed: re-read required
```
The problematic load is the first load that loads content after its been saved but before the save result has been handled:
```
  ┌ save began:		42
  │ ...
┌─┼ load began 		(34 or 42)
│ │ ...
└─┼ load completed:	42 <- this load adds 9 characters (spurious conflict)
  └ save completed:	42
```
I implemented an `is_syncing` flag that guards sections where we are saving or loading a file and I had the editor always reload after a save. The new output (with saves and loads still extended with `thread::sleep()` calls) looks perfect:
```
load began
load completed:	0
save began:	4
save completed:	4
load began
load completed:	4
save began:	23
save completed:	23
load began
load completed:	23
save began:	32
save completed:	32
load began
load completed:	32
save began:	39
save completed:	39
load began
load completed:	39
save began:	42
save completed:	42
load began
load completed:	42
save began:	68
save completed:	68
load began
load completed:	68
save began:	76
save completed:	76
load began
load completed:	76
```