### PR TITLE
server: resolve deadlock

### DIFF
--- a/server/src/account_service.rs
+++ b/server/src/account_service.rs
@@ -63,7 +63,7 @@ where
         let now = get_time().0 as u64;
         let root = root.add_time(now);
 
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
         let handle = db.begin_transaction()?;
 
         if db.accounts.get().contains_key(&Owner(request.public_key)) {
@@ -102,14 +102,15 @@ where
         &self, context: RequestContext<GetPublicKeyRequest>,
     ) -> Result<GetPublicKeyResponse, ServerError<GetPublicKeyError>> {
         let request = &context.request;
-        self.public_key_from_username(&request.username)
+        self.public_key_from_username(&request.username).await
     }
 
-    pub fn public_key_from_username(
+    pub async fn public_key_from_username(
         &self, username: &str,
     ) -> Result<GetPublicKeyResponse, ServerError<GetPublicKeyError>> {
         self.index_db
-            .lock()?
+            .lock()
+            .await
             .usernames
             .get()
             .get(username)
@@ -120,14 +121,15 @@ where
     pub async fn get_username(
         &self, context: RequestContext<GetUsernameRequest>,
     ) -> Result<GetUsernameResponse, ServerError<GetUsernameError>> {
-        self.username_from_public_key(context.request.key)
+        self.username_from_public_key(context.request.key).await
     }
 
-    pub fn username_from_public_key(
+    pub async fn username_from_public_key(
         &self, key: PublicKey,
     ) -> Result<GetUsernameResponse, ServerError<GetUsernameError>> {
         self.index_db
-            .lock()?
+            .lock()
+            .await
             .accounts
             .get()
             .get(&Owner(key))
@@ -138,7 +140,7 @@ where
     pub async fn get_usage(
         &self, context: RequestContext<GetUsageRequest>,
     ) -> Result<GetUsageResponse, ServerError<GetUsageError>> {
-        let mut lock = self.index_db.lock()?;
+        let mut lock = self.index_db.lock().await;
         let db = lock.deref_mut();
 
         let cap = Self::get_cap(db, &context.public_key)?;
@@ -222,7 +224,7 @@ where
         &self, context: RequestContext<AdminDisappearAccountRequest>,
     ) -> Result<(), ServerError<AdminDisappearAccountError>> {
         let owner = {
-            let db = &self.index_db.lock()?;
+            let db = &self.index_db.lock().await;
 
             if !Self::is_admin::<AdminDisappearAccountError>(
                 db,
@@ -256,7 +258,7 @@ where
     pub async fn admin_list_users(
         &self, context: RequestContext<AdminListUsersRequest>,
     ) -> Result<AdminListUsersResponse, ServerError<AdminListUsersError>> {
-        let (db, request) = (&self.index_db.lock()?, &context.request);
+        let (db, request) = (&self.index_db.lock().await, &context.request);
 
         if !Self::is_admin::<AdminListUsersError>(
             db,
@@ -308,7 +310,7 @@ where
     pub async fn admin_get_account_info(
         &self, context: RequestContext<AdminGetAccountInfoRequest>,
     ) -> Result<AdminGetAccountInfoResponse, ServerError<AdminGetAccountInfoError>> {
-        let (mut lock, request) = (self.index_db.lock()?, &context.request);
+        let (mut lock, request) = (self.index_db.lock().await, &context.request);
         let db = lock.deref_mut();
 
         if !Self::is_admin::<AdminGetAccountInfoError>(
@@ -409,7 +411,7 @@ where
         let mut docs_to_delete = Vec::new();
 
         {
-            let mut lock = self.index_db.lock()?;
+            let mut lock = self.index_db.lock().await;
             let db = lock.deref_mut();
             let tx = db.begin_transaction()?;
 

--- a/server/src/billing/app_store_service.rs
+++ b/server/src/billing/app_store_service.rs
@@ -32,12 +32,13 @@ where
     G: GooglePlayClient,
     D: DocumentService,
 {
-    pub fn get_public_key_from_tx(
+    pub async fn get_public_key_from_tx(
         &self, trans: &TransactionInfo,
     ) -> Result<PublicKey, ServerError<AppStoreNotificationError>> {
         let public_key: PublicKey = self
             .index_db
-            .lock()?
+            .lock()
+            .await
             .app_store_ids
             .get()
             .get(&trans.app_account_token)

--- a/server/src/billing/billing_service.rs
+++ b/server/src/billing/billing_service.rs
@@ -45,11 +45,11 @@ where
     G: GooglePlayClient,
     D: DocumentService,
 {
-    fn lock_subscription_profile(
+    async fn lock_subscription_profile(
         &self, public_key: &PublicKey,
     ) -> Result<Account, ServerError<LockBillingWorkflowError>> {
         let owner = Owner(*public_key);
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
         let tx = db.begin_transaction()?;
         let mut account = db
             .accounts
@@ -77,12 +77,13 @@ where
         Ok(account)
     }
 
-    fn release_subscription_profile<T: Debug>(
+    async fn release_subscription_profile<T: Debug>(
         &self, public_key: PublicKey, mut account: Account,
     ) -> Result<(), ServerError<T>> {
         account.billing_info.last_in_payment_flow = 0;
         self.index_db
-            .lock()?
+            .lock()
+            .await
             .accounts
             .insert(Owner(public_key), account)?;
         Ok(())
@@ -93,12 +94,12 @@ where
     ) -> Result<UpgradeAccountAppStoreResponse, ServerError<UpgradeAccountAppStoreError>> {
         let request = &context.request;
 
-        let mut account = self.lock_subscription_profile(&context.public_key)?;
+        let mut account = self.lock_subscription_profile(&context.public_key).await?;
 
         debug!("Upgrading the account of a user through app store billing");
 
         {
-            let db = self.index_db.lock()?;
+            let db = self.index_db.lock().await;
             if let Some(owner) = db.app_store_ids.get().get(&request.app_account_token) {
                 if let Some(other_account) = db.accounts.get().get(owner) {
                     if let Some(BillingPlatform::AppStore(ref info)) =
@@ -139,14 +140,16 @@ where
         }));
 
         self.index_db
-            .lock()?
+            .lock()
+            .await
             .app_store_ids
             .insert(request.app_account_token.clone(), Owner(context.public_key))?;
 
         self.release_subscription_profile::<UpgradeAccountAppStoreError>(
             context.public_key,
             account,
-        )?;
+        )
+        .await?;
 
         Ok(UpgradeAccountAppStoreResponse {})
     }
@@ -156,7 +159,7 @@ where
     ) -> Result<UpgradeAccountGooglePlayResponse, ServerError<UpgradeAccountGooglePlayError>> {
         let request = &context.request;
 
-        let mut account = self.lock_subscription_profile(&context.public_key)?;
+        let mut account = self.lock_subscription_profile(&context.public_key).await?;
 
         if account.billing_info.is_premium() {
             return Err(ClientError(UpgradeAccountGooglePlayError::AlreadyPremium));
@@ -182,14 +185,16 @@ where
         )?);
 
         self.index_db
-            .lock()?
+            .lock()
+            .await
             .google_play_ids
             .insert(request.account_id.clone(), Owner(context.public_key))?;
 
         self.release_subscription_profile::<UpgradeAccountGooglePlayError>(
             context.public_key,
             account,
-        )?;
+        )
+        .await?;
 
         debug!("Successfully upgraded a user through a google play subscription. public_key");
 
@@ -203,7 +208,7 @@ where
 
         debug!("Attempting to upgrade the account tier of to premium");
 
-        let mut account = self.lock_subscription_profile(&context.public_key)?;
+        let mut account = self.lock_subscription_profile(&context.public_key).await?;
 
         if account.billing_info.is_premium() {
             return Err(ClientError(UpgradeAccountStripeError::AlreadyPremium));
@@ -222,10 +227,8 @@ where
             .await?;
 
         account.billing_info.billing_platform = Some(BillingPlatform::Stripe(user_info));
-        self.release_subscription_profile::<UpgradeAccountStripeError>(
-            context.public_key,
-            account,
-        )?;
+        self.release_subscription_profile::<UpgradeAccountStripeError>(context.public_key, account)
+            .await?;
 
         debug!("Successfully upgraded the account tier of from free to premium");
 
@@ -237,7 +240,8 @@ where
     ) -> Result<GetSubscriptionInfoResponse, ServerError<GetSubscriptionInfoError>> {
         let platform = self
             .index_db
-            .lock()?
+            .lock()
+            .await
             .accounts
             .get()
             .get(&Owner(context.public_key))
@@ -267,14 +271,14 @@ where
     pub async fn cancel_subscription(
         &self, context: RequestContext<CancelSubscriptionRequest>,
     ) -> Result<CancelSubscriptionResponse, ServerError<CancelSubscriptionError>> {
-        let mut account = self.lock_subscription_profile(&context.public_key)?;
+        let mut account = self.lock_subscription_profile(&context.public_key).await?;
 
         if account.billing_info.data_cap() == FREE_TIER_USAGE_SIZE {
             return Err(ClientError(CancelSubscriptionError::NotPremium));
         }
 
         {
-            let mut lock = self.index_db.lock()?;
+            let mut lock = self.index_db.lock().await;
             let db = lock.deref_mut();
 
             let mut tree = ServerTree::new(
@@ -332,7 +336,8 @@ where
         }
     }
 
-        self.release_subscription_profile::<CancelSubscriptionError>(context.public_key, account)?;
+        self.release_subscription_profile::<CancelSubscriptionError>(context.public_key, account)
+            .await?;
 
         Ok(CancelSubscriptionResponse {})
     }
@@ -343,7 +348,7 @@ where
         let request = &context.request;
 
         {
-            let db = self.index_db.lock()?;
+            let db = self.index_db.lock().await;
 
             if !Self::is_admin::<AdminSetUserTierError>(
                 &db,
@@ -356,13 +361,14 @@ where
 
         let public_key = self
             .index_db
-            .lock()?
+            .lock()
+            .await
             .usernames
             .get()
             .get(&request.username)
             .ok_or(ClientError(AdminSetUserTierError::UserNotFound))?
             .0;
-        let mut account = self.lock_subscription_profile(&public_key)?;
+        let mut account = self.lock_subscription_profile(&public_key).await?;
 
         let billing_config = &self.config.billing;
 
@@ -417,7 +423,8 @@ where
 
         account.username = request.username.clone();
 
-        self.release_subscription_profile::<AdminSetUserTierError>(public_key, account)?;
+        self.release_subscription_profile::<AdminSetUserTierError>(public_key, account)
+            .await?;
 
         Ok(AdminSetUserTierResponse {})
     }
@@ -430,10 +437,11 @@ where
     ) -> Result<(), ServerError<T>> {
         let millis_between_lock_attempts = self.config.billing.time_between_lock_attempts;
         loop {
-            match self.lock_subscription_profile(public_key) {
+            match self.lock_subscription_profile(public_key).await {
                 Ok(ref mut sub_profile) => {
                     update_subscription_profile(sub_profile)?;
-                    self.release_subscription_profile(*public_key, sub_profile.clone())?;
+                    self.release_subscription_profile(*public_key, sub_profile.clone())
+                        .await?;
                     break;
                 }
                 Err(ClientError(ExistingRequestPending)) => {
@@ -462,7 +470,7 @@ where
                 if let Some(stripe::InvoiceBillingReason::SubscriptionCycle) =
                     invoice.billing_reason
                 {
-                    let public_key = self.get_public_key_from_invoice(invoice)?;
+                    let public_key = self.get_public_key_from_invoice(invoice).await?;
                     let owner = Owner(public_key);
 
                     debug!(
@@ -491,7 +499,7 @@ where
                 if let Some(stripe::InvoiceBillingReason::SubscriptionCycle) =
                     invoice.billing_reason
                 {
-                    let public_key = self.get_public_key_from_invoice(invoice)?;
+                    let public_key = self.get_public_key_from_invoice(invoice).await?;
                     let owner = Owner(public_key);
 
                     debug!(
@@ -567,8 +575,9 @@ where
                 return Ok(());
             }
 
-            let public_key =
-                self.get_public_key_from_subnotif(&sub_notif, &subscription, &notification_type)?;
+            let public_key = self
+                .get_public_key_from_subnotif(&sub_notif, &subscription, &notification_type)
+                .await?;
             let owner = Owner(public_key);
 
             debug!(
@@ -685,12 +694,13 @@ where
                 .encoded_transaction_info
                 .ok_or(ClientError(AppStoreNotificationError::InvalidJWS))?,
         )?;
-        let public_key = self.get_public_key_from_tx(&trans)?;
+        let public_key = self.get_public_key_from_tx(&trans).await?;
 
         let owner = Owner(public_key);
         let maybe_username = &self
             .index_db
-            .lock()?
+            .lock()
+            .await
             .accounts
             .get()
             .get(&owner)

--- a/server/src/billing/google_play_service.rs
+++ b/server/src/billing/google_play_service.rs
@@ -22,7 +22,7 @@ where
     G: GooglePlayClient,
     D: DocumentService,
 {
-    pub fn get_public_key_from_subnotif(
+    pub async fn get_public_key_from_subnotif(
         &self, sub_notif: &SubscriptionNotification, subscription: &SubscriptionPurchase,
         notification_type: &NotificationType,
     ) -> Result<PublicKey, ServerError<GooglePlayWebhookError>> {
@@ -41,7 +41,8 @@ where
 
         let public_key: PublicKey = self
             .index_db
-            .lock()?
+            .lock()
+            .await
             .google_play_ids
             .get()
             .get(account_id)

--- a/server/src/billing/stripe_service.rs
+++ b/server/src/billing/stripe_service.rs
@@ -75,7 +75,8 @@ where
                         info!(?owner, ?customer_id, "Created customer_id");
 
                         self.index_db
-                            .lock()?
+                            .lock()
+                            .await
                             .stripe_ids
                             .insert(customer_id, Owner(*public_key))?;
 
@@ -152,7 +153,7 @@ where
         })
     }
 
-    pub fn get_public_key_from_invoice(
+    pub async fn get_public_key_from_invoice(
         &self, invoice: &Invoice,
     ) -> Result<PublicKey, ServerError<StripeWebhookError>> {
         let customer_id = match invoice.customer.as_ref().ok_or_else(|| {
@@ -166,7 +167,8 @@ where
 
         let public_key = self
             .index_db
-            .lock()?
+            .lock()
+            .await
             .stripe_ids
             .get()
             .get(&customer_id)

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -40,7 +40,7 @@ where
             let mut prior_deleted = HashSet::new();
             let mut current_deleted = HashSet::new();
 
-            let mut lock = self.index_db.lock()?;
+            let mut lock = self.index_db.lock().await;
             let db = lock.deref_mut();
             let tx = db.begin_transaction()?;
 
@@ -212,7 +212,7 @@ where
         let req_pk = context.public_key;
 
         {
-            let mut lock = self.index_db.lock()?;
+            let mut lock = self.index_db.lock().await;
             let db = lock.deref_mut();
             let usage_cap =
                 Self::get_cap(db, &context.public_key).map_err(|err| internal!("{:?}", err))?;
@@ -312,8 +312,8 @@ where
             .await?;
         debug!(?id, ?hmac, "Inserted document contents");
 
-        let result = || {
-            let mut lock = self.index_db.lock()?;
+        let result = async {
+            let mut lock = self.index_db.lock().await;
             let db = lock.deref_mut();
             let tx = db.begin_transaction()?;
 
@@ -351,7 +351,7 @@ where
             Ok(())
         };
 
-        let result = result();
+        let result = result.await;
 
         if result.is_err() {
             // Cleanup the NEW file created if, for some reason, the tx failed
@@ -384,7 +384,7 @@ where
     ) -> Result<GetDocumentResponse, ServerError<GetDocumentError>> {
         let request = &context.request;
         {
-            let mut lock = self.index_db.lock()?;
+            let mut lock = self.index_db.lock().await;
             let db = lock.deref_mut();
             let tx = db.begin_transaction()?;
 
@@ -434,7 +434,7 @@ where
         &self, context: RequestContext<GetFileIdsRequest>,
     ) -> Result<GetFileIdsResponse, ServerError<GetFileIdsError>> {
         let owner = Owner(context.public_key);
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
         let db = db.deref_mut();
 
         Ok(GetFileIdsResponse {
@@ -457,7 +457,7 @@ where
         let request = &context.request;
         let owner = Owner(context.public_key);
 
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
         let db = db.deref_mut();
         let mut tree = ServerTree::new(
             owner,
@@ -502,7 +502,7 @@ where
         let mut docs_to_delete = Vec::new();
 
         {
-            let mut db = self.index_db.lock()?;
+            let mut db = self.index_db.lock().await;
             let db = db.deref_mut();
             let tx = db.begin_transaction()?;
 
@@ -613,7 +613,7 @@ where
         &self, context: RequestContext<AdminValidateAccountRequest>,
     ) -> Result<AdminValidateAccount, ServerError<AdminValidateAccountError>> {
         let request = &context.request;
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
         if !Self::is_admin::<AdminValidateAccountError>(
             &db,
             &context.public_key,
@@ -682,7 +682,7 @@ where
     pub async fn admin_validate_server(
         &self, context: RequestContext<AdminValidateServerRequest>,
     ) -> Result<AdminValidateServer, ServerError<AdminValidateServerError>> {
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
         let db = db.deref_mut();
 
         if !Self::is_admin::<AdminValidateServerError>(
@@ -893,7 +893,7 @@ where
         &self, context: RequestContext<AdminFileInfoRequest>,
     ) -> Result<AdminFileInfoResponse, ServerError<AdminFileInfoError>> {
         let request = &context.request;
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
         let db = db.deref_mut();
         if !Self::is_admin::<AdminFileInfoError>(
             db,
@@ -938,7 +938,7 @@ where
     pub async fn admin_rebuild_index(
         &self, context: RequestContext<AdminRebuildIndexRequest>,
     ) -> Result<(), ServerError<AdminRebuildIndexError>> {
-        let mut db = self.index_db.lock()?;
+        let mut db = self.index_db.lock().await;
 
         match context.request.index {
             ServerIndex::OwnedFiles => {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,7 +5,8 @@ use document_service::DocumentService;
 use lb_rs::model::clock;
 use std::env;
 use std::fmt::Debug;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use lb_rs::logic::{pubkey, SharedError};
 use lb_rs::model::api::{ErrorWrapper, Request, RequestWrapper};

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -93,7 +93,7 @@ where
         loop {
             info!("Metrics refresh started");
 
-            let public_keys_and_usernames = self.index_db.lock()?.usernames.get().clone();
+            let public_keys_and_usernames = self.index_db.lock().await.usernames.get().clone();
 
             let total_users_ever = public_keys_and_usernames.len() as i64;
             let mut total_documents = 0;
@@ -109,7 +109,7 @@ where
 
             for (username, owner) in public_keys_and_usernames {
                 {
-                    let mut db = self.index_db.lock()?;
+                    let mut db = self.index_db.lock().await;
                     let maybe_user_info = Self::get_user_info(&mut db, owner)?;
 
                     let user_info = match maybe_user_info {

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -95,17 +95,16 @@ macro_rules! core_req {
 
                         debug!("request verified successfully");
                         let req_pk = request.signed_request.public_key;
-                        let username = match state.index_db.lock().map(|db| {
-                            db.accounts
+                        let username = {
+                            let db = state.index_db.lock().await;
+                            match db
+                                .accounts
                                 .get()
                                 .get(&Owner(req_pk))
                                 .map(|account| account.username.clone())
-                        }) {
-                            Ok(Some(username)) => username,
-                            Ok(None) => "~unknown~".to_string(),
-                            Err(error) => {
-                                error!(?error, "dbrs error");
-                                "~error~".to_string()
+                            {
+                                Some(username) => username,
+                                None => "~unknown~".to_string(),
                             }
                         };
                         let req_pk = base64::encode(req_pk.serialize_compressed());


### PR DESCRIPTION
- we're not supposed to hold a std lib mutex across an await point
- there's some places we do this and we could trivially not (some billing code)
- there's some places we do this and it's a bit tricky (`error!` will invoke pagerduty).
- we could solve this nicely using channels, and I would also like tracing-gcp to nicely stream directly to gcp using channels
- I would also like one user's problems to not impact another user (#3063 is when I'll take a thorough pass over server concerns).
- I believe the nature of the deadlock was something like: q a pages (while holding std lib mutex), while there are n requests in the queue. The call to pagerduty likely needs to take a certain amount of time alongside n being sufficiently large.
- this used to happen once in a blue moon but either as a result of more traffic generally (🚀 i guess) or as a result of increased pagerduty latency (or both, or something else unknown like different compiler optimizations or something weird) this seems to have been hit a few times
- the "i don't want to reason about this solution" is to just use a tokio mutex for now 
- this fix was verified by me not being able to perform an admin action, applying this patch, and then being able to perform the admin action