### PR TITLE
lb-rs: improve logging

### DIFF
--- a/clients/cli/src/debug.rs
+++ b/clients/cli/src/debug.rs
@@ -50,3 +50,10 @@ pub async fn whereami() -> Result<(), CliError> {
     println!("Core: {}", config.writeable_path);
     Ok(())
 }
+
+#[tokio::main]
+pub async fn debug_info() -> Result<(), CliError> {
+    let lb = &core().await?;
+    println!("{}", lb.debug_info("None Provided".to_string()).await?);
+    Ok(())
+}

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -88,11 +88,15 @@ fn run() -> CliResult<()> {
                 )
                 .subcommand(
                     Command::name("whoami").description("print who is logged into this lockbook")
-                        .handler( debug::whoami)
+                        .handler(debug::whoami)
                 )
                 .subcommand(
                     Command::name("whereami").description("print information about where this lockbook is stored and it's server url")
                         .handler(debug::whereami)
+                )
+                .subcommand(
+                    Command::name("debuginfo").description("retrieve the debug-info string to help a lockbook engineer diagnose a problem")
+                        .handler(debug::debug_info)
                 )
         )
         .subcommand(

--- a/libs/lb/lb-rs/src/service/account.rs
+++ b/libs/lb/lb-rs/src/service/account.rs
@@ -18,6 +18,7 @@ impl Lb {
     /// CoreError::ServerDisabled,
     /// CoreError::ServerUnreachable,
     /// CoreError::ClientUpdateRequired,
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn create_account(
         &self, username: &str, api_url: &str, welcome_doc: bool,
     ) -> LbResult<Account> {
@@ -66,6 +67,7 @@ impl Lb {
         Ok(account)
     }
 
+    #[instrument(level = "debug", skip(self, key), err(Debug))]
     pub async fn import_account(&self, key: &str, api_url: Option<&str>) -> LbResult<Account> {
         if self.get_account().is_ok() {
             warn!("tried to import an account, but account exists already.");
@@ -143,6 +145,7 @@ impl Lb {
             .await
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub fn export_account_private_key(&self) -> LbResult<String> {
         self.export_account_private_key_v1()
     }
@@ -170,6 +173,7 @@ impl Lb {
             .map_err(|err| core_err_unexpected(err).into())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn delete_account(&self) -> LbResult<()> {
         let account = self.get_account()?;
 

--- a/libs/lb/lb-rs/src/service/activity.rs
+++ b/libs/lb/lb-rs/src/service/activity.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 impl Lb {
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn suggested_docs(&self, settings: RankingWeights) -> LbResult<Vec<Uuid>> {
         let db = self.ro_tx().await;
         let db = db.db();
@@ -33,7 +34,7 @@ impl Lb {
         Ok(result)
     }
 
-    pub async fn add_doc_event(&self, event: DocEvent) -> LbResult<()> {
+    pub(crate) async fn add_doc_event(&self, event: DocEvent) -> LbResult<()> {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
 

--- a/libs/lb/lb-rs/src/service/admin.rs
+++ b/libs/lb/lb-rs/src/service/admin.rs
@@ -6,6 +6,7 @@ use crate::Lb;
 use uuid::Uuid;
 
 impl Lb {
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn disappear_account(&self, username: &str) -> LbResult<()> {
         let account = self.get_account()?;
 
@@ -28,6 +29,7 @@ impl Lb {
             })
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn disappear_file(&self, id: Uuid) -> LbResult<()> {
         let account = self.get_account()?;
         self.client
@@ -49,6 +51,7 @@ impl Lb {
             })
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn list_users(&self, filter: Option<AccountFilter>) -> LbResult<Vec<Username>> {
         let account = self.get_account()?;
 
@@ -67,6 +70,7 @@ impl Lb {
             .users)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn get_account_info(&self, identifier: AccountIdentifier) -> LbResult<AccountInfo> {
         let account = self.get_account()?;
 
@@ -88,6 +92,7 @@ impl Lb {
             .account)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn validate_account(&self, username: &str) -> LbResult<AdminValidateAccount> {
         let account = self.get_account()?;
         self.client
@@ -109,6 +114,7 @@ impl Lb {
             })
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn validate_server(&self) -> LbResult<AdminValidateServer> {
         let account = self.get_account()?;
         self.client
@@ -127,6 +133,7 @@ impl Lb {
             })
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn file_info(&self, id: Uuid) -> LbResult<AdminFileInfoResponse> {
         let account = self.get_account()?;
         self.client
@@ -148,6 +155,7 @@ impl Lb {
             })
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn rebuild_index(&self, index: ServerIndex) -> LbResult<()> {
         let account = self.get_account()?;
         self.client
@@ -166,6 +174,7 @@ impl Lb {
             })
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn set_user_tier(&self, username: &str, info: AdminSetUserTierInfo) -> LbResult<()> {
         let account = self.get_account()?;
         self.client

--- a/libs/lb/lb-rs/src/service/billing.rs
+++ b/libs/lb/lb-rs/src/service/billing.rs
@@ -9,6 +9,7 @@ use crate::model::errors::{core_err_unexpected, LbErrKind, LbResult};
 use crate::Lb;
 
 impl Lb {
+    #[instrument(level = "debug", skip(self, account_tier), err(Debug))]
     pub async fn upgrade_account_stripe(&self, account_tier: StripeAccountTier) -> LbResult<()> {
         let account = self.get_account()?;
 
@@ -47,6 +48,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn upgrade_account_google_play(
         &self, purchase_token: &str, account_id: &str,
     ) -> LbResult<()> {
@@ -80,6 +82,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn upgrade_account_app_store(
         &self, original_transaction_id: String, app_account_token: String,
     ) -> LbResult<()> {
@@ -113,6 +116,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn cancel_subscription(&self) -> LbResult<()> {
         let account = self.get_account()?;
 
@@ -141,6 +145,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn get_subscription_info(&self) -> LbResult<Option<SubscriptionInfo>> {
         let account = self.get_account()?;
 

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -3,14 +3,14 @@ use crate::model::errors::LbResult;
 use crate::Lb;
 use crate::{get_code_version, service::logging::LOG_FILE};
 use basic_human_duration::ChronoHumanDuration;
+use chrono::NaiveDateTime;
 use serde::Serialize;
 use std::env;
-use std::{
-    fs::File,
-    io::{Read, Seek, SeekFrom},
-    path::PathBuf,
-};
+use std::io::SeekFrom;
+use std::path::{Path, PathBuf};
 use time::Duration;
+use tokio::fs::{self, File};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 #[derive(Serialize)]
 pub struct DebugInfo {
@@ -24,21 +24,22 @@ pub struct DebugInfo {
     pub server_url: String,
     pub integrity: String,
     pub log_tail: String,
+    pub last_panic: String,
 }
 
 impl Lb {
-    fn tail_log(&self) -> LbResult<String> {
+    async fn tail_log(&self) -> LbResult<String> {
         let mut path = PathBuf::from(&self.config.writeable_path);
         if path.exists() {
             path.push(LOG_FILE);
-            let mut file = File::open(path)?;
-            let size = file.metadata()?.len();
-            let read_amount = 20 * 1024;
+            let mut file = File::open(path).await?;
+            let size = file.metadata().await?.len();
+            let read_amount = 5 * 1024;
             let pos = if read_amount > size { 0 } else { size - read_amount };
 
             let mut buffer = Vec::with_capacity(read_amount as usize);
-            file.seek(SeekFrom::Start(pos))?;
-            file.read_to_end(&mut buffer)?;
+            file.seek(SeekFrom::Start(pos)).await?;
+            file.read_to_end(&mut buffer).await?;
             if self.config.colored_logs {
                 // strip colors
                 buffer = strip_ansi_escapes::strip(buffer);
@@ -69,6 +70,58 @@ impl Lb {
         now.format("%Y-%m-%d %H:%M:%S %Z").to_string()
     }
 
+    async fn find_most_recent_panic_log(&self) -> LbResult<String> {
+        let dir_path = &self.config.writeable_path;
+        let path = Path::new(dir_path);
+
+        let prefix = "panic---";
+        let suffix = ".log";
+        let timestamp_format = "%Y-%m-%d---%H-%M-%S";
+
+        let mut most_recent_file: Option<String> = None;
+        let mut most_recent_time: Option<NaiveDateTime> = None;
+
+        let mut entries = fs::read_dir(path).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let file_name = entry.file_name().into_string().unwrap_or_default();
+
+            // Check if the filename matches the expected format
+            if file_name.starts_with(prefix) && file_name.ends_with(suffix) {
+                // Extract the timestamp portion from the filename
+                let timestamp_str = &file_name[prefix.len()..file_name.len() - suffix.len()];
+
+                // Parse the timestamp
+                if let Ok(timestamp) =
+                    NaiveDateTime::parse_from_str(timestamp_str, timestamp_format)
+                {
+                    // Compare to find the most recent timestamp
+                    match most_recent_time {
+                        Some(ref current_most_recent) => {
+                            if timestamp > *current_most_recent {
+                                most_recent_time = Some(timestamp);
+                                most_recent_file = Some(file_name.clone());
+                            }
+                        }
+                        None => {
+                            most_recent_time = Some(timestamp);
+                            most_recent_file = Some(file_name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        // If we found the most recent file, read its contents
+        if let Some(file_name) = most_recent_file {
+            let file_path = path.join(file_name);
+            let contents = fs::read_to_string(file_path).await?;
+            Ok(contents)
+        } else {
+            Ok(String::default())
+        }
+    }
+
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn debug_info(&self, os_info: String) -> LbResult<String> {
         let account = self.get_account()?;
 
@@ -76,17 +129,26 @@ impl Lb {
         let os = env::consts::OS;
         let family = env::consts::FAMILY;
 
+        let (integrity, log_tail, last_synced, last_panic) = tokio::join!(
+            self.test_repo_integrity(),
+            self.tail_log(),
+            self.human_last_synced(),
+            self.find_most_recent_panic_log()
+        );
+
+
         Ok(serde_json::to_string_pretty(&DebugInfo {
             time: self.now(),
             name: account.username.clone(),
             lb_version: get_code_version().into(),
             rust_tripple: format!("{arch}.{family}.{os}"),
             server_url: account.api_url.clone(),
-            integrity: format!("{:?}", self.test_repo_integrity().await),
-            log_tail: self.tail_log()?,
+            integrity: format!("{:?}", integrity),
+            log_tail: log_tail?,
             lb_dir: self.config.writeable_path.clone(),
-            last_synced: self.human_last_synced().await,
+            last_synced,
             os_info,
+            last_panic: last_panic?
         })?)
     }
 }

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -136,7 +136,6 @@ impl Lb {
             self.find_most_recent_panic_log()
         );
 
-
         Ok(serde_json::to_string_pretty(&DebugInfo {
             time: self.now(),
             name: account.username.clone(),
@@ -148,7 +147,7 @@ impl Lb {
             lb_dir: self.config.writeable_path.clone(),
             last_synced,
             os_info,
-            last_panic: last_panic?
+            last_panic: last_panic?,
         })?)
     }
 }

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use super::activity;
 
 impl Lb {
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn read_document(&self, id: Uuid) -> LbResult<DecryptedDocument> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -35,7 +36,9 @@ impl Lb {
         Ok(doc)
     }
 
+    #[instrument(level = "debug", skip(self, content), err(Debug))]
     pub async fn write_document(&self, id: Uuid, content: &[u8]) -> LbResult<()> {
+        debug!("doc length: {}", content.len());
         let mut tx = self.begin_tx().await;
         let db = tx.db();
 
@@ -67,6 +70,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn read_document_with_hmac(
         &self, id: Uuid,
     ) -> LbResult<(Option<DocumentHmac>, DecryptedDocument)> {
@@ -89,9 +93,11 @@ impl Lb {
         Ok((hmac, doc))
     }
 
+    #[instrument(level = "debug", skip(self, content), err(Debug))]
     pub async fn safe_write(
         &self, id: Uuid, old_hmac: Option<DocumentHmac>, content: Vec<u8>,
     ) -> LbResult<DocumentHmac> {
+        debug!("doc length: {}", content.len());
         let mut tx = self.begin_tx().await;
         let db = tx.db();
 

--- a/libs/lb/lb-rs/src/service/file.rs
+++ b/libs/lb/lb-rs/src/service/file.rs
@@ -10,6 +10,7 @@ use std::iter;
 use uuid::Uuid;
 
 impl Lb {
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn create_file(
         &self, name: &str, parent: &Uuid, file_type: FileType,
     ) -> LbResult<File> {
@@ -38,6 +39,7 @@ impl Lb {
         Ok(ui_file)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn rename_file(&self, id: &Uuid, new_name: &str) -> LbResult<()> {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
@@ -59,6 +61,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn move_file(&self, id: &Uuid, new_parent: &Uuid) -> LbResult<()> {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
@@ -77,6 +80,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn delete(&self, id: &Uuid) -> LbResult<()> {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
@@ -96,6 +100,7 @@ impl Lb {
     }
 
     // todo: keychain?
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn root(&self) -> LbResult<File> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -110,6 +115,7 @@ impl Lb {
         Ok(root)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn list_metadatas(&self) -> LbResult<Vec<File>> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -122,6 +128,7 @@ impl Lb {
         Ok(tree.decrypt_all(account, ids, &db.pub_key_lookup, true)?)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn get_children(&self, id: &Uuid) -> LbResult<Vec<File>> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -134,6 +141,7 @@ impl Lb {
         Ok(tree.decrypt_all(account, ids, &db.pub_key_lookup, true)?)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn get_and_get_children_recursively(&self, id: &Uuid) -> LbResult<Vec<File>> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -151,6 +159,7 @@ impl Lb {
         )?)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn get_file_by_id(&self, id: Uuid) -> LbResult<File> {
         let tx = self.ro_tx().await;
         let db = tx.db();

--- a/libs/lb/lb-rs/src/service/import_export.rs
+++ b/libs/lb/lb-rs/src/service/import_export.rs
@@ -17,6 +17,7 @@ pub enum ImportStatus {
 }
 
 impl Lb {
+    #[instrument(level = "debug", skip(self, update_status), err(Debug))]
     pub async fn import_files<F: Fn(ImportStatus)>(
         &self, sources: &[PathBuf], dest: Uuid, update_status: &F,
     ) -> LbResult<()> {
@@ -120,6 +121,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self, update_status), err(Debug))]
     pub async fn export_file<F: Fn(ExportFileInfo)>(
         &self, id: Uuid, dest: PathBuf, edit: bool, update_status: &Option<F>,
     ) -> LbResult<()> {

--- a/libs/lb/lb-rs/src/service/integrity.rs
+++ b/libs/lb/lb-rs/src/service/integrity.rs
@@ -11,6 +11,8 @@ const UTF8_SUFFIXES: [&str; 12] =
     ["md", "txt", "text", "markdown", "sh", "zsh", "bash", "html", "css", "js", "csv", "rs"];
 
 impl Lb {
+    // todo good contender for async treatment, to speedup debug_info
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn test_repo_integrity(&self) -> Result<Vec<Warning>, TestRepoError> {
         let tx = self.ro_tx().await;
         let db = tx.db();

--- a/libs/lb/lb-rs/src/service/network.rs
+++ b/libs/lb/lb-rs/src/service/network.rs
@@ -53,6 +53,7 @@ impl Default for Network {
 }
 
 impl Network {
+    #[instrument(level = "debug", skip(self, account, request), fields(route=T::ROUTE), err(Debug))]
     pub async fn request<T: Request>(
         &self, account: &Account, request: T,
     ) -> Result<T::Response, ApiError<T::Error>> {

--- a/libs/lb/lb-rs/src/service/path.rs
+++ b/libs/lb/lb-rs/src/service/path.rs
@@ -6,6 +6,7 @@ use crate::Lb;
 use uuid::Uuid;
 
 impl Lb {
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn create_link_at_path(&self, path: &str, target_id: Uuid) -> LbResult<File> {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
@@ -27,6 +28,7 @@ impl Lb {
         Ok(ui_file)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn create_at_path(&self, path: &str) -> LbResult<File> {
         let pub_key = self.get_pk()?;
         let mut tx = self.begin_tx().await;
@@ -48,6 +50,7 @@ impl Lb {
         Ok(ui_file)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn get_by_path(&self, path: &str) -> LbResult<File> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -64,6 +67,7 @@ impl Lb {
         Ok(ui_file)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn get_path_by_id(&self, id: Uuid) -> LbResult<String> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -75,6 +79,7 @@ impl Lb {
         Ok(path)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn list_paths(&self, filter: Option<Filter>) -> LbResult<Vec<String>> {
         let tx = self.ro_tx().await;
         let db = tx.db();

--- a/libs/lb/lb-rs/src/service/search.rs
+++ b/libs/lb/lb-rs/src/service/search.rs
@@ -86,6 +86,7 @@ impl SearchResult {
 }
 
 impl Lb {
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn search(&self, input: &str, cfg: SearchConfig) -> LbResult<Vec<SearchResult>> {
         if self.search.docs.read().await.is_empty() {
             self.build_index().await?;
@@ -128,6 +129,7 @@ impl Lb {
         Ok(results)
     }
 
+    #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn build_index(&self) -> LbResult<()> {
         let ts = clock::get_time().0 as u64;
         self.search.last_built.store(ts, Ordering::SeqCst);
@@ -196,6 +198,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self))]
     /// ensure the index is not built more frequently than every 5s
     pub fn spawn_build_index(&self) {
         tokio::spawn({

--- a/libs/lb/lb-rs/src/service/share.rs
+++ b/libs/lb/lb-rs/src/service/share.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 impl Lb {
     // todo: this can check whether the username is known already
+    #[instrument(level = "debug", skip(self))]
     pub async fn share_file(&self, id: Uuid, username: &str, mode: ShareMode) -> LbResult<()> {
         let account = self.get_account()?;
 
@@ -37,6 +38,7 @@ impl Lb {
     }
 
     // todo: move to tree
+    #[instrument(level = "debug", skip(self))]
     pub async fn get_pending_shares(&self) -> LbResult<Vec<File>> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -71,6 +73,7 @@ impl Lb {
         Ok(result)
     }
 
+    #[instrument(level = "debug", skip(self))]
     async fn delete_share(
         &self, id: &Uuid, maybe_encrypted_for: Option<PublicKey>,
     ) -> LbResult<()> {
@@ -89,6 +92,7 @@ impl Lb {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self))]
     pub async fn reject_share(&self, id: &Uuid) -> Result<(), LbErr> {
         let pk = self.get_account()?.public_key();
         let result = self.delete_share(id, Some(pk)).await;

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -81,6 +81,7 @@ impl Lb {
         Ok(SyncStatus { work_units, latest_server_ts })
     }
 
+    #[instrument(level = "debug", skip_all, err(Debug))]
     pub async fn sync(&self, f: Option<Box<dyn Fn(SyncProgress) + Send>>) -> LbResult<SyncStatus> {
         let mut ctx = self.setup_sync(f).await?;
 

--- a/libs/lb/lb-rs/src/service/usage.rs
+++ b/libs/lb/lb-rs/src/service/usage.rs
@@ -22,12 +22,14 @@ pub struct UsageItemMetric {
 }
 
 impl Lb {
+    #[instrument(level = "debug", skip(self))]
     pub async fn get_usage(&self) -> LbResult<UsageMetrics> {
         let acc = self.get_account()?;
         let usage = self.client.request(acc, GetUsageRequest {}).await?;
         Ok(get_usage(usage))
     }
 
+    #[instrument(level = "debug", skip(self))]
     pub async fn get_uncompressed_usage_breakdown(&self) -> LbResult<HashMap<Uuid, usize>> {
         let tx = self.ro_tx().await;
         let db = tx.db();
@@ -50,6 +52,7 @@ impl Lb {
     }
 
     // big async opportunity
+    #[instrument(level = "debug", skip(self))]
     pub async fn get_uncompressed_usage(&self) -> LbResult<UsageItemMetric> {
         let tx = self.ro_tx().await;
         let db = tx.db();


### PR DESCRIPTION
- authors a file anytime a crash is detected
- debug_info now will show the last crash as part of it's output
- amount of logs shown is reduced 
- instrumentation has been updated to show elapsed times
- logs have been expanded to include workspace and other modules

fixes #1110 
fixes #2456 