### PR TITLE
lb-rs: fix inital syncs on probably a lot of platforms

### DIFF
--- a/libs/lb/lb-rs/src/service/keychain.rs
+++ b/libs/lb/lb-rs/src/service/keychain.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     model::account::Account,
     model::errors::{LbErrKind, LbResult},
@@ -8,8 +10,8 @@ use tokio::sync::OnceCell;
 
 #[derive(Default, Clone)]
 pub struct Keychain {
-    account: OnceCell<Account>,
-    public_key: OnceCell<PublicKey>,
+    account: Arc<OnceCell<Account>>,
+    public_key: Arc<OnceCell<PublicKey>>,
 }
 
 impl From<Option<&Account>> for Keychain {
@@ -19,7 +21,10 @@ impl From<Option<&Account>> for Keychain {
                 let account = account.clone();
                 let pk = account.public_key();
 
-                Self { account: OnceCell::from(account), public_key: OnceCell::from(pk) }
+                Self {
+                    account: Arc::new(OnceCell::from(account)),
+                    public_key: Arc::new(OnceCell::from(pk)),
+                }
             }
             None => Self::default(),
         }


### PR DESCRIPTION
OnceCell is like an ergonomic Mutex that you only get to set once.

However I thought it was an `Arc<Mutex<T>>`, but it is not. So tasks that may have cloned core before an InitialSync has completed (and the Keychain is populated).

#3200

@smailbarkouch heads up:

This possibly also fixes some bad state that android gets in as described by @ad-tra here: https://github.com/lockbook/lockbook/issues/3203 

well it may not solve the issue, but it probably addresses the `AccountNonexistent` in that log line.

but we were skeptical that log line was correctly attributed to the issue @ad-tra was having.