### PR TITLE
workspace: change background fill

### DIFF
--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -73,12 +73,12 @@ impl<'window> WgpuWorkspace<'window> {
         self.context.begin_frame(self.raw_input.take());
 
         let workspace_response = egui::CentralPanel::default()
-        .frame(egui::Frame::default().fill(if self.context.style().visuals.dark_mode {
-            egui::Color32::BLACK
-        } else {
-            egui::Color32::WHITE
-        }))
-        .show(&self.context, |ui| self.workspace.show(ui))
+            .frame(egui::Frame::default().fill(if self.context.style().visuals.dark_mode {
+                egui::Color32::BLACK
+            } else {
+                egui::Color32::WHITE
+            }))
+            .show(&self.context, |ui| self.workspace.show(ui))
             .inner;
 
         let full_output = self.context.end_frame();

--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -73,11 +73,7 @@ impl<'window> WgpuWorkspace<'window> {
         self.context.begin_frame(self.raw_input.take());
 
         let workspace_response = egui::CentralPanel::default()
-            .frame(egui::Frame::default().fill(if self.context.style().visuals.dark_mode {
-                egui::Color32::BLACK
-            } else {
-                egui::Color32::WHITE
-            }))
+            .frame(egui::Frame::default().fill(self.context.style().visuals.window_fill))
             .show(&self.context, |ui| self.workspace.show(ui))
             .inner;
 

--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -73,8 +73,12 @@ impl<'window> WgpuWorkspace<'window> {
         self.context.begin_frame(self.raw_input.take());
 
         let workspace_response = egui::CentralPanel::default()
-            .frame(egui::Frame::default().fill(self.context.style().visuals.window_fill))
-            .show(&self.context, |ui| self.workspace.show(ui))
+        .frame(egui::Frame::default().fill(if self.context.style().visuals.dark_mode {
+            egui::Color32::BLACK
+        } else {
+            egui::Color32::WHITE
+        }))
+        .show(&self.context, |ui| self.workspace.show(ui))
             .inner;
 
         let full_output = self.context.end_frame();

--- a/libs/content/workspace/src/theme/visuals.rs
+++ b/libs/content/workspace/src/theme/visuals.rs
@@ -34,8 +34,16 @@ pub fn init(ctx: &egui::Context, dark_mode: bool) {
 
 pub fn dark(primary: ColorAlias) -> egui::Visuals {
     let mut v = egui::Visuals::dark();
-    v.window_fill = Color32::from_rgb(0, 0, 0);
-    v.extreme_bg_color = Color32::from_rgb(0, 0, 0);
+    let is_mobile = cfg!(target_os = "ios") || cfg!(target_os = "android");
+
+    if is_mobile {
+        v.window_fill = Color32::from_rgb(0, 0, 0);
+        v.extreme_bg_color = Color32::from_rgb(0, 0, 0);
+    } else {
+        v.window_fill = Color32::from_rgb(20, 20, 20);
+        v.extreme_bg_color = Color32::from_rgb(20, 20, 20);
+    }
+
     v.faint_bg_color = Color32::from_rgb(35, 35, 37);
     v.widgets.noninteractive.bg_fill = Color32::from_rgb(25, 25, 27);
     v.widgets.noninteractive.fg_stroke.color = Color32::from_rgb(242, 242, 247);

--- a/libs/content/workspace/src/theme/visuals.rs
+++ b/libs/content/workspace/src/theme/visuals.rs
@@ -34,6 +34,8 @@ pub fn init(ctx: &egui::Context, dark_mode: bool) {
 
 pub fn dark(primary: ColorAlias) -> egui::Visuals {
     let mut v = egui::Visuals::dark();
+    v.window_fill = Color32::from_rgb(0, 0, 0);
+    v.extreme_bg_color = Color32::from_rgb(0, 0, 0);
     v.faint_bg_color = Color32::from_rgb(35, 35, 37);
     v.widgets.noninteractive.bg_fill = Color32::from_rgb(25, 25, 27);
     v.widgets.noninteractive.fg_stroke.color = Color32::from_rgb(242, 242, 247);
@@ -45,6 +47,8 @@ pub fn dark(primary: ColorAlias) -> egui::Visuals {
 
 pub fn light(primary: ColorAlias) -> egui::Visuals {
     let mut v = egui::Visuals::light();
+    v.window_fill = Color32::from_rgb(255, 255, 255);
+    v.extreme_bg_color = Color32::from_rgb(255, 255, 255);
     v.widgets.hovered.bg_fill = v.widgets.active.bg_fill;
     v.widgets.active.bg_fill = ThemePalette::LIGHT[primary];
     v


### PR DESCRIPTION
This affects Android and Apple. Mainly did this for iPadOS. This does not affect the egui clients.

iPadOS:
<details>
Main Screen before:

![IMG_0106](https://github.com/user-attachments/assets/2ed6be4c-8606-4c61-92f1-9a7b95a2c624)
Main Screen after:

![IMG_0109](https://github.com/user-attachments/assets/75273f4c-7be8-4a9f-ada0-0ccd18eaa944)
Editor before:

![IMG_0107](https://github.com/user-attachments/assets/9e980d2c-392d-42fb-b850-83c3db11bee5)
Editor after:

![IMG_0110](https://github.com/user-attachments/assets/a597fbe5-7d59-4b9e-93ee-9a1f3a063f9b)
</details>

macOS
<details>
Main Screen before:

<img width="1170" alt="Screenshot 2024-11-20 at 3 22 32 PM" src="https://github.com/user-attachments/assets/1b8351d1-a3a3-4b4e-887a-45d3fa7d6140">
Main Screen after:

<img width="1170" alt="Screenshot 2024-11-20 at 3 24 00 PM" src="https://github.com/user-attachments/assets/5237eff6-61c1-4a15-b6e0-e113eb22f61e">
Editor before:

<img width="1170" alt="Screenshot 2024-11-20 at 3 22 26 PM" src="https://github.com/user-attachments/assets/d022d0ae-cfae-4a57-9d42-ff8da3b0c631">
Editor after:

<img width="1170" alt="Screenshot 2024-11-20 at 3 24 11 PM" src="https://github.com/user-attachments/assets/1d0d660e-0ee1-476e-82ec-023ba9d2da75">


</details>