### PR TITLE
lb: username based feature flags & colors

### DIFF
--- a/libs/lb/lb-rs/src/model/account.rs
+++ b/libs/lb/lb-rs/src/model/account.rs
@@ -123,8 +123,8 @@ impl Account {
     /// color associated with the username. As our platform doesn't have profile pictures this
     /// serves as a secondary queue for identification of people you collaborate with frequently.
     ///
-    /// imagine the blame view of a file color coded. If we can commit to not persisting this value 
-    /// anywhere we can even experiment with more sophisticated color science. Maybe docs.rs 
+    /// imagine the blame view of a file color coded. If we can commit to not persisting this value
+    /// anywhere we can even experiment with more sophisticated color science. Maybe docs.rs
     /// is when we can signal that this color is a stable value. I can see us doing a more HSL
     /// based generation strategy.
     ///
@@ -135,6 +135,16 @@ impl Account {
         let result = hasher.finalize();
 
         (result[0], result[1], result[2])
+    }
+
+    /// A flag for which users have volunteers as beta testers.
+    ///
+    /// Beta users are users to which riskier code is enabled first for testing.
+    /// Beta users are also users who have opted into telemetry by way of approving a PR that adds
+    /// their name to this list. Certainly telemetry in lockbook will always be opt in but the
+    /// mechanism of consent may evolve over time.
+    pub fn is_beta(&self) -> bool {
+        matches!(self.username.as_str(), "parth" | "travis")
     }
 }
 

--- a/libs/lb/lb-rs/src/model/account.rs
+++ b/libs/lb/lb-rs/src/model/account.rs
@@ -121,7 +121,7 @@ impl Account {
     ///
     /// anywhere in the app you see someone's name, a UI developer has the choice to show the
     /// color associated with the username. As our platform doesn't have profile pictures this
-    /// serves as a secondary queue for identification of people you collaborate with frequently.
+    /// serves as a secondary cue for identification of people you collaborate with frequently.
     ///
     /// imagine the blame view of a file color coded. If we can commit to not persisting this value
     /// anywhere we can even experiment with more sophisticated color science. Maybe docs.rs


### PR DESCRIPTION
# Beta Testers

We want to be able to ship risky features like collaboration, but also people are trying to depend on our platform in a more serious capacity. This introduces a lightweight way to determine if a user is a beta user.

This would also be a lightweight way to give an ultra conservative way to add opt in telemetry for this category of user. Telemetry will always be opt-in on lockbook, but potentially we may make the opt in mechanism not require a github account in the future (to record consent).

In that spirit @tvanderstad your approval is required for this PR.

# Username Colors

hashes the username and takes the first three bytes of the has as rgb values
the deterministic color experiment:
                                                                                            
anywhere in the app you see someone's name, a UI developer has the choice to show the
color associated with the username. As our platform doesn't have profile pictures this
serves as a secondary cue for identification of people you collaborate with frequently.
                                                                                            
imagine the blame view of a file color coded. If we can commit to not persisting this value
anywhere we can even experiment with more sophisticated color science. Maybe docs.rs
is when we can signal that this color is a stable value. I can see us doing a more HSL
based generation strategy.
                                                                                            
ultimately if this experiment fails we can explore having server persist this information. 

But meanwhile UI developers are encouraged to begin to experiment with these colors (guarded behind is_beta checks if appropriate).
