### PR TITLE
all: logging refinements

### DIFF
--- a/clients/admin/src/main.rs
+++ b/clients/admin/src/main.rs
@@ -10,7 +10,6 @@ use lb::blocking::Lb;
 use lb::model::api::UnixTimeMillis;
 use lb::model::core_config::Config;
 use lb::Uuid;
-use std::env;
 
 use crate::error::Error;
 use crate::indexes::CliIndex;

--- a/clients/admin/src/main.rs
+++ b/clients/admin/src/main.rs
@@ -106,7 +106,7 @@ pub enum SetUserTier {
 type Res<T> = Result<T, Error>;
 
 pub fn main() {
-    let core = Lb::init(Config::cli_config("admin")).unwrap();
+    let core = Lb::init(Config::cli_config("cli")).unwrap(); // use the cli account
 
     let result = match Admin::parse() {
         Admin::DisappearAccount { username } => disappear::account(&core, username),

--- a/clients/admin/src/main.rs
+++ b/clients/admin/src/main.rs
@@ -107,16 +107,7 @@ pub enum SetUserTier {
 type Res<T> = Result<T, Error>;
 
 pub fn main() {
-    let writeable_path = match (env::var("LOCKBOOK_PATH"), env::var("HOME"), env::var("HOMEPATH")) {
-        (Ok(s), _, _) => s,
-        (Err(_), Ok(s), _) => format!("{}/.lockbook/cli", s),
-        (Err(_), Err(_), Ok(s)) => format!("{}/.lockbook/cli", s),
-        _ => panic!("no lockbook location"),
-    };
-
-    let core =
-        Lb::init(Config { writeable_path, logs: true, colored_logs: true, background_work: false })
-            .unwrap();
+    let core = Lb::init(Config::cli_config()).unwrap();
 
     let result = match Admin::parse() {
         Admin::DisappearAccount { username } => disappear::account(&core, username),

--- a/clients/admin/src/main.rs
+++ b/clients/admin/src/main.rs
@@ -106,7 +106,7 @@ pub enum SetUserTier {
 type Res<T> = Result<T, Error>;
 
 pub fn main() {
-    let core = Lb::init(Config::cli_config()).unwrap();
+    let core = Lb::init(Config::cli_config("admin")).unwrap();
 
     let result = match Admin::parse() {
         Admin::DisappearAccount { username } => disappear::account(&core, username),

--- a/clients/cli/src/lb_fs.rs
+++ b/clients/cli/src/lb_fs.rs
@@ -24,7 +24,7 @@ fn warning() -> CliResult<()> {
 }
 
 fn copy_data() -> CliResult<()> {
-    let current_path = Config::cli_config().writeable_path;
+    let current_path = Config::writeable_path("cli");
     let target_path = format!("{}/.lockbook/drive", std::env::var("HOME").unwrap());
 
     fs_extra::copy_items(
@@ -45,8 +45,8 @@ This version will cp your your CLI's data directory and create a dedicated one f
 iterations will be more tightly integrated into host programs. lb-fs will sync changes to our server
 on startup and then every 5 minutes.
 
-This command will not return and print out logs from the NFS server. Once the server starts it will 
-mount a virtual file system to /tmp/lockbook. Ctrl-C'ing this process will shut down the server and 
+This command will not return and print out logs from the NFS server. Once the server starts it will
+mount a virtual file system to /tmp/lockbook. Ctrl-C'ing this process will shut down the server and
 unmount the file system. For now, a clean umount is critical to not requiring a restart.
 
 Press Y to proceed.

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -30,7 +30,7 @@ use lb_rs::{
 
 fn run() -> CliResult<()> {
     Command::name("lockbook")
-        .description("The private, polished note-taking platform.") 
+        .description("The private, polished note-taking platform.")
         .version(env!("CARGO_PKG_VERSION"))
         .subcommand(
             Command::name("account")
@@ -218,7 +218,7 @@ fn main() {
 }
 
 pub async fn core() -> CliResult<Lb> {
-    Lb::init(Config::cli_config())
+    Lb::init(Config::cli_config("cli"))
         .await
         .map_err(|err| CliError::from(err.to_string()))
 }

--- a/clients/egui/src/splash.rs
+++ b/clients/egui/src/splash.rs
@@ -46,21 +46,7 @@ impl SplashScreen {
         let tx = self.update_tx.clone();
 
         std::thread::spawn(move || {
-            let writeable_path = match data_dir() {
-                Ok(dir) => format!("{}/egui", dir),
-                Err(err) => {
-                    tx.send(SplashUpdate::Error(err)).unwrap();
-                    return;
-                }
-            };
-
-            let cfg = Config {
-                writeable_path,
-                logs: true,
-                stdout_logs: true,
-                colored_logs: true,
-                background_work: true,
-            };
+            let cfg = Config::ui_config("egui");
 
             tx.send(SplashUpdate::Status("Loading core...".to_string()))
                 .unwrap();

--- a/clients/egui/src/splash.rs
+++ b/clients/egui/src/splash.rs
@@ -6,7 +6,6 @@ use lb::model::errors::LbErrKind;
 
 use crate::model::AccountScreenInitData;
 use crate::settings::Settings;
-use crate::util::data_dir;
 
 pub struct SplashHandOff {
     pub settings: Arc<RwLock<Settings>>,

--- a/clients/egui/src/splash.rs
+++ b/clients/egui/src/splash.rs
@@ -54,8 +54,13 @@ impl SplashScreen {
                 }
             };
 
-            let cfg =
-                Config { logs: true, colored_logs: true, writeable_path, background_work: true };
+            let cfg = Config {
+                writeable_path,
+                logs: true,
+                stdout_logs: true,
+                colored_logs: true,
+                background_work: true,
+            };
 
             tx.send(SplashUpdate::Status("Loading core...".to_string()))
                 .unwrap();

--- a/libs/content/editor/egui_editor/src/main.rs
+++ b/libs/content/editor/egui_editor/src/main.rs
@@ -14,9 +14,11 @@ fn main() {
     }
 
     let core = lb::Core::init(&lb::Config {
-        logs: false,
-        colored_logs: false,
-        writeable_path: format!("{}/.lockbook/cli", std::env::var("HOME").unwrap()),
+        writeable_path: format!("{}/.lockbook/egui_editor", std::env::var("HOME").unwrap()),
+        logs: true,
+        stdout_logs: true,
+        colored_logs: true,
+        background_work: true,
     })
     .unwrap();
 

--- a/libs/content/editor/egui_editor/src/main.rs
+++ b/libs/content/editor/egui_editor/src/main.rs
@@ -13,14 +13,7 @@ fn main() {
         }
     }
 
-    let core = lb::Core::init(&lb::Config {
-        writeable_path: format!("{}/.lockbook/egui_editor", std::env::var("HOME").unwrap()),
-        logs: true,
-        stdout_logs: true,
-        colored_logs: true,
-        background_work: true,
-    })
-    .unwrap();
+    let core = lb::Core::init(&lb::Config::ui_config("cli")).unwrap(); // use the cli account
 
     let options = eframe::NativeOptions::default();
     eframe::run_native(

--- a/libs/lb-fs/src/lib.rs
+++ b/libs/lb-fs/src/lib.rs
@@ -20,17 +20,7 @@ pub mod utils;
 
 impl Drive {
     pub async fn init() -> Self {
-        let writeable_path = format!("{}/.lockbook/drive", std::env::var("HOME").unwrap());
-
-        let lb = Lb::init(Config {
-            writeable_path,
-            logs: false,
-            stdout_logs: false,
-            colored_logs: false,
-            background_work: false,
-        })
-        .await
-        .unwrap();
+        let lb = Lb::init(Config::cli_config("drive")).await.unwrap();
 
         let root = lb.root().await.map(|file| file.id).unwrap_or(Uuid::nil());
 

--- a/libs/lb-fs/src/lib.rs
+++ b/libs/lb-fs/src/lib.rs
@@ -25,7 +25,8 @@ impl Drive {
         let lb = Lb::init(Config {
             writeable_path,
             logs: false,
-            colored_logs: true,
+            stdout_logs: false,
+            colored_logs: false,
             background_work: false,
         })
         .await

--- a/libs/lb/lb-c/src/lib.rs
+++ b/libs/lb/lb-c/src/lib.rs
@@ -38,7 +38,13 @@ pub struct LbInitRes {
 pub extern "C" fn lb_init(writeable_path: *const c_char, logs: bool) -> LbInitRes {
     let writeable_path = rstring(writeable_path);
 
-    let config = Config { logs, colored_logs: false, writeable_path, background_work: true };
+    let config = Config {
+        writeable_path,
+        logs,
+        stdout_logs: true,
+        colored_logs: true,
+        background_work: true,
+    };
     match Lb::init(config) {
         Ok(lb) => {
             let lb = Box::into_raw(Box::new(lb));

--- a/libs/lb/lb-c/src/lib.rs
+++ b/libs/lb/lb-c/src/lib.rs
@@ -36,15 +36,10 @@ pub struct LbInitRes {
 
 #[no_mangle]
 pub extern "C" fn lb_init(writeable_path: *const c_char, logs: bool) -> LbInitRes {
-    let writeable_path = rstring(writeable_path);
+    let mut config = Config::ui_config("c");
+    config.writeable_path = rstring(writeable_path);
+    config.logs = logs;
 
-    let config = Config {
-        writeable_path,
-        logs,
-        stdout_logs: true,
-        colored_logs: true,
-        background_work: true,
-    };
     match Lb::init(config) {
         Ok(lb) => {
             let lb = Box::into_raw(Box::new(lb));

--- a/libs/lb/lb-c/src/lib.rs
+++ b/libs/lb/lb-c/src/lib.rs
@@ -36,9 +36,13 @@ pub struct LbInitRes {
 
 #[no_mangle]
 pub extern "C" fn lb_init(writeable_path: *const c_char, logs: bool) -> LbInitRes {
-    let mut config = Config::ui_config("c");
-    config.writeable_path = rstring(writeable_path);
-    config.logs = logs;
+    let config = Config {
+        writeable_path: rstring(writeable_path),
+        background_work: true,
+        logs,
+        stdout_logs: true,
+        colored_logs: false,
+    };
 
     match Lb::init(config) {
         Ok(lb) => {

--- a/libs/lb/lb-java/src/lib.rs
+++ b/libs/lb/lb-java/src/lib.rs
@@ -30,14 +30,9 @@ use lb_rs::{
 pub extern "system" fn Java_net_lockbook_Lb_init<'local>(
     mut env: JNIEnv<'local>, class: JClass<'local>, path: JString<'local>,
 ) {
-    let writeable_path = rstring(&mut env, path);
-    let config = Config {
-        logs: true,
-        colored_logs: false,
-        stdout_logs: true, // in the context of java, stdout_logs refers to android logcat
-        writeable_path,
-        background_work: true,
-    };
+    let mut config = Config::ui_config("java");
+    config.writeable_path = rstring(&mut env, path);
+    config.colored_logs = false;
 
     match Lb::init(config) {
         Ok(lb) => {

--- a/libs/lb/lb-java/src/lib.rs
+++ b/libs/lb/lb-java/src/lib.rs
@@ -30,9 +30,13 @@ use lb_rs::{
 pub extern "system" fn Java_net_lockbook_Lb_init<'local>(
     mut env: JNIEnv<'local>, class: JClass<'local>, path: JString<'local>,
 ) {
-    let mut config = Config::ui_config("java");
-    config.writeable_path = rstring(&mut env, path);
-    config.colored_logs = false;
+    let config = Config {
+        writeable_path: rstring(&mut env, path),
+        background_work: true,
+        logs: true,
+        stdout_logs: true,
+        colored_logs: false,
+    };
 
     match Lb::init(config) {
         Ok(lb) => {

--- a/libs/lb/lb-java/src/lib.rs
+++ b/libs/lb/lb-java/src/lib.rs
@@ -31,7 +31,13 @@ pub extern "system" fn Java_net_lockbook_Lb_init<'local>(
     mut env: JNIEnv<'local>, class: JClass<'local>, path: JString<'local>,
 ) {
     let writeable_path = rstring(&mut env, path);
-    let config = Config { logs: true, colored_logs: false, writeable_path, background_work: true };
+    let config = Config {
+        logs: true,
+        colored_logs: false,
+        stdout_logs: true, // in the context of java, stdout_logs refers to android logcat
+        writeable_path,
+        background_work: true,
+    };
 
     match Lb::init(config) {
         Ok(lb) => {

--- a/libs/lb/lb-rs/src/model/core_config.rs
+++ b/libs/lb/lb-rs/src/model/core_config.rs
@@ -4,16 +4,17 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
+    /// Where should lockbook store data, including logs?
+    pub writeable_path: String,
+    /// Should lb do background work like keep search indexes up to date?
+    pub background_work: bool,
+
     /// Should we log at all?
     pub logs: bool,
     /// Should logs be printed to stdout?
     pub stdout_logs: bool,
     /// Should logs be colored?
     pub colored_logs: bool,
-    /// Where should lockbook store data, including logs?
-    pub writeable_path: String,
-    /// Should lb do background work like keep search indexes up to date?
-    pub background_work: bool,
 }
 
 impl Config {
@@ -22,10 +23,10 @@ impl Config {
     pub fn cli_config(writeable_path_subfolder: &str) -> Config {
         Config {
             writeable_path: Self::writeable_path(writeable_path_subfolder),
+            background_work: false,
             logs: true,
             stdout_logs: false,
             colored_logs: true,
-            background_work: false,
         }
     }
 
@@ -34,10 +35,10 @@ impl Config {
     pub fn ui_config(writeable_path_subfolder: &str) -> Config {
         Config {
             writeable_path: Self::writeable_path(writeable_path_subfolder),
+            background_work: true,
             logs: true,
             stdout_logs: true,
             colored_logs: true,
-            background_work: true,
         }
     }
 

--- a/libs/lb/lb-rs/src/model/core_config.rs
+++ b/libs/lb/lb-rs/src/model/core_config.rs
@@ -17,24 +17,45 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn cli_config() -> Config {
-        let specified_path = env::var("LOCKBOOK_PATH");
-
-        let default_path = env::var("HOME") // unix
-            .or(env::var("HOMEPATH")) // windows
-            .map(|home| format!("{home}/.lockbook/cli"));
-
-        let Ok(writeable_path) = specified_path.or(default_path) else {
-            panic!("no location for lockbook to initialize");
-        };
-
+    /// Configures lockbook for CLI use with no stdout logs or background work. `writeable_path_subfolder` is generally
+    /// a hardcoded client name like `"cli"`.
+    pub fn cli_config(writeable_path_subfolder: &str) -> Config {
         Config {
-            writeable_path,
+            writeable_path: Self::writeable_path(writeable_path_subfolder),
             logs: true,
             stdout_logs: false,
             colored_logs: true,
             background_work: false,
         }
+    }
+
+    /// Configures lockbook for UI use with stdout logs and background work. `writeable_path_subfolder` is generally
+    /// a hardcoded client name like `"macos"`.
+    pub fn ui_config(writeable_path_subfolder: &str) -> Config {
+        Config {
+            writeable_path: Self::writeable_path(writeable_path_subfolder),
+            logs: true,
+            stdout_logs: true,
+            colored_logs: true,
+            background_work: true,
+        }
+    }
+
+    /// Produces a full writable path for lockbook to use based on environment variables and platform. Useful for
+    /// initializing the Config struct.
+    pub fn writeable_path(writeable_path_subfolder: &str) -> String {
+        let specified_path = env::var("LOCKBOOK_PATH");
+
+        let default_path =
+            env::var("HOME") // unix
+                .or(env::var("HOMEPATH")) // windows
+                .map(|home| format!("{home}/.lockbook/{writeable_path_subfolder}"));
+
+        let Ok(writeable_path) = specified_path.or(default_path) else {
+            panic!("no location for lockbook to initialize");
+        };
+
+        writeable_path
     }
 }
 

--- a/libs/lb/lb-rs/src/model/core_config.rs
+++ b/libs/lb/lb-rs/src/model/core_config.rs
@@ -4,8 +4,13 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
+    /// Should we log at all?
     pub logs: bool,
+    /// Should logs be printed to stdout?
+    pub stdout_logs: bool,
+    /// Should logs be colored?
     pub colored_logs: bool,
+    /// Where should lockbook store data, including logs?
     pub writeable_path: String,
     /// Should lb do background work like keep search indexes up to date?
     pub background_work: bool,
@@ -23,7 +28,13 @@ impl Config {
             panic!("no location for lockbook to initialize");
         };
 
-        Config { writeable_path, logs: true, colored_logs: true, background_work: false }
+        Config {
+            writeable_path,
+            logs: true,
+            stdout_logs: false,
+            colored_logs: true,
+            background_work: false,
+        }
     }
 }
 

--- a/libs/lb/lb-rs/src/service/logging.rs
+++ b/libs/lb/lb-rs/src/service/logging.rs
@@ -34,40 +34,42 @@ pub fn init(config: &Config) -> LbResult<()> {
                 .boxed(),
         );
 
-        // stdout target for non-android platforms
-        #[cfg(not(target_os = "android"))]
-        layers.push(
-            fmt::Layer::new()
-                .pretty()
-                .with_target(false)
-                .with_filter(lockbook_log_level)
-                .with_filter(filter::filter_fn(|metadata| {
-                    metadata.target().starts_with("lb_rs")
-                        || metadata.target().starts_with("dbrs")
-                        || metadata.target().starts_with("workspace")
-                        || metadata.target().starts_with("lb_fs")
-                }))
-                .boxed(),
-        );
-
-        // logcat target for android
-        #[cfg(target_os = "android")]
-        if let Some(writer) =
-            tracing_logcat::LogcatMakeWriter::new(tracing_logcat::LogcatTag::Target).ok()
-        {
+        if config.stdout_logs {
+            // stdout target for non-android platforms
+            #[cfg(not(target_os = "android"))]
             layers.push(
                 fmt::Layer::new()
-                    .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-                    .with_ansi(false)
-                    .with_writer(writer)
+                    .pretty()
+                    .with_target(false)
                     .with_filter(lockbook_log_level)
                     .with_filter(filter::filter_fn(|metadata| {
                         metadata.target().starts_with("lb_rs")
+                            || metadata.target().starts_with("dbrs")
                             || metadata.target().starts_with("workspace")
-                            || metadata.target().starts_with("lb_java")
+                            || metadata.target().starts_with("lb_fs")
                     }))
                     .boxed(),
             );
+
+            // logcat target for android
+            #[cfg(target_os = "android")]
+            if let Some(writer) =
+                tracing_logcat::LogcatMakeWriter::new(tracing_logcat::LogcatTag::Target).ok()
+            {
+                layers.push(
+                    fmt::Layer::new()
+                        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                        .with_ansi(false)
+                        .with_writer(writer)
+                        .with_filter(lockbook_log_level)
+                        .with_filter(filter::filter_fn(|metadata| {
+                            metadata.target().starts_with("lb_rs")
+                                || metadata.target().starts_with("workspace")
+                                || metadata.target().starts_with("lb_java")
+                        }))
+                        .boxed(),
+                );
+            }
         }
 
         tracing::subscriber::set_global_default(

--- a/libs/lb/lb-rs/src/service/search.rs
+++ b/libs/lb/lb-rs/src/service/search.rs
@@ -197,7 +197,6 @@ impl Lb {
         Ok(())
     }
 
-    #[instrument(level = "debug", skip(self))]
     /// ensure the index is not built more frequently than every 5s
     pub fn spawn_build_index(&self) {
         if self.config.background_work {

--- a/libs/lb/lb-rs/tests/cli_data_tests.rs
+++ b/libs/lb/lb-rs/tests/cli_data_tests.rs
@@ -3,7 +3,7 @@ use lb_rs::{model::core_config::Config, Lb};
 #[tokio::test]
 #[ignore]
 async fn pending_shares_perf() {
-    let lb = Lb::init(Config::cli_config()).await.unwrap();
+    let lb = Lb::init(Config::cli_config("test")).await.unwrap();
     for _ in 0..1000 {
         lb.get_pending_shares().await.unwrap();
     }

--- a/libs/lb/test_utils/src/lib.rs
+++ b/libs/lb/test_utils/src/lib.rs
@@ -19,6 +19,7 @@ pub fn test_config() -> Config {
     Config {
         writeable_path: format!("/tmp/{}", Uuid::new_v4()),
         logs: false,
+        stdout_logs: false,
         colored_logs: false,
         background_work: false,
     }


### PR DESCRIPTION
* fixes cli output (see below) by introducing `stdout_logs` config
  * `false` for `admin`, `cli`
  * `true` for `egui`, `lbfs`, `lb-c`, `lb-java`
* reduces code duplication by introducing helper fn for ui config (similar to helper for cli config)
* cleans up writeable path usage
  * `egui`: removed duplicate code
  * `lbfs`: removed duplicate code

cli output on master:
```
❯ lockbook list
  2025-01-10T19:13:02.840528Z DEBUG  new
    at libs/lb/lb-rs/src/service/search.rs:200
    in spawn_build_index

  2025-01-10T19:13:02.840636Z DEBUG  close, time.busy: 22.0µs, time.idle: 240µs
    at libs/lb/lb-rs/src/service/search.rs:200
    in spawn_build_index

  2025-01-10T19:13:02.840716Z DEBUG  new
    at libs/lb/lb-rs/src/service/file.rs:102
    in root

  2025-01-10T19:13:02.843366Z DEBUG  close, time.busy: 2.59ms, time.idle: 76.0µs
    at libs/lb/lb-rs/src/service/file.rs:102
    in root
...
Tests/
misc/
untitled.svg
...
```

cli output on branch:
```
❯ lockbook list
Tests/
misc/
untitled.svg
...
```

follow-up to https://github.com/lockbook/lockbook/pull/3275