### PR TITLE
all: no openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -2514,21 +2514,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2541,12 +2532,6 @@ dependencies = [
  "quote",
  "syn 2.0.65",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2788,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "gh_release"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6a9e499ad324676bfed60626791a3c37ca633a58146a118276c1adb0fe0a55"
+checksum = "70b9740022daec827ad262c86a989cce0326932276bdb405b5c51b5e78c6ca8c"
 dependencies = [
  "reqwest",
  "serde",
@@ -3395,19 +3380,6 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -4421,7 +4393,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -4436,7 +4408,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -4573,24 +4545,6 @@ dependencies = [
  "termcolor",
  "thiserror",
  "unicode-xid",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -5080,48 +5034,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "orbclient"
@@ -5955,12 +5871,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding 2.3.1",
  "pin-project-lite",
@@ -5972,7 +5886,6 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url 2.5.2",
@@ -7092,16 +7005,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.65",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/clients/egui/Cargo.toml
+++ b/clients/egui/Cargo.toml
@@ -22,9 +22,7 @@ image = { version = "0.24", default-features = false, features = [
     "bmp",
     "ico",
 ] }
-lb = { package = "lb-rs", path = "../../libs/lb/lb-rs", default-features = false, features = [
-    "native-tls",
-] }
+lb = { package = "lb-rs", path = "../../libs/lb/lb-rs", default-features = false }
 lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
 lbeditor = { package = "egui_editor", path = "../../libs/content/editor/egui_editor" }
 minidom = { git = "https://github.com/lockbook/minidom" }

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -8,9 +8,7 @@ egui = "0.28.1"
 egui_wgpu_backend = "0.30"
 env_logger = "0.10"
 image = "0.24.7"
-lb = { package = "lb-rs", path = "../../libs/lb/lb-rs", default-features = false, features = [
-    "native-tls",
-] }
+lb = { package = "lb-rs", path = "../../libs/lb/lb-rs", default-features = false }
 lbeditor = { package = "egui_editor", path = "../../libs/content/editor/egui_editor" }
 lbeguiapp = { package = "lockbook-egui", path = "../egui", default-features = false, features = [
     "egui_wgpu_backend",

--- a/clients/windows/Cargo.toml
+++ b/clients/windows/Cargo.toml
@@ -10,9 +10,7 @@ egui = "0.28.1"
 egui_wgpu_backend = "0.30"
 env_logger = "0.10"
 image = "0.24.7"
-lb = { package = "lb-rs", path = "../../libs/lb/lb-rs", default-features = false, features = [
-    "native-tls",
-] }
+lb = { package = "lb-rs", path = "../../libs/lb/lb-rs" }
 lbeditor = { package = "egui_editor", path = "../../libs/content/editor/egui_editor" }
 lbeguiapp = { package = "lockbook-egui", path = "../egui", default-features = false, features = [
     "egui_wgpu_backend",

--- a/libs/content/editor/egui_editor/Cargo.toml
+++ b/libs/content/editor/egui_editor/Cargo.toml
@@ -15,13 +15,4 @@ debug-window = ["dep:eframe"]
 egui = "0.28.1"
 workspace = { path = "../../workspace" }
 eframe = { version = "0.28.1", optional = true }
-
-# todo: maybe move this switch into lb itself
-[target.'cfg(not(target_os = "android"))'.dependencies]
-lb = { package = "lb-rs", path = "../../../lb/lb-rs", default-features = false, features = [
-    "native-tls",
-] }
-[target.'cfg(target_os = "android")'.dependencies]
-lb = { package = "lb-rs", path = "../../../lb/lb-rs", default-features = false, features = [
-    "rustls-tls",
-] }
+lb = { package = "lb-rs", path = "../../../lb/lb-rs" }

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -32,21 +32,14 @@ tracing = "0.1.5"
 tracing-test = "0.2.5"
 indexmap = { version = "2.5.0", features = ["rayon"] }
 
-# todo: maybe move this switch into lb itself
-[target.'cfg(not(target_os = "android"))'.dependencies]
-lb-rs = { package = "lb-rs", path = "../../lb/lb-rs", default-features = false, features = [
-    "native-tls",
-] }
-reqwest = { version = "0.11", features = ["blocking"] }
+lb-rs = { path = "../../lb/lb-rs" }
 
-[target.'cfg(target_os = "android")'.dependencies]
-lb-rs = { package = "lb-rs", path = "../../lb/lb-rs", default-features = false, features = [
-    "rustls-tls",
-] }
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",
     "rustls-tls",
 ] }
+
+[target.'cfg(target_os = "android")'.dependencies]
 ndk-sys = "0.4"
 raw-window-handle = "0.6"
 jni = "0.21.0"

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -14,9 +14,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 bench = false
 
 [features]
-default = ["rustls-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
-native-tls = ["reqwest/native-tls"]
+default = []
 no-network = ["db-rs/clone"]
 
 [dependencies]
@@ -27,7 +25,7 @@ bincode = "1.3.3"
 time = "0.3.20"
 diffy = "0.3.0"
 indexmap = { version = "2.5.0", features = ["rayon"] }
-reqwest = { version = "0.11.1", default-features = false, features = ["json"] }
+reqwest = { version = "0.11.1", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 uuid = { version = "1.2.2", features = ["v4", "serde"] }

--- a/utils/dev-tool/Cargo.toml
+++ b/utils/dev-tool/Cargo.toml
@@ -8,4 +8,5 @@ clap = { version = "4.1.4", features = ["derive"] }
 dotenvy = "0.15.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.83"
-reqwest = { version = "0.11.11", features = ["blocking"], default-features = false }
+reqwest = { version = "0.11.11", features = ["blocking", "rustls-tls"], default-features = false }
+

--- a/utils/releaser/Cargo.toml
+++ b/utils/releaser/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 cli-rs = "0.1.12"
-gh_release = "0.1.1"
+gh_release = "0.1.2"
 toml = "0.7.0"
 toml_edit = "0.19.0"
 sha2 = "0.10.2"


### PR DESCRIPTION
try to use rustls-tls for everything. I believe we did native-tls for windows on arm but I see some language in the BUILDING.md that makes me feel like it shouldn't be a problem: https://github.com/briansmith/ring/blob/main/BUILDING.md

if we need to we can re-introduce native-tls just for windows, possibly just for windows on arm. But as it stood we were depending on native-tls for everything which is an annoying dependency to satisfy everywhere.