### PR TITLE
lb-rs: 50x time debug_info takes

### DIFF
--- a/libs/lb/lb-rs/src/model/errors.rs
+++ b/libs/lb/lb-rs/src/model/errors.rs
@@ -541,7 +541,6 @@ impl fmt::Display for TestRepoError {
 pub enum Warning {
     EmptyFile(Uuid),
     InvalidUTF8(Uuid),
-    UnreadableDrawing(Uuid),
 }
 
 impl fmt::Display for Warning {
@@ -549,7 +548,6 @@ impl fmt::Display for Warning {
         match self {
             Self::EmptyFile(id) => write!(f, "empty file: {}", id),
             Self::InvalidUTF8(id) => write!(f, "invalid utf8 in file: {}", id),
-            Self::UnreadableDrawing(id) => write!(f, "unreadable drawing: {}", id),
         }
     }
 }

--- a/libs/lb/lb-rs/src/service/integrity.rs
+++ b/libs/lb/lb-rs/src/service/integrity.rs
@@ -1,14 +1,14 @@
-use std::path::Path;
+use std::num::NonZeroUsize;
+use std::thread;
 
-use crate::logic::file_like::FileLike;
+use futures::{stream, StreamExt};
+
+use crate::logic::filename::DocumentType;
 use crate::logic::tree_like::TreeLike;
 use crate::model::file_metadata::Owner;
 
 use crate::model::errors::{TestRepoError, Warning};
 use crate::Lb;
-
-const UTF8_SUFFIXES: [&str; 12] =
-    ["md", "txt", "text", "markdown", "sh", "zsh", "bash", "html", "css", "js", "csv", "rs"];
 
 impl Lb {
     // todo good contender for async treatment, to speedup debug_info
@@ -35,31 +35,37 @@ impl Lb {
             }
         }
 
+        drop(tree);
+
         let mut warnings = Vec::new();
-        for id in tree.ids() {
-            let file = tree.find(&id)?;
-            let id = *file.id();
-            let doc = file.is_document();
-            let cont = file.document_hmac().is_some();
-            let not_deleted = !tree.calculate_deleted(&id)?;
-            if not_deleted && doc && cont {
-                let doc = self.read_document_helper(id, &mut tree).await?;
+        let mut tasks = vec![];
+        for file in self.list_metadatas().await? {
+            if file.is_document() {
+                let is_text =
+                    DocumentType::from_file_name_using_extension(&file.name) == DocumentType::Text;
 
-                if doc.len() as u64 == 0 {
-                    warnings.push(Warning::EmptyFile(id));
-                    continue;
+                if is_text {
+                    tasks.push(async move { (file.id, self.read_document(file.id, false).await) });
                 }
+            }
+        }
 
-                let name = tree.name(&id, &self.keychain)?;
-                let extension = Path::new(&name)
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .unwrap_or("");
+        let mut results = stream::iter(tasks).buffer_unordered(
+            thread::available_parallelism()
+                .unwrap_or(NonZeroUsize::new(4).unwrap())
+                .into(),
+        );
 
-                if UTF8_SUFFIXES.contains(&extension) && String::from_utf8(doc.clone()).is_err() {
-                    warnings.push(Warning::InvalidUTF8(id));
-                    continue;
-                }
+        while let Some((id, res)) = results.next().await {
+            let doc = res?;
+            if doc.is_empty() {
+                warnings.push(Warning::EmptyFile(id));
+                continue;
+            }
+
+            if String::from_utf8(doc).is_err() {
+                warnings.push(Warning::InvalidUTF8(id));
+                continue;
             }
         }
 

--- a/libs/lb/lb-rs/tests/cli_data_tests.rs
+++ b/libs/lb/lb-rs/tests/cli_data_tests.rs
@@ -10,6 +10,7 @@ async fn pending_shares_perf() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn debug_info_test() {
     let lb = Lb::init(Config::cli_config("cli")).await.unwrap();
     for _ in 0..2 {

--- a/libs/lb/lb-rs/tests/cli_data_tests.rs
+++ b/libs/lb/lb-rs/tests/cli_data_tests.rs
@@ -3,8 +3,16 @@ use lb_rs::{model::core_config::Config, Lb};
 #[tokio::test]
 #[ignore]
 async fn pending_shares_perf() {
-    let lb = Lb::init(Config::cli_config("test")).await.unwrap();
+    let lb = Lb::init(Config::cli_config("cli")).await.unwrap();
     for _ in 0..1000 {
         lb.get_pending_shares().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn debug_info_test() {
+    let lb = Lb::init(Config::cli_config("cli")).await.unwrap();
+    for _ in 0..2 {
+        lb.debug_info("none".to_string()).await.unwrap();
     }
 }


### PR DESCRIPTION
- 95% of the time was taken reading every document serially.
- this does have some value -- we get to check to make sure we can decrypt every document, but these checks fully overlap with our metadata assertions (if you can decrypt filename you can prob decrypt document)
- we're also going to move to a world where all docs aren't present locally
- so I made two changes here: only try to validate text files 
- and do this in parallel
- it's much faster from the CLI now, probably will be even faster in other settings once long lived caches are saturated by organic use

fixes #3164
