### PR TITLE
workspace: task management refinements

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -303,7 +303,7 @@ impl AccountScreen {
                 AccountUpdate::ShareAccepted(result) => match result {
                     Ok(_) => {
                         self.modals.file_picker = None;
-                        self.workspace.perform_sync();
+                        self.workspace.tasks.queue_sync();
                         // todo: figure out how to call reveal_file after the file tree is updated with the new sync info
                     }
                     Err(msg) => self.modals.error = Some(ErrorModal::new(msg)),
@@ -334,7 +334,7 @@ impl AccountScreen {
                 AccountUpdate::FileShared(result) => match result {
                     Ok(_) => {
                         self.modals.create_share = None;
-                        self.workspace.perform_sync();
+                        self.workspace.tasks.queue_sync();
                     }
                     Err(msg) => {
                         if let Some(m) = &mut self.modals.create_share {

--- a/clients/egui/src/account/modals/mod.rs
+++ b/clients/egui/src/account/modals/mod.rs
@@ -63,7 +63,7 @@ impl super::AccountScreen {
             } else if let Some(inner) = response.inner {
                 use SettingsResponse::*;
                 match inner {
-                    SuccessfullyUpgraded => self.workspace.refresh_sync_status(),
+                    SuccessfullyUpgraded => self.workspace.tasks.queue_sync_status_update(),
                 }
             }
         }

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -122,7 +122,7 @@ impl super::AccountScreen {
             .padding(egui::vec2(10.0, 7.0))
             .frame(true)
             .rounding(egui::Rounding::same(5.0))
-            .is_loading(self.workspace.status.syncing())
+            .is_loading(self.workspace.syncing())
             .show(ui);
 
         if sync_btn.clicked() {

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -126,7 +126,7 @@ impl super::AccountScreen {
             .show(ui);
 
         if sync_btn.clicked() {
-            self.workspace.perform_sync();
+            self.workspace.tasks.queue_sync();
             self.sync.btn_lost_hover_after_sync = false;
         }
 

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -122,7 +122,7 @@ impl super::AccountScreen {
             .padding(egui::vec2(10.0, 7.0))
             .frame(true)
             .rounding(egui::Rounding::same(5.0))
-            .is_loading(self.workspace.syncing())
+            .is_loading(self.workspace.visibly_syncing())
             .show(ui);
 
         if sync_btn.clicked() {

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -192,8 +192,10 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getStatus(
 ) -> jstring {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
 
-    let status =
-        WsStatus { syncing: obj.workspace.syncing(), msg: obj.workspace.status.message.clone() };
+    let status = WsStatus {
+        syncing: obj.workspace.visibly_syncing(),
+        msg: obj.workspace.status.message.clone(),
+    };
 
     return env
         .new_string(serde_json::to_string(&status).unwrap())

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -192,10 +192,8 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getStatus(
 ) -> jstring {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
 
-    let status = WsStatus {
-        syncing: obj.workspace.status.syncing(),
-        msg: obj.workspace.status.message.clone(),
-    };
+    let status =
+        WsStatus { syncing: obj.workspace.syncing(), msg: obj.workspace.status.message.clone() };
 
     return env
         .new_string(serde_json::to_string(&status).unwrap())

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -241,7 +241,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_requestSync(
     _env: JNIEnv, _: JClass, obj: jlong,
 ) {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
-    obj.workspace.perform_sync();
+    obj.workspace.tasks.queue_sync();
 }
 
 #[no_mangle]

--- a/libs/content/workspace-ffi/src/android/response.rs
+++ b/libs/content/workspace-ffi/src/android/response.rs
@@ -42,7 +42,6 @@ impl From<crate::Response> for AndroidResponse {
                     new_folder_clicked,
                     tab_title_clicked,
                     file_created,
-                    error: _,
                     settings_updated: _,
                     sync_done,
                     status_updated,

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -33,7 +33,7 @@ pub extern "C" fn open_file(obj: *mut c_void, id: CUuid, new_file: bool) {
 #[no_mangle]
 pub extern "C" fn request_sync(obj: *mut c_void) {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
-    obj.workspace.perform_sync()
+    obj.workspace.tasks.queue_sync();
 }
 
 #[no_mangle]

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -201,7 +201,7 @@ pub struct FfiWsStatus {
 #[no_mangle]
 pub unsafe extern "C" fn get_status(obj: *mut c_void) -> FfiWsStatus {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-    let syncing = obj.workspace.status.syncing();
+    let syncing = obj.workspace.syncing();
     let msg = obj.workspace.status.message.clone();
     let msg = CString::new(msg)
         .expect("Could not Rust String -> C String")

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -201,7 +201,7 @@ pub struct FfiWsStatus {
 #[no_mangle]
 pub unsafe extern "C" fn get_status(obj: *mut c_void) -> FfiWsStatus {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-    let syncing = obj.workspace.syncing();
+    let syncing = obj.workspace.visibly_syncing();
     let msg = obj.workspace.status.message.clone();
     let msg = CString::new(msg)
         .expect("Could not Rust String -> C String")

--- a/libs/content/workspace-ffi/src/apple/ios/response.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/response.rs
@@ -41,7 +41,6 @@ impl From<crate::Response> for IOSResponse {
                     new_folder_clicked,
                     tab_title_clicked,
                     file_created,
-                    error: _,
                     settings_updated: _,
                     sync_done,
                     status_updated,

--- a/libs/content/workspace-ffi/src/apple/macos/response.rs
+++ b/libs/content/workspace-ffi/src/apple/macos/response.rs
@@ -34,7 +34,6 @@ impl From<crate::Response> for MacOSResponse {
                     new_folder_clicked,
                     tab_title_clicked: _,
                     file_created,
-                    error: _,
                     settings_updated: _,
                     sync_done,
                     status_updated,

--- a/libs/content/workspace/src/output.rs
+++ b/libs/content/workspace/src/output.rs
@@ -30,7 +30,8 @@ pub struct Response {
 
 #[derive(Default, Clone)]
 pub struct WsStatus {
-    pub error: Option<String>,
+    pub sync_error: Option<String>,
+    pub sync_status_update_error: Option<String>,
     pub offline: bool,
     pub update_req: bool,
     pub out_of_space: bool,

--- a/libs/content/workspace/src/output.rs
+++ b/libs/content/workspace/src/output.rs
@@ -1,5 +1,4 @@
 use lb_rs::{model::file::File, service::sync::SyncStatus, Uuid};
-use std::time::Instant;
 
 // todo: dirty docs
 #[derive(Debug, Default, Clone)]
@@ -13,8 +12,6 @@ pub struct Response {
 
     pub new_folder_clicked: bool,
     pub tab_title_clicked: bool,
-
-    pub error: Option<String>,
 
     pub settings_updated: bool,
 
@@ -34,59 +31,15 @@ pub struct Response {
 #[derive(Default, Clone)]
 pub struct WsStatus {
     pub error: Option<String>,
-    pub sync_started: Option<Instant>, // Some if there is a sync in progress
     pub offline: bool,
     pub update_req: bool,
     pub out_of_space: bool,
     pub usage: f64,
-    pub sync_progress: f32,
     pub dirtyness: DirtynessMsg,
     pub sync_message: Option<String>,
 
     /// summary of the booleans above
     pub message: String,
-}
-
-impl WsStatus {
-    pub fn populate_message(&mut self) {
-        if let Some(error) = &self.error {
-            self.message = format!("err: {error}");
-            return;
-        }
-        if self.offline {
-            self.message = "Offline".to_string();
-            return;
-        }
-
-        if self.out_of_space {
-            self.message = "You're out of space, buy more in settings!".to_string();
-        }
-
-        if self.syncing() {
-            if let Some(msg) = &self.sync_message {
-                self.message = msg.to_string();
-                return;
-            }
-        }
-
-        if !self.dirtyness.dirty_files.is_empty() {
-            let size = self.dirtyness.dirty_files.len();
-            if size == 1 {
-                self.message = format!("{size} file needs to be synced");
-            } else {
-                self.message = format!("{size} files need to be synced");
-            }
-            return;
-        }
-
-        self.message = format!("Last synced: {}", self.dirtyness.last_synced);
-    }
-
-    pub fn syncing(&self) -> bool {
-        self.sync_started
-            .map(|s| s.elapsed().as_millis() > 300)
-            .unwrap_or(false)
-    }
 }
 
 #[derive(Clone)]

--- a/libs/content/workspace/src/output.rs
+++ b/libs/content/workspace/src/output.rs
@@ -34,7 +34,6 @@ pub struct WsStatus {
     pub offline: bool,
     pub update_req: bool,
     pub out_of_space: bool,
-    pub usage: f64,
     pub dirtyness: DirtynessMsg,
     pub sync_message: Option<String>,
 
@@ -42,7 +41,7 @@ pub struct WsStatus {
     pub message: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DirtynessMsg {
     pub last_synced: String,
     pub dirty_files: Vec<Uuid>,

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -417,7 +417,7 @@ impl Workspace {
             Icon::SCHEDULE.size(icon_size)
         } else if self.tasks.load_or_save_in_progress(tab.id) {
             Icon::SAVE.size(icon_size)
-        } else if tab.is_dirty() {
+        } else if tab.is_dirty(&self.tasks) {
             Icon::CIRCLE.size(icon_size)
         } else {
             Icon::CHECK_CIRCLE.size(icon_size)
@@ -588,7 +588,7 @@ impl Workspace {
                     "save queued"
                 } else if self.tasks.load_or_save_in_progress(tab.id) {
                     "save in progress"
-                } else if tab.is_dirty() {
+                } else if tab.is_dirty(&self.tasks) {
                     "unsaved changes"
                 } else {
                     "all changes saved"

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -23,7 +23,7 @@ impl Workspace {
 
         self.process_updates();
         self.process_keys();
-        self.status.populate_message();
+        self.status.message = self.status_message();
 
         if self.is_empty() {
             self.show_empty_workspace(ui);

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -6,6 +6,7 @@ use egui::{EventFilter, Id, Key, Modifiers, Sense, TextWrapMode, ViewportCommand
 use std::collections::HashMap;
 use std::mem;
 use std::time::{Duration, Instant};
+use tracing::instrument;
 
 use crate::output::Response;
 use crate::tab::{TabContent, TabFailure};
@@ -14,6 +15,7 @@ use crate::widgets::Button;
 use crate::workspace::Workspace;
 
 impl Workspace {
+    #[instrument(level="trace", skip_all, fields(frame = self.ctx.frame_nr()))]
     pub fn show(&mut self, ui: &mut egui::Ui) -> Response {
         if self.ctx.input(|inp| !inp.raw.events.is_empty()) {
             self.user_last_seen = Instant::now();

--- a/libs/content/workspace/src/syncing.rs
+++ b/libs/content/workspace/src/syncing.rs
@@ -71,7 +71,8 @@ impl Workspace {
 
         for id in server_ids {
             for i in 0..self.tabs.len() {
-                if self.tabs[i].id == id {
+                if self.tabs[i].id == id && !self.tabs[i].is_closing {
+                    tracing::info!("Reloading file after sync: {}", id);
                     self.open_file(id, false, false);
                 }
             }

--- a/libs/content/workspace/src/syncing.rs
+++ b/libs/content/workspace/src/syncing.rs
@@ -1,7 +1,7 @@
 use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::work_unit::WorkUnit;
 use lb_rs::service::sync::SyncStatus;
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::task_manager::{CompletedSync, CompletedSyncStatusUpdate};
 use crate::workspace::Workspace;
@@ -43,7 +43,7 @@ impl Workspace {
         for id in server_ids {
             for i in 0..self.tabs.len() {
                 if self.tabs[i].id == id && !self.tabs[i].is_closing {
-                    tracing::debug!("Reloading file after sync: {}", id);
+                    debug!("Reloading file after sync: {}", id);
                     self.open_file(id, false, false);
                 }
             }

--- a/libs/content/workspace/src/syncing.rs
+++ b/libs/content/workspace/src/syncing.rs
@@ -3,29 +3,19 @@ use lb_rs::model::work_unit::WorkUnit;
 use lb_rs::service::sync::SyncStatus;
 use tracing::error;
 
-use crate::output::DirtynessMsg;
-use crate::task_manager::CompletedSync;
+use crate::task_manager::{CompletedSync, CompletedSyncStatusUpdate};
 use crate::workspace::Workspace;
-use std::time::Instant;
 
 impl Workspace {
-    // todo should anyone outside workspace ever call this? Or should they call something more
-    // general that would allow workspace to determine if a sync is needed
-    pub fn perform_sync(&mut self) {
-        self.out.status_updated = true;
-        self.tasks.queue_sync();
-    }
-
     pub fn sync_done(&mut self, outcome: CompletedSync) {
-        let CompletedSync { status_result, timing: _ } = outcome;
+        let CompletedSync { status_result, timing } = outcome;
 
         self.out.status_updated = true;
-        self.last_sync = Some(Instant::now());
+        self.last_sync_completed = Some(timing.completed_at);
         match status_result {
             Ok(done) => {
-                self.status.error = None;
-                self.status.offline = false;
-                self.refresh_sync_status();
+                self.status = Default::default();
+                self.tasks.queue_sync_status_update();
                 self.refresh_files(&done);
                 self.out.sync_done = Some(done)
             }
@@ -42,20 +32,7 @@ impl Workspace {
         }
     }
 
-    pub fn refresh_sync_status(&mut self) {
-        let last_synced = self.core.get_last_synced_human_string().unwrap();
-        let dirty_files = self.core.get_local_changes().unwrap();
-        let pending_shares = self.core.get_pending_shares().unwrap();
-
-        let dirty = DirtynessMsg { last_synced, dirty_files, pending_shares };
-
-        self.out.status_updated = true;
-        self.status.dirtyness = dirty;
-
-        self.last_sync_status_refresh = Some(Instant::now());
-    }
-
-    pub fn refresh_files(&mut self, work: &SyncStatus) {
+    fn refresh_files(&mut self, work: &SyncStatus) {
         let server_ids = work.work_units.iter().filter_map(|wu| match wu {
             WorkUnit::LocalChange { .. } => None,
             WorkUnit::ServerChange(id) => Some(*id),
@@ -67,6 +44,23 @@ impl Workspace {
                     tracing::debug!("Reloading file after sync: {}", id);
                     self.open_file(id, false, false);
                 }
+            }
+        }
+    }
+
+    pub fn sync_status_update_done(&mut self, outcome: CompletedSyncStatusUpdate) {
+        let CompletedSyncStatusUpdate { status_result, timing } = outcome;
+
+        self.out.status_updated = true;
+        self.last_sync_status_refresh_completed = Some(timing.completed_at);
+        match status_result {
+            Ok(dirtyness) => {
+                self.status.dirtyness = dirtyness;
+                self.status.error = None;
+            }
+            Err(err) => {
+                error!("Unhandled sync status update error: {:?}", err);
+                self.status.error = format!("{:?}", err).into();
             }
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -397,3 +397,17 @@ impl Editor {
         None
     }
 }
+
+// used by task manager to offload serialization to a background thread
+impl Clone for Editor {
+    fn clone(&self) -> Self {
+        Self::new(
+            self.core.clone(),
+            &self.buffer.current.text,
+            self.file_id,
+            self.hmac,
+            self.needs_name,
+            self.appearance.plaintext_mode,
+        )
+    }
+}

--- a/libs/content/workspace/src/tab/markdown_editor/editor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/editor.rs
@@ -397,17 +397,3 @@ impl Editor {
         None
     }
 }
-
-// used by task manager to offload serialization to a background thread
-impl Clone for Editor {
-    fn clone(&self) -> Self {
-        Self::new(
-            self.core.clone(),
-            &self.buffer.current.text,
-            self.file_id,
-            self.hmac,
-            self.needs_name,
-            self.appearance.plaintext_mode,
-        )
-    }
-}

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -2,6 +2,7 @@ use crate::tab::image_viewer::ImageViewer;
 use crate::tab::markdown_editor::Editor as Markdown;
 use crate::tab::pdf_viewer::PdfViewer;
 use crate::tab::svg_editor::SVGEditor;
+use crate::task_manager::TaskManager;
 use chrono::DateTime;
 use egui::Id;
 use lb_rs::blocking::Lb;
@@ -32,8 +33,12 @@ pub struct Tab {
 }
 
 impl Tab {
-    pub fn is_dirty(&self) -> bool {
-        self.last_changed > self.last_saved
+    pub fn is_dirty(&self, tasks: &TaskManager) -> bool {
+        if let Some(queued_at) = tasks.save_queued_at(self.id) {
+            self.last_changed > queued_at
+        } else {
+            self.last_changed > self.last_saved
+        }
     }
 }
 

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -10,6 +10,7 @@ use lb_rs::model::errors::{LbErr, LbErrKind};
 use lb_rs::model::file::File;
 use lb_rs::model::file_metadata::{DocumentHmac, FileType};
 use lb_rs::{svg, Uuid};
+use tracing::instrument;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -77,6 +78,7 @@ impl TabContent {
     }
 
     /// Clones the content required to save the tab. This is intended for use on the UI thread.
+    #[instrument(level = "error", skip_all)]
     pub fn clone_content(&self) -> Option<TabSaveContent> {
         match self {
             TabContent::Markdown(md) => {

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -10,9 +10,9 @@ use lb_rs::model::errors::{LbErr, LbErrKind};
 use lb_rs::model::file::File;
 use lb_rs::model::file_metadata::{DocumentHmac, FileType};
 use lb_rs::{svg, Uuid};
-use tracing::instrument;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use tracing::instrument;
 
 pub mod image_viewer;
 pub mod markdown_editor;

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -82,7 +82,7 @@ impl TabContent {
     pub fn clone_content(&self) -> Option<TabSaveContent> {
         match self {
             TabContent::Markdown(md) => {
-                Some(TabSaveContent::Bytes(md.buffer.current.text.clone().into_bytes()))
+                Some(TabSaveContent::String(md.buffer.current.text.clone()))
             }
             TabContent::Svg(svg) => Some(TabSaveContent::Svg(svg.buffer.clone())),
             _ => None,

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -35,6 +35,9 @@ use tracing::Level;
 
 pub struct SVGEditor {
     pub buffer: Buffer,
+    pub opened_content: Buffer,
+    pub open_file_hmac: Option<DocumentHmac>,
+
     history: History,
     pub toolbar: Toolbar,
     inner_rect: egui::Rect,
@@ -71,7 +74,7 @@ impl SVGEditor {
     ) -> Self {
         let content = std::str::from_utf8(bytes).unwrap();
 
-        let mut buffer = Buffer::new(content, hmac);
+        let mut buffer = Buffer::new(content);
         for (_, el) in buffer.elements.iter_mut() {
             if let Element::Path(path) = el {
                 path.data
@@ -85,6 +88,8 @@ impl SVGEditor {
 
         Self {
             buffer,
+            opened_content: Buffer::new(content),
+            open_file_hmac: hmac,
             history: History::default(),
             toolbar,
             inner_rect: egui::Rect::NOTHING,
@@ -262,24 +267,4 @@ impl SVGEditor {
     //         );
     //     }
     // }
-}
-
-// used by task manager to offload serialization to a background thread
-impl Clone for SVGEditor {
-    fn clone(&self) -> Self {
-        Self {
-            buffer: self.buffer.clone(),
-            history: History::default(),
-            toolbar: Toolbar::new(),
-            inner_rect: egui::Rect::NOTHING,
-            lb: self.lb.clone(),
-            open_file: self.open_file,
-            skip_frame: self.skip_frame,
-            painter: self.painter.clone(),
-            renderer: Renderer::new(0),
-            has_queued_save_request: self.has_queued_save_request,
-            allow_viewport_changes: self.allow_viewport_changes,
-            settings: self.settings,
-        }
-    }
 }

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -263,3 +263,23 @@ impl SVGEditor {
     //     }
     // }
 }
+
+// used by task manager to offload serialization to a background thread
+impl Clone for SVGEditor {
+    fn clone(&self) -> Self {
+        Self {
+            buffer: self.buffer.clone(),
+            history: History::default(),
+            toolbar: Toolbar::new(),
+            inner_rect: egui::Rect::NOTHING,
+            lb: self.lb.clone(),
+            open_file: self.open_file,
+            skip_frame: self.skip_frame,
+            painter: self.painter.clone(),
+            renderer: Renderer::new(0),
+            has_queued_save_request: self.has_queued_save_request,
+            allow_viewport_changes: self.allow_viewport_changes,
+            settings: self.settings,
+        }
+    }
+}

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -675,7 +675,7 @@ impl TaskManager {
             let in_progress_time = timing.completed_at.duration_since(timing.started_at);
             if let Err(err) = &status_result {
                 error!("sync failed ({:?}): {:?}", in_progress_time, err);
-            } else if in_progress_time > Duration::from_secs(1) {
+            } else if in_progress_time > Duration::from_secs(5) {
                 warn!("synced ({:?}); status = {:?}", in_progress_time, status_result);
             } else {
                 debug!("synced ({:?})", in_progress_time);

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -464,11 +464,7 @@ impl TaskManager {
                 .started_at
                 .duration_since(in_progress_load.timing.queued_at);
             if queue_time > Duration::from_secs(1) {
-                warn!(
-                    "load of file {} spent {}ms in the task queue",
-                    request.id,
-                    queue_time.as_millis()
-                );
+                warn!("load of file {} spent {:?} in the task queue", request.id, queue_time);
             }
             tasks.in_progress_loads.push(in_progress_load);
 
@@ -511,11 +507,7 @@ impl TaskManager {
                 .started_at
                 .duration_since(in_progress_save.timing.queued_at);
             if queue_time > Duration::from_secs(1) {
-                warn!(
-                    "save of file {} spent {}ms in the task queue",
-                    request.id,
-                    queue_time.as_millis()
-                );
+                warn!("save of file {} spent {:?} in the task queue", request.id, queue_time);
             }
             tasks.in_progress_saves.push(in_progress_save);
 
@@ -531,7 +523,7 @@ impl TaskManager {
                 .started_at
                 .duration_since(in_progress_sync.timing.queued_at);
             if queue_time > Duration::from_secs(1) {
-                warn!("sync spent {}ms in the task queue", queue_time.as_millis());
+                warn!("sync spent {:?} in the task queue", queue_time);
             }
             tasks.in_progress_sync = Some(in_progress_sync);
 
@@ -546,7 +538,7 @@ impl TaskManager {
                 .started_at
                 .duration_since(in_progress_update.timing.queued_at);
             if queue_time > Duration::from_secs(1) {
-                warn!("sync status update spent {}ms in the task queue", queue_time.as_millis());
+                warn!("sync status update spent {:?} in the task queue", queue_time);
             }
             tasks.in_progress_sync_status_update = Some(in_progress_update);
 
@@ -594,16 +586,11 @@ impl TaskManager {
             let timing = CompletedTiming::new(in_progress_load.timing);
             let in_progress_time = timing.completed_at.duration_since(timing.started_at);
             if let Err(err) = &content_result {
-                error!(
-                    "load of file {} failed ({}ms): {:?}",
-                    request.id,
-                    in_progress_time.as_millis(),
-                    err
-                );
+                error!("load of file {} failed ({:?}): {:?}", request.id, in_progress_time, err);
             } else if in_progress_time > Duration::from_secs(1) {
-                warn!("loaded file {} ({}ms)", request.id, in_progress_time.as_millis());
+                warn!("loaded file {} ({:?})", request.id, in_progress_time);
             } else {
-                debug!("loaded file {} ({}ms)", request.id, in_progress_time.as_millis());
+                debug!("loaded file {} ({:?})", request.id, in_progress_time);
             }
 
             let completed_load =
@@ -644,16 +631,11 @@ impl TaskManager {
             let timing = CompletedTiming::new(in_progress_save.timing);
             let in_progress_time = timing.completed_at.duration_since(timing.started_at);
             if let Err(err) = &new_hmac_result {
-                error!(
-                    "save of file {} failed ({}ms): {:?}",
-                    request.id,
-                    in_progress_time.as_millis(),
-                    err
-                );
+                error!("save of file {} failed ({:?}): {:?}", request.id, in_progress_time, err);
             } else if in_progress_time > Duration::from_secs(1) {
-                warn!("saved file {} ({}ms)", request.id, in_progress_time.as_millis());
+                warn!("saved file {} ({:?})", request.id, in_progress_time);
             } else {
-                debug!("saved file {} ({}ms)", request.id, in_progress_time.as_millis());
+                debug!("saved file {} ({:?})", request.id, in_progress_time);
             }
 
             let completed_save = CompletedSave {
@@ -692,11 +674,11 @@ impl TaskManager {
             let timing = CompletedTiming::new(in_progress_sync.timing);
             let in_progress_time = timing.completed_at.duration_since(timing.started_at);
             if let Err(err) = &status_result {
-                error!("sync failed ({}ms): {:?}", in_progress_time.as_millis(), err);
+                error!("sync failed ({:?}): {:?}", in_progress_time, err);
             } else if in_progress_time > Duration::from_secs(1) {
-                warn!("synced ({}ms); status = {:?}", in_progress_time.as_millis(), status_result);
+                warn!("synced ({:?}); status = {:?}", in_progress_time, status_result);
             } else {
-                debug!("synced ({}ms)", in_progress_time.as_millis());
+                debug!("synced ({:?})", in_progress_time);
             }
 
             let completed_sync = CompletedSync { status_result, timing };
@@ -726,15 +708,11 @@ impl TaskManager {
             let timing = CompletedTiming::new(in_progress_update.timing);
             let in_progress_time = timing.completed_at.duration_since(timing.started_at);
             if let Err(err) = &status_result {
-                error!("update sync status failed ({}ms): {:?}", in_progress_time.as_millis(), err);
+                error!("update sync status failed ({:?}): {:?}", in_progress_time, err);
             } else if in_progress_time > Duration::from_secs(1) {
-                warn!(
-                    "sync status updated ({}ms); status = {:?}",
-                    in_progress_time.as_millis(),
-                    status_result
-                );
+                warn!("sync status updated ({:?}); status = {:?}", in_progress_time, status_result);
             } else {
-                debug!("sync status updated ({}ms)", in_progress_time.as_millis());
+                debug!("sync status updated ({:?})", in_progress_time);
             }
 
             let completed_update = CompletedSyncStatusUpdate { status_result, timing };

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -10,7 +10,7 @@ use lb_rs::model::errors::LbResult;
 use lb_rs::model::file_metadata::DocumentHmac;
 use lb_rs::service::sync::{SyncProgress, SyncStatus};
 use lb_rs::Uuid;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::tab::{Tab, TabContent};
 

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -483,7 +483,7 @@ impl TaskManager {
             let in_progress_save = InProgressSave::new(queued_save);
             let (old_hmac, seq, content) = {
                 let Some(tab) = tabs.iter().find(|tab| tab.id == request.id) else {
-                    error!("could not launch save because its tab does not exist",);
+                    error!("could not launch save because its tab does not exist");
                     continue;
                 };
 
@@ -497,7 +497,7 @@ impl TaskManager {
 
                 let time = Instant::now().duration_since(start);
                 if time > Duration::from_millis(100) {
-                    warn!("spent {time:?} on UI thread cloning content",);
+                    warn!("spent {time:?} on UI thread cloning content");
                 }
 
                 (old_hmac, seq, content)
@@ -535,7 +535,7 @@ impl TaskManager {
         }
 
         if let Some(update) = sync_status_update_to_launch {
-            let span = span!(Level::TRACE, "sync_status_update_launch",);
+            let span = span!(Level::TRACE, "sync_status_update_launch");
             let _enter = span.enter();
 
             let in_progress_update = InProgressSyncStatusUpdate::new(update);
@@ -568,7 +568,7 @@ impl TaskManager {
     }
 
     /// Move a request to in-progress, then call this from a background thread
-    #[instrument(level = "debug", skip(self), fields(thread = format!("{:?}", thread::current().id())))]
+    #[instrument(level = "warn", skip(self), fields(thread = format!("{:?}", thread::current().id())))]
     fn background_load(&self, request: LoadRequest) {
         let id = request.id;
         let content_result = self.core.read_document_with_hmac(id);
@@ -580,7 +580,6 @@ impl TaskManager {
             for load in mem::take(&mut tasks.in_progress_loads) {
                 if load.request.id == id {
                     in_progress_load = Some(load); // use latest of duplicate ids
-                    break;
                 } else {
                     tasks.in_progress_loads.push(load); // put back the ones we're not completing
                 }
@@ -629,7 +628,6 @@ impl TaskManager {
             for save in mem::take(&mut tasks.in_progress_saves) {
                 if save.request.id == id {
                     in_progress_save = Some(save); // use latest of duplicate ids
-                    break;
                 } else {
                     tasks.in_progress_saves.push(save); // put back the ones we're not completing
                 }

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -387,7 +387,9 @@ impl TaskManager {
                 .iter()
                 .any(|completed_save| completed_save.request.id == id)
             {
-                continue; // result of completed save must be processed before another save to the same file
+                // result of completed save must be processed before another save to the same file; this guarantees
+                // that the hmac from the completed save is used for the next, preventing a ReReadRequired error
+                continue;
             }
             ids_to_save.push(id);
         }

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -250,6 +250,31 @@ impl TaskManager {
         self.tasks.lock().unwrap().load_or_save_in_progress(id)
     }
 
+    pub fn save_queued_at(&self, id: Uuid) -> Option<Instant> {
+        let tasks = self.tasks.lock().unwrap();
+        if let Some(queued_save) = tasks
+            .queued_saves
+            .iter()
+            .find(|queued_save| queued_save.request.id == id)
+        {
+            Some(queued_save.timing.queued_at)
+        } else if let Some(in_progress_save) = tasks
+            .in_progress_saves
+            .iter()
+            .find(|in_progress_save| in_progress_save.request.id == id)
+        {
+            Some(in_progress_save.timing.queued_at)
+        } else if let Some(completed_save) = tasks
+            .completed_saves
+            .iter()
+            .find(|completed_save| completed_save.request.id == id)
+        {
+            Some(completed_save.timing.queued_at)
+        } else {
+            None
+        }
+    }
+
     /// Launches whichever queued tasks are ready to be launched, moving their status from queued to in-progress.
     /// In-progress tasks have status moved to completed by background threads. This fn called whenever a task is
     /// queued or explicitly - background threads will not call it and will instead only call request_repaint() when

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
-use tracing::{debug, instrument, trace, warn};
+use std::{fs, thread};
+use tracing::{debug, error, instrument, trace, warn};
 
 use crate::output::{Response, WsStatus};
 use crate::tab::image_viewer::{is_supported_image_fmt, ImageViewer};

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -626,7 +626,7 @@ impl Workspace {
             "Offline".to_string()
         } else if self.status.out_of_space {
             "You're out of space, buy more in settings!".to_string()
-        } else if let (true, Some(msg)) = (self.syncing(), &self.status.sync_message) {
+        } else if let (true, Some(msg)) = (self.visibly_syncing(), &self.status.sync_message) {
             msg.to_string()
         } else if !self.status.dirtyness.dirty_files.is_empty() {
             let size = self.status.dirtyness.dirty_files.len();
@@ -640,7 +640,7 @@ impl Workspace {
         }
     }
 
-    pub fn syncing(&self) -> bool {
+    pub fn visibly_syncing(&self) -> bool {
         self.tasks
             .sync_started_at()
             .map(|s| s.elapsed().as_millis() > 300)

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -460,7 +460,7 @@ impl Workspace {
                     self.ctx.request_repaint_after(duration_until_next_sync);
                 }
             } else {
-                self.tasks.queue_sync();
+                self.perform_sync();
             }
         }
         if self.cfg.get_auto_save() {

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -9,8 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
-use std::{fs, thread};
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, instrument, trace, warn};
 
 use crate::output::{Response, WsStatus};
 use crate::tab::image_viewer::{is_supported_image_fmt, ImageViewer};
@@ -472,7 +471,7 @@ impl Workspace {
             let tasks = self.tasks.tasks.lock().unwrap();
             if let Some(sync) = tasks.in_progress_sync.as_ref() {
                 while let Ok(progress) = sync.progress.try_recv() {
-                    debug!("sync progress: {}", progress);
+                    trace!("sync {}", progress);
                     self.status.sync_message = Some(progress.msg);
                     self.out.status_updated = true;
                 }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -620,8 +620,10 @@ impl Workspace {
     }
 
     pub fn status_message(&self) -> String {
-        if let Some(error) = &self.status.error {
-            format!("err: {error}")
+        if let Some(error) = &self.status.sync_error {
+            format!("sync error: {error}")
+        } else if let Some(error) = &self.status.sync_status_update_error {
+            format!("sync status update error: {error}")
         } else if self.status.offline {
             "Offline".to_string()
         } else if self.status.out_of_space {

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -225,7 +225,7 @@ impl Workspace {
 
     pub fn save_tab(&mut self, i: usize) {
         if let Some(tab) = self.tabs.get_mut(i) {
-            if tab.is_dirty() {
+            if tab.is_dirty(&self.tasks) {
                 self.tasks.queue_save(SaveRequest { id: tab.id });
             }
         }

--- a/libs/lb/lb-rs/src/repo/mod.rs
+++ b/libs/lb/lb-rs/src/repo/mod.rs
@@ -67,10 +67,7 @@ impl Lb {
         let guard = self.db.read().await;
 
         if start.elapsed() > std::time::Duration::from_millis(100) {
-            tracing::warn!(
-                "lock acquisition for readonly transaction took {:?} to acquire",
-                start.elapsed()
-            );
+            tracing::warn!("readonly transaction lock acquisition took {:?}", start.elapsed());
         }
 
         LbRO { guard }
@@ -87,10 +84,7 @@ impl Lb {
         let tx = guard.begin_transaction().unwrap();
 
         if start.elapsed() > std::time::Duration::from_millis(100) {
-            tracing::warn!(
-                "lock acquisition for write transaction took {:?} to acquire",
-                start.elapsed()
-            );
+            tracing::warn!("readwrite transaction lock acquisition took {:?}", start.elapsed());
         }
 
         LbTx { guard, tx }

--- a/libs/lb/lb-rs/src/repo/mod.rs
+++ b/libs/lb/lb-rs/src/repo/mod.rs
@@ -58,11 +58,11 @@ impl<'a> LbTx<'a> {
 
 impl Lb {
     pub async fn ro_tx(&self) -> LbRO<'_> {
+        let start = std::time::Instant::now();
+
         // let guard = tokio::time::timeout(std::time::Duration::from_secs(1), self.db.read())
         //     .await
         //     .unwrap();
-
-        let start = std::time::Instant::now();
 
         let guard = self.db.read().await;
 
@@ -77,11 +77,11 @@ impl Lb {
     }
 
     pub async fn begin_tx(&self) -> LbTx<'_> {
+        let start = std::time::Instant::now();
+
         // let mut guard = tokio::time::timeout(std::time::Duration::from_secs(1), self.db.write())
         //     .await
         //     .unwrap();
-
-        let start = std::time::Instant::now();
 
         let mut guard = self.db.write().await;
         let tx = guard.begin_transaction().unwrap();

--- a/libs/lb/lb-rs/src/repo/mod.rs
+++ b/libs/lb/lb-rs/src/repo/mod.rs
@@ -62,7 +62,16 @@ impl Lb {
         //     .await
         //     .unwrap();
 
+        let start = std::time::Instant::now();
+
         let guard = self.db.read().await;
+
+        if start.elapsed() > std::time::Duration::from_millis(100) {
+            tracing::warn!(
+                "lock acquisition for readonly transaction took {:?} to acquire",
+                start.elapsed()
+            );
+        }
 
         LbRO { guard }
     }
@@ -72,8 +81,17 @@ impl Lb {
         //     .await
         //     .unwrap();
 
+        let start = std::time::Instant::now();
+
         let mut guard = self.db.write().await;
         let tx = guard.begin_transaction().unwrap();
+
+        if start.elapsed() > std::time::Duration::from_millis(100) {
+            tracing::warn!(
+                "lock acquisition for write transaction took {:?} to acquire",
+                start.elapsed()
+            );
+        }
 
         LbTx { guard, tx }
     }

--- a/libs/lb/lb-rs/src/repo/mod.rs
+++ b/libs/lb/lb-rs/src/repo/mod.rs
@@ -81,11 +81,12 @@ impl Lb {
         //     .unwrap();
 
         let mut guard = self.db.write().await;
-        let tx = guard.begin_transaction().unwrap();
 
         if start.elapsed() > std::time::Duration::from_millis(100) {
             warn!("readwrite transaction lock acquisition took {:?}", start.elapsed());
         }
+
+        let tx = guard.begin_transaction().unwrap();
 
         LbTx { guard, tx }
     }

--- a/libs/lb/lb-rs/src/repo/mod.rs
+++ b/libs/lb/lb-rs/src/repo/mod.rs
@@ -67,7 +67,7 @@ impl Lb {
         let guard = self.db.read().await;
 
         if start.elapsed() > std::time::Duration::from_millis(100) {
-            tracing::warn!("readonly transaction lock acquisition took {:?}", start.elapsed());
+            warn!("readonly transaction lock acquisition took {:?}", start.elapsed());
         }
 
         LbRO { guard }
@@ -84,7 +84,7 @@ impl Lb {
         let tx = guard.begin_transaction().unwrap();
 
         if start.elapsed() > std::time::Duration::from_millis(100) {
-            tracing::warn!("readwrite transaction lock acquisition took {:?}", start.elapsed());
+            warn!("readwrite transaction lock acquisition took {:?}", start.elapsed());
         }
 
         LbTx { guard, tx }

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -38,7 +38,6 @@ impl Lb {
 
     #[instrument(level = "debug", skip(self, content), err(Debug))]
     pub async fn write_document(&self, id: Uuid, content: &[u8]) -> LbResult<()> {
-        debug!("doc length: {}", content.len());
         let mut tx = self.begin_tx().await;
         let db = tx.db();
 
@@ -96,7 +95,6 @@ impl Lb {
     pub async fn safe_write(
         &self, id: Uuid, old_hmac: Option<DocumentHmac>, content: Vec<u8>,
     ) -> LbResult<DocumentHmac> {
-        debug!("doc length: {}", content.len());
         let mut tx = self.begin_tx().await;
         let db = tx.db();
 

--- a/libs/lb/lb-rs/src/service/file.rs
+++ b/libs/lb/lb-rs/src/service/file.rs
@@ -36,8 +36,6 @@ impl Lb {
 
         let ui_file = tree.decrypt(&self.keychain, &id, &db.pub_key_lookup)?;
 
-        info!("created {:?} with id {id}", file_type);
-
         self.spawn_build_index();
 
         Ok(ui_file)

--- a/libs/lb/lb-rs/src/service/logging.rs
+++ b/libs/lb/lb-rs/src/service/logging.rs
@@ -38,7 +38,6 @@ pub fn init(config: &Config) -> LbResult<()> {
         #[cfg(not(target_os = "android"))]
         layers.push(
             fmt::Layer::new()
-                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .pretty()
                 .with_target(false)
                 .with_filter(lockbook_log_level)

--- a/libs/lb/lb-rs/src/service/logging.rs
+++ b/libs/lb/lb-rs/src/service/logging.rs
@@ -38,6 +38,7 @@ pub fn init(config: &Config) -> LbResult<()> {
         #[cfg(not(target_os = "android"))]
         layers.push(
             fmt::Layer::new()
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .pretty()
                 .with_target(false)
                 .with_filter(lockbook_log_level)

--- a/libs/lb/lb-rs/src/service/logging.rs
+++ b/libs/lb/lb-rs/src/service/logging.rs
@@ -42,7 +42,9 @@ pub fn init(config: &Config) -> LbResult<()> {
                 .with_target(false)
                 .with_filter(lockbook_log_level)
                 .with_filter(filter::filter_fn(|metadata| {
-                    metadata.target().starts_with("workspace")
+                    metadata.target().starts_with("lb_rs")
+                        || metadata.target().starts_with("dbrs")
+                        || metadata.target().starts_with("workspace")
                         || metadata.target().starts_with("lb_fs")
                 }))
                 .boxed(),

--- a/libs/lb/lb-rs/src/service/network.rs
+++ b/libs/lb/lb-rs/src/service/network.rs
@@ -86,7 +86,7 @@ impl Network {
             {
                 Ok(o) => {
                     if start.elapsed() > Duration::from_millis(1000) {
-                        warn!("network request took {}ms", start.elapsed().as_millis());
+                        warn!("network request took {:?}", start.elapsed());
                     }
                     break o;
                 }

--- a/libs/lb/lb-rs/src/service/network.rs
+++ b/libs/lb/lb-rs/src/service/network.rs
@@ -85,7 +85,7 @@ impl Network {
                 .await
             {
                 Ok(o) => {
-                    if start.elapsed() > Duration::from_millis(100) {
+                    if start.elapsed() > Duration::from_millis(1000) {
                         warn!("network request took {}ms", start.elapsed().as_millis());
                     }
                     break o;

--- a/libs/lb/lb-rs/src/service/network.rs
+++ b/libs/lb/lb-rs/src/service/network.rs
@@ -70,7 +70,7 @@ impl Network {
         .map_err(|err| ApiError::Serialize(err.to_string()))?;
 
         if serialized_request.len() > 1024 * 1024 {
-            tracing::warn!("making network request with {} bytes", serialized_request.len());
+            warn!("making network request with {} bytes", serialized_request.len());
         }
 
         let mut retries = 0;

--- a/libs/lb/lb-rs/src/service/network.rs
+++ b/libs/lb/lb-rs/src/service/network.rs
@@ -69,7 +69,7 @@ impl Network {
         })
         .map_err(|err| ApiError::Serialize(err.to_string()))?;
 
-        if serialized_request.len() > 1024 * 1024 {
+        if serialized_request.len() > 10 * 1024 * 1024 {
             warn!("making network request with {} bytes", serialized_request.len());
         }
 

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -618,11 +618,15 @@ impl Lb {
                                             String::from_utf8_lossy(&base_document).to_string();
                                         let remote_document =
                                             String::from_utf8_lossy(&remote_document).to_string();
+                                        let local_document =
+                                            String::from_utf8_lossy(&local_document).to_string();
 
-                                        let mut local_buffer = crate::svg::buffer::Buffer::new(
-                                            String::from_utf8_lossy(&local_document).as_ref(),
-                                            None,
-                                        );
+                                        let base_buffer =
+                                            crate::svg::buffer::Buffer::new(&base_document);
+                                        let remote_buffer =
+                                            crate::svg::buffer::Buffer::new(&remote_document);
+                                        let mut local_buffer =
+                                            crate::svg::buffer::Buffer::new(&local_document);
 
                                         for (_, el) in local_buffer.elements.iter_mut() {
                                             if let Element::Path(path) = el {
@@ -635,8 +639,8 @@ impl Lb {
                                             &mut local_buffer.elements,
                                             &mut local_buffer.weak_images,
                                             local_buffer.master_transform,
-                                            &base_document,
-                                            &remote_document,
+                                            &base_buffer,
+                                            &remote_buffer,
                                         );
 
                                         let merged_document = local_buffer.serialize();

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -287,7 +287,7 @@ impl Lb {
 
         drop(tx);
         if start.elapsed() > std::time::Duration::from_millis(100) {
-            tracing::warn!("sync fetch_docs held lock for {:?}", start.elapsed());
+            warn!("sync fetch_docs held lock for {:?}", start.elapsed());
         }
 
         let num_docs = docs_to_pull.len();
@@ -913,7 +913,7 @@ impl Lb {
         db.base_metadata.stage(&mut db.local_metadata).prune()?;
 
         if start.elapsed() > std::time::Duration::from_millis(100) {
-            tracing::warn!("sync merge held lock for {:?}", start.elapsed());
+            warn!("sync merge held lock for {:?}", start.elapsed());
         }
 
         Ok(())
@@ -1002,7 +1002,7 @@ impl Lb {
 
         drop(tx);
         if start.elapsed() > std::time::Duration::from_millis(100) {
-            tracing::warn!("sync push_docs held lock for {:?}", start.elapsed());
+            warn!("sync push_docs held lock for {:?}", start.elapsed());
         }
 
         let docs_count = updates.len();

--- a/libs/lb/lb-rs/src/svg/buffer.rs
+++ b/libs/lb/lb-rs/src/svg/buffer.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use crate::model::file_metadata::DocumentHmac;
-
 use bezier_rs::{Bezier, Subpath};
 use glam::{DAffine2, DMat2, DVec2};
 use indexmap::IndexMap;
@@ -25,9 +23,6 @@ const WEAK_IMAGE_G_ID: &str = "lb_images";
 
 #[derive(Default, Clone)]
 pub struct Buffer {
-    pub open_file_hmac: Option<DocumentHmac>,
-    pub opened_content: String,
-
     pub elements: IndexMap<Uuid, Element>,
     pub weak_images: WeakImages,
     pub master_transform: Transform,
@@ -35,7 +30,7 @@ pub struct Buffer {
 }
 
 impl Buffer {
-    pub fn new(content: &str, open_file_hmac: Option<DocumentHmac>) -> Self {
+    pub fn new(content: &str) -> Self {
         let mut elements = IndexMap::default();
         let mut master_transform = Transform::identity();
         let mut id_map = HashMap::default();
@@ -59,24 +54,13 @@ impl Buffer {
             });
         }
 
-        Self {
-            open_file_hmac,
-            opened_content: content.to_string(),
-            elements,
-            master_transform,
-            id_map,
-            weak_images,
-        }
+        Self { elements, master_transform, id_map, weak_images }
     }
 
     pub fn reload(
         local_elements: &mut IndexMap<Uuid, Element>, local_weak_images: &mut WeakImages,
-        local_master_transform: Transform, base_content: &str, remote_content: &str,
+        local_master_transform: Transform, base_buffer: &Self, remote_buffer: &Self,
     ) {
-        let base_buffer = Buffer::new(base_content, None);
-
-        let remote_buffer = Buffer::new(remote_content, None);
-
         // todo: convert weak images
         for (id, base_img) in base_buffer.weak_images.iter() {
             if let Some(remote_img) = remote_buffer.weak_images.get(id) {

--- a/libs/lb/lb-rs/src/svg/buffer.rs
+++ b/libs/lb/lb-rs/src/svg/buffer.rs
@@ -23,7 +23,7 @@ use super::{
 const ZOOM_G_ID: &str = "lb_master_transform";
 const WEAK_IMAGE_G_ID: &str = "lb_images";
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Buffer {
     pub open_file_hmac: Option<DocumentHmac>,
     pub opened_content: String,

--- a/libs/lb/lb-rs/src/svg/element.rs
+++ b/libs/lb/lb-rs/src/svg/element.rs
@@ -98,7 +98,7 @@ impl Image {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
 pub struct WeakImages(HashMap<Uuid, WeakImage>);
 
 impl Deref for WeakImages {


### PR DESCRIPTION
**changes**
- tab content is now copied for save when the save is launched (rather than when it's queued) and canvas contents are now serialized on a background thread
- tasks once again rely on periodic check-ins from the UI thread via workspace (required to prevent file self-conflicts)
- introduces a tab `is_closing` ("purgatory") state which collapses the tab's tab to just a status indicator and removes it when all dependent tasks are complete (i.e. if a save was in progress, finish saving the tab before closing)
  - closing a tab now generally just moves it to this state
  - we check each frame if it's ready to close
  - some interactions (like opening the file again) will remove the state leaving the tab as a normal tab
- clean ups including removal of unpopulated/unused fields `workspace.out.error` and `workspace.status.usage`
- logging improvements
  - logs from `lbrs` and `dbrs` are now visible in stdout
  - workspace `info!`-logs task updates like queues, launches, and completions for saves, loads, and syncs
  - workspace `warn!`-logs when tasks take a long time (>1s for async tasks, >100ms for work on UI thread)
  - workspace `error!`-logs when tasks fail
  - lbrs `warn!`-logs when locks are held for a long time (>100ms)
  - lbrs `warn!`-logs when network requests are large (>1MB) or take a long time (>1s)
- fixes https://github.com/lockbook/lockbook/issues/3270
- fixes https://github.com/lockbook/lockbook/issues/3271

**notes for reviewers**
- review the interesting bits I called out in my self-review
- QA a big svg; try closing it while it's still saving
- logging
  - is my usage of tracing good? should I be using more spans (difficult when tasks cross threads or otherwise aren't single fns)? should I be providing format arguments differently?
  - any opportunity for helper fn's here? unsure how to create a helper for logging warnings when tasks take a long time without requiring closures (prob not worth)

**todo**
- [x] fix autosave is_dirty mechanism so it doesn't queue a save if the previous save hasn't finished (with the same content)
- [x] fix sync status refresh sometimes taking >2s on the UI thread