### PR TITLE
ios: fix double tap space to insert period

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -149,11 +149,8 @@ pub unsafe extern "C" fn get_selected(obj: *mut c_void) -> CTextRange {
 
     CTextRange {
         none: false,
-        start: CTextPosition {
-            pos: markdown.buffer.current.selection.start().0,
-            ..Default::default()
-        },
-        end: CTextPosition { pos: markdown.buffer.current.selection.end().0, ..Default::default() },
+        start: CTextPosition { pos: markdown.buffer.current.selection.start().0, none: false },
+        end: CTextPosition { pos: markdown.buffer.current.selection.end().0, none: false },
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/3047

I did record a demo but didn't bother uploading because it looks exactly how you'd expect.