### PR TITLE
lb-rs: perf inquiry ch 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
- [profile.release]
- debug = true
-
+#  [profile.release]
+#  debug = true
 # [profile.bench]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
-#  [profile.release]
-#  debug = true
+[profile.release]
+debug = true
 # [profile.bench]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,8 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
-# [profile.release]
+ [profile.release]
+ debug = true
+
+# [profile.bench]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true
 # [profile.bench]
 # debug = true

--- a/clients/cli/src/lb_fs.rs
+++ b/clients/cli/src/lb_fs.rs
@@ -1,7 +1,8 @@
-use crate::{core, ensure_account, input, writable_path};
+use crate::{core, ensure_account, input};
 use cli_rs::cli_error::CliResult;
 use fs_extra::dir::CopyOptions;
 use lb_fs::fs_impl::Drive;
+use lb_rs::model::core_config::Config;
 
 #[tokio::main]
 pub async fn mount() -> CliResult<()> {
@@ -23,7 +24,7 @@ fn warning() -> CliResult<()> {
 }
 
 fn copy_data() -> CliResult<()> {
-    let current_path = writable_path()?;
+    let current_path = Config::cli_config().writeable_path;
     let target_path = format!("{}/.lockbook/drive", std::env::var("HOME").unwrap());
 
     fs_extra::copy_items(

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -217,22 +217,8 @@ fn main() {
     run().exit();
 }
 
-fn writable_path() -> CliResult<String> {
-    let specified_path = env::var("LOCKBOOK_PATH");
-
-    let default_path = env::var("HOME") // unix
-        .or(env::var("HOMEPATH")) // windows
-        .map(|home| format!("{home}/.lockbook/cli"));
-
-    Ok(specified_path
-        .or(default_path)
-        .map_err(|_| "no cli location")?)
-}
-
 pub async fn core() -> CliResult<Lb> {
-    let writeable_path = writable_path()?;
-
-    Lb::init(Config { writeable_path, logs: true, colored_logs: true, background_work: false })
+    Lb::init(Config::cli_config())
         .await
         .map_err(|err| CliError::from(err.to_string()))
 }

--- a/clients/linux/default.nix
+++ b/clients/linux/default.nix
@@ -1,0 +1,64 @@
+# This file is only relevant for Nix and NixOS users.
+# What's actually meant by "Nix" here is not UNIX, but the *package manager* Nix, see https://nixos.org/.
+# If you are
+#   on macOS (and not using nix-darwin)
+#   or on Windows (and not using Nix in WSL),
+# you can carelessly ignore this file.
+#
+# Otherwise, if you *do* use Nix the package manager,
+# this file declares
+#   common dependencies
+#   and some nice tools
+# which you'll most likely need when working with wgpu.
+# Feel free to copy it into your own project if deemed useful.
+#
+# To use this file, just run `nix-shell` in this folder,
+# which will drop you into a shell
+# with all the deps needed for building wgpu available.
+#
+# Or if you're using direnv (https://direnv.net/),
+# use `direnv allow` to automatically always use this file
+# if you're navigating into this or a subfolder.
+
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell rec {
+  buildInputs = with pkgs; [
+    # necessary for building wgpu in 3rd party packages (in most cases)
+    libxkbcommon
+    wayland xorg.libX11 xorg.libXcursor xorg.libXrandr xorg.libXi
+    alsa-lib
+    fontconfig freetype
+    shaderc directx-shader-compiler
+    pkg-config cmake
+    mold # could use any linker, needed for rustix (but mold is fast)
+
+    libGL
+    vulkan-headers vulkan-loader
+    vulkan-tools vulkan-tools-lunarg
+    vulkan-extension-layer
+    vulkan-validation-layers # don't need them *strictly* but immensely helpful
+
+    # necessary for developing (all of) wgpu itself
+    # cargo-nextest cargo-fuzz
+
+    # nice for developing wgpu itself
+    # typos 
+
+    # # if you don't already have rust installed through other means,
+    # # this shell.nix can do that for you with this below
+    # yq # for tomlq below
+    # rustup
+
+    # # nice tools
+    # gdb rr
+    # evcxr
+    # valgrind
+    # renderdoc
+  ];
+
+  shellHook = ''
+    export PATH="$PATH:''${CARGO_HOME:-~/.cargo}/bin"
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${builtins.toString (pkgs.lib.makeLibraryPath buildInputs)}";
+  '';
+}

--- a/libs/lb/lb-rs/src/logic/core_ops.rs
+++ b/libs/lb/lb-rs/src/logic/core_ops.rs
@@ -4,11 +4,12 @@ use crate::logic::secret_filename::{HmacSha256, SecretFileName};
 use crate::logic::signed_file::SignedFile;
 use crate::logic::staged::{StagedTree, StagedTreeLike};
 use crate::logic::tree_like::{TreeLike, TreeLikeMut};
-use crate::logic::{compression_service, symkey, validate, SharedErrorKind, SharedResult};
+use crate::logic::{compression_service, symkey, validate};
 use crate::model::access_info::{UserAccessInfo, UserAccessMode};
-use crate::model::account::Account;
+use crate::model::errors::{LbErrKind, LbResult};
 use crate::model::file::{File, Share, ShareMode};
 use crate::model::file_metadata::{FileMetadata, FileType, Owner};
+use crate::service::keychain::Keychain;
 use db_rs::LookupTable;
 use hmac::{Mac, NewMac};
 use libsecp256k1::PublicKey;
@@ -26,12 +27,15 @@ where
 {
     /// convert FileMetadata into File. fields have been decrypted, public keys replaced with usernames, deleted files filtered out, etc.
     pub fn decrypt(
-        &mut self, account: &Account, id: &Uuid, public_key_cache: &LookupTable<Owner, String>,
-    ) -> SharedResult<File> {
+        &mut self, keychain: &Keychain, id: &Uuid, public_key_cache: &LookupTable<Owner, String>,
+    ) -> LbResult<File> {
+        let account = keychain.get_account()?;
+        let pk = keychain.get_pk()?;
+
         let meta = self.find(id)?.clone();
         let file_type = meta.file_type();
         let last_modified = meta.timestamped_value.timestamp as u64;
-        let name = self.name_using_links(id, account)?;
+        let name = self.name_using_links(id, keychain)?;
         let parent = self.parent_using_links(id)?;
         let last_modified_by = account.username.clone();
         let id = *id;
@@ -48,7 +52,7 @@ where
             };
             shares.push(Share {
                 mode,
-                shared_by: if user_access_key.encrypted_by == account.public_key() {
+                shared_by: if user_access_key.encrypted_by == pk {
                     account.username.clone()
                 } else {
                     public_key_cache
@@ -57,7 +61,7 @@ where
                         .cloned()
                         .unwrap_or_else(|| String::from("<unknown>"))
                 },
-                shared_with: if user_access_key.encrypted_for == account.public_key() {
+                shared_with: if user_access_key.encrypted_for == pk {
                     account.username.clone()
                 } else {
                     public_key_cache
@@ -74,9 +78,9 @@ where
 
     /// convert FileMetadata into File. fields have been decrypted, public keys replaced with usernames, deleted files filtered out, etc.
     pub fn decrypt_all<I>(
-        &mut self, account: &Account, ids: I, public_key_cache: &LookupTable<Owner, String>,
+        &mut self, keychain: &Keychain, ids: I, public_key_cache: &LookupTable<Owner, String>,
         skip_invisible: bool,
-    ) -> SharedResult<Vec<File>>
+    ) -> LbResult<Vec<File>>
     where
         I: Iterator<Item = Uuid>,
     {
@@ -87,14 +91,14 @@ where
                 continue;
             }
 
-            let finalized = self.decrypt(account, &id, public_key_cache)?;
+            let finalized = self.decrypt(keychain, &id, public_key_cache)?;
             files.push(finalized);
         }
 
         Ok(files)
     }
 
-    fn is_invisible_id(&mut self, id: Uuid) -> SharedResult<bool> {
+    fn is_invisible_id(&mut self, id: Uuid) -> LbResult<bool> {
         Ok(self.find(&id)?.is_link()
             || self.calculate_deleted(&id)?
             || self.in_pending_share(&id)?)
@@ -102,18 +106,18 @@ where
 
     pub fn create_op(
         &mut self, id: Uuid, key: AESKey, parent: &Uuid, name: &str, file_type: FileType,
-        account: &Account,
-    ) -> SharedResult<(SignedFile, Uuid)> {
+        keychain: &Keychain,
+    ) -> LbResult<(SignedFile, Uuid)> {
         validate::file_name(name)?;
 
         if self.maybe_find(parent).is_none() {
-            return Err(SharedErrorKind::FileParentNonexistent.into());
+            return Err(LbErrKind::FileParentNonexistent.into());
         }
         let parent_owner = self.find(parent)?.owner().0;
-        let parent_key = self.decrypt_key(parent, account)?;
+        let parent_key = self.decrypt_key(parent, keychain)?;
         let file =
             FileMetadata::create(id, key, &parent_owner, *parent, &parent_key, name, file_type)?
-                .sign(account)?;
+                .sign(keychain)?;
         let id = *file.id();
 
         debug!("new {:?} with id: {}", file_type, id);
@@ -121,37 +125,37 @@ where
     }
 
     pub fn rename_op(
-        &mut self, id: &Uuid, name: &str, account: &Account,
-    ) -> SharedResult<SignedFile> {
+        &mut self, id: &Uuid, name: &str, keychain: &Keychain,
+    ) -> LbResult<SignedFile> {
         let mut file = self.find(id)?.timestamped_value.value.clone();
 
         validate::file_name(name)?;
         if self.maybe_find(file.parent()).is_none() {
-            return Err(SharedErrorKind::InsufficientPermission.into());
+            return Err(LbErrKind::InsufficientPermission.into());
         }
-        let parent_key = self.decrypt_key(file.parent(), account)?;
-        let key = self.decrypt_key(id, account)?;
+        let parent_key = self.decrypt_key(file.parent(), keychain)?;
+        let key = self.decrypt_key(id, keychain)?;
         file.name = SecretFileName::from_str(name, &key, &parent_key)?;
-        let file = file.sign(account)?;
+        let file = file.sign(keychain)?;
 
         Ok(file)
     }
 
     pub fn move_op(
-        &mut self, id: &Uuid, new_parent: &Uuid, account: &Account,
-    ) -> SharedResult<Vec<SignedFile>> {
+        &mut self, id: &Uuid, new_parent: &Uuid, keychain: &Keychain,
+    ) -> LbResult<Vec<SignedFile>> {
         let mut file = self.find(id)?.timestamped_value.value.clone();
         if self.maybe_find(new_parent).is_none() {
-            return Err(SharedErrorKind::FileParentNonexistent.into());
+            return Err(LbErrKind::FileParentNonexistent.into());
         }
-        let key = self.decrypt_key(id, account)?;
-        let parent_key = self.decrypt_key(new_parent, account)?;
+        let key = self.decrypt_key(id, keychain)?;
+        let parent_key = self.decrypt_key(new_parent, keychain)?;
         let owner = self.find(new_parent)?.owner();
         file.owner = owner;
         file.parent = *new_parent;
         file.folder_access_key = symkey::encrypt(&parent_key, &key)?;
-        file.name = SecretFileName::from_str(&self.name(id, account)?, &key, &parent_key)?;
-        let file = file.sign(account)?;
+        file.name = SecretFileName::from_str(&self.name(id, keychain)?, &key, &parent_key)?;
+        let file = file.sign(keychain)?;
 
         let mut result = vec![file];
         for id in self.descendants(id)? {
@@ -160,38 +164,38 @@ where
             }
             let mut descendant = self.find(&id)?.timestamped_value.value.clone();
             descendant.owner = owner;
-            result.push(descendant.sign(account)?);
+            result.push(descendant.sign(keychain)?);
         }
 
         Ok(result)
     }
 
-    pub fn delete_op(&self, id: &Uuid, account: &Account) -> SharedResult<SignedFile> {
+    pub fn delete_op(&self, id: &Uuid, keychain: &Keychain) -> LbResult<SignedFile> {
         let mut file = self.find(id)?.timestamped_value.value.clone();
 
         file.is_deleted = true;
-        let file = file.sign(account)?;
+        let file = file.sign(keychain)?;
 
         Ok(file)
     }
 
     pub fn add_share_op(
-        &mut self, id: Uuid, sharee: Owner, mode: ShareMode, account: &Account,
-    ) -> SharedResult<SignedFile> {
-        let owner = Owner(account.public_key());
+        &mut self, id: Uuid, sharee: Owner, mode: ShareMode, keychain: &Keychain,
+    ) -> LbResult<SignedFile> {
+        let owner = Owner(keychain.get_pk()?);
         let access_mode = match mode {
             ShareMode::Write => UserAccessMode::Write,
             ShareMode::Read => UserAccessMode::Read,
         };
         if self.calculate_deleted(&id)? {
-            return Err(SharedErrorKind::FileNonexistent.into());
+            return Err(LbErrKind::FileNonexistent.into());
         }
         let id =
             if let FileType::Link { target } = self.find(&id)?.file_type() { target } else { id };
         let mut file = self.find(&id)?.timestamped_value.value.clone();
         validate::not_root(&file)?;
         if mode == ShareMode::Write && file.owner.0 != owner.0 {
-            return Err(SharedErrorKind::InsufficientPermission.into());
+            return Err(LbErrKind::InsufficientPermission.into());
         }
         // check for and remove duplicate shares
         let mut found = false;
@@ -199,7 +203,7 @@ where
             if user_access.encrypted_for == sharee.0 {
                 found = true;
                 if user_access.mode == access_mode && !user_access.deleted {
-                    return Err(SharedErrorKind::DuplicateShare.into());
+                    return Err(LbErrKind::ShareAlreadyExists.into());
                 }
             }
         }
@@ -208,20 +212,20 @@ where
                 .retain(|k| k.encrypted_for != sharee.0);
         }
         file.user_access_keys.push(UserAccessInfo::encrypt(
-            account,
+            keychain.get_account()?,
             &owner.0,
             &sharee.0,
-            &self.decrypt_key(&id, account)?,
+            &self.decrypt_key(&id, keychain)?,
             access_mode,
         )?);
-        let file = file.sign(account)?;
+        let file = file.sign(keychain)?;
 
         Ok(file)
     }
 
     pub fn delete_share_op(
-        &mut self, id: &Uuid, maybe_encrypted_for: Option<PublicKey>, account: &Account,
-    ) -> SharedResult<Vec<SignedFile>> {
+        &mut self, id: &Uuid, maybe_encrypted_for: Option<PublicKey>, keychain: &Keychain,
+    ) -> LbResult<Vec<SignedFile>> {
         let mut result = Vec::new();
         let mut file = self.find(id)?.timestamped_value.value.clone();
 
@@ -238,17 +242,17 @@ where
             }
         }
         if !found {
-            return Err(SharedErrorKind::ShareNonexistent.into());
+            return Err(LbErrKind::ShareNonexistent.into());
         }
-        result.push(file.sign(account)?);
+        result.push(file.sign(keychain)?);
 
         // delete any links pointing to file
         if let Some(encrypted_for) = maybe_encrypted_for {
-            if encrypted_for == account.public_key() {
+            if encrypted_for == keychain.get_pk()? {
                 if let Some(link) = self.linked_by(id)? {
                     let mut link = self.find(&link)?.timestamped_value.value.clone();
                     link.is_deleted = true;
-                    result.push(link.sign(account)?);
+                    result.push(link.sign(keychain)?);
                 }
             }
         }
@@ -257,9 +261,9 @@ where
     }
 
     pub fn decrypt_document(
-        &mut self, id: &Uuid, doc: &EncryptedDocument, account: &Account,
-    ) -> SharedResult<DecryptedDocument> {
-        let key = self.decrypt_key(id, account)?;
+        &mut self, id: &Uuid, doc: &EncryptedDocument, keychain: &Keychain,
+    ) -> LbResult<DecryptedDocument> {
+        let key = self.decrypt_key(id, keychain)?;
         let compressed = symkey::decrypt(&key, doc)?;
         let doc = compression_service::decompress(&compressed)?;
 
@@ -267,24 +271,24 @@ where
     }
 
     pub fn update_document_op(
-        &mut self, id: &Uuid, document: &[u8], account: &Account,
-    ) -> SharedResult<(SignedFile, EncryptedDocument)> {
+        &mut self, id: &Uuid, document: &[u8], keychain: &Keychain,
+    ) -> LbResult<(SignedFile, EncryptedDocument)> {
         let id = match self.find(id)?.file_type() {
             FileType::Document | FileType::Folder => *id,
             FileType::Link { target } => target,
         };
         let mut file: FileMetadata = self.find(&id)?.timestamped_value.value.clone();
         validate::is_document(&file)?;
-        let key = self.decrypt_key(&id, account)?;
+        let key = self.decrypt_key(&id, keychain)?;
         let hmac = {
-            let mut mac =
-                HmacSha256::new_from_slice(&key).map_err(SharedErrorKind::HmacCreationError)?;
+            let mut mac = HmacSha256::new_from_slice(&key)
+                .map_err(|err| LbErrKind::Unexpected(format!("hmac creation error: {:?}", err)))?;
             mac.update(document);
             mac.finalize().into_bytes()
         }
         .into();
         file.document_hmac = Some(hmac);
-        let file = file.sign(account)?;
+        let file = file.sign(keychain)?;
         let document = compression_service::compress(document)?;
         let document = symkey::encrypt(&key, &document)?;
 
@@ -300,116 +304,114 @@ where
 {
     pub fn create_unvalidated(
         &mut self, id: Uuid, key: AESKey, parent: &Uuid, name: &str, file_type: FileType,
-        account: &Account,
-    ) -> SharedResult<Uuid> {
-        let (op, id) = self.create_op(id, key, parent, name, file_type, account)?;
+        keychain: &Keychain,
+    ) -> LbResult<Uuid> {
+        let (op, id) = self.create_op(id, key, parent, name, file_type, keychain)?;
         self.stage_and_promote(Some(op))?;
         Ok(id)
     }
 
     pub fn create(
         &mut self, id: Uuid, key: AESKey, parent: &Uuid, name: &str, file_type: FileType,
-        account: &Account,
-    ) -> SharedResult<Uuid> {
+        keychain: &Keychain,
+    ) -> LbResult<Uuid> {
         if self.calculate_deleted(parent)? {
-            return Err(SharedErrorKind::FileParentNonexistent.into());
+            return Err(LbErrKind::FileParentNonexistent.into());
         }
 
-        let (op, id) = self.create_op(id, key, parent, name, file_type, account)?;
-        self.stage_validate_and_promote(Some(op), Owner(account.public_key()))?;
+        let (op, id) = self.create_op(id, key, parent, name, file_type, keychain)?;
+        self.stage_validate_and_promote(Some(op), Owner(keychain.get_pk()?))?;
         Ok(id)
     }
 
     pub fn rename_unvalidated(
-        &mut self, id: &Uuid, name: &str, account: &Account,
-    ) -> SharedResult<()> {
-        let op = self.rename_op(id, name, account)?;
+        &mut self, id: &Uuid, name: &str, keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.rename_op(id, name, keychain)?;
         self.stage_and_promote(Some(op))?;
         Ok(())
     }
 
-    pub fn rename(&mut self, id: &Uuid, name: &str, account: &Account) -> SharedResult<()> {
-        let op = self.rename_op(id, name, account)?;
-        self.stage_validate_and_promote(Some(op), Owner(account.public_key()))?;
+    pub fn rename(&mut self, id: &Uuid, name: &str, keychain: &Keychain) -> LbResult<()> {
+        let op = self.rename_op(id, name, keychain)?;
+        self.stage_validate_and_promote(Some(op), Owner(keychain.get_pk()?))?;
         Ok(())
     }
 
     pub fn move_unvalidated(
-        &mut self, id: &Uuid, new_parent: &Uuid, account: &Account,
-    ) -> SharedResult<()> {
-        let op = self.move_op(id, new_parent, account)?;
+        &mut self, id: &Uuid, new_parent: &Uuid, keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.move_op(id, new_parent, keychain)?;
         self.stage_and_promote(op)?;
         Ok(())
     }
 
-    pub fn move_file(
-        &mut self, id: &Uuid, new_parent: &Uuid, account: &Account,
-    ) -> SharedResult<()> {
+    pub fn move_file(&mut self, id: &Uuid, new_parent: &Uuid, keychain: &Keychain) -> LbResult<()> {
         if self.maybe_find(new_parent).is_none() || self.calculate_deleted(new_parent)? {
-            return Err(SharedErrorKind::FileParentNonexistent.into());
+            return Err(LbErrKind::FileParentNonexistent.into());
         }
-        let op = self.move_op(id, new_parent, account)?;
-        self.stage_validate_and_promote(op, Owner(account.public_key()))?;
+        let op = self.move_op(id, new_parent, keychain)?;
+        self.stage_validate_and_promote(op, Owner(keychain.get_pk()?))?;
         Ok(())
     }
 
-    pub fn delete_unvalidated(&mut self, id: &Uuid, account: &Account) -> SharedResult<()> {
-        let op = self.delete_op(id, account)?;
+    pub fn delete_unvalidated(&mut self, id: &Uuid, keychain: &Keychain) -> LbResult<()> {
+        let op = self.delete_op(id, keychain)?;
         self.stage_and_promote(Some(op))?;
         Ok(())
     }
 
-    pub fn delete(&mut self, id: &Uuid, account: &Account) -> SharedResult<()> {
-        let op = self.delete_op(id, account)?;
-        self.stage_validate_and_promote(Some(op), Owner(account.public_key()))?;
+    pub fn delete(&mut self, id: &Uuid, keychain: &Keychain) -> LbResult<()> {
+        let op = self.delete_op(id, keychain)?;
+        self.stage_validate_and_promote(Some(op), Owner(keychain.get_pk()?))?;
         Ok(())
     }
 
     pub fn add_share_unvalidated(
-        &mut self, id: Uuid, sharee: Owner, mode: ShareMode, account: &Account,
-    ) -> SharedResult<()> {
-        let op = self.add_share_op(id, sharee, mode, account)?;
+        &mut self, id: Uuid, sharee: Owner, mode: ShareMode, keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.add_share_op(id, sharee, mode, keychain)?;
         self.stage_and_promote(Some(op))?;
         Ok(())
     }
 
     pub fn add_share(
-        &mut self, id: Uuid, sharee: Owner, mode: ShareMode, account: &Account,
-    ) -> SharedResult<()> {
-        let op = self.add_share_op(id, sharee, mode, account)?;
-        self.stage_validate_and_promote(Some(op), Owner(account.public_key()))?;
+        &mut self, id: Uuid, sharee: Owner, mode: ShareMode, keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.add_share_op(id, sharee, mode, keychain)?;
+        self.stage_validate_and_promote(Some(op), Owner(keychain.get_pk()?))?;
         Ok(())
     }
 
     pub fn delete_share_unvalidated(
-        &mut self, id: &Uuid, maybe_encrypted_for: Option<PublicKey>, account: &Account,
-    ) -> SharedResult<()> {
-        let op = self.delete_share_op(id, maybe_encrypted_for, account)?;
+        &mut self, id: &Uuid, maybe_encrypted_for: Option<PublicKey>, keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.delete_share_op(id, maybe_encrypted_for, keychain)?;
         self.stage_and_promote(op)?;
         Ok(())
     }
 
     pub fn delete_share(
-        &mut self, id: &Uuid, maybe_encrypted_for: Option<PublicKey>, account: &Account,
-    ) -> SharedResult<()> {
-        let op = self.delete_share_op(id, maybe_encrypted_for, account)?;
-        self.stage_validate_and_promote(op, Owner(account.public_key()))?;
+        &mut self, id: &Uuid, maybe_encrypted_for: Option<PublicKey>, keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.delete_share_op(id, maybe_encrypted_for, keychain)?;
+        self.stage_validate_and_promote(op, Owner(keychain.get_pk()?))?;
         Ok(())
     }
 
     pub fn update_document_unvalidated(
-        &mut self, id: &Uuid, document: &[u8], account: &Account,
-    ) -> SharedResult<EncryptedDocument> {
-        let (op, document) = self.update_document_op(id, document, account)?;
+        &mut self, id: &Uuid, document: &[u8], keychain: &Keychain,
+    ) -> LbResult<EncryptedDocument> {
+        let (op, document) = self.update_document_op(id, document, keychain)?;
         self.stage_and_promote(Some(op))?;
         Ok(document)
     }
 
     pub fn update_document(
-        &mut self, id: &Uuid, document: &[u8], account: &Account,
-    ) -> SharedResult<EncryptedDocument> {
-        let (op, document) = self.update_document_op(id, document, account)?;
-        self.stage_validate_and_promote(Some(op), Owner(account.public_key()))?;
+        &mut self, id: &Uuid, document: &[u8], keychain: &Keychain,
+    ) -> LbResult<EncryptedDocument> {
+        let (op, document) = self.update_document_op(id, document, keychain)?;
+        self.stage_validate_and_promote(Some(op), Owner(keychain.get_pk()?))?;
         Ok(document)
     }
 }

--- a/libs/lb/lb-rs/src/logic/core_tree.rs
+++ b/libs/lb/lb-rs/src/logic/core_tree.rs
@@ -2,7 +2,6 @@ use crate::logic::file_like::FileLike;
 use crate::logic::tree_like::{TreeLike, TreeLikeMut};
 use crate::logic::SharedResult;
 use serde::Serialize;
-use std::collections::HashSet;
 use uuid::Uuid;
 
 impl<F> TreeLike for db_rs::LookupTable<Uuid, F>
@@ -11,8 +10,8 @@ where
 {
     type F = F;
 
-    fn ids(&self) -> HashSet<&Uuid> {
-        self.get().keys().collect()
+    fn ids(&self) -> Vec<Uuid> {
+        self.get().keys().copied().collect()
     }
 
     fn maybe_find(&self, id: &Uuid) -> Option<&Self::F> {

--- a/libs/lb/lb-rs/src/logic/lazy.rs
+++ b/libs/lb/lb-rs/src/logic/lazy.rs
@@ -198,7 +198,7 @@ impl<T: TreeLike> LazyTree<T> {
     }
 
     pub fn linked_by(&mut self, id: &Uuid) -> SharedResult<Option<Uuid>> {
-        for link_id in self.owned_ids() {
+        for link_id in self.ids() {
             if let FileType::Link { target } = self.find(&link_id)?.file_type() {
                 if id == &target && !self.calculate_deleted(&link_id)? {
                     return Ok(Some(link_id));
@@ -315,6 +315,7 @@ impl<T: TreeLike> LazyTree<T> {
         }
     }
 
+    // todo: this is dead code
     pub fn stage_removals(self, removed: HashSet<Uuid>) -> LazyTree<StagedTree<T, Option<T::F>>> {
         // todo: optimize by performing minimal updates on self caches
         LazyTree::<StagedTree<T, Option<T::F>>> {
@@ -327,7 +328,7 @@ impl<T: TreeLike> LazyTree<T> {
 
     // todo: optimize
     pub fn assert_names_decryptable(&mut self, keychain: &Keychain) -> SharedResult<()> {
-        for id in self.owned_ids() {
+        for id in self.ids() {
             if self.name(&id, keychain).is_err() {
                 return Err(SharedErrorKind::ValidationFailure(
                     ValidationFailure::NonDecryptableFileName(id),
@@ -366,7 +367,7 @@ where
     pub fn stage_and_promote<S: TreeLikeMut<F = T::F>>(
         &mut self, mut staged: S,
     ) -> SharedResult<()> {
-        for id in staged.owned_ids() {
+        for id in staged.ids() {
             if let Some(removed) = staged.remove(id)? {
                 self.tree.insert(removed)?;
             }
@@ -388,6 +389,7 @@ where
         Ok(())
     }
 
+    // todo: this is dead code
     pub fn stage_removals_and_promote(&mut self, removed: HashSet<Uuid>) -> SharedResult<()> {
         for id in removed {
             self.tree.remove(id)?;
@@ -409,7 +411,7 @@ where
     pub fn promote(self) -> SharedResult<LazyTree<Base>> {
         let mut staged = self.tree.staged;
         let mut base = self.tree.base;
-        for id in staged.owned_ids() {
+        for id in staged.ids() {
             if let Some(removed) = staged.remove(id)? {
                 base.insert(removed)?;
             }
@@ -449,7 +451,7 @@ where
 impl<T: TreeLike> TreeLike for LazyTree<T> {
     type F = T::F;
 
-    fn ids(&self) -> HashSet<&Uuid> {
+    fn ids(&self) -> Vec<Uuid> {
         self.tree.ids()
     }
 

--- a/libs/lb/lb-rs/src/logic/path_ops.rs
+++ b/libs/lb/lb-rs/src/logic/path_ops.rs
@@ -91,8 +91,8 @@ where
             Some(Filter::DocumentsOnly) => {
                 let mut ids = HashSet::new();
                 for id in self.ids() {
-                    if self.find(id)?.is_document() {
-                        ids.insert(*id);
+                    if self.find(&id)?.is_document() {
+                        ids.insert(id);
                     }
                 }
                 ids
@@ -100,20 +100,20 @@ where
             Some(Filter::FoldersOnly) => {
                 let mut ids = HashSet::new();
                 for id in self.ids() {
-                    if self.find(id)?.is_folder() {
-                        ids.insert(*id);
+                    if self.find(&id)?.is_folder() {
+                        ids.insert(id);
                     }
                 }
                 ids
             }
             Some(Filter::LeafNodesOnly) => {
-                let mut retained = self.owned_ids();
+                let mut retained: HashSet<Uuid> = self.ids().into_iter().collect();
                 for id in self.ids() {
-                    retained.remove(self.find(id)?.parent());
+                    retained.remove(self.find(&id)?.parent());
                 }
                 retained
             }
-            None => self.owned_ids(),
+            None => self.ids().into_iter().collect(),
         };
 
         // remove deleted; include links not linked files

--- a/libs/lb/lb-rs/src/logic/server_ops.rs
+++ b/libs/lb/lb-rs/src/logic/server_ops.rs
@@ -14,10 +14,8 @@ impl<'a> LazyTree<ServerTree<'a>> {
     /// Validates a diff prior to staging it. Performs individual validations, then validations that
     /// require a tree
     pub fn stage_diff(
-        mut self, changes: Vec<FileDiff<SignedFile>>,
+        self, changes: Vec<FileDiff<SignedFile>>,
     ) -> SharedResult<LazyServerStaged1<'a>> {
-        self.tree.ids.extend(changes.iter().map(|diff| *diff.id()));
-
         // Check new.id == old.id
         for change in &changes {
             if let Some(old) = &change.old {
@@ -58,7 +56,8 @@ impl<'a> LazyTree<ServerTree<'a>> {
                     }
                 }
                 None => {
-                    if self.maybe_find(change.new.id()).is_some() {
+                    // if you're claiming this file is new, it must be globally unique
+                    if self.tree.files.maybe_find(change.new.id()).is_some() {
                         return Err(SharedErrorKind::OldVersionRequired.into());
                     }
                 }

--- a/libs/lb/lb-rs/src/logic/server_tree.rs
+++ b/libs/lb/lb-rs/src/logic/server_tree.rs
@@ -43,6 +43,8 @@ impl<'a> ServerTree<'a> {
             to_get_descendants.extend(children);
         }
 
+        debug!("server tree created with ids: {:?}", ids);
+
         Ok(Self { ids, owned_files, shared_files, file_children, files })
     }
 }
@@ -50,8 +52,8 @@ impl<'a> ServerTree<'a> {
 impl TreeLike for ServerTree<'_> {
     type F = ServerFile;
 
-    fn ids(&self) -> HashSet<&Uuid> {
-        self.ids.iter().collect()
+    fn ids(&self) -> Vec<Uuid> {
+        self.ids.iter().copied().collect()
     }
 
     fn maybe_find(&self, id: &Uuid) -> Option<&Self::F> {

--- a/libs/lb/lb-rs/src/logic/signed_file.rs
+++ b/libs/lb/lb-rs/src/logic/signed_file.rs
@@ -3,7 +3,6 @@ use crate::logic::file_like::FileLike;
 use crate::logic::tree_like::{TreeLike, TreeLikeMut};
 use crate::logic::SharedResult;
 use crate::model::file_metadata::FileMetadata;
-use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use uuid::Uuid;
 
@@ -29,12 +28,11 @@ where
 {
     type F = F;
 
-    fn ids(&self) -> HashSet<&Uuid> {
-        let mut hashset = HashSet::new();
-        if let Some(f) = self {
-            hashset.insert(f.id());
+    fn ids(&self) -> Vec<Uuid> {
+        match self {
+            Some(f) => vec![*f.id()],
+            None => vec![],
         }
-        hashset
     }
 
     fn maybe_find(&self, id: &Uuid) -> Option<&F> {

--- a/libs/lb/lb-rs/src/logic/staged.rs
+++ b/libs/lb/lb-rs/src/logic/staged.rs
@@ -65,14 +65,11 @@ where
 {
     pub fn new(base: Base, staged: Staged) -> Self {
         let mut new = HashSet::new();
-        tracing::debug!("base: {:?}, staged: {:?}, new: {:?}", base.ids(), staged.ids(), new);
         for id in staged.ids() {
             if base.maybe_find(&id).is_none() {
-                tracing::debug!("base is missing {id}, so we insert to new");
                 new.insert(id);
             }
         }
-        tracing::debug!("base: {:?}, staged: {:?}, new: {:?}", base.ids(), staged.ids(), new);
         Self { base, staged, removed: HashSet::new(), new }
     }
 }
@@ -140,13 +137,6 @@ where
         all_ids.extend(&self.new);
         all_ids.retain(|id| !self.removed.contains(id));
 
-        let mut ids = HashSet::new();
-        for id in &all_ids {
-            if ids.contains(id) {
-                panic!("duplicate id found, base ids: {:?}, new: {:?}", self.base.ids(), self.new);
-            }
-            ids.insert(id);
-        }
         all_ids
     }
 

--- a/libs/lb/lb-rs/src/model/core_config.rs
+++ b/libs/lb/lb-rs/src/model/core_config.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -7,6 +9,22 @@ pub struct Config {
     pub writeable_path: String,
     /// Should lb do background work like keep search indexes up to date?
     pub background_work: bool,
+}
+
+impl Config {
+    pub fn cli_config() -> Config {
+        let specified_path = env::var("LOCKBOOK_PATH");
+
+        let default_path = env::var("HOME") // unix
+            .or(env::var("HOMEPATH")) // windows
+            .map(|home| format!("{home}/.lockbook/cli"));
+
+        let Ok(writeable_path) = specified_path.or(default_path) else {
+            panic!("no location for lockbook to initialize");
+        };
+
+        Config { writeable_path, logs: true, colored_logs: true, background_work: false }
+    }
 }
 
 // todo: we added background work as a flag to speed up test execution in debug mode

--- a/libs/lb/lb-rs/src/model/errors.rs
+++ b/libs/lb/lb-rs/src/model/errors.rs
@@ -502,6 +502,9 @@ impl From<SharedError> for TestRepoError {
 
 impl From<LbErr> for TestRepoError {
     fn from(value: LbErr) -> Self {
+        if value.kind == LbErrKind::AccountNonexistent {
+            return Self::NoAccount;
+        }
         Self::Core(value)
     }
 }

--- a/libs/lb/lb-rs/src/model/file_metadata.rs
+++ b/libs/lb/lb-rs/src/model/file_metadata.rs
@@ -103,18 +103,12 @@ impl fmt::Display for FileMetadata {
     }
 }
 
-#[derive(Serialize, Deserialize, Eq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Copy)]
 pub struct Owner(pub PublicKey);
 
 impl Hash for Owner {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.serialize().hash(state)
-    }
-}
-
-impl PartialEq for Owner {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.serialize() == other.0.serialize()
     }
 }
 

--- a/libs/lb/lb-rs/src/model/file_metadata.rs
+++ b/libs/lb/lb-rs/src/model/file_metadata.rs
@@ -9,11 +9,13 @@ use uuid::Uuid;
 use super::access_info::{EncryptedFolderAccessKey, UserAccessInfo, UserAccessMode};
 use super::account::Account;
 use super::clock::get_time;
+use super::errors::LbResult;
 use crate::logic::crypto::AESKey;
 use crate::logic::file_like::FileLike;
 use crate::logic::secret_filename::SecretFileName;
 use crate::logic::signed_file::SignedFile;
 use crate::logic::{pubkey, symkey, SharedResult};
+use crate::service::keychain::Keychain;
 
 pub type DocumentHmac = [u8; 32];
 
@@ -72,8 +74,12 @@ impl FileMetadata {
         })
     }
 
-    pub fn sign(self, account: &Account) -> SharedResult<SignedFile> {
-        pubkey::sign(&account.private_key, self, get_time)
+    pub fn sign(self, keychain: &Keychain) -> LbResult<SignedFile> {
+        Ok(pubkey::sign(&keychain.get_account()?.private_key, &keychain.get_pk()?, self, get_time)?)
+    }
+
+    pub fn sign_with(self, account: &Account) -> LbResult<SignedFile> {
+        Ok(pubkey::sign(&account.private_key, &account.public_key(), self, get_time)?)
     }
 }
 

--- a/libs/lb/lb-rs/src/repo/mod.rs
+++ b/libs/lb/lb-rs/src/repo/mod.rs
@@ -24,7 +24,10 @@ pub struct CoreV3 {
     pub root: Single<Uuid>,
     pub local_metadata: LookupTable<Uuid, SignedFile>,
     pub base_metadata: LookupTable<Uuid, SignedFile>,
+
+    /// map from pub key to username
     pub pub_key_lookup: LookupTable<Owner, String>,
+
     pub doc_events: List<DocEvent>,
 }
 

--- a/libs/lb/lb-rs/src/service/account.rs
+++ b/libs/lb/lb-rs/src/service/account.rs
@@ -37,7 +37,7 @@ impl Lb {
 
         let account = Account::new(username.clone(), api_url.to_string());
 
-        let root = FileMetadata::create_root(&account)?.sign(&account)?;
+        let root = FileMetadata::create_root(&account)?.sign_with(&account)?;
         let root_id = *root.id();
 
         let last_synced = self

--- a/libs/lb/lb-rs/src/service/account.rs
+++ b/libs/lb/lb-rs/src/service/account.rs
@@ -51,7 +51,7 @@ impl Lb {
         db.last_synced.insert(last_synced as i64)?;
         db.root.insert(root_id)?;
 
-        self.cache_account(account.clone()).await?;
+        self.keychain.cache_account(account.clone()).await?;
 
         tx.end();
 
@@ -111,7 +111,7 @@ impl Lb {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
         db.account.insert(account.clone())?;
-        self.cache_account(account.clone()).await?;
+        self.keychain.cache_account(account.clone()).await?;
 
         Ok(account)
     }
@@ -132,7 +132,7 @@ impl Lb {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
         db.account.insert(account.clone())?;
-        self.cache_account(account.clone()).await?;
+        self.keychain.cache_account(account.clone()).await?;
 
         Ok(account)
     }

--- a/libs/lb/lb-rs/src/service/file.rs
+++ b/libs/lb/lb-rs/src/service/file.rs
@@ -25,12 +25,16 @@ impl Lb {
             .to_staged(&mut db.local_metadata)
             .to_lazy();
 
-        let account = db.account.get().ok_or(LbErrKind::AccountNonexistent)?;
+        let id = tree.create(
+            Uuid::new_v4(),
+            symkey::generate_key(),
+            parent,
+            name,
+            file_type,
+            &self.keychain,
+        )?;
 
-        let id =
-            tree.create(Uuid::new_v4(), symkey::generate_key(), parent, name, file_type, account)?;
-
-        let ui_file = tree.decrypt(account, &id, &db.pub_key_lookup)?;
+        let ui_file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;
 
         info!("created {:?} with id {id}", file_type);
 
@@ -50,11 +54,10 @@ impl Lb {
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
             .to_lazy();
-        let account = self.get_account()?;
 
         let id = &tree.linked_by(id)?.unwrap_or(*id);
 
-        tree.rename(id, new_name, account)?;
+        tree.rename(id, new_name, &self.keychain)?;
 
         self.spawn_build_index();
 
@@ -69,11 +72,10 @@ impl Lb {
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
             .to_lazy();
-        let account = self.get_account()?;
 
         let id = &tree.linked_by(id)?.unwrap_or(*id);
 
-        tree.move_file(id, new_parent, account)?;
+        tree.move_file(id, new_parent, &self.keychain)?;
 
         self.spawn_build_index();
 
@@ -88,11 +90,10 @@ impl Lb {
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
             .to_lazy();
-        let account = self.get_account()?;
 
         let id = &tree.linked_by(id)?.unwrap_or(*id);
 
-        tree.delete(id, account)?;
+        tree.delete(id, &self.keychain)?;
 
         self.spawn_build_index();
 
@@ -106,11 +107,10 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = self.get_account()?;
 
         let root_id = db.root.get().ok_or(LbErrKind::RootNonexistent)?;
 
-        let root = tree.decrypt(account, root_id, &db.pub_key_lookup)?;
+        let root = tree.decrypt(&self.keychain, root_id, &db.pub_key_lookup)?;
 
         Ok(root)
     }
@@ -121,11 +121,10 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = self.get_account()?;
 
         let ids = tree.owned_ids().into_iter();
 
-        Ok(tree.decrypt_all(account, ids, &db.pub_key_lookup, true)?)
+        tree.decrypt_all(&self.keychain, ids, &db.pub_key_lookup, true)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
@@ -134,11 +133,10 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = self.get_account()?;
 
         let ids = tree.children_using_links(id)?.into_iter();
 
-        Ok(tree.decrypt_all(account, ids, &db.pub_key_lookup, true)?)
+        tree.decrypt_all(&self.keychain, ids, &db.pub_key_lookup, true)
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
@@ -147,16 +145,15 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = self.get_account()?;
 
         let descendants = tree.descendants_using_links(id)?;
 
-        Ok(tree.decrypt_all(
-            account,
+        tree.decrypt_all(
+            &self.keychain,
             descendants.into_iter().chain(iter::once(*id)),
             &db.pub_key_lookup,
             false,
-        )?)
+        )
     }
 
     #[instrument(level = "debug", skip(self), err(Debug))]
@@ -166,8 +163,6 @@ impl Lb {
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
 
-        let account = self.get_account()?;
-
         if tree.calculate_deleted(&id)? {
             return Err(LbErrKind::FileNonexistent.into());
         }
@@ -175,7 +170,7 @@ impl Lb {
             return Err(LbErrKind::FileNonexistent.into());
         }
 
-        let file = tree.decrypt(account, &id, &db.pub_key_lookup)?;
+        let file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;
 
         Ok(file)
     }

--- a/libs/lb/lb-rs/src/service/file.rs
+++ b/libs/lb/lb-rs/src/service/file.rs
@@ -122,7 +122,7 @@ impl Lb {
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
 
-        let ids = tree.owned_ids().into_iter();
+        let ids = tree.ids().into_iter();
 
         tree.decrypt_all(&self.keychain, ids, &db.pub_key_lookup, true)
     }

--- a/libs/lb/lb-rs/src/service/file.rs
+++ b/libs/lb/lb-rs/src/service/file.rs
@@ -166,7 +166,7 @@ impl Lb {
         if tree.calculate_deleted(&id)? {
             return Err(LbErrKind::FileNonexistent.into());
         }
-        if tree.access_mode(Owner(self.get_pk()?), &id)? < Some(UserAccessMode::Read) {
+        if tree.access_mode(Owner(self.keychain.get_pk()?), &id)? < Some(UserAccessMode::Read) {
             return Err(LbErrKind::FileNonexistent.into());
         }
 

--- a/libs/lb/lb-rs/src/service/integrity.rs
+++ b/libs/lb/lb-rs/src/service/integrity.rs
@@ -18,16 +18,15 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = db.account.get().ok_or(TestRepoError::NoAccount)?;
 
         if db.last_synced.get().unwrap_or(&0) != &0 && db.root.get().is_none() {
             return Err(TestRepoError::NoRootFolder);
         }
 
-        tree.validate(Owner(account.public_key()))?;
+        tree.validate(Owner(self.keychain.get_pk()?))?;
 
         for id in tree.owned_ids() {
-            let name = tree.name(&id, account)?;
+            let name = tree.name(&id, &self.keychain)?;
             if name.is_empty() {
                 return Err(TestRepoError::FileNameEmpty(id));
             }
@@ -51,7 +50,7 @@ impl Lb {
                     continue;
                 }
 
-                let name = tree.name(&id, account)?;
+                let name = tree.name(&id, &self.keychain)?;
                 let extension = Path::new(&name)
                     .extension()
                     .and_then(|ext| ext.to_str())

--- a/libs/lb/lb-rs/src/service/integrity.rs
+++ b/libs/lb/lb-rs/src/service/integrity.rs
@@ -25,7 +25,7 @@ impl Lb {
 
         tree.validate(Owner(self.keychain.get_pk()?))?;
 
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             let name = tree.name(&id, &self.keychain)?;
             if name.is_empty() {
                 return Err(TestRepoError::FileNameEmpty(id));
@@ -36,7 +36,7 @@ impl Lb {
         }
 
         let mut warnings = Vec::new();
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             let file = tree.find(&id)?;
             let id = *file.id();
             let doc = file.is_document();

--- a/libs/lb/lb-rs/src/service/keychain.rs
+++ b/libs/lb/lb-rs/src/service/keychain.rs
@@ -45,33 +45,7 @@ impl From<Option<&Account>> for Keychain {
 
 impl Lb {
     pub fn get_account(&self) -> LbResult<&Account> {
-        self.keychain
-            .account
-            .get()
-            .ok_or_else(|| LbErrKind::AccountNonexistent.into())
-    }
-
-    pub fn get_pk(&self) -> LbResult<PublicKey> {
-        self.keychain
-            .public_key
-            .get()
-            .copied()
-            .ok_or_else(|| LbErrKind::AccountNonexistent.into())
-    }
-
-    #[doc(hidden)]
-    pub async fn cache_account(&self, account: Account) -> LbResult<()> {
-        let pk = account.public_key();
-        self.keychain
-            .account
-            .set(account)
-            .map_err(|_| LbErrKind::AccountExists)?;
-        self.keychain
-            .public_key
-            .set(pk)
-            .map_err(|_| LbErrKind::AccountExists)?;
-
-        Ok(())
+        self.keychain.get_account()
     }
 }
 

--- a/libs/lb/lb-rs/src/service/network.rs
+++ b/libs/lb/lb-rs/src/service/network.rs
@@ -58,7 +58,8 @@ impl Network {
         &self, account: &Account, request: T,
     ) -> Result<T::Response, ApiError<T::Error>> {
         let signed_request =
-            pubkey::sign(&account.private_key, request, self.get_time).map_err(ApiError::Sign)?;
+            pubkey::sign(&account.private_key, &account.public_key(), request, self.get_time)
+                .map_err(ApiError::Sign)?;
 
         let client_version = String::from((self.get_code_version)());
 

--- a/libs/lb/lb-rs/src/service/path.rs
+++ b/libs/lb/lb-rs/src/service/path.rs
@@ -11,17 +11,15 @@ impl Lb {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
 
-        let pub_key = self.get_pk()?;
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
             .to_lazy();
-        let account = self.get_account()?;
 
         let root = db.root.get().ok_or(LbErrKind::RootNonexistent)?;
 
-        let id = tree.create_link_at_path(path, target_id, root, account, &pub_key)?;
+        let id = tree.create_link_at_path(path, target_id, root, &self.keychain)?;
 
-        let ui_file = tree.decrypt(account, &id, &db.pub_key_lookup)?;
+        let ui_file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;
 
         self.spawn_build_index();
 
@@ -30,20 +28,18 @@ impl Lb {
 
     #[instrument(level = "debug", skip(self), err(Debug))]
     pub async fn create_at_path(&self, path: &str) -> LbResult<File> {
-        let pub_key = self.get_pk()?;
         let mut tx = self.begin_tx().await;
         let db = tx.db();
 
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
             .to_lazy();
-        let account = self.get_account()?;
 
         let root = db.root.get().ok_or(LbErrKind::RootNonexistent)?;
 
-        let id = tree.create_at_path(path, root, account, &pub_key)?;
+        let id = tree.create_at_path(path, root, &self.keychain)?;
 
-        let ui_file = tree.decrypt(account, &id, &db.pub_key_lookup)?;
+        let ui_file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;
 
         self.spawn_build_index();
 
@@ -56,13 +52,12 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = self.get_account()?;
 
         let root = db.root.get().ok_or(LbErrKind::RootNonexistent)?;
 
-        let id = tree.path_to_id(path, root, account)?;
+        let id = tree.path_to_id(path, root, &self.keychain)?;
 
-        let ui_file = tree.decrypt(account, &id, &db.pub_key_lookup)?;
+        let ui_file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;
 
         Ok(ui_file)
     }
@@ -73,8 +68,7 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = self.get_account()?;
-        let path = tree.id_to_path(&id, account)?;
+        let path = tree.id_to_path(&id, &self.keychain)?;
 
         Ok(path)
     }
@@ -85,8 +79,7 @@ impl Lb {
         let db = tx.db();
 
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-        let account = self.get_account()?;
-        let paths = tree.list_paths(filter, account)?;
+        let paths = tree.list_paths(filter, &self.keychain)?;
 
         Ok(paths)
     }

--- a/libs/lb/lb-rs/src/service/search.rs
+++ b/libs/lb/lb-rs/src/service/search.rs
@@ -134,7 +134,6 @@ impl Lb {
         let ts = clock::get_time().0 as u64;
         self.search.last_built.store(ts, Ordering::SeqCst);
         // fetch metadata once; use single lazy tree to re-use key decryption work for all files (lb lock)
-        let account = self.get_account()?;
         let mut tree = {
             let tx = self.ro_tx().await;
             let db = tx.db();
@@ -154,8 +153,8 @@ impl Lb {
             if tree.in_pending_share(&id)? {
                 continue;
             }
-            let name = tree.name_using_links(&id, account)?;
-            let path = tree.id_to_path(&id, account)?;
+            let name = tree.name_using_links(&id, &self.keychain)?;
+            let path = tree.id_to_path(&id, &self.keychain)?;
 
             // once per file, re-lock lb to read document using up-to-date hmac (lb lock)
             // because lock has been dropped in the meantime, original `tree` is now arbitrarily out-of-date
@@ -175,7 +174,7 @@ impl Lb {
                         let content = if encrypted_content.value.len() <= CONTENT_MAX_LEN_BYTES {
                             // use the original tree to decrypt the content
                             let decrypted_content =
-                                tree.decrypt_document(&id, &encrypted_content, account)?;
+                                tree.decrypt_document(&id, &encrypted_content, &self.keychain)?;
                             Some(String::from_utf8_lossy(&decrypted_content).into_owned())
                         } else {
                             None

--- a/libs/lb/lb-rs/src/service/search.rs
+++ b/libs/lb/lb-rs/src/service/search.rs
@@ -146,7 +146,7 @@ impl Lb {
 
         // construct replacement index
         let mut replacement_index = Vec::new();
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             if tree.calculate_deleted(&id)? {
                 continue;
             }

--- a/libs/lb/lb-rs/src/service/share.rs
+++ b/libs/lb/lb-rs/src/service/share.rs
@@ -47,7 +47,7 @@ impl Lb {
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
 
         let mut result = Vec::new();
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             // file must not be deleted
             if tree.calculate_deleted(&id)? {
                 continue;

--- a/libs/lb/lb-rs/src/service/share.rs
+++ b/libs/lb/lb-rs/src/service/share.rs
@@ -30,7 +30,7 @@ impl Lb {
             .to_lazy();
         db.pub_key_lookup.insert(sharee, String::from(username))?;
 
-        tree.add_share(id, sharee, mode, account)?;
+        tree.add_share(id, sharee, mode, &self.keychain)?;
 
         self.spawn_build_index();
 
@@ -43,7 +43,6 @@ impl Lb {
         let tx = self.ro_tx().await;
         let db = tx.db();
 
-        let account = &self.get_account()?.clone(); // todo: don't clone
         let owner = Owner(self.get_pk()?);
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
 
@@ -66,7 +65,7 @@ impl Lb {
                 continue;
             }
 
-            let file = tree.decrypt(account, &id, &db.pub_key_lookup)?;
+            let file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;
 
             result.push(file);
         }
@@ -83,9 +82,8 @@ impl Lb {
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
             .to_lazy();
-        let account = self.get_account()?;
 
-        tree.delete_share(id, maybe_encrypted_for, account)?;
+        tree.delete_share(id, maybe_encrypted_for, &self.keychain)?;
 
         self.spawn_build_index();
 
@@ -94,7 +92,7 @@ impl Lb {
 
     #[instrument(level = "debug", skip(self))]
     pub async fn reject_share(&self, id: &Uuid) -> Result<(), LbErr> {
-        let pk = self.get_account()?.public_key();
+        let pk = self.keychain.get_pk()?;
         let result = self.delete_share(id, Some(pk)).await;
 
         self.spawn_build_index();

--- a/libs/lb/lb-rs/src/service/share.rs
+++ b/libs/lb/lb-rs/src/service/share.rs
@@ -48,18 +48,21 @@ impl Lb {
 
         let mut result = Vec::new();
         for id in tree.ids() {
-            // file must not be deleted
-            if tree.calculate_deleted(&id)? {
-                continue;
-            }
             // file must be owned by another user
             if tree.find(&id)?.owner() == owner {
                 continue;
             }
+
             // file must be shared with this user
             if tree.find(&id)?.access_mode(&owner).is_none() {
                 continue;
             }
+
+            // file must not be deleted
+            if tree.calculate_deleted(&id)? {
+                continue;
+            }
+
             // file must not have any links pointing to it
             if tree.linked_by(&id)?.is_some() {
                 continue;

--- a/libs/lb/lb-rs/src/service/share.rs
+++ b/libs/lb/lb-rs/src/service/share.rs
@@ -43,7 +43,7 @@ impl Lb {
         let tx = self.ro_tx().await;
         let db = tx.db();
 
-        let owner = Owner(self.get_pk()?);
+        let owner = Owner(self.keychain.get_pk()?);
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
 
         let mut result = Vec::new();

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -328,7 +328,7 @@ impl Lb {
         let remote_changes = &ctx.remote_changes;
 
         // fetch document updates and local documents for merge
-        let me = Owner(self.get_pk()?);
+        let me = Owner(self.keychain.get_pk()?);
 
         // compute merge changes
         let merge_changes = {
@@ -1075,7 +1075,7 @@ impl Lb {
         let tx = self.ro_tx().await;
         let db = tx.db();
 
-        let me = Owner(self.get_pk()?);
+        let me = Owner(self.keychain.get_pk()?);
         let remote = db.base_metadata.stage(remote_changes).to_lazy();
         let mut result = Vec::new();
 

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -187,7 +187,6 @@ impl Lb {
         }
 
         let mut base_staged = (&mut db.base_metadata).to_lazy().stage(None);
-        // todo this deserves more scrutiny before this is merged
         base_staged.tree.removed = prunable_ids.clone().into_iter().collect();
         base_staged.promote()?;
 

--- a/libs/lb/lb-rs/src/service/usage.rs
+++ b/libs/lb/lb-rs/src/service/usage.rs
@@ -37,7 +37,7 @@ impl Lb {
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
         let mut breakdown = HashMap::default();
 
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             let is_file_deleted = tree.calculate_deleted(&id)?;
             let file = tree.find(&id)?;
 
@@ -60,7 +60,7 @@ impl Lb {
         let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
 
         let mut local_usage: u64 = 0;
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             let is_file_deleted = tree.calculate_deleted(&id)?;
             let file = tree.find(&id)?;
 

--- a/libs/lb/lb-rs/tests/account_service_tests.rs
+++ b/libs/lb/lb-rs/tests/account_service_tests.rs
@@ -178,7 +178,7 @@ async fn import_account_nonexistent() {
 
     let mut tx = core2.begin_tx().await;
     tx.db().account.insert(account.clone()).unwrap();
-    core2.cache_account(account).await.unwrap();
+    core2.keychain.cache_account(account).await.unwrap();
 
     let account_string = core2.export_account_private_key().unwrap();
 
@@ -211,7 +211,7 @@ async fn import_account_public_key_mismatch() {
             .unwrap();
         account2.username = account1.username;
 
-        core3.cache_account(account2).await.unwrap();
+        core3.keychain.cache_account(account2).await.unwrap();
         core3.export_account_private_key().unwrap()
     };
 

--- a/libs/lb/lb-rs/tests/api_new_account_tests.rs
+++ b/libs/lb/lb-rs/tests/api_new_account_tests.rs
@@ -12,7 +12,7 @@ async fn random_account() -> Account {
 async fn test_account(account: &Account) -> Result<NewAccountResponse, ApiError<NewAccountError>> {
     let root = FileMetadata::create_root(account)
         .unwrap()
-        .sign(account)
+        .sign_with(account)
         .unwrap();
     Network::default()
         .request(account, NewAccountRequest::new(account, &root))

--- a/libs/lb/lb-rs/tests/cli_data_tests.rs
+++ b/libs/lb/lb-rs/tests/cli_data_tests.rs
@@ -1,0 +1,10 @@
+use lb_rs::{model::core_config::Config, Lb};
+
+#[tokio::test]
+// #[ignore]
+async fn pending_shares_perf() {
+    let lb = Lb::init(Config::cli_config()).await.unwrap();
+    for _ in 0..1000 {
+        lb.get_pending_shares().await.unwrap();
+    }
+}

--- a/libs/lb/lb-rs/tests/cli_data_tests.rs
+++ b/libs/lb/lb-rs/tests/cli_data_tests.rs
@@ -1,7 +1,7 @@
 use lb_rs::{model::core_config::Config, Lb};
 
 #[tokio::test]
-// #[ignore]
+#[ignore]
 async fn pending_shares_perf() {
     let lb = Lb::init(Config::cli_config()).await.unwrap();
     for _ in 0..1000 {

--- a/libs/lb/lb-rs/tests/integrity_tests.rs
+++ b/libs/lb/lb-rs/tests/integrity_tests.rs
@@ -62,12 +62,8 @@ async fn test_invalid_file_name_slash() {
     let mut tx = core.begin_tx().await;
     let db = tx.db();
     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-    let key = tree
-        .decrypt_key(&doc.id, &db.account.get().unwrap().clone())
-        .unwrap();
-    let parent = tree
-        .decrypt_key(&doc.parent, &db.account.get().unwrap().clone())
-        .unwrap();
+    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
     let new_name = SecretFileName::from_str("te/st", &key, &parent).unwrap();
     let mut doc = tree.find(&doc.id).unwrap().clone();
     doc.timestamped_value.value.name = new_name;
@@ -85,12 +81,8 @@ async fn empty_filename() {
     let mut tx = core.begin_tx().await;
     let db = tx.db();
     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-    let key = tree
-        .decrypt_key(&doc.id, &db.account.get().unwrap().clone())
-        .unwrap();
-    let parent = tree
-        .decrypt_key(&doc.parent, &db.account.get().unwrap().clone())
-        .unwrap();
+    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
     let new_name = SecretFileName::from_str("", &key, &parent).unwrap();
     let mut doc = tree.find(&doc.id).unwrap().clone();
     doc.timestamped_value.value.name = new_name;
@@ -169,12 +161,8 @@ async fn test_name_conflict() {
     let mut tx = core.begin_tx().await;
     let db = tx.db();
     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-    let key = tree
-        .decrypt_key(&doc.id, &db.account.get().unwrap().clone())
-        .unwrap();
-    let parent = tree
-        .decrypt_key(&doc.parent, &db.account.get().unwrap().clone())
-        .unwrap();
+    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
     let new_name = SecretFileName::from_str("document2.md", &key, &parent).unwrap();
     let mut doc = tree.find(&doc.id).unwrap().clone();
     doc.timestamped_value.value.name = new_name;

--- a/libs/lb/lb-rs/tests/path_tests.rs
+++ b/libs/lb/lb-rs/tests/path_tests.rs
@@ -2,26 +2,24 @@ use lb_rs::logic::file_like::FileLike;
 use lb_rs::logic::tree_like::TreeLike;
 use lb_rs::model::account::Account;
 use lb_rs::model::file_metadata::{FileMetadata, FileType};
+use lb_rs::service::keychain::Keychain;
 use test_utils::*;
 
 #[tokio::test]
 async fn test_create_path() {
     let account = &Account::new(random_name(), url());
-    let pk = &account.public_key();
+    let keychain = Keychain::from(Some(account));
     let root = FileMetadata::create_root(account)
         .unwrap()
-        .sign(account)
+        .sign(&keychain)
         .unwrap();
 
     let mut tree = vec![root.clone()].to_lazy().stage(vec![]);
-    tree.create_at_path("test1", root.id(), account, pk)
-        .unwrap();
-    tree.create_at_path("test2", root.id(), account, pk)
-        .unwrap();
-    tree.create_at_path("test3", root.id(), account, pk)
-        .unwrap();
+    tree.create_at_path("test1", root.id(), &keychain).unwrap();
+    tree.create_at_path("test2", root.id(), &keychain).unwrap();
+    tree.create_at_path("test3", root.id(), &keychain).unwrap();
 
-    let paths = tree.list_paths(None, account).unwrap();
+    let paths = tree.list_paths(None, &keychain).unwrap();
     assert_eq!(paths.len(), 4);
     assert!(paths.contains(&"/".to_string()));
     assert!(paths.contains(&"/test1".to_string()));
@@ -32,17 +30,17 @@ async fn test_create_path() {
 #[tokio::test]
 async fn test_path2() {
     let account = &Account::new(random_name(), url());
-    let pk = &account.public_key();
+    let keychain = Keychain::from(Some(account));
     let root = FileMetadata::create_root(account)
         .unwrap()
-        .sign(account)
+        .sign(&keychain)
         .unwrap();
 
     let mut tree = vec![root.clone()].to_lazy().stage(vec![]);
-    tree.create_at_path("test1/2/3", root.id(), account, pk)
+    tree.create_at_path("test1/2/3", root.id(), &keychain)
         .unwrap();
 
-    let paths = tree.list_paths(None, account).unwrap();
+    let paths = tree.list_paths(None, &keychain).unwrap();
 
     assert_eq!(paths.len(), 4);
     assert!(paths.contains(&"/".to_string()));
@@ -54,49 +52,49 @@ async fn test_path2() {
 #[tokio::test]
 async fn test_path_to_id() {
     let account = &Account::new(random_name(), url());
-    let pk = &account.public_key();
+    let keychain = Keychain::from(Some(account));
     let root = FileMetadata::create_root(account)
         .unwrap()
-        .sign(account)
+        .sign(&keychain)
         .unwrap();
 
     let mut tree = vec![root.clone()].to_lazy().stage(vec![]);
-    tree.create_at_path("test1/2/3", root.id(), account, pk)
+    tree.create_at_path("test1/2/3", root.id(), &keychain)
         .unwrap();
 
-    assert_eq!(tree.path_to_id("/", root.id(), account).unwrap(), *root.id());
+    assert_eq!(tree.path_to_id("/", root.id(), &keychain).unwrap(), *root.id());
 
-    let test1_id = tree.path_to_id("/test1", root.id(), account).unwrap();
-    assert_eq!(tree.name_using_links(&test1_id, account).unwrap(), "test1");
+    let test1_id = tree.path_to_id("/test1", root.id(), &keychain).unwrap();
+    assert_eq!(tree.name_using_links(&test1_id, &keychain).unwrap(), "test1");
 
-    let two_id = tree.path_to_id("/test1/2", root.id(), account).unwrap();
-    assert_eq!(tree.name_using_links(&two_id, account).unwrap(), "2");
+    let two_id = tree.path_to_id("/test1/2", root.id(), &keychain).unwrap();
+    assert_eq!(tree.name_using_links(&two_id, &keychain).unwrap(), "2");
 
-    let three_id = tree.path_to_id("/test1/2/3", root.id(), account).unwrap();
-    assert_eq!(tree.name_using_links(&three_id, account).unwrap(), "3");
+    let three_id = tree.path_to_id("/test1/2/3", root.id(), &keychain).unwrap();
+    assert_eq!(tree.name_using_links(&three_id, &keychain).unwrap(), "3");
 }
 
 #[tokio::test]
 async fn test_path_file_types() {
     let account = &Account::new(random_name(), url());
-    let pk = &account.public_key();
+    let keychain = Keychain::from(Some(account));
     let root = FileMetadata::create_root(account)
         .unwrap()
-        .sign(account)
+        .sign(&keychain)
         .unwrap();
 
     let mut tree = vec![root.clone()].to_lazy().stage(vec![]);
-    tree.create_at_path("test1/2/3", root.id(), account, pk)
+    tree.create_at_path("test1/2/3", root.id(), &keychain)
         .unwrap();
 
-    assert_eq!(tree.path_to_id("/", root.id(), account).unwrap(), *root.id());
+    assert_eq!(tree.path_to_id("/", root.id(), &keychain).unwrap(), *root.id());
 
-    let test1_id = tree.path_to_id("/test1", root.id(), account).unwrap();
+    let test1_id = tree.path_to_id("/test1", root.id(), &keychain).unwrap();
     assert_eq!(tree.find(&test1_id).unwrap().file_type(), FileType::Folder);
 
-    let two_id = tree.path_to_id("/test1/2", root.id(), account).unwrap();
+    let two_id = tree.path_to_id("/test1/2", root.id(), &keychain).unwrap();
     assert_eq!(tree.find(&two_id).unwrap().file_type(), FileType::Folder);
 
-    let three_id = tree.path_to_id("/test1/2/3", root.id(), account).unwrap();
+    let three_id = tree.path_to_id("/test1/2/3", root.id(), &keychain).unwrap();
     assert_eq!(tree.find(&three_id).unwrap().file_type(), FileType::Document);
 }

--- a/libs/lb/lb-rs/tests/sync_service_share_tests.rs
+++ b/libs/lb/lb-rs/tests/sync_service_share_tests.rs
@@ -1,4 +1,3 @@
-use lb_rs::model::core_config::Config;
 use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::file::ShareMode;
 use lb_rs::Lb;
@@ -646,13 +645,4 @@ async fn test_share_link_read() {
     cores[1].sync(None).await.unwrap();
 
     cores[2].sync(None).await.unwrap();
-}
-
-#[tokio::test]
-// #[ignore]
-async fn pending_shares_perf() {
-    let lb = Lb::init(Config::cli_config()).await.unwrap();
-    for _ in 0..10 {
-        lb.get_pending_shares().await.unwrap();
-    }
 }

--- a/libs/lb/lb-rs/tests/sync_service_share_tests.rs
+++ b/libs/lb/lb-rs/tests/sync_service_share_tests.rs
@@ -1,3 +1,4 @@
+use lb_rs::model::core_config::Config;
 use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::file::ShareMode;
 use lb_rs::Lb;
@@ -645,4 +646,13 @@ async fn test_share_link_read() {
     cores[1].sync(None).await.unwrap();
 
     cores[2].sync(None).await.unwrap();
+}
+
+#[tokio::test]
+// #[ignore]
+async fn pending_shares_perf() {
+    let lb = Lb::init(Config::cli_config()).await.unwrap();
+    for _ in 0..10 {
+        lb.get_pending_shares().await.unwrap();
+    }
 }

--- a/libs/lb/lb-rs/tests/tree_composition_tests.rs
+++ b/libs/lb/lb-rs/tests/tree_composition_tests.rs
@@ -3,6 +3,7 @@ use lb_rs::logic::symkey;
 use lb_rs::logic::tree_like::TreeLike;
 use lb_rs::model::account::Account;
 use lb_rs::model::file_metadata::{FileMetadata, FileType};
+use lb_rs::service::keychain::Keychain;
 use test_utils::*;
 use uuid::Uuid;
 
@@ -18,9 +19,10 @@ async fn test_empty() {
 #[tokio::test]
 async fn test_stage_promote() {
     let account = &Account::new(random_name(), url());
+    let keychain = Keychain::from(Some(account));
     let root = FileMetadata::create_root(account)
         .unwrap()
-        .sign(account)
+        .sign(&keychain)
         .unwrap();
 
     let mut files = vec![root.clone()].to_lazy().stage(vec![]);
@@ -31,7 +33,7 @@ async fn test_stage_promote() {
             root.id(),
             "test",
             FileType::Folder,
-            account,
+            &keychain,
         )
         .unwrap();
     let files = files.tree.to_staged(Some(op)).to_lazy();
@@ -48,9 +50,10 @@ async fn test_stage_promote() {
 #[tokio::test]
 async fn test_stage_unstage() {
     let account = &Account::new(random_name(), url());
+    let keychain = Keychain::from(Some(account));
     let root = FileMetadata::create_root(account)
         .unwrap()
-        .sign(account)
+        .sign(&keychain)
         .unwrap();
 
     let mut files = vec![root.clone()].to_lazy().stage(vec![]);
@@ -61,7 +64,7 @@ async fn test_stage_unstage() {
             root.id(),
             "test",
             FileType::Folder,
-            account,
+            &keychain,
         )
         .unwrap();
     let files = files.tree.stage(Some(op)).to_lazy();

--- a/libs/lb/lb-rs/tests/validate_tests.rs
+++ b/libs/lb/lb-rs/tests/validate_tests.rs
@@ -23,7 +23,7 @@ async fn create_two_files_with_same_path() {
         &root.id,
         "document",
         FileType::Document,
-        account,
+        &core.keychain,
     )
     .unwrap();
     tree.create_unvalidated(
@@ -32,7 +32,7 @@ async fn create_two_files_with_same_path() {
         &root.id,
         "document",
         FileType::Document,
-        account,
+        &core.keychain,
     )
     .unwrap();
     let result = tree.validate(Owner(account.public_key()));
@@ -86,7 +86,7 @@ async fn directly_shared_link() {
     );
     tx.db()
         .local_metadata
-        .insert(link.id, link.sign(accounts[1]).unwrap())
+        .insert(link.id, link.sign(&cores[1].keychain).unwrap())
         .unwrap();
 
     let db = tx.db();

--- a/libs/lb/test_utils/src/assert.rs
+++ b/libs/lb/test_utils/src/assert.rs
@@ -189,7 +189,6 @@ pub async fn local_work_paths(lb: &Lb, expected_paths: &[&'static str]) {
     let tx = lb.ro_tx().await;
     let db = tx.db();
 
-    let account = db.account.get().unwrap().clone();
     let mut local = db.base_metadata.stage(&db.local_metadata).to_lazy();
     let mut actual_paths = dirty
         .iter()
@@ -199,7 +198,7 @@ pub async fn local_work_paths(lb: &Lb, expected_paths: &[&'static str]) {
         .filter(|id| !local.in_pending_share(id).unwrap())
         .collect::<Vec<_>>()
         .iter()
-        .map(|id| local.id_to_path(id, &account))
+        .map(|id| local.id_to_path(id, &lb.keychain))
         .collect::<Result<Vec<String>, _>>()
         .unwrap();
     actual_paths.sort_unstable();
@@ -247,7 +246,7 @@ pub async fn server_work_paths(core: &Lb, expected_paths: &[&'static str]) {
         .filter(|id| !remote.in_pending_share(id).unwrap())
         .collect::<Vec<_>>()
         .iter()
-        .map(|id| remote.id_to_path(id, account))
+        .map(|id| remote.id_to_path(id, &core.keychain))
         .collect::<Result<Vec<String>, _>>()
         .unwrap();
     actual_paths.sort_unstable();

--- a/libs/lb/test_utils/src/assert.rs
+++ b/libs/lb/test_utils/src/assert.rs
@@ -238,7 +238,7 @@ pub async fn server_work_paths(core: &Lb, expected_paths: &[&'static str]) {
     let mut actual_paths = remote
         .tree
         .staged
-        .owned_ids()
+        .ids()
         .iter()
         .filter(|id| !matches!(remote.find(id).unwrap().file_type(), FileType::Link { .. }))
         .collect::<Vec<_>>()

--- a/server/src/account_service.rs
+++ b/server/src/account_service.rs
@@ -161,7 +161,7 @@ where
     where
         T: TreeLike,
     {
-        let ids = tree.owned_ids();
+        let ids = tree.ids();
         let root_id = ids
             .iter()
             .find(|file_id| match tree.find(file_id) {
@@ -421,7 +421,7 @@ where
                 &mut db.metas,
             )?
             .to_lazy();
-            let metas_to_delete = tree.owned_ids();
+            let metas_to_delete = tree.ids();
 
             for id in metas_to_delete.clone() {
                 if !tree.calculate_deleted(&id)? {

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -62,14 +62,14 @@ where
                 .map(|f| f.size_bytes)
                 .sum::<u64>();
 
-            for id in tree.owned_ids() {
+            for id in tree.ids() {
                 if tree.calculate_deleted(&id)? {
                     prior_deleted.insert(id);
                 }
             }
 
             let mut tree = tree.stage_diff(request.updates.clone())?;
-            for id in tree.owned_ids() {
+            for id in tree.ids() {
                 if tree.calculate_deleted(&id)? {
                     current_deleted.insert(id);
                 }
@@ -91,7 +91,7 @@ where
 
             let tree = tree.promote()?;
 
-            for id in tree.owned_ids() {
+            for id in tree.ids() {
                 if tree.find(&id)?.is_document()
                     && current_deleted.contains(&id)
                     && !prior_deleted.contains(&id)
@@ -445,7 +445,9 @@ where
                 &mut db.file_children,
                 &mut db.metas,
             )?
-            .owned_ids(),
+            .ids()
+            .into_iter()
+            .collect(),
         })
     }
 
@@ -467,7 +469,7 @@ where
         .to_lazy();
 
         let mut result_ids = HashSet::new();
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             let file = tree.find(&id)?;
             if file.version >= request.since_metadata_version {
                 result_ids.insert(id);
@@ -643,7 +645,7 @@ where
         )?
         .to_lazy();
 
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             if !tree.calculate_deleted(&id)? {
                 let file = tree.find(&id)?;
                 if file.is_document() && file.document_hmac().is_some() {

--- a/server/src/loggers.rs
+++ b/server/src/loggers.rs
@@ -62,7 +62,9 @@ fn file_logger(config: &Config) -> RollingFileAppender {
 
 fn server_logs() -> FilterFn {
     filter::filter_fn(|metadata| {
-        metadata.target().starts_with("lockbook") || metadata.target().starts_with("dbrs")
+        metadata.target().starts_with("lockbook")
+            || metadata.target().starts_with("dbrs")
+            || metadata.target().starts_with("lb_rs")
     })
 }
 

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -215,7 +215,7 @@ where
 
         let mut ids = Vec::new();
 
-        for id in tree.owned_ids() {
+        for id in tree.ids() {
             if !tree.calculate_deleted(&id)? {
                 ids.push(id);
             }


### PR DESCRIPTION
# perf inquiry

Logs report `get_pending_shares` being called often and consuming a lot of resources while being calculated.

```
2024-12-20T17:39:11.300169Z DEBUG get_pending_shares: lb_rs::service::share: close time.busy=1.93ms time.idle=1.11µs
```

These are values on an ultra-powerful machine (i9-14), on Smail's M1 I saw values of ~20ms, I'm sure the situation is much worse on an intel Ultrabook. But the ratios of `busy / idle` is mostly the same, suggesting that we're not blocked on IO or anything like that. 

I believe this call is overall representative of most metadata operations, and we want these to be much faster than they are.

Let's see what the CPU spends most of it's time during this:

```rust
    let lb = Lb::init(Config::cli_config()).await.unwrap();
    for _ in 0..1000 {
        lb.get_pending_shares().await.unwrap();
    }
```

![pasted_image_2024-12-20_18-12-11](https://github.com/user-attachments/assets/be54f4a0-0a73-4a43-86e2-d612d6a55695)


There are 2 skill issues that dominate how we're spending our time:
+ We recompute cryptography for every core call. This accounts for 40% of our CPU time.
+ We pass around ids in owned (and cloned) `HashSet`s, the memory allocations (collect) and O(n) operations associated with this accounts for another 40% of our CPU time. 

# Making Crypto Faster

Let's start with making sure we don't recompute crypto (because it's easier).

`LazyTree` hangs on to some cached values to speed up some algorithms, especially ones that are related to tree traversal. For instance, to calculate whether something is deleted you need to walk up to the parents to make sure they're not deleted.

These calculations are usually pretty cheap, except for the cryptographic ones. Usually these calculations can change due to a number of factors well. For instance if you move a file somewhere you want to invalidate any stored ideas about whether or not this file has been deleted. So the lifetime of the `LazyTree` is always less than the lifetime of a _transaction_ within lb. While a `LazyTree` exists, you know nothing else is going on, because of the complexity of the computation. However, again the cryptograpic operations don't fall into this category.

So let's treat them differently, instead of tying the lifetime of our cryptographic cache to the lifetime of the `LazyTree` (a core call or smaller), let's tie it to the lifetime of `Lb` instead. 

![pasted_image_2024-12-21_00-00-50](https://github.com/user-attachments/assets/edd81101-5585-4679-a383-302fa7f566d1)

Great, cryptography doesn't even show up here anymore for `get_pending_shares`. And it's about 30% faster. Let's move onto the trickier optimization -- our memory management. Virtually all the remaining time is spent juggling memory.

# Onto Memory

Our `TreeLike` trait is a fundemental building block of the abstractions within the `lb` library. A "tree" in lockbook can take many shapes, it could be a `LookupTable` (piece of the local db), it could be a `Vec<FileMetadata>` that just came from our server, or it could be a list of hypothetical changes that we're checking for validity.

Very often we're iterating over a set of `Uuid`s (the fundemental identifier of any type of content in our platform: metadata or content, encrypted or decrypted). 

Part of the `TreeLike` contract requires these two implementations:
```rust
fn ids(&self) -> HashSet<&Uuid>;
fn owned_ids(&self) -> HashSet<Uuid>;
```

There's a number of things I don't like about this:
+ the word *owned* here refers to the borrow checker, which is confusing because we also model the idea of ownership of files for the purposes of access control and billing.
+ the only difference here is between whether or not `&Uuid` is borrowed, which `impl`s `Copy` which means that the "non-owned" version very likely performs similarly to the owned version.
+ unless however, `owned_ids` is implemented like this: `self.ids().iter().map(|id| **id).collect()` which it is, which makes `owned_ids` much slower.
+ finally the core purpose of this idea is to provide a base set for a programer to iterate over. Iterating through a `HashSet` is a bad time performance wise.

Here are some options that come to mind:
+ With very little effort we can address all of the above by making `ids(&self) -> Vec<Uuid>`. We lose the built in uniqueness, but in most cases the underlying data structure is a `HashMap`. We do still need some mechanism to enforce uniqueness for `StagedTree` situation. But inherent to the `StagedTree` situation -- changes are generally a smaller set of the overlying situation, so we can do some fast `Vec` scans instead of incurring the cost of populating a hashset.
+ There's probably some world where we can more heavily use `Iterators` (comments indicate that we think this is blocked on some fancy language features but we can probably expose some `&dyn impl Iter<Item = Uuid>`) which could provide genuine speedups for read only operations as we wouldn't need to allocate a container like `Vec`. I think this could be cool to explore in the future because we could make a lot of our data operations composable filters like: `files().documents().not_deleted()` etc. But I have the sense that something like `base.ids().zip(local.ids()).unique()` may perform poorly. 

All this is certainly worth revisiting in the future, but for now I believe the `Vec<Uuid>` gets us 80% of the value for 5% of the effort.

Even better, it looks like `StagedTree` has some constructs for hanging on to intermediate state (for things like `removed` files). I added a `new` file which keeps track of the new ids, so we don't even have to do that scan.

Most of the code changed over from `{ HashSet<&Uuid> | HashSet<Uuid> } -> Vec<Uuid>` 
pretty trivially. Our algorith is a good bit faster, and most of the allocations, collect, and clone statements have dissapeared from our flamegraph. Let's take a look at what remains.
# anything else?

![pasted_image_2024-12-23_19-01-55](https://github.com/user-attachments/assets/32f4d583-b1d5-42bb-8b71-ebad5ea87ebe)

Looking at this flamegraph I see no obvious room for improvement. Our time is dominated by `linked_by` and `calculate_delete` which both involve some manner of tree-traversal. So as a last step I'll take a moment to audit what the code is doing.

```rust
        for id in tree.ids() {
            // file must not be deleted
            if tree.calculate_deleted(&id)? {
                continue;
            }
            // file must be owned by another user
            if tree.find(&id)?.owner() == owner {
                continue;
            }
            // file must be shared with this user
            if tree.find(&id)?.access_mode(&owner).is_none() {
                continue;
            }
            // file must not have any links pointing to it
            if tree.linked_by(&id)?.is_some() {
                continue;
            }

            let file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;

            result.push(file);
        }
```

We're trying to figure out which files are pending shares, for almost every situation this is like finding a needle in a haystack. `calculate_deleted` is pretty expensive, and the ownership check right below it is significantly cheaper and would disqualify the vast majority of metadata, could we re-order these checks better?
+ ownership & access control is O(1)
+ calculate_deleted is O(log n)
+ linked_by is O(n)

Just re-ordering these checks cuts the execution time in almost half.

About 50% of the new remaining time is occupied by `linked_by`: 
![pasted_image_2024-12-23_19-16-48](https://github.com/user-attachments/assets/55adfa35-a0aa-4e93-8042-4312772e622d)

# linked by
linked_by is heavily used for remapping ids and for decryption to power the following UXs:
+ you can place a share wherever you want
+ you can name that share whatever you want

we call it twice, once explicitly to filter out any shares that have already been accepted, and then as a part of the final decryption routine for the client.

so we like that, let's checkout it's implementation to see if there's any low hanging fruit.

I think there is some low hanging fruit, I think linked ids are a good candidate for the lazy tree cache. In some sense a better candidate than deleted -- O(n) vs O(log n). The size of the cache is also going to usually be very miniscule. So great value cache item.

This change resulted in about a 3x speedup.

![pasted_image_2024-12-23_19-56-32](https://github.com/user-attachments/assets/4f55c686-a702-4508-a0cd-7dd6770386b3)

the remaining time is taken up by:
+ `eq` on pubkey
+ `hash` on uuid

I have a strong desire to call it quits at this point, but I need to find out why `PublicKey`s `eq` has `serialize` in it's stack...

```rust
impl PartialEq for Owner {
    fn eq(&self, other: &Self) -> bool {
        self.0.serialize() == other.0.serialize()
    }
}
```

maybe we could not and just `#[derive(PartialEq)]`. Skipping this results in another roughly 2-3x speedup.

![pasted_image_2024-12-23_20-51-21](https://github.com/user-attachments/assets/49736f4c-36eb-42dc-9ee8-8580fa82d47a)

At this point we're spending most of our time hashing UUIDs. That's probably a good place to leave it for now.

# Summary
Let's step through these changes and see what our overall time difference was. I'm going to bump the number of `pending_shares` calls up to 5k to make it easy to differentiate against the initial app startup: 
* baseline startup + 2500its: **5s**
* don't repeat crypto: **4s**
* owned_ids: **3.3s**
* linked_by: **0.25s**
* don't ser for eq: **0.16s**

Almost everything should yield signficant speeds to almost every core and server call, though there is still much more cruft to root out in this manner.