### PR TITLE
workspace: not all tabs are files

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -17,7 +17,6 @@ use lb::model::file_metadata::FileType;
 use lb::service::import_export::ImportStatus;
 use lb::Uuid;
 use tree::FilesExt;
-use workspace_rs::tab::TabContent;
 use workspace_rs::theme::icons::Icon;
 use workspace_rs::widgets::Button;
 use workspace_rs::workspace::Workspace;
@@ -232,14 +231,9 @@ impl AccountScreen {
 
                 if let Some(file) = wso.selected_file {
                     if !self.tree.selected.contains(&file) {
-                        // must be a real file to reveal
-                        if let Some(tab) = self.workspace.tabs.iter().find(|t| t.id == file) {
-                            if !matches!(tab.content, Some(TabContent::Graph(_))) {
-                                self.tree.cursor = Some(file);
-                                self.tree.selected.clear();
-                                self.tree.selected.insert(file);
-                            }
-                        }
+                        self.tree.cursor = Some(file);
+                        self.tree.selected.clear();
+                        self.tree.selected.insert(file);
                     }
                 }
 
@@ -450,12 +444,12 @@ impl AccountScreen {
             .inner;
 
         if resp.new_file.is_some() {
-            self.workspace.create_file(false, false);
+            self.workspace.create_file(false);
             ui.memory_mut(|m| m.focused().map(|f| m.surrender_focus(f))); // surrender focus - editor will take it
         }
 
         if resp.new_drawing.is_some() {
-            self.workspace.create_file(true, false);
+            self.workspace.create_file(true);
         }
 
         if let Some(file) = resp.new_folder_modal {
@@ -667,9 +661,6 @@ impl AccountScreen {
                 println!("error moving file: {:?}", err);
                 return;
             } else {
-                if let Some(tab) = self.workspace.get_mut_tab_by_id(f) {
-                    tab.path = self.core.get_path_by_id(f).unwrap();
-                }
                 ctx.request_repaint();
             }
         }
@@ -774,7 +765,7 @@ impl AccountScreen {
 
         let mut tabs_to_delete = vec![];
         for (i, tab) in self.workspace.tabs.iter().enumerate() {
-            if files.iter().any(|f| f.id.eq(&tab.id)) {
+            if files.iter().any(|f| Some(f.id) == tab.id()) {
                 tabs_to_delete.push(i);
             }
         }

--- a/clients/egui/src/account/syncing.rs
+++ b/clients/egui/src/account/syncing.rs
@@ -108,12 +108,12 @@ impl super::AccountScreen {
         ui.visuals_mut().widgets.active.fg_stroke = text_stroke;
 
         ui.visuals_mut().widgets.inactive.bg_fill =
-            ui.visuals().widgets.active.bg_fill.linear_multiply(0.1);
+            ui.visuals().widgets.active.bg_fill.gamma_multiply(0.1);
         ui.visuals_mut().widgets.hovered.bg_fill =
-            ui.visuals().widgets.active.bg_fill.linear_multiply(0.2);
+            ui.visuals().widgets.active.bg_fill.gamma_multiply(0.2);
 
         ui.visuals_mut().widgets.active.bg_fill =
-            ui.visuals().widgets.active.bg_fill.linear_multiply(0.3);
+            ui.visuals().widgets.active.bg_fill.gamma_multiply(0.3);
 
         let sync_btn = Button::default()
             .text("Sync")

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 use std::panic::catch_unwind;
 use workspace_rs::tab::markdown_editor::input::{Event, Location, Region};
 use workspace_rs::tab::svg_editor::Tool;
-use workspace_rs::tab::ExtendedInput;
 use workspace_rs::tab::TabContent;
+use workspace_rs::tab::{ContentState, ExtendedInput};
 
 use super::keyboard::AndroidKeys;
 use super::response::*;
@@ -215,6 +215,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_openDoc(
     obj.workspace.open_file(id, new_file == 1, true);
 }
 
+// todo: can't close non-file tabs (mind map)
 #[no_mangle]
 pub extern "system" fn Java_app_lockbook_workspace_Workspace_closeDoc(
     mut env: JNIEnv, _: JClass, obj: jlong, jid: JString,
@@ -224,7 +225,12 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_closeDoc(
     let rid: String = env.get_string(&jid).unwrap().into();
     let id = Uuid::parse_str(&rid).unwrap();
 
-    if let Some(tab_id) = obj.workspace.tabs.iter().position(|tab| tab.id == id) {
+    if let Some(tab_id) = obj
+        .workspace
+        .tabs
+        .iter()
+        .position(|tab| tab.id() == Some(id))
+    {
         obj.workspace.close_tab(tab_id);
     }
 }
@@ -254,15 +260,15 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_currentTab(
 
     match obj.workspace.current_tab() {
         Some(tab) => match &tab.content {
-            Some(tab) => match tab {
+            ContentState::Open(tab) => match tab {
                 TabContent::Image(_) => 2,
                 TabContent::Markdown(_) => 3,
                 // TabContent::PlainText(_) => 4,
                 TabContent::Pdf(_) => 5,
                 TabContent::Svg(_) => 6,
-                TabContent::Graph(_) => 7,
+                TabContent::MindMap(_) => 7,
             },
-            None => 1,
+            _ => 1,
         },
         None => 0,
     }

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -171,6 +171,7 @@ pub unsafe extern "C" fn tab_renamed(obj: *mut c_void, id: *const c_char, new_na
     obj.workspace.file_renamed(id, new_name);
 }
 
+// todo: can't close non-file tabs (mind map)
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
@@ -184,7 +185,12 @@ pub unsafe extern "C" fn close_tab(obj: *mut c_void, id: *const c_char) {
         .parse()
         .expect("Could not String -> Uuid");
 
-    if let Some(tab_id) = obj.workspace.tabs.iter().position(|tab| tab.id == id) {
+    if let Some(tab_id) = obj
+        .workspace
+        .tabs
+        .iter()
+        .position(|tab| tab.id() == Some(id))
+    {
         obj.workspace.close_tab(tab_id);
     }
 }

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -10,8 +10,8 @@ use workspace_rs::tab::markdown_editor::input::{cursor, mutation};
 use workspace_rs::tab::markdown_editor::input::{Bound, Event, Increment, Offset, Region};
 use workspace_rs::tab::markdown_editor::output::ui_text_input_tokenizer::UITextInputTokenizer as _;
 use workspace_rs::tab::svg_editor::Tool;
-use workspace_rs::tab::ExtendedInput as _;
 use workspace_rs::tab::TabContent;
+use workspace_rs::tab::{ContentState, ExtendedInput as _};
 
 use super::super::response::*;
 use super::response::*;
@@ -752,7 +752,13 @@ pub unsafe extern "C" fn free_selection_rects(rects: UITextSelectionRects) {
 #[no_mangle]
 pub unsafe extern "C" fn get_tabs_ids(obj: *mut c_void) -> TabsIds {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-    let ids: Vec<CUuid> = obj.workspace.tabs.iter().map(|tab| tab.id.into()).collect();
+    let ids: Vec<CUuid> = obj
+        .workspace
+        .tabs
+        .iter()
+        .flat_map(|tab| tab.id())
+        .map(|id| id.into())
+        .collect();
 
     TabsIds { size: ids.len() as i32, ids: Box::into_raw(ids.into_boxed_slice()) as *const CUuid }
 }
@@ -835,15 +841,15 @@ pub unsafe extern "C" fn current_tab(obj: *mut c_void) -> i64 {
 
     match obj.workspace.current_tab() {
         Some(tab) => match &tab.content {
-            Some(tab) => match tab {
+            ContentState::Open(tab) => match tab {
                 TabContent::Image(_) => 2,
                 TabContent::Markdown(_) => 3,
                 // TabContent::PlainText(_) => 4,
                 TabContent::Pdf(_) => 5,
                 TabContent::Svg(_) => 6,
-                TabContent::Graph(_) => 7,
+                TabContent::MindMap(_) => 7,
             },
-            None => 1,
+            _ => 1,
         },
         None => 0,
     }
@@ -879,7 +885,7 @@ pub unsafe extern "C" fn set_pencil_only_drawing(obj: *mut c_void, val: bool) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     obj.workspace.tabs.iter_mut().for_each(|t| {
-        if let Some(TabContent::Svg(svg)) = &mut t.content {
+        if let ContentState::Open(TabContent::Svg(svg)) = &mut t.content {
             svg.settings.pencil_only_drawing = val
         }
     });
@@ -912,7 +918,7 @@ pub unsafe extern "C" fn close_active_tab(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
     if !obj.workspace.tabs.is_empty() {
-        obj.workspace.close_tab(obj.workspace.active_tab)
+        obj.workspace.close_tab(obj.workspace.current_tab)
     }
 }
 

--- a/libs/content/workspace-ffi/src/lib.rs
+++ b/libs/content/workspace-ffi/src/lib.rs
@@ -72,7 +72,7 @@ impl<'window> WgpuWorkspace<'window> {
         self.context.begin_frame(self.raw_input.take());
 
         let workspace_response = egui::CentralPanel::default()
-            .frame(egui::Frame::default().fill(self.context.style().visuals.window_fill))
+            .frame(egui::Frame::default().fill(self.context.style().visuals.panel_fill))
             .show(&self.context, |ui| self.workspace.show(ui))
             .inner;
 

--- a/libs/content/workspace/src/file_cache.rs
+++ b/libs/content/workspace/src/file_cache.rs
@@ -56,11 +56,7 @@ impl FilesExt for [File] {
     }
 
     fn get_by_id(&self, id: Uuid) -> Option<&File> {
-        if let Some(file) = self.iter().find(|f| f.id == id) {
-            Some(&file)
-        } else {
-            None
-        }
+        self.iter().find(|f| f.id == id)
     }
 
     fn children(&self, id: Uuid) -> Vec<&File> {

--- a/libs/content/workspace/src/file_cache.rs
+++ b/libs/content/workspace/src/file_cache.rs
@@ -40,7 +40,7 @@ impl Debug for FileCache {
 
 pub trait FilesExt {
     fn root(&self) -> Uuid;
-    fn get_by_id(&self, id: Uuid) -> &File;
+    fn get_by_id(&self, id: Uuid) -> Option<&File>;
     fn children(&self, id: Uuid) -> Vec<&File>;
     fn descendents(&self, id: Uuid) -> Vec<&File>;
 }
@@ -55,11 +55,11 @@ impl FilesExt for [File] {
         unreachable!("unable to find root in metadata list")
     }
 
-    fn get_by_id(&self, id: Uuid) -> &File {
+    fn get_by_id(&self, id: Uuid) -> Option<&File> {
         if let Some(file) = self.iter().find(|f| f.id == id) {
-            file
+            Some(&file)
         } else {
-            unreachable!("unable to find file with id: {:?}", id)
+            None
         }
     }
 
@@ -83,5 +83,23 @@ impl FilesExt for [File] {
             descendents.push(child);
         }
         descendents
+    }
+}
+
+impl FilesExt for Vec<File> {
+    fn root(&self) -> Uuid {
+        self.as_slice().root()
+    }
+
+    fn get_by_id(&self, id: Uuid) -> Option<&File> {
+        self.as_slice().get_by_id(id)
+    }
+
+    fn children(&self, id: Uuid) -> Vec<&File> {
+        self.as_slice().children(id)
+    }
+
+    fn descendents(&self, id: Uuid) -> Vec<&File> {
+        self.as_slice().descendents(id)
     }
 }

--- a/libs/content/workspace/src/mind_map/show.rs
+++ b/libs/content/workspace/src/mind_map/show.rs
@@ -327,6 +327,10 @@ impl MindMap {
 
     fn draw_graph(&mut self, ui: &mut egui::Ui, screen_size: egui::Vec2) {
         let screen = ui.available_rect_before_wrap();
+
+        ui.painter()
+            .rect_filled(screen, 0., ui.visuals().extreme_bg_color);
+
         let center =
             Pos2::new((screen.max.x + screen.min.x) / 2.0, (screen.max.y + screen.min.y) / 2.0);
         let radius = (15.0) / ((self.graph.len() as f32).sqrt() / 3.0).max(1.0);
@@ -557,11 +561,11 @@ impl MindMap {
             && self.cursor_loc.y < max_range.y
     }
 
-    pub fn stop(&mut self, stop: bool) {
+    pub fn stop(&mut self) {
         self.graph_complete = true;
         {
             let mut stop_lock = self.stop.write().unwrap();
-            *stop_lock = stop;
+            *stop_lock = true;
         }
     }
 

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -162,14 +162,12 @@ impl Workspace {
                                 ui.label(WidgetText::from(RichText::from("TIPS").weak().small()));
                                 for tip in TIPS {
                                     let mut layout_job = LayoutJob::default();
-                                    RichText::new("- ")
-                                        .color(ui.style().visuals.hyperlink_color)
-                                        .append_to(
-                                            &mut layout_job,
-                                            ui.style(),
-                                            FontSelection::Default,
-                                            Align::Center,
-                                        );
+                                    RichText::new("- ").color(weak_blue).append_to(
+                                        &mut layout_job,
+                                        ui.style(),
+                                        FontSelection::Default,
+                                        Align::Center,
+                                    );
                                     RichText::from(tip)
                                         .color(ui.style().visuals.text_color())
                                         .append_to(
@@ -185,9 +183,9 @@ impl Workspace {
                                 ui.add_space(50.);
 
                                 ui.label(WidgetText::from(RichText::from("TOOLS").weak().small()));
-                                ui.visuals_mut().widgets.inactive.fg_stroke.color = blue;
-                                ui.visuals_mut().widgets.hovered.fg_stroke.color = weak_blue;
-                                ui.visuals_mut().widgets.active.fg_stroke.color = weak_blue;
+                                ui.visuals_mut().widgets.inactive.fg_stroke.color = weak_blue;
+                                ui.visuals_mut().widgets.hovered.fg_stroke.color = blue;
+                                ui.visuals_mut().widgets.active.fg_stroke.color = blue;
 
                                 if Button::default()
                                     .icon(&Icon::LANGUAGE)
@@ -243,13 +241,9 @@ impl Workspace {
                                                     rect,
                                                     3.,
                                                     if resp.hovered() || resp.clicked() {
-                                                        ui.visuals().widgets.inactive.bg_fill
+                                                        weakest_blue
                                                     } else {
-                                                        ui.visuals()
-                                                            .widgets
-                                                            .inactive
-                                                            .bg_fill
-                                                            .gamma_multiply(0.5)
+                                                        weaker_blue
                                                     },
                                                 );
 
@@ -326,10 +320,7 @@ impl Workspace {
                                                 Sense::hover(),
                                             );
 
-                                            ui.label(
-                                                RichText::new("- ")
-                                                    .color(ui.style().visuals.hyperlink_color),
-                                            );
+                                            ui.label(RichText::new("- ").color(weak_blue));
 
                                             // This is enough width to show the year and month of a pasted_image_...
                                             // but not the day, which seems sufficient
@@ -345,7 +336,7 @@ impl Workspace {
                                             );
 
                                             ui.visuals_mut().widgets.inactive.fg_stroke.color =
-                                                ui.style().visuals.hyperlink_color;
+                                                weak_blue;
                                             ui.visuals_mut().widgets.hovered.fg_stroke.color = blue;
                                             ui.visuals_mut().widgets.active.fg_stroke.color = blue;
 

--- a/libs/content/workspace/src/syncing.rs
+++ b/libs/content/workspace/src/syncing.rs
@@ -43,7 +43,7 @@ impl Workspace {
 
         for id in server_ids {
             for i in 0..self.tabs.len() {
-                if self.tabs[i].id == id && !self.tabs[i].is_closing {
+                if self.tabs[i].id() == Some(id) && !self.tabs[i].is_closing {
                     debug!("Reloading file after sync: {}", id);
                     self.open_file(id, false, false);
                 }

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -1,3 +1,5 @@
+use crate::file_cache::FileCache;
+use crate::file_cache::FilesExt as _;
 use crate::mind_map::show::MindMap;
 use crate::tab::image_viewer::ImageViewer;
 use crate::tab::markdown_editor::Editor as Markdown;
@@ -6,6 +8,7 @@ use crate::tab::svg_editor::SVGEditor;
 use crate::task_manager::TaskManager;
 use crate::theme::icons::Icon;
 use crate::workspace::Workspace;
+
 use chrono::DateTime;
 use egui::Id;
 use lb_rs::blocking::Lb;
@@ -13,9 +16,9 @@ use lb_rs::model::errors::{LbErr, LbErrKind};
 use lb_rs::model::file::File;
 use lb_rs::model::file_metadata::{DocumentHmac, FileType};
 use lb_rs::{svg, Uuid};
+use std::ops::IndexMut;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
-use tracing::instrument;
 
 pub mod image_viewer;
 pub mod markdown_editor;
@@ -23,22 +26,105 @@ pub mod pdf_viewer;
 pub mod svg_editor;
 
 pub struct Tab {
-    pub id: lb_rs::Uuid,
-    pub name: String,
-    pub rename: Option<String>,
-    pub path: String,
-    pub failure: Option<TabFailure>,
-    pub content: Option<TabContent>,
-    pub is_closing: bool,
+    pub content: ContentState,
 
-    pub is_new_file: bool,
     pub last_changed: Instant,
     pub last_saved: Instant,
+
+    pub rename: Option<String>,
+    pub is_closing: bool,
 }
 
 impl Tab {
+    pub fn id(&self) -> Option<Uuid> {
+        match &self.content {
+            ContentState::Loading(id) => Some(*id),
+            ContentState::Open(TabContent::Markdown(md)) => Some(md.file_id),
+            ContentState::Open(TabContent::Svg(svg)) => Some(svg.open_file),
+            _ => None,
+        }
+    }
+
+    pub fn hmac(&self) -> Option<DocumentHmac> {
+        match &self.content {
+            ContentState::Open(TabContent::Markdown(md)) => md.hmac,
+            ContentState::Open(TabContent::Svg(svg)) => svg.open_file_hmac,
+            _ => None,
+        }
+    }
+
+    pub fn seq(&self) -> usize {
+        match &self.content {
+            ContentState::Open(TabContent::Markdown(md)) => md.buffer.current.seq,
+            _ => 0,
+        }
+    }
+
+    pub fn markdown(&self) -> Option<&Markdown> {
+        match &self.content {
+            ContentState::Open(TabContent::Markdown(md)) => Some(md),
+            _ => None,
+        }
+    }
+
+    pub fn markdown_mut(&mut self) -> Option<&mut Markdown> {
+        match &mut self.content {
+            ContentState::Open(TabContent::Markdown(md)) => Some(md),
+            _ => None,
+        }
+    }
+
+    pub fn svg(&self) -> Option<&SVGEditor> {
+        match &self.content {
+            ContentState::Open(TabContent::Svg(svg)) => Some(svg),
+            _ => None,
+        }
+    }
+
+    pub fn svg_mut(&mut self) -> Option<&mut SVGEditor> {
+        match &mut self.content {
+            ContentState::Open(TabContent::Svg(svg)) => Some(svg),
+            _ => None,
+        }
+    }
+
+    pub fn mind_map(&self) -> Option<&MindMap> {
+        match &self.content {
+            ContentState::Open(TabContent::MindMap(mm)) => Some(mm),
+            _ => None,
+        }
+    }
+
+    pub fn mind_map_mut(&mut self) -> Option<&mut MindMap> {
+        match &mut self.content {
+            ContentState::Open(TabContent::MindMap(mm)) => Some(mm),
+            _ => None,
+        }
+    }
+
+    /// Clones the content required to save the tab. This is intended for use on the UI thread. Returns `None` if the
+    /// tab does not have an editable file type open.
+    pub fn clone_content(&self) -> Option<TabSaveContent> {
+        match &self.content {
+            ContentState::Open(content) => content.clone_content(),
+            _ => None,
+        }
+    }
+
+    pub fn title(&self, files: &Option<FileCache>) -> String {
+        match (self.id(), files) {
+            (Some(id), Some(files)) => files
+                .files
+                .get_by_id(id)
+                .map(|f| f.name.clone())
+                .unwrap_or("Unknown".into()),
+            (Some(_), None) => "Loading".into(),
+            (None, _) => "Mind Map".into(),
+        }
+    }
+
     pub fn is_dirty(&self, tasks: &TaskManager) -> bool {
-        if let Some(queued_at) = tasks.save_queued_at(self.id) {
+        if let Some(queued_at) = self.id().and_then(|id| tasks.save_queued_at(id)) {
             self.last_changed > queued_at
         } else {
             self.last_changed > self.last_saved
@@ -46,12 +132,40 @@ impl Tab {
     }
 }
 
+pub trait TabsExt: IndexMut<usize, Output = Tab> {
+    fn position_by_id(&self, id: Uuid) -> Option<usize>;
+    fn get_by_id(&self, id: Uuid) -> Option<&Tab> {
+        self.position_by_id(id).map(|pos| &self[pos])
+    }
+    fn get_mut_by_id(&mut self, id: Uuid) -> Option<&mut Tab> {
+        self.position_by_id(id).map(move |pos| &mut self[pos])
+    }
+}
+
+impl TabsExt for [Tab] {
+    fn position_by_id(&self, id: Uuid) -> Option<usize> {
+        self.iter().position(|tab| tab.id() == Some(id))
+    }
+}
+
+impl TabsExt for Vec<Tab> {
+    fn position_by_id(&self, id: Uuid) -> Option<usize> {
+        self.iter().position(|tab| tab.id() == Some(id))
+    }
+}
+
+pub enum ContentState {
+    Loading(Uuid),
+    Open(TabContent),
+    Failed(TabFailure),
+}
+
 pub enum TabContent {
     Image(ImageViewer),
     Markdown(Markdown),
     Pdf(PdfViewer),
     Svg(SVGEditor),
-    Graph(MindMap),
+    MindMap(MindMap),
 }
 
 impl std::fmt::Debug for TabContent {
@@ -61,12 +175,20 @@ impl std::fmt::Debug for TabContent {
             TabContent::Markdown(_) => write!(f, "TabContent::Markdown"),
             TabContent::Pdf(_) => write!(f, "TabContent::Pdf"),
             TabContent::Svg(_) => write!(f, "TabContent::Svg"),
-            TabContent::Graph(_) => write!(f, "TabContent::Graph"),
+            TabContent::MindMap(_) => write!(f, "TabContent::Graph"),
         }
     }
 }
 
 impl TabContent {
+    pub fn id(&self) -> Option<Uuid> {
+        match self {
+            TabContent::Markdown(md) => Some(md.file_id),
+            TabContent::Svg(svg) => Some(svg.open_file),
+            _ => None,
+        }
+    }
+
     pub fn hmac(&self) -> Option<DocumentHmac> {
         match self {
             TabContent::Markdown(md) => md.hmac,
@@ -82,8 +204,8 @@ impl TabContent {
         }
     }
 
-    /// Clones the content required to save the tab. This is intended for use on the UI thread.
-    #[instrument(level = "error", skip_all)]
+    /// Clones the content required to save the tab. This is intended for use on the UI thread. Returns `None` if the
+    /// content type is not editable.
     pub fn clone_content(&self) -> Option<TabSaveContent> {
         match self {
             TabContent::Markdown(md) => {
@@ -116,7 +238,6 @@ impl TabSaveContent {
 
 #[derive(Debug)]
 pub enum TabFailure {
-    DeletedFromSync,
     SimpleMisc(String),
     Unexpected(String),
 }
@@ -126,6 +247,15 @@ impl From<LbErr> for TabFailure {
         match err.kind {
             LbErrKind::Unexpected(msg) => Self::Unexpected(msg),
             _ => Self::SimpleMisc(format!("{:?}", err)),
+        }
+    }
+}
+
+impl TabFailure {
+    pub fn msg(&self) -> String {
+        match self {
+            TabFailure::SimpleMisc(msg) => msg.clone(),
+            TabFailure::Unexpected(msg) => format!("Unexpected error: {}", msg),
         }
     }
 }
@@ -178,24 +308,24 @@ impl TabStatus {
 }
 
 impl Workspace {
-    pub fn tab_status(&self, id: Uuid) -> TabStatus {
-        if let Some(tab) = self.tabs.iter().find(|t| t.id == id) {
-            if self.tasks.load_in_progress(tab.id) {
-                TabStatus::LoadInProgress
-            } else if self.tasks.save_in_progress(tab.id) {
-                TabStatus::SaveInProgress
-            } else if self.tasks.load_queued(tab.id) {
-                TabStatus::LoadQueued
-            } else if self.tasks.save_queued(tab.id) {
-                TabStatus::SaveQueued
-            } else if tab.is_dirty(&self.tasks) {
-                TabStatus::Dirty
-            } else {
-                TabStatus::Clean
+    pub fn tab_status(&self, i: usize) -> TabStatus {
+        if let Some(tab) = self.tabs.get(i) {
+            if let Some(id) = tab.id() {
+                if self.tasks.load_in_progress(id) {
+                    return TabStatus::LoadInProgress;
+                } else if self.tasks.save_in_progress(id) {
+                    return TabStatus::SaveInProgress;
+                } else if self.tasks.load_queued(id) {
+                    return TabStatus::LoadQueued;
+                } else if self.tasks.save_queued(id) {
+                    return TabStatus::SaveQueued;
+                }
             }
-        } else {
-            TabStatus::Clean
+            if tab.is_dirty(&self.tasks) {
+                return TabStatus::Dirty;
+            }
         }
+        TabStatus::Clean // can't get any cleaner than nonexistent!
     }
 }
 

--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -42,7 +42,7 @@ pub struct SVGEditor {
     pub toolbar: Toolbar,
     inner_rect: egui::Rect,
     lb: Lb,
-    open_file: Uuid,
+    pub open_file: Uuid,
     skip_frame: bool,
     // last_render: Instant,
     renderer: Renderer,

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -14,6 +14,7 @@ use tracing::{debug, error, instrument, span, trace, warn, Level};
 
 use crate::file_cache::FileCache;
 use crate::output::DirtynessMsg;
+use crate::tab::TabsExt as _;
 use crate::tab::{Tab, TabSaveContent};
 
 #[derive(Default)]
@@ -541,16 +542,16 @@ impl TaskManager {
             let request = queued_save.request.clone();
             let in_progress_save = InProgressSave::new(queued_save);
             let (old_hmac, seq, content) = {
-                let Some(tab) = tabs.iter().find(|tab| tab.id == request.id) else {
+                let Some(tab) = tabs.get_by_id(request.id) else {
                     error!("could not launch save because its tab does not exist");
                     continue;
                 };
 
                 let start = Instant::now();
 
-                let old_hmac = tab.content.as_ref().and_then(|c| c.hmac());
-                let seq = tab.content.as_ref().map(|c| c.seq()).unwrap_or_default();
-                let Some(content) = tab.content.as_ref().and_then(|c| c.clone_content()) else {
+                let old_hmac = tab.hmac();
+                let seq = tab.seq();
+                let Some(content) = tab.clone_content() else {
                     break;
                 };
 
@@ -836,4 +837,26 @@ impl TaskManager {
 
         self.ctx.request_repaint();
     }
+
+    pub fn task_status(&self, id: Uuid) -> TaskStatus {
+        if self.load_in_progress(id) {
+            TaskStatus::LoadInProgress
+        } else if self.save_in_progress(id) {
+            TaskStatus::SaveInProgress
+        } else if self.load_queued(id) {
+            TaskStatus::LoadQueued
+        } else if self.save_queued(id) {
+            TaskStatus::SaveQueued
+        } else {
+            TaskStatus::Clean
+        }
+    }
+}
+
+pub enum TaskStatus {
+    LoadInProgress,
+    SaveInProgress,
+    LoadQueued,
+    SaveQueued,
+    Clean,
 }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -20,15 +20,16 @@ use crate::tab::image_viewer::{is_supported_image_fmt, ImageViewer};
 use crate::tab::markdown_editor::Editor as Markdown;
 use crate::tab::pdf_viewer::PdfViewer;
 use crate::tab::svg_editor::SVGEditor;
-use crate::tab::{Tab, TabContent, TabFailure, TabSaveContent};
+use crate::tab::{ContentState, Tab, TabContent, TabFailure, TabSaveContent, TabsExt as _};
+use crate::task_manager;
 use crate::task_manager::{
-    self, CompletedLoad, CompletedSave, CompletedTiming, LoadRequest, SaveRequest, TaskManager,
+    CompletedLoad, CompletedSave, CompletedTiming, LoadRequest, SaveRequest, TaskManager,
 };
 
 pub struct Workspace {
     // User activity
     pub tabs: Vec<Tab>,
-    pub active_tab: usize,
+    pub current_tab: usize,
     pub user_last_seen: Instant,
 
     // Files and task status
@@ -50,7 +51,7 @@ pub struct Workspace {
     pub focused_parent: Option<Uuid>, // set to the folder where new files should be created
 
     // Transient state (consider removing)
-    pub active_tab_changed: bool, // used to scroll to active tab when it changes
+    pub current_tab_changed: bool, // used to scroll to current tab when it changes
     pub last_touch_event: Option<Instant>, // used to disable tooltips on touch devices
 }
 
@@ -62,7 +63,7 @@ impl Workspace {
 
         let mut ws = Self {
             tabs: Default::default(),
-            active_tab: Default::default(),
+            current_tab: Default::default(),
             user_last_seen: Instant::now(),
 
             tasks: TaskManager::new(core.clone(), ctx.clone()),
@@ -80,11 +81,11 @@ impl Workspace {
             show_tabs: true,
             focused_parent: Default::default(),
 
-            active_tab_changed: Default::default(),
+            current_tab_changed: Default::default(),
             last_touch_event: Default::default(),
         };
 
-        let (open_tabs, active_tab) = ws.cfg.get_tabs();
+        let (open_tabs, current_tab) = ws.cfg.get_tabs();
 
         open_tabs.iter().for_each(|&file_id| {
             if core.get_file_by_id(file_id).is_ok() {
@@ -92,25 +93,26 @@ impl Workspace {
                 ws.open_file(file_id, false, false);
             }
         });
-        if let Some(active_tab) = active_tab {
-            info!(id = ?active_tab, "setting persisted active tab");
-            ws.active_tab = open_tabs
+        if let Some(current_tab) = current_tab {
+            info!(id = ?current_tab, "setting persisted current tab");
+            ws.current_tab = open_tabs
                 .iter()
-                .position(|&id| id == active_tab)
+                .position(|&id| id == current_tab)
                 .unwrap_or_default();
         }
 
         ws
     }
 
+    // todo: what happens if a save is in progress? what about non-file tabs?
     pub fn invalidate_egui_references(&mut self, ctx: &Context, core: &Lb) {
         self.ctx = ctx.clone();
         self.core = core.clone();
 
-        let ids: Vec<Uuid> = self.tabs.iter().map(|tab| tab.id).collect();
-        let maybe_active_tab_id = self.current_tab().map(|tab| tab.id);
+        let ids: Vec<Uuid> = self.tabs.iter().flat_map(|tab| tab.id()).collect();
+        let maybe_current_tab_id = self.current_tab().map(|tab| tab.id());
 
-        while self.active_tab != 0 {
+        while self.current_tab != 0 {
             self.close_tab(self.tabs.len() - 1);
         }
 
@@ -118,61 +120,40 @@ impl Workspace {
             self.open_file(id, false, false)
         }
 
-        if let Some(active_tab_id) = maybe_active_tab_id {
-            self.active_tab = self
+        if let Some(current_tab_id) = maybe_current_tab_id {
+            self.current_tab = self
                 .tabs
                 .iter()
-                .position(|tab| tab.id == active_tab_id)
+                .position(|tab| tab.id() == current_tab_id)
                 .unwrap_or(0);
-            self.active_tab_changed = true;
+            self.current_tab_changed = true;
         }
     }
 
-    /// upsert returns true if a tab was created
-    pub fn upsert_tab(
-        &mut self, id: Uuid, name: &str, path: &str, is_new_file: bool, make_active: bool,
-    ) -> bool {
-        for (i, tab) in self.tabs.iter().enumerate() {
-            if tab.id == id {
-                self.tabs[i].name = name.to_string();
-                self.tabs[i].path = path.to_string();
-                self.tabs[i].failure = None;
-                if make_active {
-                    self.active_tab = i;
-                    // only stop a tab from closing if it's being made active (e.g. user clicked file tree node)
-                    self.tabs[i].is_closing = false;
-                }
-                // tab exists already
-                return false;
-            }
+    /// Loads a file, creating a tab for it if needed, and returns true if a tab was created
+    pub fn load_file(&mut self, id: Uuid, make_current: bool) -> bool {
+        if make_current && self.make_current_by_id(id) {
+            return false;
         }
 
-        let now = Instant::now();
+        self.create_tab(ContentState::Loading(id), make_current);
 
-        let new_tab = Tab {
-            id,
-            rename: None,
-            name: name.to_owned(),
-            path: path.to_owned(),
-            failure: None,
-            content: None,
-            is_closing: false,
-            last_changed: now,
-            is_new_file,
-            last_saved: now,
-        };
-        self.tabs.push(new_tab);
-        if make_active {
-            self.active_tab = self.tabs.len() - 1;
-            self.active_tab_changed = true;
-        }
-
-        // tab was created
         true
     }
 
+    pub fn create_tab(&mut self, content: ContentState, make_current: bool) {
+        let now = Instant::now();
+        let new_tab =
+            Tab { content, last_changed: now, last_saved: now, rename: None, is_closing: false };
+        self.tabs.push(new_tab);
+        if make_current {
+            self.current_tab = self.tabs.len() - 1;
+            self.current_tab_changed = true;
+        }
+    }
+
     pub fn get_mut_tab_by_id(&mut self, id: Uuid) -> Option<&mut Tab> {
-        self.tabs.iter_mut().find(|tab| tab.id == id)
+        self.tabs.get_mut_by_id(id)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -180,51 +161,56 @@ impl Workspace {
     }
 
     pub fn current_tab(&self) -> Option<&Tab> {
-        self.tabs.get(self.active_tab)
+        self.tabs.get(self.current_tab)
+    }
+
+    pub fn current_tab_id(&self) -> Option<Uuid> {
+        self.tabs.get(self.current_tab).and_then(|tab| tab.id())
+    }
+
+    pub fn current_tab_title(&self) -> Option<String> {
+        self.current_tab().map(|tab| tab.title(&self.files))
     }
 
     pub fn current_tab_mut(&mut self) -> Option<&mut Tab> {
-        self.tabs.get_mut(self.active_tab)
+        self.tabs.get_mut(self.current_tab)
     }
 
     pub fn current_tab_markdown(&self) -> Option<&Markdown> {
-        let current_tab = self.current_tab()?;
-
-        if let Some(TabContent::Markdown(markdown)) = &current_tab.content {
-            return Some(markdown);
-        }
-
-        None
+        self.current_tab()?.markdown()
     }
 
     pub fn current_tab_markdown_mut(&mut self) -> Option<&mut Markdown> {
-        let current_tab = self.current_tab_mut()?;
-
-        if let Some(TabContent::Markdown(markdown)) = &mut current_tab.content {
-            return Some(markdown);
-        }
-
-        None
+        self.current_tab_mut()?.markdown_mut()
     }
+
     pub fn current_tab_svg_mut(&mut self) -> Option<&mut SVGEditor> {
-        let current_tab = self.current_tab_mut()?;
-
-        if let Some(TabContent::Svg(svg)) = &mut current_tab.content {
-            return Some(svg);
-        }
-
-        None
+        self.current_tab_mut()?.svg_mut()
     }
 
-    pub fn goto_tab_id(&mut self, id: Uuid) -> bool {
-        for (i, tab) in self.tabs.iter().enumerate() {
-            if tab.id == id {
-                self.active_tab = i;
-                self.active_tab_changed = true;
-                return true;
-            }
+    /// Makes the tab the current tab, if it exists. Returns true if the tab exists.
+    pub fn make_current(&mut self, i: usize) -> bool {
+        if i < self.tabs.len() {
+            self.current_tab = i;
+            self.current_tab_changed = true;
+            self.tabs[i].is_closing = false;
+            self.out.selected_file = self.tabs[i].id();
+            self.ctx
+                .send_viewport_cmd(ViewportCommand::Title(self.tabs[i].title(&self.files)));
+
+            true
+        } else {
+            false
         }
-        false
+    }
+
+    /// Makes the tab with the given id the current tab, if it exists. Returns true if the tab exists.
+    pub fn make_current_by_id(&mut self, id: Uuid) -> bool {
+        if let Some(i) = self.tabs.iter().position(|t| t.id() == Some(id)) {
+            self.make_current(i)
+        } else {
+            false
+        }
     }
 
     pub fn save_all_tabs(&mut self) {
@@ -236,63 +222,52 @@ impl Workspace {
 
     pub fn save_tab(&mut self, i: usize) {
         if let Some(tab) = self.tabs.get_mut(i) {
-            if tab.is_dirty(&self.tasks) {
-                self.tasks.queue_save(SaveRequest { id: tab.id });
+            if let Some(id) = tab.id() {
+                if tab.is_dirty(&self.tasks) {
+                    self.tasks.queue_save(SaveRequest { id });
+                }
             }
         }
     }
 
-    pub fn open_file(&mut self, id: Uuid, is_new_file: bool, make_active: bool) {
-        let fname = match self.core.get_file_by_id(id) {
-            Ok(f) => f.name,
-            Err(err) => {
-                if let Some(t) = self.tabs.iter_mut().find(|t| t.id == id) {
-                    t.failure = match err.kind {
-                        LbErrKind::FileNonexistent => Some(TabFailure::DeletedFromSync),
-                        _ => Some(err.into()),
-                    }
-                }
-                return;
+    pub fn open_file(&mut self, id: Uuid, is_new_file: bool, make_current: bool) {
+        if self.tabs.get_by_id(id).is_some() {
+            if make_current {
+                self.make_current_by_id(id);
             }
-        };
+            return;
+        }
 
-        let fpath = self.core.get_path_by_id(id).unwrap(); // TODO
-
-        let tab_created = self.upsert_tab(id, &fname, &fpath, is_new_file, make_active);
+        let tab_created = self.load_file(id, make_current);
 
         self.tasks
             .queue_load(LoadRequest { id, is_new_file, tab_created });
     }
 
     pub fn close_tab(&mut self, i: usize) {
-        if self.tabs[i].name == "Mind Map" {
-            if let Some(TabContent::Graph(graph_app)) = &mut self.tabs[i].content {
-                graph_app.stop(true);
-            }
+        if let ContentState::Open(TabContent::MindMap(mm)) = &mut self.tabs[i].content {
+            mm.stop();
         }
+
         self.save_tab(i);
         self.tabs[i].is_closing = true;
     }
 
     pub fn remove_tab(&mut self, i: usize) {
-        let tab = &self.tabs[i];
-        if let Some(TabContent::Markdown(md)) = &tab.content {
-            if md.focused(&self.ctx) {
-                md.surrender_focus(&self.ctx);
-            }
+        if let Some(md) = self.tabs[i].markdown_mut() {
+            md.surrender_focus(&self.ctx);
         }
 
         self.tabs.remove(i);
-        let n_tabs = self.tabs.len();
         self.out.tabs_changed = true;
-        if self.active_tab >= n_tabs && n_tabs > 0 {
-            self.active_tab = n_tabs - 1;
+
+        if !self.tabs.is_empty() && self.current_tab >= self.tabs.len() {
+            self.current_tab -= 1;
         }
-        self.active_tab_changed = true;
+        self.current_tab_changed = true;
     }
 
     #[instrument(level = "trace", skip_all)]
-
     pub fn process_updates(&mut self) {
         let task_manager::Response {
             completed_loads,
@@ -313,11 +288,10 @@ impl Workspace {
                         timing: _,
                     } = load;
 
-                    if let Some((name, id)) =
-                        self.current_tab().map(|tab| (tab.name.clone(), tab.id))
-                    {
-                        self.ctx.send_viewport_cmd(ViewportCommand::Title(name));
-                        self.out.selected_file = Some(id);
+                    if let Some(tab) = self.current_tab() {
+                        self.ctx
+                            .send_viewport_cmd(ViewportCommand::Title(tab.title(&self.files)));
+                        self.out.selected_file = tab.id();
                     };
 
                     let ctx = self.ctx.clone();
@@ -325,35 +299,42 @@ impl Workspace {
                     let writeable_dir = &self.core.get_config().writeable_path;
                     let show_tabs = self.show_tabs;
 
-                    let canvas_settings = self.tabs.iter().find_map(|t| {
-                        if let Some(TabContent::Svg(svg)) = &t.content {
-                            Some(svg.settings)
-                        } else {
-                            None
-                        }
-                    });
+                    let canvas_settings = self
+                        .tabs
+                        .iter()
+                        .find_map(|tab| tab.svg().map(|svg| svg.settings));
 
-                    if let Some(tab) = self.get_mut_tab_by_id(id) {
+                    if let Some(tab) = self.tabs.get_mut_by_id(id) {
                         let (maybe_hmac, bytes) = match content_result {
                             Ok((hmac, bytes)) => (hmac, bytes),
                             Err(err) => {
                                 let msg = format!("failed to load file: {:?}", err);
                                 error!(msg);
-                                tab.failure = Some(TabFailure::Unexpected(msg.clone()));
+                                tab.content =
+                                    ContentState::Failed(TabFailure::Unexpected(msg.clone()));
                                 self.out.failure_messages.push(msg);
                                 return;
                             }
                         };
-                        let ext = tab.name.split('.').last().unwrap_or_default();
 
-                        if is_supported_image_fmt(ext) {
-                            tab.content = Some(TabContent::Image(ImageViewer::new(
+                        let ext = match self.core.get_file_by_id(id) {
+                            Ok(file) => file.name.split('.').last().unwrap_or_default().to_owned(),
+                            Err(e) => {
+                                self.out
+                                    .failure_messages
+                                    .push(format!("failed to get id for loaded file: {:?}", e));
+                                continue;
+                            }
+                        };
+
+                        if is_supported_image_fmt(&ext) {
+                            tab.content = ContentState::Open(TabContent::Image(ImageViewer::new(
                                 &id.to_string(),
-                                ext,
+                                &ext,
                                 &bytes,
                             )));
                         } else if ext == "pdf" {
-                            tab.content = Some(TabContent::Pdf(PdfViewer::new(
+                            tab.content = ContentState::Open(TabContent::Pdf(PdfViewer::new(
                                 &bytes,
                                 &ctx,
                                 writeable_dir,
@@ -361,7 +342,7 @@ impl Workspace {
                             )));
                         } else if ext == "svg" {
                             if tab_created {
-                                tab.content = Some(TabContent::Svg(SVGEditor::new(
+                                tab.content = ContentState::Open(TabContent::Svg(SVGEditor::new(
                                     &bytes,
                                     &ctx,
                                     core.clone(),
@@ -370,44 +351,38 @@ impl Workspace {
                                     canvas_settings,
                                 )));
                             } else {
-                                match tab.content.as_mut() {
-                                    Some(TabContent::Svg(svg)) => {
-                                        Buffer::reload(
-                                            &mut svg.buffer.elements,
-                                            &mut svg.buffer.weak_images,
-                                            svg.buffer.master_transform,
-                                            &svg.opened_content,
-                                            &svg::buffer::Buffer::new(
-                                                String::from_utf8_lossy(&bytes).as_ref(),
-                                            ),
-                                        );
+                                let svg = tab.svg_mut().unwrap();
 
-                                        svg.open_file_hmac = maybe_hmac;
-                                    }
-                                    _ => unreachable!(),
-                                };
+                                Buffer::reload(
+                                    &mut svg.buffer.elements,
+                                    &mut svg.buffer.weak_images,
+                                    svg.buffer.master_transform,
+                                    &svg.opened_content,
+                                    &svg::buffer::Buffer::new(
+                                        String::from_utf8_lossy(&bytes).as_ref(),
+                                    ),
+                                );
+
+                                svg.open_file_hmac = maybe_hmac;
                             }
                         } else if ext == "md" || ext == "txt" {
                             if tab_created {
-                                tab.content = Some(TabContent::Markdown(Markdown::new(
-                                    core.clone(),
-                                    &String::from_utf8_lossy(&bytes),
-                                    id,
-                                    maybe_hmac,
-                                    is_new_file,
-                                    ext != "md",
-                                )));
+                                tab.content =
+                                    ContentState::Open(TabContent::Markdown(Markdown::new(
+                                        core.clone(),
+                                        &String::from_utf8_lossy(&bytes),
+                                        id,
+                                        maybe_hmac,
+                                        is_new_file,
+                                        ext != "md",
+                                    )));
                             } else {
-                                match tab.content.as_mut() {
-                                    Some(TabContent::Markdown(md)) => {
-                                        md.reload(String::from_utf8_lossy(&bytes).into());
-                                        md.hmac = maybe_hmac;
-                                    }
-                                    _ => unreachable!(),
-                                };
+                                let md = tab.markdown_mut().unwrap();
+                                md.reload(String::from_utf8_lossy(&bytes).into());
+                                md.hmac = maybe_hmac;
                             }
                         } else {
-                            tab.failure = Some(TabFailure::SimpleMisc(format!(
+                            tab.content = ContentState::Failed(TabFailure::SimpleMisc(format!(
                                 "Unsupported file extension: {}",
                                 ext
                             )));
@@ -440,19 +415,16 @@ impl Workspace {
                         match new_hmac_result {
                             Ok(hmac) => {
                                 tab.last_saved = started_at;
-                                match (tab.content.as_mut(), content) {
-                                    (
-                                        Some(TabContent::Markdown(md)),
-                                        TabSaveContent::String(content),
-                                    ) => {
+                                if let Some(md) = tab.markdown_mut() {
+                                    if let TabSaveContent::String(content) = content {
                                         md.hmac = Some(hmac);
                                         md.buffer.saved(seq, content);
                                     }
-                                    (Some(TabContent::Svg(svg)), TabSaveContent::Svg(content)) => {
+                                } else if let Some(svg) = tab.svg_mut() {
+                                    if let TabSaveContent::Svg(content) = content {
                                         svg.open_file_hmac = Some(hmac);
                                         svg.opened_content = content;
                                     }
-                                    _ => {}
                                 }
                                 sync = true;
                             }
@@ -461,7 +433,9 @@ impl Workspace {
                                     debug!("reloading file after save failed with re-read required: {}", id);
                                     self.open_file(id, false, false);
                                 } else {
-                                    tab.failure = Some(TabFailure::Unexpected(format!("{:?}", err)))
+                                    tab.content = ContentState::Failed(TabFailure::Unexpected(
+                                        format!("{:?}", err),
+                                    ))
                                 }
                             }
                         }
@@ -583,24 +557,30 @@ impl Workspace {
             let i = i - removed_tabs;
             let tab = &self.tabs[i];
             if tab.is_closing
-                && !self.tasks.load_or_save_queued(tab.id)
-                && !self.tasks.load_or_save_in_progress(tab.id)
+                && !tab
+                    .id()
+                    .map(|id| self.tasks.load_or_save_queued(id))
+                    .unwrap_or_default()
+                && !tab
+                    .id()
+                    .map(|id| self.tasks.load_or_save_in_progress(id))
+                    .unwrap_or_default()
             {
                 self.remove_tab(i);
                 removed_tabs += 1;
 
                 let title = match self.current_tab() {
-                    Some(tab) => tab.name.clone(),
+                    Some(tab) => tab.title(&self.files),
                     None => "Lockbook".to_owned(),
                 };
                 self.ctx.send_viewport_cmd(ViewportCommand::Title(title));
 
-                self.out.selected_file = self.current_tab().map(|tab| tab.id);
+                self.out.selected_file = self.current_tab().and_then(|tab| tab.id());
             }
         }
     }
 
-    pub fn create_file(&mut self, is_drawing: bool, is_graph: bool) {
+    pub fn create_file(&mut self, is_drawing: bool) {
         let focused_parent = self
             .focused_parent
             .unwrap_or_else(|| self.core.get_root().unwrap().id);
@@ -612,9 +592,6 @@ impl Workspace {
             focused_parent.id
         };
 
-        if is_graph {
-            self.graph_called(self.core.clone());
-        }
         let file_format = if is_drawing { "svg" } else { "md" };
         let new_file = NameComponents::from(&format!("untitled.{}", file_format))
             .next_in_children(self.core.get_children(&focused_parent).unwrap());
@@ -629,14 +606,13 @@ impl Workspace {
         self.ctx.request_repaint();
     }
 
-    pub fn graph_called(&mut self, core: Lb) {
-        if !self.tabs.iter().any(|t| t.name == "Mind Map") {
-            let id = Uuid::new_v4();
-            self.upsert_tab(id, "Mind Map", "", false, true);
-            if let Some(tab) = self.get_mut_tab_by_id(id) {
-                tab.content = Some(TabContent::Graph(MindMap::new(&core)));
-            }
-        }
+    /// Opens or focuses the tab for the mind map
+    pub fn upsert_mind_map(&mut self, core: Lb) {
+        if let Some(i) = self.tabs.iter().position(|t| t.mind_map().is_some()) {
+            self.make_current(i);
+        } else {
+            self.create_tab(ContentState::Open(TabContent::MindMap(MindMap::new(&core))), true);
+        };
     }
 
     pub fn rename_file(&mut self, req: (Uuid, String), by_user: bool) {
@@ -658,28 +634,22 @@ impl Workspace {
 
     pub fn file_renamed(&mut self, id: Uuid, new_name: String) {
         let mut different_file_type = false;
-        if let Some(tab) = self.get_mut_tab_by_id(id) {
+        if let Some(tab) = self.tabs.get_mut_by_id(id) {
             different_file_type = !NameComponents::from(&new_name)
                 .extension
-                .eq(&NameComponents::from(&tab.name).extension);
-
-            tab.name = new_name.clone();
+                .eq(&NameComponents::from(&tab.title(&self.files)).extension);
         }
 
-        let mut is_tab_active = false;
-        if let Some(tab) = self.current_tab() {
-            if tab.id == id {
-                self.ctx
-                    .send_viewport_cmd(ViewportCommand::Title(tab.name.clone()));
-                is_tab_active = true;
-            }
+        if Some(id) == self.current_tab_id() {
+            self.ctx
+                .send_viewport_cmd(ViewportCommand::Title(new_name.clone()));
         }
 
         if different_file_type {
-            self.open_file(id, false, is_tab_active);
+            self.open_file(id, false, false);
         }
 
-        self.out.file_renamed = Some((id, new_name.clone()));
+        self.out.file_renamed = Some((id, new_name));
         self.tasks.queue_file_cache_refresh();
         self.ctx.request_repaint();
     }
@@ -741,14 +711,14 @@ pub struct WsPersistentStore {
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
 struct WsPresistentData {
     open_tabs: Vec<Uuid>,
-    active_tab: Option<Uuid>,
+    current_tab: Option<Uuid>,
     auto_save: bool,
     auto_sync: bool,
 }
 
 impl Default for WsPresistentData {
     fn default() -> Self {
-        Self { auto_save: true, auto_sync: true, open_tabs: Vec::default(), active_tab: None }
+        Self { auto_save: true, auto_sync: true, open_tabs: Vec::default(), current_tab: None }
     }
 }
 
@@ -768,14 +738,15 @@ impl WsPersistentStore {
         }
     }
 
-    pub fn set_tabs(&mut self, tabs: &[Tab], active_tab_index: usize) {
+    // todo: store non-file (mind map) tabs?
+    pub fn set_tabs(&mut self, tabs: &[Tab], current_tab_index: usize) {
         let mut data_lock = self.data.write().unwrap();
-        data_lock.open_tabs = tabs.iter().map(|t| t.id).collect();
+        data_lock.open_tabs = tabs.iter().flat_map(|t| t.id()).collect();
         if !tabs.is_empty() {
-            if let Some(tab) = tabs.get(active_tab_index) {
-                data_lock.active_tab = Some(tab.id);
+            if let Some(tab) = tabs.get(current_tab_index) {
+                data_lock.current_tab = tab.id();
             } else {
-                data_lock.active_tab = Some(tabs[0].id);
+                data_lock.current_tab = tabs[0].id();
             }
         }
         self.write_to_file();
@@ -783,7 +754,7 @@ impl WsPersistentStore {
 
     pub fn get_tabs(&self) -> (Vec<Uuid>, Option<Uuid>) {
         let data_lock = self.data.read().unwrap();
-        (data_lock.open_tabs.clone(), data_lock.active_tab)
+        (data_lock.open_tabs.clone(), data_lock.current_tab)
     }
 
     pub fn get_auto_sync(&self) -> bool {


### PR DESCRIPTION
...and some visual updates
* updates tab data model so not all tabs need a file
* re-adds mind map button to workspace landing page
* fixes problems when mind map is the only tab
* fixes problems when creating a file while mind map is open
* fixes problems closing mind map via the tab strip button

<details>
<img width="1412" alt="Screenshot 2025-01-30 at 7 58 02 PM" src="https://github.com/user-attachments/assets/58287487-91e3-4302-b268-828894b6d165" />
<img width="1412" alt="Screenshot 2025-01-30 at 7 58 07 PM" src="https://github.com/user-attachments/assets/ac3c4e02-30da-4804-b02c-bff2ceefcc3b" />
<img width="1412" alt="Screenshot 2025-01-30 at 7 58 21 PM" src="https://github.com/user-attachments/assets/b9313113-7934-41c2-bfc1-03614101e714" />

</details>