### PR TITLE
egui: file tree refinements

### DIFF
--- a/clients/egui/src/account/modals/file_picker.rs
+++ b/clients/egui/src/account/modals/file_picker.rs
@@ -222,7 +222,6 @@ fn show_node(
     if Button::default()
         .text(node.name.clone().as_str())
         .icon(&Icon::FOLDER)
-        .icon_style(icon_style)
         .show(ui)
         .clicked()
     {

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -741,8 +741,6 @@ impl FileTree {
                     } else {
                         // focus to suggested
                         ui.memory_mut(|m| m.request_focus(suggested_docs_id));
-                        self.selected.clear();
-                        self.cut.clear();
                         self.cursor = if self.expanded.contains(&self.suggested_docs_folder_id) {
                             self.suggested_docs.lock().unwrap().last().copied()
                         } else {
@@ -825,9 +823,7 @@ impl FileTree {
             }
         }
 
-        if ui
-            .memory(|m| m.has_focus(Id::new("suggested_docs")) || m.has_focus(Id::new("file_tree")))
-        {
+        if ui.memory(|m| m.has_focus(suggested_docs_id) || m.has_focus(file_tree_id)) {
             // enter/space: open selected files or toggle folder expansion
             if ui.input_mut(|i| {
                 i.consume_key(Modifiers::NONE, Key::Enter)
@@ -861,6 +857,11 @@ impl FileTree {
                     self.expanded.retain(|id| !expanded_folders.contains(id));
                 }
             }
+        }
+
+        if !ui.memory(|m| m.has_focus(file_tree_id)) {
+            self.selected.clear();
+            self.cut.clear();
         }
 
         resp

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -10,7 +10,7 @@ use std::{
 
 use egui::{
     text_edit::TextEditState, Color32, Context, Event, EventFilter, Id, Key, LayerId, Modifiers,
-    Order, Pos2, Rect, Sense, TextEdit, Ui, Vec2, WidgetText,
+    Order, Pos2, Rect, Sense, Style, TextEdit, Ui, Vec2, WidgetText,
 };
 use lb::{
     blocking::Lb,
@@ -1051,7 +1051,7 @@ impl FileTree {
                 ui.memory_mut(|m| m.request_focus(file_tree_id));
             }
 
-            return resp;
+            return resp; // note: early return
         }
 
         // render
@@ -1085,6 +1085,7 @@ impl FileTree {
 
             let file_resp = Button::default()
                 .icon(icon)
+                .icon_color(ui.style().visuals.widgets.active.bg_fill)
                 .text(text)
                 .default_fill(default_fill)
                 .frame(true)

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -261,6 +261,8 @@ impl Editor {
                     continue;
                 }
 
+                ctx.memory_mut(|m| m.request_focus(self.id()));
+
                 return vec![Event::Select { region }];
             }
         }

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -7,7 +7,7 @@ pub struct Button<'a> {
     icon: Option<&'a Icon>,
     text: Option<WidgetText>,
     text_style: Option<egui::TextStyle>,
-    icon_style: Option<egui::Style>,
+    icon_color: Option<egui::Color32>,
     icon_alignment: Option<egui::Align>,
     padding: Option<egui::Vec2>,
     is_loading: bool,
@@ -41,8 +41,8 @@ impl<'a> Button<'a> {
         Self { text_style: Some(text_style), ..self }
     }
 
-    pub fn icon_style(self, icon_style: egui::Style) -> Self {
-        Self { icon_style: Some(icon_style), ..self }
+    pub fn icon_color(self, icon_color: egui::Color32) -> Self {
+        Self { icon_color: Some(icon_color), ..self }
     }
 
     pub fn padding(self, padding: impl Into<egui::Vec2>) -> Self {
@@ -109,9 +109,7 @@ impl<'a> Button<'a> {
 
         if ui.is_rect_visible(rect) {
             let text_visuals = ui.style().interact(&resp).to_owned();
-            let icon_visuals = self.icon_style.as_ref().unwrap_or(ui.style().as_ref());
-            let icon_visuals = icon_visuals.interact(&resp);
-            let icon_color = icon_visuals.text_color();
+            let icon_color = self.icon_color.unwrap_or(text_visuals.text_color());
 
             // In stark contrast to its documentation, resp.hovered() is often true even if something is being dragged
             // and even when it does not contain the pointer! Some suffering occurred here to get desirable behavior.


### PR DESCRIPTION
Fixes the following issues based on @Parth's feedback in [discord](https://discord.com/channels/1014184997751619664/1026208854280777789/1319090707558039665):
* [x] drag too sensitive (spatially)
* [x] folder auto expand too sensitive (spatially)
* [x] add color (blue folder icons?)
* [x] interacting with editor should focus editor

Made issues for unaddressed feedback:
* https://github.com/lockbook/lockbook/issues/3225
* https://github.com/lockbook/lockbook/issues/3226
* https://github.com/lockbook/lockbook/issues/3227
* https://github.com/lockbook/lockbook/issues/3228

<details>
![image](https://github.com/user-attachments/assets/e47d8e53-55c4-43c5-9f84-bfc087c39116)

</details>