### PR TITLE
lb-rs: elim SharedError

### DIFF
--- a/libs/lb/lb-java/src/java_utils.rs
+++ b/libs/lb/lb-java/src/java_utils.rs
@@ -1,10 +1,10 @@
 use jni::{
-    objects::{JByteArray, JClass, JObject, JString, JThrowable, JValue},
+   objects::{JByteArray, JClass, JObject, JString, JThrowable, JValue},
     JNIEnv,
 };
 use lb_rs::{
     blocking::Lb,
-    model::errors::{LbErr, LbErrKind},
+    model::{errors::{LbErr, LbErrKind}, ValidationFailure},
 };
 
 pub(crate) fn rstring<'local>(env: &mut JNIEnv<'local>, input: JString<'local>) -> String {
@@ -82,21 +82,15 @@ pub(crate) fn throw_err<'local>(env: &mut JNIEnv<'local>, err: LbErr) -> JObject
         LbErrKind::FileNonexistent => "FileNonexistent",
         LbErrKind::FileNotDocument => "FileNotDocument",
         LbErrKind::FileParentNonexistent => "FileParentNonexistent",
-        LbErrKind::FolderMovedIntoSelf => "FolderMovedIntoSelf",
         LbErrKind::InsufficientPermission => "InsufficientPermission",
         LbErrKind::InvalidPurchaseToken => "InvalidPurchaseToken",
         LbErrKind::InvalidAuthDetails => "InvalidAuthDetails",
         LbErrKind::KeyPhraseInvalid => "KeyPhraseInvalid",
-        LbErrKind::LinkInSharedFolder => "LinkInSharedFolder",
-        LbErrKind::LinkTargetIsOwned => "LinkTargetIsOwned",
-        LbErrKind::LinkTargetNonexistent => "LinkTargetNonexistent",
-        LbErrKind::MultipleLinksToSameFile => "MultipleLinksToSameFile",
         LbErrKind::NotPremium => "NotPremium",
         LbErrKind::UsageIsOverDataCap => "UsageIsOverDataCap",
         LbErrKind::UsageIsOverFreeTierDataCap => "UsageIsOverFreeTierDataCap",
         LbErrKind::OldCardDoesNotExist => "OldCardDoesNotExist",
         LbErrKind::PathContainsEmptyFileName => "PathContainsEmptyFileName",
-        LbErrKind::PathTaken => "PathTaken",
         LbErrKind::RootModificationInvalid => "RootModificationInvalid",
         LbErrKind::RootNonexistent => "RootNonexistent",
         LbErrKind::ServerDisabled => "ServerDisabled",
@@ -109,7 +103,21 @@ pub(crate) fn throw_err<'local>(env: &mut JNIEnv<'local>, err: LbErr) -> JObject
         LbErrKind::UsernamePublicKeyMismatch => "UsernamePublicKeyMismatch",
         LbErrKind::UsernameTaken => "UsernameTaken",
         LbErrKind::ReReadRequired => "ReReadRequired",
+        LbErrKind::Validation(vf) => match vf {
+            ValidationFailure::Cycle(_) => "FolderMovedIntoSelf",
+            ValidationFailure::PathConflict(_) => "PathTaken",
+            ValidationFailure::FileNameTooLong(_) => todo!(),
+            ValidationFailure::NonFolderWithChildren(_) => todo!(),
+            ValidationFailure::OwnedLink(_) => "LinkTargetIsOwned",
+            ValidationFailure::BrokenLink(_) => "LinkTargetNonexistent",
+            ValidationFailure::DuplicateLink { .. } => "MultipleLinksToSameFile",
+            ValidationFailure::SharedLink { .. } => "LinkInSharedFolder",
+            // todo: give this scenario it's own type
+            ValidationFailure::DeletedFileUpdated(_) => "FileNonexistent",
+            _ => "Unexpected"
+        }
         LbErrKind::Unexpected(_) => "Unexpected",
+        _ => "Unexpected"
     };
     let enum_constant = env
         .get_static_field(enum_class, name, "Lnet/lockbook/LbError$LbEC;")

--- a/libs/lb/lb-java/src/java_utils.rs
+++ b/libs/lb/lb-java/src/java_utils.rs
@@ -81,7 +81,6 @@ pub(crate) fn throw_err<'local>(env: &mut JNIEnv<'local>, err: LbErr) -> JObject
         LbErrKind::FileNameEmpty => "FileNameEmpty",
         LbErrKind::FileNonexistent => "FileNonexistent",
         LbErrKind::FileNotDocument => "FileNotDocument",
-        LbErrKind::FileNotFolder => "FileNotFolder",
         LbErrKind::FileParentNonexistent => "FileParentNonexistent",
         LbErrKind::FolderMovedIntoSelf => "FolderMovedIntoSelf",
         LbErrKind::InsufficientPermission => "InsufficientPermission",

--- a/libs/lb/lb-java/src/java_utils.rs
+++ b/libs/lb/lb-java/src/java_utils.rs
@@ -1,10 +1,13 @@
 use jni::{
-   objects::{JByteArray, JClass, JObject, JString, JThrowable, JValue},
+    objects::{JByteArray, JClass, JObject, JString, JThrowable, JValue},
     JNIEnv,
 };
 use lb_rs::{
     blocking::Lb,
-    model::{errors::{LbErr, LbErrKind}, ValidationFailure},
+    model::{
+        errors::{LbErr, LbErrKind},
+        ValidationFailure,
+    },
 };
 
 pub(crate) fn rstring<'local>(env: &mut JNIEnv<'local>, input: JString<'local>) -> String {
@@ -114,10 +117,10 @@ pub(crate) fn throw_err<'local>(env: &mut JNIEnv<'local>, err: LbErr) -> JObject
             ValidationFailure::SharedLink { .. } => "LinkInSharedFolder",
             // todo: give this scenario it's own type
             ValidationFailure::DeletedFileUpdated(_) => "FileNonexistent",
-            _ => "Unexpected"
-        }
+            _ => "Unexpected",
+        },
         LbErrKind::Unexpected(_) => "Unexpected",
-        _ => "Unexpected"
+        _ => "Unexpected",
     };
     let enum_constant = env
         .get_static_field(enum_class, name, "Lnet/lockbook/LbError$LbEC;")

--- a/libs/lb/lb-rs/src/blocking.rs
+++ b/libs/lb/lb-rs/src/blocking.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         core_config::Config,
         crypto::DecryptedDocument,
-        errors::{LbResult, TestRepoError, Warning},
+        errors::{LbResult,  Warning},
         file::{File, ShareMode},
         file_metadata::{DocumentHmac, FileType},
         path_ops::Filter,
@@ -236,7 +236,7 @@ impl Lb {
         self.rt.block_on(self.lb.search(input, cfg))
     }
 
-    pub fn validate(&self) -> Result<Vec<Warning>, TestRepoError> {
+    pub fn validate(&self) -> LbResult<Vec<Warning>> {
         self.rt.block_on(self.lb.test_repo_integrity())
     }
 

--- a/libs/lb/lb-rs/src/blocking.rs
+++ b/libs/lb/lb-rs/src/blocking.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         core_config::Config,
         crypto::DecryptedDocument,
-        errors::{LbResult,  Warning},
+        errors::{LbResult, Warning},
         file::{File, ShareMode},
         file_metadata::{DocumentHmac, FileType},
         path_ops::Filter,

--- a/libs/lb/lb-rs/src/model/access_info.rs
+++ b/libs/lb/lb-rs/src/model/access_info.rs
@@ -1,8 +1,10 @@
 use crate::model::account::Account;
 use crate::model::crypto::{AESEncrypted, AESKey};
-use crate::model::{pubkey, symkey, SharedResult};
+use crate::model::{pubkey, symkey};
 use libsecp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
+
+use super::errors::LbResult;
 
 pub type EncryptedUserAccessKey = AESEncrypted<AESKey>;
 pub type EncryptedFolderAccessKey = AESEncrypted<AESKey>;
@@ -36,7 +38,7 @@ impl UserAccessInfo {
     pub fn encrypt(
         account: &Account, encrypted_by: &PublicKey, encrypted_for: &PublicKey, key: &AESKey,
         mode: UserAccessMode,
-    ) -> SharedResult<Self> {
+    ) -> LbResult<Self> {
         let private_key = account.private_key;
         let user_key = pubkey::get_aes_key(&private_key, encrypted_for)?;
         let encrypted_file_key = symkey::encrypt(&user_key, key)?;
@@ -49,7 +51,7 @@ impl UserAccessInfo {
         })
     }
 
-    pub fn decrypt(&self, account: &Account) -> SharedResult<AESKey> {
+    pub fn decrypt(&self, account: &Account) -> LbResult<AESKey> {
         let shared_secret = pubkey::get_aes_key(&account.private_key, &self.encrypted_by)?;
         let encrypted = &self.access_key;
         let decrypted = symkey::decrypt(&shared_secret, encrypted)?;

--- a/libs/lb/lb-rs/src/model/account.rs
+++ b/libs/lb/lb-rs/src/model/account.rs
@@ -1,4 +1,4 @@
-use crate::model::{pubkey, SharedErrorKind, SharedResult};
+use crate::model::pubkey;
 use bip39_dict::Language;
 use libsecp256k1::{PublicKey, SecretKey};
 use serde::{Deserialize, Serialize};

--- a/libs/lb/lb-rs/src/model/api.rs
+++ b/libs/lb/lb-rs/src/model/api.rs
@@ -80,7 +80,6 @@ pub enum UpsertError {
     RootModificationInvalid,
 
     /// Found update to a deleted file
-    #[deprecated]
     DeletedFileUpdated,
 
     /// Over the User's Tier Limit

--- a/libs/lb/lb-rs/src/model/api.rs
+++ b/libs/lb/lb-rs/src/model/api.rs
@@ -80,6 +80,7 @@ pub enum UpsertError {
     RootModificationInvalid,
 
     /// Found update to a deleted file
+    #[deprecated]
     DeletedFileUpdated,
 
     /// Over the User's Tier Limit

--- a/libs/lb/lb-rs/src/model/compression_service.rs
+++ b/libs/lb/lb-rs/src/model/compression_service.rs
@@ -4,7 +4,6 @@ use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
 
-
 use super::errors::{LbErrKind, LbResult};
 
 pub fn compress(content: &[u8]) -> LbResult<Vec<u8>> {

--- a/libs/lb/lb-rs/src/model/compression_service.rs
+++ b/libs/lb/lb-rs/src/model/compression_service.rs
@@ -4,7 +4,6 @@ use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
 
-use crate::model::{SharedErrorKind, SharedResult};
 
 use super::errors::{LbErrKind, LbResult};
 

--- a/libs/lb/lb-rs/src/model/compression_service.rs
+++ b/libs/lb/lb-rs/src/model/compression_service.rs
@@ -6,22 +6,25 @@ use flate2::Compression;
 
 use crate::model::{SharedErrorKind, SharedResult};
 
-pub fn compress(content: &[u8]) -> SharedResult<Vec<u8>> {
+use super::errors::{LbErrKind, LbResult};
+
+pub fn compress(content: &[u8]) -> LbResult<Vec<u8>> {
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
     encoder
         .write_all(content)
-        .map_err(|_| SharedErrorKind::Unexpected("unexpected compression error"))?;
-    encoder
+        .map_err(|err| LbErrKind::Unexpected(format!("unexpected compression error: {err:?}")))?;
+
+    Ok(encoder
         .finish()
-        .map_err(|_| SharedErrorKind::Unexpected("unexpected compression error").into())
+        .map_err(|err| LbErrKind::Unexpected(format!("unexpected compression error: {err:?}")))?)
 }
 
-pub fn decompress(content: &[u8]) -> SharedResult<Vec<u8>> {
+pub fn decompress(content: &[u8]) -> LbResult<Vec<u8>> {
     let mut decoder = ZlibDecoder::new(content);
     let mut result = Vec::<u8>::new();
     decoder
         .read_to_end(&mut result)
-        .map_err(|_| SharedErrorKind::Unexpected("unexpected decompression error"))?;
+        .map_err(|err| LbErrKind::Unexpected(format!("unexpected compression error: {err:?}")))?;
     Ok(result)
 }
 

--- a/libs/lb/lb-rs/src/model/core_tree.rs
+++ b/libs/lb/lb-rs/src/model/core_tree.rs
@@ -4,6 +4,8 @@ use crate::model::SharedResult;
 use serde::Serialize;
 use uuid::Uuid;
 
+use super::errors::{LbResult, Unexpected};
+
 impl<F> TreeLike for db_rs::LookupTable<Uuid, F>
 where
     F: FileLike + Serialize,
@@ -23,15 +25,15 @@ impl<F> TreeLikeMut for db_rs::LookupTable<Uuid, F>
 where
     F: FileLike + Serialize,
 {
-    fn insert(&mut self, f: Self::F) -> SharedResult<Option<Self::F>> {
-        Ok(db_rs::LookupTable::insert(self, *f.id(), f)?)
+    fn insert(&mut self, f: Self::F) -> LbResult<Option<Self::F>> {
+        Ok(db_rs::LookupTable::insert(self, *f.id(), f).map_unexpected()?)
     }
 
-    fn remove(&mut self, id: Uuid) -> SharedResult<Option<Self::F>> {
-        Ok(db_rs::LookupTable::remove(self, &id)?)
+    fn remove(&mut self, id: Uuid) -> LbResult<Option<Self::F>> {
+        Ok(db_rs::LookupTable::remove(self, &id).map_unexpected()?)
     }
 
-    fn clear(&mut self) -> SharedResult<()> {
-        Ok(db_rs::LookupTable::clear(self)?)
+    fn clear(&mut self) -> LbResult<()> {
+        Ok(db_rs::LookupTable::clear(self).map_unexpected()?)
     }
 }

--- a/libs/lb/lb-rs/src/model/core_tree.rs
+++ b/libs/lb/lb-rs/src/model/core_tree.rs
@@ -1,6 +1,5 @@
 use crate::model::file_like::FileLike;
 use crate::model::tree_like::{TreeLike, TreeLikeMut};
-use crate::model::SharedResult;
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -26,14 +25,14 @@ where
     F: FileLike + Serialize,
 {
     fn insert(&mut self, f: Self::F) -> LbResult<Option<Self::F>> {
-        Ok(db_rs::LookupTable::insert(self, *f.id(), f).map_unexpected()?)
+        db_rs::LookupTable::insert(self, *f.id(), f).map_unexpected()
     }
 
     fn remove(&mut self, id: Uuid) -> LbResult<Option<Self::F>> {
-        Ok(db_rs::LookupTable::remove(self, &id).map_unexpected()?)
+        db_rs::LookupTable::remove(self, &id).map_unexpected()
     }
 
     fn clear(&mut self) -> LbResult<()> {
-        Ok(db_rs::LookupTable::clear(self).map_unexpected()?)
+        db_rs::LookupTable::clear(self).map_unexpected()
     }
 }

--- a/libs/lb/lb-rs/src/model/errors.rs
+++ b/libs/lb/lb-rs/src/model/errors.rs
@@ -1,5 +1,4 @@
 use std::backtrace::Backtrace;
-use std::collections::HashSet;
 use std::fmt::Display;
 use std::fmt::{self, Formatter};
 use std::io;
@@ -11,7 +10,7 @@ use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use uuid::Uuid;
 
-use crate::model::{SharedError, SharedErrorKind, ValidationFailure};
+use crate::model::{SharedError, ValidationFailure};
 use crate::service::network::ApiError;
 
 use super::api;
@@ -146,9 +145,7 @@ impl From<LbErrKind> for LbErr {
 
 impl From<SharedError> for LbErr {
     fn from(err: SharedError) -> Self {
-        let kind = match err.kind {
-            _ => LbErrKind::Unexpected(format!("unexpected shared error {:?}", err)),
-        };
+        let kind = LbErrKind::Unexpected(format!("unexpected shared error {:?}", err));
         Self { kind, backtrace: err.backtrace }
     }
 }

--- a/libs/lb/lb-rs/src/model/errors.rs
+++ b/libs/lb/lb-rs/src/model/errors.rs
@@ -143,12 +143,7 @@ impl From<LbErrKind> for LbErr {
 impl From<SharedError> for LbErr {
     fn from(err: SharedError) -> Self {
         let kind = match err.kind {
-            SharedErrorKind::FileNonexistent => LbErrKind::FileNonexistent,
-            SharedErrorKind::FileParentNonexistent => LbErrKind::FileParentNonexistent,
             SharedErrorKind::Unexpected(err) => LbErrKind::Unexpected(err.to_string()),
-            SharedErrorKind::FileNotFolder => LbErrKind::FileNotFolder,
-            SharedErrorKind::FileNotDocument => LbErrKind::FileNotDocument,
-            SharedErrorKind::KeyPhraseInvalid => LbErrKind::KeyPhraseInvalid,
             SharedErrorKind::ValidationFailure(failure) => match failure {
                 ValidationFailure::Cycle(_) => LbErrKind::FolderMovedIntoSelf,
                 ValidationFailure::PathConflict(_) => LbErrKind::PathTaken,

--- a/libs/lb/lb-rs/src/model/errors.rs
+++ b/libs/lb/lb-rs/src/model/errors.rs
@@ -32,6 +32,12 @@ impl Display for LbErr {
     }
 }
 
+/// The purpose of this Display implementation is to provide uniformity for the
+/// description of errors that a customer may see. And to provide a productivity
+/// boost for the UI developer processing (and ultimately showing) these errors.
+/// If an error is not expected to be propegated outside of this crate the
+/// the language associated with the error will reflect that (and may use an
+/// uglier debug impl for details).
 impl Display for LbErrKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -118,9 +124,26 @@ impl Display for LbErrKind {
             }
             LbErrKind::Validation(validation_failure) => match validation_failure {
                 ValidationFailure::Cycle(_) => write!(f, "Cannot move a folder into itself"),
-                ValidationFailure::NonFolderWithChildren(_) => write!(f, "A document or a link was treated as a folder."),
-                ValidationFailure::PathConflict(_) => write!(f, "A file already exists at that path."),
-                ValidationFailure::DeletedFileUpdated(id) => write!(f, "this file has been deleted {id}"),
+                ValidationFailure::NonFolderWithChildren(_) => {
+                    write!(f, "A document or a link was treated as a folder.")
+                }
+                ValidationFailure::PathConflict(_) => {
+                    write!(f, "A file already exists at that path.")
+                }
+                ValidationFailure::DeletedFileUpdated(id) => {
+                    write!(f, "this file has been deleted {id}")
+                }
+                ValidationFailure::FileNameTooLong(_) => write!(f, "this filename is too long!"),
+                ValidationFailure::OwnedLink(_) => {
+                    write!(f, "you cannot have a link to a file you own")
+                }
+                ValidationFailure::BrokenLink(_) => write!(f, "that link target does not exist!"),
+                ValidationFailure::DuplicateLink { .. } => {
+                    write!(f, "you already have a link to that file")
+                }
+                ValidationFailure::SharedLink { .. } => {
+                    write!(f, "you cannot place a link inside a shared folder!")
+                }
                 _ => write!(f, "unexpected validation failure: {validation_failure:?}"),
             },
             LbErrKind::Diff(diff_error) => {
@@ -240,6 +263,7 @@ pub enum LbErrKind {
     AlreadyPremium,
     AppStoreAccountAlreadyLinked,
     AlreadySyncing,
+    // todo: group billing
     CannotCancelSubscriptionForAppStore,
     CardDecline,
     CardExpired,
@@ -255,7 +279,9 @@ pub enum LbErrKind {
     DiskPathTaken,
     DrawingInvalid,
     ExistingRequestPending,
+    // todo: Group
     FileNameContainsSlash,
+    // todo: #[deprecated]
     FileNameTooLong,
     FileNameEmpty,
     FileNonexistent,
@@ -277,6 +303,7 @@ pub enum LbErrKind {
     ShareAlreadyExists,
     ShareNonexistent,
     TryAgain,
+    // todo: group username errors
     UsernameInvalid,
     UsernameNotFound,
     UsernamePublicKeyMismatch,

--- a/libs/lb/lb-rs/src/model/errors.rs
+++ b/libs/lb/lb-rs/src/model/errors.rs
@@ -317,6 +317,15 @@ pub fn core_err_unexpected<T: fmt::Debug>(err: T) -> LbErrKind {
     LbErrKind::Unexpected(format!("{:?}", err))
 }
 
+// todo call location becomes useless here, and we want that
+pub fn unexpected<T: fmt::Debug>(err: T) -> LbErr {
+    LbErrKind::Unexpected(format!("{:?}", err)).into()
+}
+
+pub trait Unexpected {
+    fn unexpected_err(self) -> LbErr;
+}
+
 impl From<db_rs::DbError> for LbErr {
     fn from(err: db_rs::DbError) -> Self {
         core_err_unexpected(err).into()

--- a/libs/lb/lb-rs/src/model/file_metadata.rs
+++ b/libs/lb/lb-rs/src/model/file_metadata.rs
@@ -33,7 +33,7 @@ pub struct FileMetadata {
 }
 
 impl FileMetadata {
-    pub fn create_root(account: &Account) -> SharedResult<Self> {
+    pub fn create_root(account: &Account) -> LbResult<Self> {
         let id = Uuid::new_v4();
         let key = symkey::generate_key();
         let pub_key = account.public_key();
@@ -60,7 +60,7 @@ impl FileMetadata {
     pub fn create(
         id: Uuid, key: AESKey, owner: &PublicKey, parent: Uuid, parent_key: &AESKey, name: &str,
         file_type: FileType,
-    ) -> SharedResult<Self> {
+    ) -> LbResult<Self> {
         Ok(FileMetadata {
             id,
             file_type,

--- a/libs/lb/lb-rs/src/model/file_metadata.rs
+++ b/libs/lb/lb-rs/src/model/file_metadata.rs
@@ -14,7 +14,7 @@ use crate::model::crypto::AESKey;
 use crate::model::file_like::FileLike;
 use crate::model::secret_filename::SecretFileName;
 use crate::model::signed_file::SignedFile;
-use crate::model::{pubkey, symkey, SharedResult};
+use crate::model::{pubkey, symkey};
 use crate::service::keychain::Keychain;
 
 pub type DocumentHmac = [u8; 32];
@@ -75,11 +75,11 @@ impl FileMetadata {
     }
 
     pub fn sign(self, keychain: &Keychain) -> LbResult<SignedFile> {
-        Ok(pubkey::sign(&keychain.get_account()?.private_key, &keychain.get_pk()?, self, get_time)?)
+        pubkey::sign(&keychain.get_account()?.private_key, &keychain.get_pk()?, self, get_time)
     }
 
     pub fn sign_with(self, account: &Account) -> LbResult<SignedFile> {
-        Ok(pubkey::sign(&account.private_key, &account.public_key(), self, get_time)?)
+        pubkey::sign(&account.private_key, &account.public_key(), self, get_time)
     }
 }
 

--- a/libs/lb/lb-rs/src/model/lazy.rs
+++ b/libs/lb/lb-rs/src/model/lazy.rs
@@ -352,16 +352,33 @@ pub type LazyStage2<Base, Local, Staged> = LazyTree<Stage2<Base, Local, Staged>>
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq)]
 pub enum ValidationFailure {
     Orphan(Uuid),
+
+    /// A folder was moved into itself
     Cycle(HashSet<Uuid>),
+
+    /// A filename is not available
     PathConflict(HashSet<Uuid>),
+
+    /// This filename is too long
     FileNameTooLong(Uuid),
+
+    /// A link or document was treated as a folder
     NonFolderWithChildren(Uuid),
+
+    /// You cannot have a link to a file you own
+    OwnedLink(Uuid),
+
+    /// You cannot have a link that points to a nonexistent file
+    BrokenLink(Uuid),
+
+    /// You cannot have multiple links to the same file
+    DuplicateLink { target: Uuid },
+
+    /// You cannot have a link inside a shared folder
+    SharedLink { link: Uuid, shared_ancestor: Uuid },
+
     FileWithDifferentOwnerParent(Uuid),
     NonDecryptableFileName(Uuid),
-    SharedLink { link: Uuid, shared_ancestor: Uuid },
-    DuplicateLink { target: Uuid },
-    BrokenLink(Uuid),
-    OwnedLink(Uuid),
     DeletedFileUpdated(Uuid),
 }
 

--- a/libs/lb/lb-rs/src/model/lazy.rs
+++ b/libs/lb/lb-rs/src/model/lazy.rs
@@ -371,7 +371,7 @@ where
 {
     pub fn stage_and_promote<S: TreeLikeMut<F = T::F>>(
         &mut self, mut staged: S,
-    ) -> SharedResult<()> {
+    ) -> LbResult<()> {
         for id in staged.ids() {
             if let Some(removed) = staged.remove(id)? {
                 self.tree.insert(removed)?;
@@ -396,7 +396,7 @@ where
     }
 
     // todo: this is dead code
-    pub fn stage_removals_and_promote(&mut self, removed: HashSet<Uuid>) -> SharedResult<()> {
+    pub fn stage_removals_and_promote(&mut self, removed: HashSet<Uuid>) -> LbResult<()> {
         for id in removed {
             self.tree.remove(id)?;
         }

--- a/libs/lb/lb-rs/src/model/lazy.rs
+++ b/libs/lb/lb-rs/src/model/lazy.rs
@@ -334,13 +334,10 @@ impl<T: TreeLike> LazyTree<T> {
     }
 
     // todo: optimize
-    pub fn assert_names_decryptable(&mut self, keychain: &Keychain) -> SharedResult<()> {
+    pub fn assert_names_decryptable(&mut self, keychain: &Keychain) -> LbResult<()> {
         for id in self.ids() {
             if self.name(&id, keychain).is_err() {
-                return Err(SharedErrorKind::ValidationFailure(
-                    ValidationFailure::NonDecryptableFileName(id),
-                )
-                .into());
+                return Err(LbErrKind::Validation(ValidationFailure::NonDecryptableFileName(id)))?;
             }
         }
         Ok(())

--- a/libs/lb/lb-rs/src/model/lazy.rs
+++ b/libs/lb/lb-rs/src/model/lazy.rs
@@ -4,8 +4,8 @@ use crate::model::errors::{LbErrKind, LbResult};
 use crate::model::file_like::FileLike;
 use crate::model::file_metadata::{FileType, Owner};
 use crate::model::staged::StagedTree;
-use crate::model::tree_like::{TreeLike, TreeLikeMut};
 use crate::model::symkey;
+use crate::model::tree_like::{TreeLike, TreeLikeMut};
 use crate::service::keychain::Keychain;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -372,10 +372,15 @@ pub enum ValidationFailure {
     BrokenLink(Uuid),
 
     /// You cannot have multiple links to the same file
-    DuplicateLink { target: Uuid },
+    DuplicateLink {
+        target: Uuid,
+    },
 
     /// You cannot have a link inside a shared folder
-    SharedLink { link: Uuid, shared_ancestor: Uuid },
+    SharedLink {
+        link: Uuid,
+        shared_ancestor: Uuid,
+    },
 
     FileWithDifferentOwnerParent(Uuid),
     NonDecryptableFileName(Uuid),
@@ -386,9 +391,7 @@ impl<T> LazyTree<T>
 where
     T: TreeLikeMut,
 {
-    pub fn stage_and_promote<S: TreeLikeMut<F = T::F>>(
-        &mut self, mut staged: S,
-    ) -> LbResult<()> {
+    pub fn stage_and_promote<S: TreeLikeMut<F = T::F>>(&mut self, mut staged: S) -> LbResult<()> {
         for id in staged.ids() {
             if let Some(removed) = staged.remove(id)? {
                 self.tree.insert(removed)?;

--- a/libs/lb/lb-rs/src/model/lazy.rs
+++ b/libs/lb/lb-rs/src/model/lazy.rs
@@ -5,7 +5,7 @@ use crate::model::file_like::FileLike;
 use crate::model::file_metadata::{FileType, Owner};
 use crate::model::staged::StagedTree;
 use crate::model::tree_like::{TreeLike, TreeLikeMut};
-use crate::model::{symkey, SharedErrorKind, SharedResult};
+use crate::model::symkey;
 use crate::service::keychain::Keychain;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -31,4 +31,3 @@ pub mod validate;
 pub mod work_unit;
 
 pub use lazy::ValidationFailure;
-

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -32,22 +32,3 @@ pub mod work_unit;
 
 pub use lazy::ValidationFailure;
 
-use std::backtrace::Backtrace;
-
-
-pub type SharedResult<T> = Result<T, SharedError>;
-
-#[derive(Debug)]
-pub struct SharedError {
-    pub kind: SharedErrorKind,
-    pub backtrace: Option<Backtrace>,
-}
-
-impl From<SharedErrorKind> for SharedError {
-    fn from(kind: SharedErrorKind) -> Self {
-        Self { kind, backtrace: Some(Backtrace::force_capture()) }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum SharedErrorKind {}

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -37,7 +37,6 @@ use std::io;
 
 use db_rs::DbError;
 use hmac::crypto_mac::{InvalidKeyLength, MacError};
-use uuid::Uuid;
 
 pub type SharedResult<T> = Result<T, SharedError>;
 
@@ -63,7 +62,6 @@ pub enum SharedErrorKind {
     ParseError(libsecp256k1::Error),
     SharedSecretUnexpectedSize,
     SharedSecretError(libsecp256k1::Error),
-    ValidationFailure(ValidationFailure),
 
     Io(String),
 

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -55,13 +55,8 @@ impl From<SharedErrorKind> for SharedError {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SharedErrorKind {
-    FileNonexistent,
-    FileParentNonexistent,
-    FileNotFolder,
-    FileNotDocument,
     SignatureInvalid,
     WrongPublicKey,
-    KeyPhraseInvalid,
     SignatureInTheFuture(u64),
     SignatureExpired(u64),
     BincodeError(String),

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -36,7 +36,6 @@ use std::backtrace::Backtrace;
 use std::io;
 
 use db_rs::DbError;
-use hmac::crypto_mac::{InvalidKeyLength, MacError};
 
 pub type SharedResult<T> = Result<T, SharedError>;
 
@@ -53,35 +52,4 @@ impl From<SharedErrorKind> for SharedError {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum SharedErrorKind {
-    BincodeError(String),
-    Encryption(aead::Error),
-    HmacCreationError(InvalidKeyLength),
-    Decryption(aead::Error),
-    HmacValidationError(MacError),
-    ParseError(libsecp256k1::Error),
-    SharedSecretUnexpectedSize,
-    SharedSecretError(libsecp256k1::Error),
-
-    Io(String),
-
-    Db(String),
-}
-
-impl From<DbError> for SharedError {
-    fn from(value: DbError) -> Self {
-        SharedErrorKind::Db(format!("db error: {:?}", value)).into()
-    }
-}
-
-impl From<bincode::Error> for SharedError {
-    fn from(err: bincode::Error) -> Self {
-        SharedErrorKind::BincodeError(err.to_string()).into()
-    }
-}
-
-impl From<io::Error> for SharedError {
-    fn from(err: io::Error) -> Self {
-        SharedErrorKind::Io(err.to_string()).into()
-    }
-}
+pub enum SharedErrorKind {}

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -55,13 +55,7 @@ impl From<SharedErrorKind> for SharedError {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SharedErrorKind {
-    PathContainsEmptyFileName,
-    PathTaken,
-    RootNonexistent,
     FileNonexistent,
-    FileNameContainsSlash,
-    RootModificationInvalid,
-    FileNameEmpty,
     FileParentNonexistent,
     FileNotFolder,
     FileNotDocument,
@@ -77,34 +71,9 @@ pub enum SharedErrorKind {
     HmacValidationError(MacError),
     ParseError(libsecp256k1::Error),
     ShareNonexistent,
-    DuplicateShare,
     SharedSecretUnexpectedSize,
     SharedSecretError(libsecp256k1::Error),
     ValidationFailure(ValidationFailure),
-
-    /// Arises during a call to upsert, when the caller does not have the correct old version of the
-    /// File they're trying to modify
-    OldVersionIncorrect,
-
-    /// Arises during a call to upsert, when the old file is not known to the server
-    OldFileNotFound,
-
-    /// Arises during a call to upsert, when the caller suggests that a file is new, but the id already
-    /// exists
-    OldVersionRequired,
-
-    /// Arises during a call to upsert, when the person making the request is not an owner of the file
-    /// or has not signed the update
-    InsufficientPermission,
-
-    /// Arises during a call to upsert, when a diff's new.id != old.id
-    DiffMalformed,
-
-    /// Metas in upsert cannot contain changes to digest
-    HmacModificationInvalid,
-
-    /// Found update to a deleted file
-    DeletedFileUpdated(Uuid),
 
     Io(String),
 

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -55,17 +55,12 @@ impl From<SharedErrorKind> for SharedError {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SharedErrorKind {
-    SignatureInvalid,
-    WrongPublicKey,
-    SignatureInTheFuture(u64),
-    SignatureExpired(u64),
     BincodeError(String),
     Encryption(aead::Error),
     HmacCreationError(InvalidKeyLength),
     Decryption(aead::Error),
     HmacValidationError(MacError),
     ParseError(libsecp256k1::Error),
-    ShareNonexistent,
     SharedSecretUnexpectedSize,
     SharedSecretError(libsecp256k1::Error),
     ValidationFailure(ValidationFailure),
@@ -73,8 +68,6 @@ pub enum SharedErrorKind {
     Io(String),
 
     Db(String),
-
-    Unexpected(&'static str),
 }
 
 impl From<DbError> for SharedError {

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -33,9 +33,7 @@ pub mod work_unit;
 pub use lazy::ValidationFailure;
 
 use std::backtrace::Backtrace;
-use std::io;
 
-use db_rs::DbError;
 
 pub type SharedResult<T> = Result<T, SharedError>;
 

--- a/libs/lb/lb-rs/src/model/path_ops.rs
+++ b/libs/lb/lb-rs/src/model/path_ops.rs
@@ -184,7 +184,9 @@ where
 
                     current = match self.find(&child)?.file_type() {
                         FileType::Document => {
-                            return Err(LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(child)))?;
+                            return Err(LbErrKind::Validation(
+                                ValidationFailure::NonFolderWithChildren(child),
+                            ))?;
                         }
                         FileType::Folder => child,
                         FileType::Link { target } => {

--- a/libs/lb/lb-rs/src/model/path_ops.rs
+++ b/libs/lb/lb-rs/src/model/path_ops.rs
@@ -11,6 +11,8 @@ use crate::service::keychain::Keychain;
 use std::collections::HashSet;
 use uuid::Uuid;
 
+use super::ValidationFailure;
+
 impl<Base, Local, Staged> LazyTree<Staged>
 where
     Base: TreeLike<F = SignedFile>,
@@ -175,12 +177,14 @@ where
 
                 if self.name_using_links(&child, keychain)? == path_components[index] {
                     if index == path_components.len() - 1 {
-                        return Err(LbErrKind::PathTaken.into());
+                        return Err(LbErrKind::Validation(ValidationFailure::PathConflict(
+                            HashSet::from([child]),
+                        )))?;
                     }
 
                     current = match self.find(&child)?.file_type() {
                         FileType::Document => {
-                            return Err(LbErrKind::FileNotFolder.into());
+                            return Err(LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(child)))?;
                         }
                         FileType::Folder => child,
                         FileType::Link { target } => {

--- a/libs/lb/lb-rs/src/model/pubkey.rs
+++ b/libs/lb/lb-rs/src/model/pubkey.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::convert::TryInto;
 
-use super::errors::{LbErrKind, LbResult, SignError};
+use super::errors::{core_err_unexpected, unexpected, LbErrKind, LbResult, SignError};
 
 pub fn generate_key() -> SecretKey {
     SecretKey::random(&mut OsRng)
@@ -75,12 +75,12 @@ pub fn verify<T: Serialize>(
     }
 }
 
-pub fn get_aes_key(sk: &SecretKey, pk: &PublicKey) -> SharedResult<AESKey> {
+pub fn get_aes_key(sk: &SecretKey, pk: &PublicKey) -> LbResult<AESKey> {
     SharedSecret::<Sha256>::new(pk, sk)
-        .map_err(SharedErrorKind::SharedSecretError)?
+        .map_err(unexpected)?
         .as_ref()
         .try_into()
-        .map_err(|_| SharedErrorKind::SharedSecretUnexpectedSize.into())
+        .map_err(unexpected)
 }
 
 #[cfg(test)]

--- a/libs/lb/lb-rs/src/model/secret_filename.rs
+++ b/libs/lb/lb-rs/src/model/secret_filename.rs
@@ -1,6 +1,5 @@
 use crate::model::crypto::{AESEncrypted, AESKey};
 use crate::model::symkey::{convert_key, generate_nonce};
-use crate::model::{SharedErrorKind, SharedResult};
 use aead::{generic_array::GenericArray, Aead};
 use hmac::{Hmac, Mac, NewMac};
 use serde::{Deserialize, Serialize};

--- a/libs/lb/lb-rs/src/model/secret_filename.rs
+++ b/libs/lb/lb-rs/src/model/secret_filename.rs
@@ -54,8 +54,7 @@ impl SecretFileName {
 
     pub fn verify_hmac(&self, key: &AESKey, parent_key: &AESKey) -> LbResult<()> {
         let decrypted = self.to_string(key)?;
-        let mut mac =
-            HmacSha256::new_from_slice(parent_key).map_unexpected()?;
+        let mut mac = HmacSha256::new_from_slice(parent_key).map_unexpected()?;
         mac.update(decrypted.as_ref());
         mac.verify(&self.hmac)
             .map_err(|err| LbErrKind::Crypto(CryptoError::HmacVerification(err)))?;

--- a/libs/lb/lb-rs/src/model/server_ops.rs
+++ b/libs/lb/lb-rs/src/model/server_ops.rs
@@ -1,3 +1,4 @@
+use super::errors::{DiffError, LbErrKind, LbResult};
 use crate::model::clock::get_time;
 use crate::model::file_like::FileLike;
 use crate::model::file_metadata::FileDiff;
@@ -6,7 +7,6 @@ use crate::model::server_file::{IntoServerFile, ServerFile};
 use crate::model::server_tree::ServerTree;
 use crate::model::signed_file::SignedFile;
 use crate::model::tree_like::TreeLike;
-use super::errors::{DiffError, LbErrKind, LbResult};
 
 type LazyServerStaged1<'a> = LazyStaged1<ServerTree<'a>, Vec<ServerFile>>;
 

--- a/libs/lb/lb-rs/src/model/server_ops.rs
+++ b/libs/lb/lb-rs/src/model/server_ops.rs
@@ -6,21 +6,19 @@ use crate::model::server_file::{IntoServerFile, ServerFile};
 use crate::model::server_tree::ServerTree;
 use crate::model::signed_file::SignedFile;
 use crate::model::tree_like::TreeLike;
-use crate::model::{SharedErrorKind, SharedResult};
+use super::errors::{DiffError, LbErrKind, LbResult};
 
 type LazyServerStaged1<'a> = LazyStaged1<ServerTree<'a>, Vec<ServerFile>>;
 
 impl<'a> LazyTree<ServerTree<'a>> {
     /// Validates a diff prior to staging it. Performs individual validations, then validations that
     /// require a tree
-    pub fn stage_diff(
-        self, changes: Vec<FileDiff<SignedFile>>,
-    ) -> SharedResult<LazyServerStaged1<'a>> {
+    pub fn stage_diff(self, changes: Vec<FileDiff<SignedFile>>) -> LbResult<LazyServerStaged1<'a>> {
         // Check new.id == old.id
         for change in &changes {
             if let Some(old) = &change.old {
                 if old.id() != change.new.id() {
-                    return Err(SharedErrorKind::DiffMalformed.into());
+                    return Err(LbErrKind::Diff(DiffError::DiffMalformed))?;
                 }
             }
         }
@@ -32,12 +30,12 @@ impl<'a> LazyTree<ServerTree<'a>> {
                     if old.timestamped_value.value.document_hmac
                         != change.new.timestamped_value.value.document_hmac
                     {
-                        return Err(SharedErrorKind::HmacModificationInvalid.into());
+                        return Err(LbErrKind::Diff(DiffError::HmacModificationInvalid))?;
                     }
                 }
                 None => {
                     if change.new.timestamped_value.value.document_hmac.is_some() {
-                        return Err(SharedErrorKind::HmacModificationInvalid.into());
+                        return Err(LbErrKind::Diff(DiffError::HmacModificationInvalid))?;
                     }
                 }
             }
@@ -49,16 +47,16 @@ impl<'a> LazyTree<ServerTree<'a>> {
                 Some(old) => {
                     let current = &self
                         .maybe_find(old.id())
-                        .ok_or(SharedErrorKind::OldFileNotFound)?
+                        .ok_or(LbErrKind::Diff(DiffError::OldFileNotFound))?
                         .file;
                     if current != old {
-                        return Err(SharedErrorKind::OldVersionIncorrect.into());
+                        return Err(LbErrKind::Diff(DiffError::OldVersionIncorrect))?;
                     }
                 }
                 None => {
                     // if you're claiming this file is new, it must be globally unique
                     if self.tree.files.maybe_find(change.new.id()).is_some() {
-                        return Err(SharedErrorKind::OldVersionRequired.into());
+                        return Err(LbErrKind::Diff(DiffError::OldVersionRequired))?;
                     }
                 }
             }

--- a/libs/lb/lb-rs/src/model/server_tree.rs
+++ b/libs/lb/lb-rs/src/model/server_tree.rs
@@ -2,7 +2,6 @@ use crate::model::file_like::FileLike;
 use crate::model::file_metadata::Owner;
 use crate::model::server_file::ServerFile;
 use crate::model::tree_like::{TreeLike, TreeLikeMut};
-use crate::model::SharedResult;
 use db_rs::{LookupSet, LookupTable};
 use std::collections::HashSet;
 use std::iter::FromIterator;

--- a/libs/lb/lb-rs/src/model/server_tree.rs
+++ b/libs/lb/lb-rs/src/model/server_tree.rs
@@ -9,6 +9,8 @@ use std::iter::FromIterator;
 use tracing::*;
 use uuid::Uuid;
 
+use super::errors::LbResult;
+
 pub struct ServerTree<'a> {
     pub ids: HashSet<Uuid>,
     pub owned_files: &'a mut LookupSet<Owner, Uuid>,
@@ -22,7 +24,7 @@ impl<'a> ServerTree<'a> {
         owner: Owner, owned_files: &'a mut LookupSet<Owner, Uuid>,
         shared_files: &'a mut LookupSet<Owner, Uuid>, file_children: &'a mut LookupSet<Uuid, Uuid>,
         files: &'a mut LookupTable<Uuid, ServerFile>,
-    ) -> SharedResult<Self> {
+    ) -> LbResult<Self> {
         let (owned_ids, shared_ids) =
             match (owned_files.get().get(&owner), shared_files.get().get(&owner)) {
                 (Some(owned_ids), Some(shared_ids)) => (owned_ids.clone(), shared_ids.clone()),

--- a/libs/lb/lb-rs/src/model/server_tree.rs
+++ b/libs/lb/lb-rs/src/model/server_tree.rs
@@ -66,7 +66,7 @@ impl TreeLike for ServerTree<'_> {
 }
 
 impl TreeLikeMut for ServerTree<'_> {
-    fn insert(&mut self, f: Self::F) -> SharedResult<Option<Self::F>> {
+    fn insert(&mut self, f: Self::F) -> LbResult<Option<Self::F>> {
         let id = *f.id();
         let owner = f.owner();
         let maybe_prior = LookupTable::insert(self.files, id, f.clone())?;
@@ -121,12 +121,12 @@ impl TreeLikeMut for ServerTree<'_> {
         Ok(maybe_prior)
     }
 
-    fn remove(&mut self, _id: Uuid) -> SharedResult<Option<Self::F>> {
+    fn remove(&mut self, _id: Uuid) -> LbResult<Option<Self::F>> {
         error!("remove metadata called in server!");
         Ok(None)
     }
 
-    fn clear(&mut self) -> SharedResult<()> {
+    fn clear(&mut self) -> LbResult<()> {
         error!("clear called in server!");
         Ok(())
     }

--- a/libs/lb/lb-rs/src/model/signed_file.rs
+++ b/libs/lb/lb-rs/src/model/signed_file.rs
@@ -2,7 +2,6 @@ use crate::model::crypto::ECSigned;
 use crate::model::file_like::FileLike;
 use crate::model::file_metadata::FileMetadata;
 use crate::model::tree_like::{TreeLike, TreeLikeMut};
-use crate::model::SharedResult;
 use std::fmt::{Display, Formatter};
 use uuid::Uuid;
 

--- a/libs/lb/lb-rs/src/model/signed_file.rs
+++ b/libs/lb/lb-rs/src/model/signed_file.rs
@@ -6,6 +6,8 @@ use crate::model::SharedResult;
 use std::fmt::{Display, Formatter};
 use uuid::Uuid;
 
+use super::errors::LbResult;
+
 pub type SignedFile = ECSigned<FileMetadata>;
 
 // Impl'd to avoid comparing encrypted
@@ -52,11 +54,11 @@ impl<F> TreeLikeMut for Option<F>
 where
     F: FileLike,
 {
-    fn insert(&mut self, f: F) -> SharedResult<Option<F>> {
+    fn insert(&mut self, f: F) -> LbResult<Option<F>> {
         Ok(self.replace(f))
     }
 
-    fn remove(&mut self, id: Uuid) -> SharedResult<Option<F>> {
+    fn remove(&mut self, id: Uuid) -> LbResult<Option<F>> {
         if let Some(f) = self {
             if &id == f.id() {
                 Ok(self.take())
@@ -68,7 +70,7 @@ where
         }
     }
 
-    fn clear(&mut self) -> SharedResult<()> {
+    fn clear(&mut self) -> LbResult<()> {
         *self = None;
         Ok(())
     }

--- a/libs/lb/lb-rs/src/model/staged.rs
+++ b/libs/lb/lb-rs/src/model/staged.rs
@@ -1,6 +1,5 @@
 use crate::model::file_like::FileLike;
 use crate::model::tree_like::{TreeLike, TreeLikeMut};
-use crate::model::SharedResult;
 use std::collections::HashSet;
 use uuid::Uuid;
 

--- a/libs/lb/lb-rs/src/model/staged.rs
+++ b/libs/lb/lb-rs/src/model/staged.rs
@@ -4,6 +4,8 @@ use crate::model::SharedResult;
 use std::collections::HashSet;
 use uuid::Uuid;
 
+use super::errors::LbResult;
+
 pub trait StagedTreeLike: TreeLike {
     type Base: TreeLike<F = Self::F>;
     type Staged: TreeLike<F = Self::F>;
@@ -22,7 +24,7 @@ where
 {
     fn staged_mut(&mut self) -> &mut Self::Staged;
 
-    fn prune(&mut self) -> SharedResult<()> {
+    fn prune(&mut self) -> LbResult<()> {
         let mut prunable = vec![];
         for id in self.staged().ids() {
             if let Some(staged) = self.staged().maybe_find(&id) {
@@ -40,7 +42,7 @@ where
         Ok(())
     }
 
-    fn pruned(mut self) -> SharedResult<Self> {
+    fn pruned(mut self) -> LbResult<Self> {
         self.prune()?;
         Ok(self)
     }
@@ -156,7 +158,7 @@ where
     Base: TreeLike,
     Staged: TreeLikeMut<F = Base::F>,
 {
-    fn insert(&mut self, f: Self::F) -> SharedResult<Option<Self::F>> {
+    fn insert(&mut self, f: Self::F) -> LbResult<Option<Self::F>> {
         // if we're inserting it, it can't be removed
         self.removed.remove(f.id());
 
@@ -171,7 +173,7 @@ where
         self.staged.insert(f)
     }
 
-    fn remove(&mut self, id: Uuid) -> SharedResult<Option<Self::F>> {
+    fn remove(&mut self, id: Uuid) -> LbResult<Option<Self::F>> {
         self.removed.insert(id);
         if let Some(staged) = self.staged.remove(id)? {
             Ok(Some(staged))
@@ -180,7 +182,7 @@ where
         }
     }
 
-    fn clear(&mut self) -> SharedResult<()> {
+    fn clear(&mut self) -> LbResult<()> {
         self.removed.extend(self.ids());
         Ok(())
     }

--- a/libs/lb/lb-rs/src/model/symkey.rs
+++ b/libs/lb/lb-rs/src/model/symkey.rs
@@ -1,5 +1,4 @@
 use crate::model::crypto::*;
-use crate::model::{SharedErrorKind, SharedResult};
 use aead::{generic_array::GenericArray, Aead, NewAead};
 use aes_gcm::Aes256Gcm;
 use rand::rngs::OsRng;

--- a/libs/lb/lb-rs/src/model/symkey.rs
+++ b/libs/lb/lb-rs/src/model/symkey.rs
@@ -7,6 +7,8 @@ use rand::RngCore;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use super::errors::{CryptoError, LbErrKind, LbResult, Unexpected};
+
 pub fn generate_key() -> AESKey {
     let mut random_bytes = [0u8; 32];
     OsRng.fill_bytes(&mut random_bytes);
@@ -15,20 +17,21 @@ pub fn generate_key() -> AESKey {
 
 pub fn encrypt<T: Serialize + DeserializeOwned>(
     key: &AESKey, to_encrypt: &T,
-) -> SharedResult<AESEncrypted<T>> {
-    let serialized = bincode::serialize(to_encrypt)?;
+) -> LbResult<AESEncrypted<T>> {
+    let serialized = bincode::serialize(to_encrypt).map_unexpected()?;
     let nonce = &generate_nonce();
     let encrypted = convert_key(key)
         .encrypt(GenericArray::from_slice(nonce), aead::Payload { msg: &serialized, aad: &[] })
-        .map_err(SharedErrorKind::Encryption)?;
+        .map_unexpected()?;
     Ok(AESEncrypted::new(encrypted, nonce.to_vec()))
 }
-pub fn decrypt<T: DeserializeOwned>(key: &AESKey, to_decrypt: &AESEncrypted<T>) -> SharedResult<T> {
+
+pub fn decrypt<T: DeserializeOwned>(key: &AESKey, to_decrypt: &AESEncrypted<T>) -> LbResult<T> {
     let nonce = GenericArray::from_slice(&to_decrypt.nonce);
     let decrypted = convert_key(key)
         .decrypt(nonce, aead::Payload { msg: &to_decrypt.value, aad: &[] })
-        .map_err(SharedErrorKind::Decryption)?;
-    let deserialized = bincode::deserialize(&decrypted)?;
+        .map_err(|err| LbErrKind::Crypto(CryptoError::Decryption(err)))?;
+    let deserialized = bincode::deserialize(&decrypted).map_unexpected()?;
     Ok(deserialized)
 }
 

--- a/libs/lb/lb-rs/src/model/tree_like.rs
+++ b/libs/lb/lb-rs/src/model/tree_like.rs
@@ -1,7 +1,6 @@
 use crate::model::file_like::FileLike;
 use crate::model::lazy::LazyTree;
 use crate::model::staged::StagedTree;
-use crate::model::{SharedErrorKind, SharedResult};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use uuid::Uuid;

--- a/libs/lb/lb-rs/src/model/tree_like.rs
+++ b/libs/lb/lb-rs/src/model/tree_like.rs
@@ -66,9 +66,9 @@ pub trait TreeLike: Sized {
 }
 
 pub trait TreeLikeMut: TreeLike {
-    fn insert(&mut self, f: Self::F) -> SharedResult<Option<Self::F>>;
-    fn remove(&mut self, id: Uuid) -> SharedResult<Option<Self::F>>;
-    fn clear(&mut self) -> SharedResult<()>;
+    fn insert(&mut self, f: Self::F) -> LbResult<Option<Self::F>>;
+    fn remove(&mut self, id: Uuid) -> LbResult<Option<Self::F>>;
+    fn clear(&mut self) -> LbResult<()>;
 }
 
 impl<T> TreeLike for &T
@@ -105,15 +105,15 @@ impl<T> TreeLikeMut for &mut T
 where
     T: TreeLikeMut,
 {
-    fn insert(&mut self, f: Self::F) -> SharedResult<Option<Self::F>> {
+    fn insert(&mut self, f: Self::F) -> LbResult<Option<Self::F>> {
         T::insert(self, f)
     }
 
-    fn remove(&mut self, id: Uuid) -> SharedResult<Option<Self::F>> {
+    fn remove(&mut self, id: Uuid) -> LbResult<Option<Self::F>> {
         T::remove(self, id)
     }
 
-    fn clear(&mut self) -> SharedResult<()> {
+    fn clear(&mut self) -> LbResult<()> {
         T::clear(self)
     }
 }
@@ -137,7 +137,7 @@ impl<F> TreeLikeMut for Vec<F>
 where
     F: FileLike,
 {
-    fn insert(&mut self, f: F) -> SharedResult<Option<F>> {
+    fn insert(&mut self, f: F) -> LbResult<Option<F>> {
         for (i, value) in self.iter().enumerate() {
             if value.id() == f.id() {
                 let old = std::mem::replace(&mut self[i], f);
@@ -150,7 +150,7 @@ where
         Ok(None)
     }
 
-    fn remove(&mut self, id: Uuid) -> SharedResult<Option<F>> {
+    fn remove(&mut self, id: Uuid) -> LbResult<Option<F>> {
         for (i, value) in self.iter().enumerate() {
             if *value.id() == id {
                 return Ok(Some(self.remove(i)));
@@ -160,7 +160,7 @@ where
         Ok(None)
     }
 
-    fn clear(&mut self) -> SharedResult<()> {
+    fn clear(&mut self) -> LbResult<()> {
         self.clear();
         Ok(())
     }
@@ -185,15 +185,15 @@ impl<F> TreeLikeMut for HashMap<Uuid, F>
 where
     F: FileLike,
 {
-    fn insert(&mut self, f: F) -> SharedResult<Option<F>> {
+    fn insert(&mut self, f: F) -> LbResult<Option<F>> {
         Ok(self.insert(*f.id(), f))
     }
 
-    fn remove(&mut self, id: Uuid) -> SharedResult<Option<F>> {
+    fn remove(&mut self, id: Uuid) -> LbResult<Option<F>> {
         Ok(self.remove(&id))
     }
 
-    fn clear(&mut self) -> SharedResult<()> {
+    fn clear(&mut self) -> LbResult<()> {
         self.clear();
         Ok(())
     }

--- a/libs/lb/lb-rs/src/model/tree_like.rs
+++ b/libs/lb/lb-rs/src/model/tree_like.rs
@@ -24,9 +24,9 @@ pub trait TreeLike: Sized {
         self.maybe_find(file.parent())
     }
 
-    fn find_parent<F2: FileLike>(&self, file: &F2) -> SharedResult<&Self::F> {
+    fn find_parent<F2: FileLike>(&self, file: &F2) -> LbResult<&Self::F> {
         self.maybe_find_parent(file)
-            .ok_or_else(|| SharedErrorKind::FileParentNonexistent.into())
+            .ok_or_else(|| LbErrKind::FileParentNonexistent.into())
     }
 
     fn all_files(&self) -> LbResult<Vec<&Self::F>> {

--- a/libs/lb/lb-rs/src/model/tree_like.rs
+++ b/libs/lb/lb-rs/src/model/tree_like.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use uuid::Uuid;
 
+use super::errors::{LbErrKind, LbResult};
+
 pub trait TreeLike: Sized {
     type F: FileLike + Debug;
 
@@ -13,9 +15,9 @@ pub trait TreeLike: Sized {
     fn ids(&self) -> Vec<Uuid>;
     fn maybe_find(&self, id: &Uuid) -> Option<&Self::F>;
 
-    fn find(&self, id: &Uuid) -> SharedResult<&Self::F> {
+    fn find(&self, id: &Uuid) -> LbResult<&Self::F> {
         self.maybe_find(id)
-            .ok_or_else(|| SharedErrorKind::FileNonexistent.into())
+            .ok_or_else(|| LbErrKind::FileNonexistent.into())
     }
 
     fn maybe_find_parent<F2: FileLike>(&self, file: &F2) -> Option<&Self::F> {
@@ -27,7 +29,7 @@ pub trait TreeLike: Sized {
             .ok_or_else(|| SharedErrorKind::FileParentNonexistent.into())
     }
 
-    fn all_files(&self) -> SharedResult<Vec<&Self::F>> {
+    fn all_files(&self) -> LbResult<Vec<&Self::F>> {
         let ids = self.ids();
         let mut all = Vec::with_capacity(ids.len());
         for id in self.ids() {

--- a/libs/lb/lb-rs/src/model/validate.rs
+++ b/libs/lb/lb-rs/src/model/validate.rs
@@ -82,7 +82,7 @@ where
     }
 
     // note: deleted access keys permissible
-    pub fn assert_all_files_decryptable(&mut self, owner: Owner) -> SharedResult<()> {
+    pub fn assert_all_files_decryptable(&mut self, owner: Owner) -> LbResult<()> {
         for file in self.ids().into_iter().filter_map(|id| self.maybe_find(&id)) {
             if self.maybe_find_parent(file).is_none()
                 && !file
@@ -90,7 +90,7 @@ where
                     .iter()
                     .any(|k| k.encrypted_for == owner.0)
             {
-                Err(SharedErrorKind::ValidationFailure(ValidationFailure::Orphan(*file.id())))?;
+                Err(LbErrKind::Validation(ValidationFailure::Orphan(*file.id())))?;
             }
         }
         Ok(())

--- a/libs/lb/lb-rs/src/model/validate.rs
+++ b/libs/lb/lb-rs/src/model/validate.rs
@@ -28,19 +28,19 @@ pub fn not_root<F: FileLike>(file: &F) -> LbResult<()> {
     }
 }
 
-pub fn is_folder<F: FileLike>(file: &F) -> SharedResult<()> {
+pub fn is_folder<F: FileLike>(file: &F) -> LbResult<()> {
     if file.is_folder() {
         Ok(())
     } else {
-        Err(SharedErrorKind::FileNotFolder.into())
+        Err(LbErrKind::FileNotFolder)?
     }
 }
 
-pub fn is_document<F: FileLike>(file: &F) -> SharedResult<()> {
+pub fn is_document<F: FileLike>(file: &F) -> LbResult<()> {
     if file.is_document() {
         Ok(())
     } else {
-        Err(SharedErrorKind::FileNotDocument.into())
+        Err(LbErrKind::FileNotDocument)?
     }
 }
 

--- a/libs/lb/lb-rs/src/model/validate.rs
+++ b/libs/lb/lb-rs/src/model/validate.rs
@@ -5,7 +5,7 @@ use crate::model::filename::MAX_ENCRYPTED_FILENAME_LENGTH;
 use crate::model::lazy::LazyTree;
 use crate::model::staged::StagedTreeLike;
 use crate::model::tree_like::TreeLike;
-use crate::model::{SharedErrorKind, SharedResult, ValidationFailure};
+use crate::model::ValidationFailure;
 use std::collections::{HashMap, HashSet};
 
 use super::errors::{LbErrKind, LbResult};

--- a/libs/lb/lb-rs/src/model/validate.rs
+++ b/libs/lb/lb-rs/src/model/validate.rs
@@ -8,19 +8,21 @@ use crate::model::tree_like::TreeLike;
 use crate::model::{SharedErrorKind, SharedResult, ValidationFailure};
 use std::collections::{HashMap, HashSet};
 
-pub fn file_name(name: &str) -> SharedResult<()> {
+use super::errors::{LbErrKind, LbResult};
+
+pub fn file_name(name: &str) -> LbResult<()> {
     if name.is_empty() {
-        Err(SharedErrorKind::FileNameEmpty)?;
+        Err(LbErrKind::FileNameEmpty)?;
     }
     if name.contains('/') {
-        Err(SharedErrorKind::FileNameContainsSlash)?;
+        Err(LbErrKind::FileNameContainsSlash)?;
     }
     Ok(())
 }
 
-pub fn not_root<F: FileLike>(file: &F) -> SharedResult<()> {
+pub fn not_root<F: FileLike>(file: &F) -> LbResult<()> {
     if file.is_root() {
-        Err(SharedErrorKind::RootModificationInvalid.into())
+        Err(LbErrKind::RootModificationInvalid)?
     } else {
         Ok(())
     }
@@ -42,9 +44,9 @@ pub fn is_document<F: FileLike>(file: &F) -> SharedResult<()> {
     }
 }
 
-pub fn path(path: &str) -> SharedResult<()> {
+pub fn path(path: &str) -> LbResult<()> {
     if path.contains("//") || path.is_empty() {
-        Err(SharedErrorKind::PathContainsEmptyFileName)?;
+        Err(LbErrKind::PathContainsEmptyFileName)?;
     }
 
     Ok(())
@@ -56,7 +58,7 @@ where
     Base: TreeLike<F = T::F>,
     Local: TreeLike<F = T::F>,
 {
-    pub fn validate(&mut self, owner: Owner) -> SharedResult<()> {
+    pub fn validate(&mut self, owner: Owner) -> LbResult<()> {
         // point checks
         self.assert_no_root_changes()?;
         self.assert_no_changes_to_deleted_files()?;
@@ -94,24 +96,22 @@ where
         Ok(())
     }
 
-    pub fn assert_all_filenames_size_limit(&self) -> SharedResult<()> {
+    pub fn assert_all_filenames_size_limit(&self) -> LbResult<()> {
         for file in self.all_files()? {
             if file.secret_name().encrypted_value.value.len() > MAX_ENCRYPTED_FILENAME_LENGTH {
-                return Err(SharedErrorKind::ValidationFailure(
-                    ValidationFailure::FileNameTooLong(*file.id()),
-                ))?;
+                return Err(LbErrKind::Validation(ValidationFailure::FileNameTooLong(*file.id())))?;
             }
         }
         Ok(())
     }
 
-    pub fn assert_only_folders_have_children(&self) -> SharedResult<()> {
+    pub fn assert_only_folders_have_children(&self) -> LbResult<()> {
         for file in self.all_files()? {
             if let Some(parent) = self.maybe_find(file.parent()) {
                 if !parent.is_folder() {
-                    Err(SharedErrorKind::ValidationFailure(
-                        ValidationFailure::NonFolderWithChildren(*parent.id()),
-                    ))?;
+                    Err(LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(
+                        *parent.id(),
+                    )))?;
                 }
             }
         }
@@ -120,7 +120,7 @@ where
 
     // note: deleted files exempt because otherwise moving a folder with a deleted file in it
     // to/from a folder with a different owner would require updating a deleted file
-    pub fn assert_all_files_same_owner_as_parent(&mut self) -> SharedResult<()> {
+    pub fn assert_all_files_same_owner_as_parent(&mut self) -> LbResult<()> {
         for id in self.ids() {
             if self.calculate_deleted(&id)? {
                 continue;
@@ -128,9 +128,9 @@ where
             let file = self.find(&id)?;
             if let Some(parent) = self.maybe_find(file.parent()) {
                 if parent.owner() != file.owner() {
-                    Err(SharedErrorKind::ValidationFailure(
-                        ValidationFailure::FileWithDifferentOwnerParent(*file.id()),
-                    ))?;
+                    Err(LbErrKind::Validation(ValidationFailure::FileWithDifferentOwnerParent(
+                        *file.id(),
+                    )))?;
                 }
             }
         }
@@ -138,7 +138,7 @@ where
     }
 
     // assumption: no orphans
-    pub fn assert_no_cycles(&mut self) -> SharedResult<()> {
+    pub fn assert_no_cycles(&mut self) -> LbResult<()> {
         let mut owners_with_found_roots = HashSet::new();
         let mut no_cycles_in_ancestors = HashSet::new();
         for id in self.ids() {
@@ -152,12 +152,10 @@ where
                         ancestors.insert(*current_file.id());
                         break;
                     } else {
-                        Err(SharedErrorKind::ValidationFailure(ValidationFailure::Cycle(
-                            HashSet::from([id]),
-                        )))?;
+                        Err(LbErrKind::Validation(ValidationFailure::Cycle(HashSet::from([id]))))?;
                     }
                 } else if ancestors.contains(current_file.parent()) {
-                    Err(SharedErrorKind::ValidationFailure(ValidationFailure::Cycle(
+                    Err(LbErrKind::Validation(ValidationFailure::Cycle(
                         self.ancestors(current_file.id())?,
                     )))?;
                 }
@@ -168,7 +166,7 @@ where
                         if !current_file.user_access_keys().is_empty() {
                             break;
                         } else {
-                            return Err(SharedErrorKind::FileParentNonexistent.into());
+                            return Err(LbErrKind::FileParentNonexistent)?;
                         }
                     }
                 }
@@ -178,7 +176,7 @@ where
         Ok(())
     }
 
-    pub fn assert_no_path_conflicts(&mut self) -> SharedResult<()> {
+    pub fn assert_no_path_conflicts(&mut self) -> LbResult<()> {
         let mut id_by_name = HashMap::new();
         for id in self.ids() {
             if !self.calculate_deleted(&id)? {
@@ -187,9 +185,10 @@ where
                     continue;
                 }
                 if let Some(conflicting) = id_by_name.remove(file.secret_name()) {
-                    Err(SharedErrorKind::ValidationFailure(ValidationFailure::PathConflict(
-                        HashSet::from([conflicting, *file.id()]),
-                    )))?;
+                    Err(LbErrKind::Validation(ValidationFailure::PathConflict(HashSet::from([
+                        conflicting,
+                        *file.id(),
+                    ]))))?;
                 }
                 id_by_name.insert(file.secret_name().clone(), *file.id());
             }
@@ -197,19 +196,19 @@ where
         Ok(())
     }
 
-    pub fn assert_no_shared_links(&self) -> SharedResult<()> {
+    pub fn assert_no_shared_links(&self) -> LbResult<()> {
         for link in self.ids() {
             let meta = self.find(&link)?;
             if let FileType::Link { target: _ } = meta.file_type() {
                 if meta.is_shared() {
-                    Err(SharedErrorKind::ValidationFailure(ValidationFailure::SharedLink {
+                    Err(LbErrKind::Validation(ValidationFailure::SharedLink {
                         link,
                         shared_ancestor: link,
                     }))?;
                 }
                 for ancestor in self.ancestors(&link)? {
                     if self.find(&ancestor)?.is_shared() {
-                        Err(SharedErrorKind::ValidationFailure(ValidationFailure::SharedLink {
+                        Err(LbErrKind::Validation(ValidationFailure::SharedLink {
                             link,
                             shared_ancestor: ancestor,
                         }))?;
@@ -220,7 +219,7 @@ where
         Ok(())
     }
 
-    pub fn assert_no_duplicate_links(&mut self) -> SharedResult<()> {
+    pub fn assert_no_duplicate_links(&mut self) -> LbResult<()> {
         let mut linked_targets = HashSet::new();
         for link in self.ids() {
             if self.calculate_deleted(&link)? {
@@ -228,9 +227,7 @@ where
             }
             if let FileType::Link { target } = self.find(&link)?.file_type() {
                 if !linked_targets.insert(target) {
-                    Err(SharedErrorKind::ValidationFailure(ValidationFailure::DuplicateLink {
-                        target,
-                    }))?;
+                    Err(LbErrKind::Validation(ValidationFailure::DuplicateLink { target }))?;
                 }
             }
         }
@@ -242,25 +239,23 @@ where
     // note: a deleted link to a nonexistent file is not considered broken, because targets of
     // deleted links may have their shares deleted, would not appear in the server tree for a user,
     // and would be pruned from client trees
-    pub fn assert_no_broken_links(&mut self) -> SharedResult<()> {
+    pub fn assert_no_broken_links(&mut self) -> LbResult<()> {
         for link in self.ids() {
             if let FileType::Link { target } = self.find(&link)?.file_type() {
                 if !self.calculate_deleted(&link)? && self.maybe_find(&target).is_none() {
-                    Err(SharedErrorKind::ValidationFailure(ValidationFailure::BrokenLink(link)))?;
+                    Err(LbErrKind::Validation(ValidationFailure::BrokenLink(link)))?;
                 }
             }
         }
         Ok(())
     }
 
-    pub fn assert_no_owned_links(&self) -> SharedResult<()> {
+    pub fn assert_no_owned_links(&self) -> LbResult<()> {
         for link in self.ids() {
             if let FileType::Link { target } = self.find(&link)?.file_type() {
                 if let Some(target_owner) = self.maybe_find(&target).map(|f| f.owner()) {
                     if self.find(&link)?.owner() == target_owner {
-                        Err(SharedErrorKind::ValidationFailure(ValidationFailure::OwnedLink(
-                            link,
-                        )))?;
+                        Err(LbErrKind::Validation(ValidationFailure::OwnedLink(link)))?;
                     }
                 }
             }
@@ -268,17 +263,17 @@ where
         Ok(())
     }
 
-    pub fn assert_no_root_changes(&mut self) -> SharedResult<()> {
+    pub fn assert_no_root_changes(&mut self) -> LbResult<()> {
         for id in self.tree.staged().ids() {
             // already root
             if let Some(base) = self.tree.base().maybe_find(&id) {
                 if base.is_root() {
-                    Err(SharedErrorKind::RootModificationInvalid)?;
+                    Err(LbErrKind::RootModificationInvalid)?;
                 }
             }
             // newly root
             if self.find(&id)?.is_root() {
-                Err(SharedErrorKind::ValidationFailure(ValidationFailure::Cycle(
+                Err(LbErrKind::Validation(ValidationFailure::Cycle(
                     vec![id].into_iter().collect(),
                 )))?;
             }
@@ -286,12 +281,12 @@ where
         Ok(())
     }
 
-    pub fn assert_no_changes_to_deleted_files(&mut self) -> SharedResult<()> {
+    pub fn assert_no_changes_to_deleted_files(&mut self) -> LbResult<()> {
         for id in self.tree.staged().ids() {
             // already deleted files cannot have updates
             let mut base = self.tree.base().to_lazy();
             if base.maybe_find(&id).is_some() && base.calculate_deleted(&id)? {
-                Err(SharedErrorKind::DeletedFileUpdated(id))?;
+                Err(LbErrKind::Validation(ValidationFailure::DeletedFileUpdated(id)))?;
             }
             // newly deleted files cannot have non-deletion updates
             if self.calculate_deleted(&id)? {
@@ -301,7 +296,7 @@ where
                         .iter()
                         .any(|d| d != &Diff::Deleted)
                     {
-                        Err(SharedErrorKind::DeletedFileUpdated(id))?;
+                        Err(LbErrKind::Validation(ValidationFailure::DeletedFileUpdated(id)))?;
                     }
                 }
             }
@@ -309,7 +304,7 @@ where
         Ok(())
     }
 
-    pub fn assert_changes_authorized(&mut self, owner: Owner) -> SharedResult<()> {
+    pub fn assert_changes_authorized(&mut self, owner: Owner) -> LbResult<()> {
         // Design rationale:
         // * No combination of individually valid changes should compose into an invalid change.
         //   * Owner and write access must be indistinguishable, otherwise you could e.g. move a
@@ -353,11 +348,11 @@ where
                                     < Some(UserAccessMode::Write)
                                 {
                                     // parent is shared with access < write
-                                    Err(SharedErrorKind::InsufficientPermission)?;
+                                    Err(LbErrKind::InsufficientPermission)?;
                                 }
                             } else {
                                 // this file is shared and its parent is not
-                                Err(SharedErrorKind::InsufficientPermission)?;
+                                Err(LbErrKind::InsufficientPermission)?;
                             }
                         }
                     }
@@ -367,8 +362,8 @@ where
                             let parent = if let Some(ref old) = file_diff.old {
                                 old.parent()
                             } else {
-                                return Err(SharedErrorKind::Unexpected(
-                                    "Non-New FileDiff with no old",
+                                return Err(LbErrKind::Unexpected(
+                                    "Non-New FileDiff with no old".to_string(),
                                 )
                                 .into());
                             };
@@ -379,11 +374,11 @@ where
                                     < Some(UserAccessMode::Write)
                                 {
                                     // parent is shared with access < write
-                                    Err(SharedErrorKind::InsufficientPermission)?;
+                                    Err(LbErrKind::InsufficientPermission)?;
                                 }
                             } else {
                                 // this file is shared and its parent is not
-                                Err(SharedErrorKind::InsufficientPermission)?;
+                                Err(LbErrKind::InsufficientPermission)?;
                             }
                         }
                         // check access for staged parent
@@ -398,11 +393,11 @@ where
                                         < Some(UserAccessMode::Write)
                                     {
                                         // parent is shared with access < write
-                                        Err(SharedErrorKind::InsufficientPermission)?;
+                                        Err(LbErrKind::InsufficientPermission)?;
                                     }
                                 } else {
                                     // this file is shared and its parent is not
-                                    Err(SharedErrorKind::InsufficientPermission)?;
+                                    Err(LbErrKind::InsufficientPermission)?;
                                 }
                             }
                         }
@@ -410,7 +405,7 @@ where
                     Diff::Hmac => {
                         // check self access
                         if self.access_mode(owner, file_diff.id())? < Some(UserAccessMode::Write) {
-                            Err(SharedErrorKind::InsufficientPermission)?;
+                            Err(LbErrKind::InsufficientPermission)?;
                         }
                     }
                     Diff::UserKeys => {
@@ -426,10 +421,9 @@ where
                                 }
                                 base_keys
                             } else {
-                                return Err(SharedErrorKind::Unexpected(
-                                    "Non-New FileDiff with no old",
-                                )
-                                .into());
+                                return Err(LbErrKind::Unexpected(
+                                    "Non-New FileDiff with no old".to_string(),
+                                ))?;
                             }
                         };
                         for key in file_diff.new.user_access_keys() {
@@ -446,21 +440,21 @@ where
                                         < Some(UserAccessMode::Write)
                                     && owner.0 != key.encrypted_for
                                 {
-                                    Err(SharedErrorKind::InsufficientPermission)?;
+                                    Err(LbErrKind::InsufficientPermission)?;
                                 }
                                 // cannot grant yourself write access
                                 if staged_mode != base_mode
                                     && self.access_mode(owner, file_diff.id())?
                                         < Some(UserAccessMode::Write)
                                 {
-                                    Err(SharedErrorKind::InsufficientPermission)?;
+                                    Err(LbErrKind::InsufficientPermission)?;
                                 }
                             } else {
                                 // adding a new share
 
                                 // to add a share, need equal access
                                 if self.access_mode(owner, file_diff.id())? < Some(key.mode) {
-                                    Err(SharedErrorKind::InsufficientPermission)?;
+                                    Err(LbErrKind::InsufficientPermission)?;
                                 }
                             }
                         }
@@ -472,7 +466,7 @@ where
         Ok(())
     }
 
-    fn diffs(&self) -> SharedResult<Vec<FileDiff<Base::F>>> {
+    fn diffs(&self) -> LbResult<Vec<FileDiff<Base::F>>> {
         let mut result = Vec::new();
         for id in self.tree.staged().ids() {
             let staged = self.tree.staged().find(&id)?;

--- a/libs/lb/lb-rs/src/model/validate.rs
+++ b/libs/lb/lb-rs/src/model/validate.rs
@@ -32,7 +32,7 @@ pub fn is_folder<F: FileLike>(file: &F) -> LbResult<()> {
     if file.is_folder() {
         Ok(())
     } else {
-        Err(LbErrKind::FileNotFolder)?
+        Err(LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(*file.id())))?
     }
 }
 

--- a/libs/lb/lb-rs/src/repo/docs.rs
+++ b/libs/lb/lb-rs/src/repo/docs.rs
@@ -1,5 +1,8 @@
 use crate::model::{
-    core_config::Config, crypto::EncryptedDocument, errors::{LbErrKind, LbResult, Unexpected}, file_metadata::DocumentHmac
+    core_config::Config,
+    crypto::EncryptedDocument,
+    errors::{LbErrKind, LbResult, Unexpected},
+    file_metadata::DocumentHmac,
 };
 use std::{
     collections::HashSet,
@@ -42,9 +45,7 @@ impl AsyncDocs {
         }
     }
 
-    pub async fn get(
-        &self, id: Uuid, hmac: Option<DocumentHmac>,
-    ) -> LbResult<EncryptedDocument> {
+    pub async fn get(&self, id: Uuid, hmac: Option<DocumentHmac>) -> LbResult<EncryptedDocument> {
         self.maybe_get(id, hmac)
             .await?
             .ok_or_else(|| LbErrKind::FileNonexistent.into())
@@ -78,7 +79,7 @@ impl AsyncDocs {
         }
     }
 
-    pub async fn delete(&self, id: Uuid, hmac: Option<DocumentHmac>) -> LbResult <()> {
+    pub async fn delete(&self, id: Uuid, hmac: Option<DocumentHmac>) -> LbResult<()> {
         if let Some(hmac) = hmac {
             let path_str = key_path(&self.location, id, hmac);
             let path = Path::new(&path_str);
@@ -105,19 +106,22 @@ impl AsyncDocs {
 
             let (id_str, hmac_str) = file_name.split_at(36); // UUIDs are 36 characters long in string form
 
-            let id = Uuid::parse_str(id_str)
-                .map_err(|err| LbErrKind::Unexpected(format!("could not parse doc name as uuid {err:?}")))?;
+            let id = Uuid::parse_str(id_str).map_err(|err| {
+                LbErrKind::Unexpected(format!("could not parse doc name as uuid {err:?}"))
+            })?;
 
             let hmac_base64 = hmac_str
                 .strip_prefix('-')
                 .ok_or(LbErrKind::Unexpected("doc name missing -".to_string()))?;
 
-            let hmac_bytes = base64::decode_config(hmac_base64, base64::URL_SAFE)
-                .map_err(|err| LbErrKind::Unexpected(format!("document disk file name malformed: {err:?}")))?;
+            let hmac_bytes =
+                base64::decode_config(hmac_base64, base64::URL_SAFE).map_err(|err| {
+                    LbErrKind::Unexpected(format!("document disk file name malformed: {err:?}"))
+                })?;
 
-            let hmac: DocumentHmac = hmac_bytes
-                .try_into()
-                .map_err(|err| LbErrKind::Unexpected(format!("document disk file name malformed {err:?}")))?;
+            let hmac: DocumentHmac = hmac_bytes.try_into().map_err(|err| {
+                LbErrKind::Unexpected(format!("document disk file name malformed {err:?}"))
+            })?;
 
             if !file_hmacs.contains(&(id, hmac)) {
                 self.delete(id, Some(hmac)).await?;

--- a/libs/lb/lb-rs/src/repo/docs.rs
+++ b/libs/lb/lb-rs/src/repo/docs.rs
@@ -1,6 +1,5 @@
 use crate::model::{
-    core_config::Config, crypto::EncryptedDocument, file_metadata::DocumentHmac, SharedErrorKind,
-    SharedResult,
+    core_config::Config, crypto::EncryptedDocument, errors::{LbErrKind, LbResult}, file_metadata::DocumentHmac, SharedErrorKind, SharedResult
 };
 use std::{
     collections::HashSet,
@@ -45,10 +44,10 @@ impl AsyncDocs {
 
     pub async fn get(
         &self, id: Uuid, hmac: Option<DocumentHmac>,
-    ) -> SharedResult<EncryptedDocument> {
+    ) -> LbResult<EncryptedDocument> {
         self.maybe_get(id, hmac)
             .await?
-            .ok_or_else(|| SharedErrorKind::FileNonexistent.into())
+            .ok_or_else(|| LbErrKind::FileNonexistent.into())
     }
 
     pub async fn maybe_get(

--- a/libs/lb/lb-rs/src/repo/docs.rs
+++ b/libs/lb/lb-rs/src/repo/docs.rs
@@ -1,5 +1,5 @@
 use crate::model::{
-    core_config::Config, crypto::EncryptedDocument, errors::{LbErrKind, LbResult, Unexpected}, file_metadata::DocumentHmac, SharedErrorKind, SharedResult
+    core_config::Config, crypto::EncryptedDocument, errors::{LbErrKind, LbResult, Unexpected}, file_metadata::DocumentHmac
 };
 use std::{
     collections::HashSet,

--- a/libs/lb/lb-rs/src/service/import_export.rs
+++ b/libs/lb/lb-rs/src/service/import_export.rs
@@ -76,7 +76,8 @@ impl Lb {
                 }
                 Err(err)
                     if matches!(
-                        err.kind, LbErrKind::Validation(ValidationFailure::PathConflict(_))
+                        err.kind,
+                        LbErrKind::Validation(ValidationFailure::PathConflict(_))
                     ) =>
                 {
                     tries += 1;

--- a/libs/lb/lb-rs/src/service/import_export.rs
+++ b/libs/lb/lb-rs/src/service/import_export.rs
@@ -1,6 +1,7 @@
 use crate::model::errors::{LbErr, LbErrKind, LbResult};
 use crate::model::file::File;
 use crate::model::file_metadata::FileType;
+use crate::model::ValidationFailure;
 use crate::Lb;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -25,7 +26,7 @@ impl Lb {
 
         let parent = self.get_file_by_id(dest).await?;
         if !parent.is_folder() {
-            return Err(LbErrKind::FileNotFolder.into());
+            return Err(LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(dest)))?;
         }
 
         let import_file_futures = FuturesUnordered::new();
@@ -73,7 +74,11 @@ impl Lb {
                     file = new_file;
                     break;
                 }
-                Err(err) if err.kind == LbErrKind::PathTaken => {
+                Err(err)
+                    if matches!(
+                        err.kind, LbErrKind::Validation(ValidationFailure::PathConflict(_))
+                    ) =>
+                {
                     tries += 1;
                     retry_name = format!("{}-{}", name, tries);
                 }

--- a/libs/lb/lb-rs/src/service/network.rs
+++ b/libs/lb/lb-rs/src/service/network.rs
@@ -7,6 +7,7 @@ use crate::get_code_version;
 use crate::model::account::Account;
 use crate::model::api::*;
 use crate::model::clock::{get_time, Timestamp};
+use crate::model::errors::LbErr;
 use crate::model::pubkey;
 
 impl<E> From<ErrorWrapper<E>> for ApiError<E> {
@@ -31,7 +32,7 @@ pub enum ApiError<E> {
     ExpiredAuth,
     InternalError,
     BadRequest,
-    Sign(crate::model::SharedError),
+    Sign(LbErr),
     Serialize(String),
     SendFailed(String),
     ReceiveFailed(String),

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -770,7 +770,7 @@ impl Lb {
                         break merge_changes;
                     }
                     Err(ref err) => match err.kind {
-                        SharedErrorKind::ValidationFailure(ref vf) => match vf {
+                        LbErrKind::Validation(ref vf) => match vf {
                             // merge changeset has resolvable validation errors and needs modification
                             ValidationFailure::Cycle(ids) => {
                                 // revert all local moves in the cycle
@@ -893,6 +893,7 @@ impl Lb {
                             | ValidationFailure::NonFolderWithChildren(_)
                             | ValidationFailure::FileWithDifferentOwnerParent(_)
                             | ValidationFailure::FileNameTooLong(_)
+                            | ValidationFailure::DeletedFileUpdated(_)
                             | ValidationFailure::NonDecryptableFileName(_) => {
                                 validate_result?;
                             }

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -17,7 +17,7 @@ use crate::model::text::buffer::Buffer;
 use crate::model::tree_like::TreeLike;
 use crate::model::work_unit::WorkUnit;
 use crate::model::{clock, svg};
-use crate::model::{symkey, SharedErrorKind, ValidationFailure};
+use crate::model::{symkey, ValidationFailure};
 use crate::Lb;
 pub use basic_human_duration::ChronoHumanDuration;
 use futures::stream;

--- a/libs/lb/lb-rs/tests/api_move_file_tests.rs
+++ b/libs/lb/lb-rs/tests/api_move_file_tests.rs
@@ -79,7 +79,9 @@ async fn move_document_deleted() {
         .await;
     assert_matches!(
         result,
-        Err(ApiError::<UpsertError>::Endpoint(UpsertError::DeletedFileUpdated))
+        Err(ApiError::<UpsertError>::Endpoint(UpsertError::Validation(
+            ValidationFailure::DeletedFileUpdated(_)
+        )))
     );
 }
 

--- a/libs/lb/lb-rs/tests/delete_and_list_tests.rs
+++ b/libs/lb/lb-rs/tests/delete_and_list_tests.rs
@@ -1,6 +1,7 @@
 use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::file_metadata::FileType;
 use lb_rs::model::path_ops::Filter;
+use lb_rs::model::ValidationFailure;
 use test_utils::*;
 
 #[tokio::test]
@@ -45,7 +46,7 @@ async fn test_create_delete_write() {
             .await
             .unwrap_err()
             .kind,
-        LbErrKind::FileNonexistent
+        LbErrKind::Validation(ValidationFailure::DeletedFileUpdated(_))
     );
 }
 
@@ -99,7 +100,7 @@ async fn test_create_parent_delete_parent_rename_doc() {
             .await
             .unwrap_err()
             .kind,
-        LbErrKind::FileNonexistent
+        LbErrKind::Validation(ValidationFailure::DeletedFileUpdated(_))
     );
 }
 
@@ -113,7 +114,7 @@ async fn test_create_parent_delete_parent_rename_parent() {
             .await
             .unwrap_err()
             .kind,
-        LbErrKind::FileNonexistent
+        LbErrKind::Validation(ValidationFailure::DeletedFileUpdated(_))
     );
 }
 
@@ -125,7 +126,7 @@ async fn test_folder_move_delete_source_doc() {
     core.delete(&doc.parent).await.unwrap();
     assert_matches!(
         core.move_file(&doc.id, &folder2.id).await.unwrap_err().kind,
-        LbErrKind::FileNonexistent
+        LbErrKind::Validation(ValidationFailure::DeletedFileUpdated(_))
     );
 }
 
@@ -140,7 +141,7 @@ async fn test_folder_move_delete_source_parent() {
             .await
             .unwrap_err()
             .kind,
-        LbErrKind::FileNonexistent
+        LbErrKind::Validation(ValidationFailure::DeletedFileUpdated(_))
     );
 }
 

--- a/libs/lb/lb-rs/tests/exhaustive_sync_check.rs
+++ b/libs/lb/lb-rs/tests/exhaustive_sync_check.rs
@@ -8,7 +8,7 @@ pub mod sync_fuzzer2 {
 
     #[ignore]
     #[tokio::test]
-    fn exhaustive_test_sync() {
+    async fn exhaustive_test_sync() {
         Coordinator::default().kick_off();
     }
 }

--- a/libs/lb/lb-rs/tests/file_ops.rs
+++ b/libs/lb/lb-rs/tests/file_ops.rs
@@ -1,4 +1,4 @@
-use lb_rs::model::errors::LbErrKind;
+use lb_rs::model::{errors::LbErrKind, ValidationFailure};
 use lb_rs::model::filename::MAX_FILENAME_LENGTH;
 use test_utils::{assert_matches, test_core_with_account};
 use uuid::Uuid;
@@ -43,7 +43,7 @@ async fn name_taken() {
     let core = test_core_with_account().await;
     core.create_at_path("doc1.md").await.unwrap();
     let id = core.create_at_path("doc2.md").await.unwrap().id;
-    assert_matches!(core.rename_file(&id, "doc1.md").await.unwrap_err().kind, LbErrKind::PathTaken);
+    assert_matches!(core.rename_file(&id, "doc1.md").await.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::PathConflict(_)));
 }
 
 #[tokio::test]
@@ -100,7 +100,7 @@ async fn move_parent_document() {
     let core = test_core_with_account().await;
     let id = core.create_at_path("folder/doc1.md").await.unwrap().id;
     let target = core.create_at_path("doc2.md").await.unwrap().id;
-    assert_matches!(core.move_file(&id, &target).await.unwrap_err().kind, LbErrKind::FileNotFolder);
+    assert_matches!(core.move_file(&id, &target).await.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(_)));
 }
 
 #[tokio::test]
@@ -121,7 +121,7 @@ async fn move_path_conflict() {
     let core = test_core_with_account().await;
     let dest = core.create_at_path("folder/test.md").await.unwrap().parent;
     let src = core.create_at_path("test.md").await.unwrap().id;
-    assert_matches!(core.move_file(&src, &dest).await.unwrap_err().kind, LbErrKind::PathTaken);
+    assert_matches!(core.move_file(&src, &dest).await.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::PathConflict(_)));
 }
 
 #[tokio::test]
@@ -135,7 +135,7 @@ async fn folder_into_self() {
         .id;
     assert_matches!(
         core.move_file(&src, &dest).await.unwrap_err().kind,
-        LbErrKind::FolderMovedIntoSelf
+        LbErrKind::Validation(ValidationFailure::Cycle(_))
     );
 }
 

--- a/libs/lb/lb-rs/tests/file_ops.rs
+++ b/libs/lb/lb-rs/tests/file_ops.rs
@@ -1,5 +1,5 @@
-use lb_rs::model::{errors::LbErrKind, ValidationFailure};
 use lb_rs::model::filename::MAX_FILENAME_LENGTH;
+use lb_rs::model::{errors::LbErrKind, ValidationFailure};
 use test_utils::{assert_matches, test_core_with_account};
 use uuid::Uuid;
 
@@ -43,7 +43,10 @@ async fn name_taken() {
     let core = test_core_with_account().await;
     core.create_at_path("doc1.md").await.unwrap();
     let id = core.create_at_path("doc2.md").await.unwrap().id;
-    assert_matches!(core.rename_file(&id, "doc1.md").await.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::PathConflict(_)));
+    assert_matches!(
+        core.rename_file(&id, "doc1.md").await.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::PathConflict(_))
+    );
 }
 
 #[tokio::test]
@@ -100,7 +103,10 @@ async fn move_parent_document() {
     let core = test_core_with_account().await;
     let id = core.create_at_path("folder/doc1.md").await.unwrap().id;
     let target = core.create_at_path("doc2.md").await.unwrap().id;
-    assert_matches!(core.move_file(&id, &target).await.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(_)));
+    assert_matches!(
+        core.move_file(&id, &target).await.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(_))
+    );
 }
 
 #[tokio::test]
@@ -121,7 +127,10 @@ async fn move_path_conflict() {
     let core = test_core_with_account().await;
     let dest = core.create_at_path("folder/test.md").await.unwrap().parent;
     let src = core.create_at_path("test.md").await.unwrap().id;
-    assert_matches!(core.move_file(&src, &dest).await.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::PathConflict(_)));
+    assert_matches!(
+        core.move_file(&src, &dest).await.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::PathConflict(_))
+    );
 }
 
 #[tokio::test]

--- a/libs/lb/lb-rs/tests/integrity_tests.rs
+++ b/libs/lb/lb-rs/tests/integrity_tests.rs
@@ -3,6 +3,7 @@ use lb_rs::model::file_like::FileLike;
 use lb_rs::model::file_metadata::FileType::Document;
 use lb_rs::model::secret_filename::SecretFileName;
 use lb_rs::model::tree_like::TreeLike;
+use lb_rs::model::ValidationFailure;
 use rand::Rng;
 use test_utils::*;
 
@@ -22,7 +23,10 @@ async fn test_integrity_no_problems_but_more_complicated() {
 #[tokio::test]
 async fn test_no_account() {
     let core = test_core().await;
-    assert_matches!(core.test_repo_integrity().await, Err(NoAccount));
+    assert_matches!(
+        core.test_repo_integrity().await.unwrap_err().kind,
+        LbErrKind::AccountNonexistent
+    );
 }
 
 #[tokio::test]
@@ -32,7 +36,7 @@ async fn test_no_root() {
     tx.db().base_metadata.clear().unwrap();
     tx.db().root.clear().unwrap();
     tx.end();
-    assert_matches!(core.test_repo_integrity().await, Err(NoRootFolder));
+    assert_matches!(core.test_repo_integrity().await.unwrap_err().kind, LbErrKind::RootNonexistent);
 }
 
 #[tokio::test]
@@ -54,152 +58,164 @@ async fn test_orphaned_children() {
     assert_matches!(core.test_repo_integrity().await.unwrap_err().kind, LbErrKind::Validation(_));
 }
 
-// #[tokio::test]
-// async fn test_invalid_file_name_slash() {
-//     let core = test_core_with_account().await;
-//     let doc = core.create_at_path("document1.md").await.unwrap();
-//     let mut tx = core.begin_tx().await;
-//     let db = tx.db();
-//     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-//     let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
-//     let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
-//     let new_name = SecretFileName::from_str("te/st", &key, &parent).unwrap();
-//     let mut doc = tree.find(&doc.id).unwrap().clone();
-//     doc.timestamped_value.value.name = new_name;
-//     tree.stage(Some(doc)).promote().unwrap();
-// 
-//     tx.end();
-// 
-//     assert_matches!(core.test_repo_integrity().await, Err(FileNameContainsSlash(_)));
-// }
-// 
-// #[tokio::test]
-// async fn empty_filename() {
-//     let core = test_core_with_account().await;
-//     let doc = core.create_at_path("document1.md").await.unwrap();
-//     let mut tx = core.begin_tx().await;
-//     let db = tx.db();
-//     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-//     let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
-//     let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
-//     let new_name = SecretFileName::from_str("", &key, &parent).unwrap();
-//     let mut doc = tree.find(&doc.id).unwrap().clone();
-//     doc.timestamped_value.value.name = new_name;
-//     tree.stage(Some(doc)).promote().unwrap();
-// 
-//     tx.end();
-// 
-//     assert_matches!(core.test_repo_integrity().await, Err(FileNameEmpty(_)));
-// }
-// 
-// #[tokio::test]
-// async fn test_cycle() {
-//     let core = test_core_with_account().await;
-//     core.create_at_path("folder1/folder2/document1.md")
-//         .await
-//         .unwrap();
-//     let parent = core.get_by_path("folder1").await.unwrap().id;
-//     core.begin_tx()
-//         .await
-//         .db()
-//         .local_metadata
-//         .get()
-//         .get(&parent)
-//         .unwrap();
-//     let mut parent = core
-//         .begin_tx()
-//         .await
-//         .db()
-//         .local_metadata
-//         .get()
-//         .get(&parent)
-//         .unwrap()
-//         .clone();
-//     let child = core.get_by_path("folder1/folder2").await.unwrap();
-//     parent.timestamped_value.value.parent = child.id;
-//     core.begin_tx()
-//         .await
-//         .db()
-//         .local_metadata
-//         .insert(*parent.id(), parent)
-//         .unwrap();
-//     assert_matches!(core.test_repo_integrity().await, Err(CycleDetected(_)));
-// }
-// 
-// #[tokio::test]
-// async fn test_documents_treated_as_folders() {
-//     let core = test_core_with_account().await;
-//     core.create_at_path("folder1/folder2/document1.md")
-//         .await
-//         .unwrap();
-//     let parent = core.get_by_path("folder1").await.unwrap();
-//     let mut parent = core
-//         .begin_tx()
-//         .await
-//         .db()
-//         .local_metadata
-//         .get()
-//         .get(&parent.id)
-//         .unwrap()
-//         .clone();
-//     parent.timestamped_value.value.file_type = Document;
-//     core.begin_tx()
-//         .await
-//         .db()
-//         .local_metadata
-//         .insert(*parent.id(), parent)
-//         .unwrap();
-//     assert_matches!(core.test_repo_integrity().await, Err(DocumentTreatedAsFolder(_)));
-// }
-// 
-// #[tokio::test]
-// async fn test_name_conflict() {
-//     let core = test_core_with_account().await;
-//     let doc = core.create_at_path("document1.md").await.unwrap();
-//     core.create_at_path("document2.md").await.unwrap();
-//     let mut tx = core.begin_tx().await;
-//     let db = tx.db();
-//     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-//     let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
-//     let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
-//     let new_name = SecretFileName::from_str("document2.md", &key, &parent).unwrap();
-//     let mut doc = tree.find(&doc.id).unwrap().clone();
-//     doc.timestamped_value.value.name = new_name;
-//     tree.stage(Some(doc)).promote().unwrap();
-// 
-//     tx.end();
-// 
-//     assert_matches!(core.test_repo_integrity().await, Err(PathConflict(_)));
-// }
-// 
-// #[tokio::test]
-// async fn test_empty_file() {
-//     let core = test_core_with_account().await;
-//     let doc = core.create_at_path("document.txt").await.unwrap();
-//     core.write_document(doc.id, &[]).await.unwrap();
-//     let warnings = core.test_repo_integrity().await;
-// 
-//     assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([EmptyFile(_)]));
-// }
-// 
-// #[tokio::test]
-// async fn test_invalid_utf8() {
-//     let core = test_core_with_account().await;
-//     let doc = core.create_at_path("document.txt").await.unwrap();
-//     core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
-//         .await
-//         .unwrap();
-//     let warnings = core.test_repo_integrity().await;
-//     assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([InvalidUTF8(_)]));
-// }
-// 
-// #[tokio::test]
-// async fn test_invalid_utf8_ignores_non_utf_file_extensions() {
-//     let core = test_core_with_account().await;
-//     let doc = core.create_at_path("document.png").await.unwrap();
-//     core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
-//         .await
-//         .unwrap();
-//     let warnings = core.test_repo_integrity().await;
-//     assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([]));
-// }
+#[tokio::test]
+async fn test_invalid_file_name_slash() {
+    let core = test_core_with_account().await;
+    let doc = core.create_at_path("document1.md").await.unwrap();
+    let mut tx = core.begin_tx().await;
+    let db = tx.db();
+    let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
+    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
+    let new_name = SecretFileName::from_str("te/st", &key, &parent).unwrap();
+    let mut doc = tree.find(&doc.id).unwrap().clone();
+    doc.timestamped_value.value.name = new_name;
+    tree.stage(Some(doc)).promote().unwrap();
+
+    tx.end();
+
+    assert_matches!(
+        core.test_repo_integrity().await.unwrap_err().kind,
+        LbErrKind::FileNameContainsSlash
+    );
+}
+
+#[tokio::test]
+async fn empty_filename() {
+    let core = test_core_with_account().await;
+    let doc = core.create_at_path("document1.md").await.unwrap();
+    let mut tx = core.begin_tx().await;
+    let db = tx.db();
+    let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
+    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
+    let new_name = SecretFileName::from_str("", &key, &parent).unwrap();
+    let mut doc = tree.find(&doc.id).unwrap().clone();
+    doc.timestamped_value.value.name = new_name;
+    tree.stage(Some(doc)).promote().unwrap();
+
+    tx.end();
+
+    assert_matches!(core.test_repo_integrity().await.unwrap_err().kind, LbErrKind::FileNameEmpty);
+}
+
+#[tokio::test]
+async fn test_cycle() {
+    let core = test_core_with_account().await;
+    core.create_at_path("folder1/folder2/document1.md")
+        .await
+        .unwrap();
+    let parent = core.get_by_path("folder1").await.unwrap().id;
+    core.begin_tx()
+        .await
+        .db()
+        .local_metadata
+        .get()
+        .get(&parent)
+        .unwrap();
+    let mut parent = core
+        .begin_tx()
+        .await
+        .db()
+        .local_metadata
+        .get()
+        .get(&parent)
+        .unwrap()
+        .clone();
+    let child = core.get_by_path("folder1/folder2").await.unwrap();
+    parent.timestamped_value.value.parent = child.id;
+    core.begin_tx()
+        .await
+        .db()
+        .local_metadata
+        .insert(*parent.id(), parent)
+        .unwrap();
+    assert_matches!(
+        core.test_repo_integrity().await.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::Cycle(_))
+    );
+}
+
+#[tokio::test]
+async fn test_documents_treated_as_folders() {
+    let core = test_core_with_account().await;
+    core.create_at_path("folder1/folder2/document1.md")
+        .await
+        .unwrap();
+    let parent = core.get_by_path("folder1").await.unwrap();
+    let mut parent = core
+        .begin_tx()
+        .await
+        .db()
+        .local_metadata
+        .get()
+        .get(&parent.id)
+        .unwrap()
+        .clone();
+    parent.timestamped_value.value.file_type = Document;
+    core.begin_tx()
+        .await
+        .db()
+        .local_metadata
+        .insert(*parent.id(), parent)
+        .unwrap();
+    assert_matches!(
+        core.test_repo_integrity().await.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(_))
+    );
+}
+
+#[tokio::test]
+async fn test_name_conflict() {
+    let core = test_core_with_account().await;
+    let doc = core.create_at_path("document1.md").await.unwrap();
+    core.create_at_path("document2.md").await.unwrap();
+    let mut tx = core.begin_tx().await;
+    let db = tx.db();
+    let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
+    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
+    let new_name = SecretFileName::from_str("document2.md", &key, &parent).unwrap();
+    let mut doc = tree.find(&doc.id).unwrap().clone();
+    doc.timestamped_value.value.name = new_name;
+    tree.stage(Some(doc)).promote().unwrap();
+
+    tx.end();
+
+    assert_matches!(
+        core.test_repo_integrity().await.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::PathConflict(_))
+    );
+}
+
+#[tokio::test]
+async fn test_empty_file() {
+    let core = test_core_with_account().await;
+    let doc = core.create_at_path("document.txt").await.unwrap();
+    core.write_document(doc.id, &[]).await.unwrap();
+    let warnings = core.test_repo_integrity().await;
+
+    assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([EmptyFile(_)]));
+}
+
+#[tokio::test]
+async fn test_invalid_utf8() {
+    let core = test_core_with_account().await;
+    let doc = core.create_at_path("document.txt").await.unwrap();
+    core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
+        .await
+        .unwrap();
+    let warnings = core.test_repo_integrity().await;
+    assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([InvalidUTF8(_)]));
+}
+
+#[tokio::test]
+async fn test_invalid_utf8_ignores_non_utf_file_extensions() {
+    let core = test_core_with_account().await;
+    let doc = core.create_at_path("document.png").await.unwrap();
+    core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
+        .await
+        .unwrap();
+    let warnings = core.test_repo_integrity().await;
+    assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([]));
+}

--- a/libs/lb/lb-rs/tests/integrity_tests.rs
+++ b/libs/lb/lb-rs/tests/integrity_tests.rs
@@ -1,5 +1,4 @@
-use lb_rs::model::errors::TestRepoError::*;
-use lb_rs::model::errors::Warning::*;
+use lb_rs::model::errors::{LbErrKind, Warning::*};
 use lb_rs::model::file_like::FileLike;
 use lb_rs::model::file_metadata::FileType::Document;
 use lb_rs::model::secret_filename::SecretFileName;
@@ -52,155 +51,155 @@ async fn test_orphaned_children() {
         .local_metadata
         .remove(&parent)
         .unwrap();
-    assert_matches!(core.test_repo_integrity().await, Err(FileOrphaned(_)));
+    assert_matches!(core.test_repo_integrity().await.unwrap_err().kind, LbErrKind::Validation(_));
 }
 
-#[tokio::test]
-async fn test_invalid_file_name_slash() {
-    let core = test_core_with_account().await;
-    let doc = core.create_at_path("document1.md").await.unwrap();
-    let mut tx = core.begin_tx().await;
-    let db = tx.db();
-    let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
-    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
-    let new_name = SecretFileName::from_str("te/st", &key, &parent).unwrap();
-    let mut doc = tree.find(&doc.id).unwrap().clone();
-    doc.timestamped_value.value.name = new_name;
-    tree.stage(Some(doc)).promote().unwrap();
-
-    tx.end();
-
-    assert_matches!(core.test_repo_integrity().await, Err(FileNameContainsSlash(_)));
-}
-
-#[tokio::test]
-async fn empty_filename() {
-    let core = test_core_with_account().await;
-    let doc = core.create_at_path("document1.md").await.unwrap();
-    let mut tx = core.begin_tx().await;
-    let db = tx.db();
-    let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
-    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
-    let new_name = SecretFileName::from_str("", &key, &parent).unwrap();
-    let mut doc = tree.find(&doc.id).unwrap().clone();
-    doc.timestamped_value.value.name = new_name;
-    tree.stage(Some(doc)).promote().unwrap();
-
-    tx.end();
-
-    assert_matches!(core.test_repo_integrity().await, Err(FileNameEmpty(_)));
-}
-
-#[tokio::test]
-async fn test_cycle() {
-    let core = test_core_with_account().await;
-    core.create_at_path("folder1/folder2/document1.md")
-        .await
-        .unwrap();
-    let parent = core.get_by_path("folder1").await.unwrap().id;
-    core.begin_tx()
-        .await
-        .db()
-        .local_metadata
-        .get()
-        .get(&parent)
-        .unwrap();
-    let mut parent = core
-        .begin_tx()
-        .await
-        .db()
-        .local_metadata
-        .get()
-        .get(&parent)
-        .unwrap()
-        .clone();
-    let child = core.get_by_path("folder1/folder2").await.unwrap();
-    parent.timestamped_value.value.parent = child.id;
-    core.begin_tx()
-        .await
-        .db()
-        .local_metadata
-        .insert(*parent.id(), parent)
-        .unwrap();
-    assert_matches!(core.test_repo_integrity().await, Err(CycleDetected(_)));
-}
-
-#[tokio::test]
-async fn test_documents_treated_as_folders() {
-    let core = test_core_with_account().await;
-    core.create_at_path("folder1/folder2/document1.md")
-        .await
-        .unwrap();
-    let parent = core.get_by_path("folder1").await.unwrap();
-    let mut parent = core
-        .begin_tx()
-        .await
-        .db()
-        .local_metadata
-        .get()
-        .get(&parent.id)
-        .unwrap()
-        .clone();
-    parent.timestamped_value.value.file_type = Document;
-    core.begin_tx()
-        .await
-        .db()
-        .local_metadata
-        .insert(*parent.id(), parent)
-        .unwrap();
-    assert_matches!(core.test_repo_integrity().await, Err(DocumentTreatedAsFolder(_)));
-}
-
-#[tokio::test]
-async fn test_name_conflict() {
-    let core = test_core_with_account().await;
-    let doc = core.create_at_path("document1.md").await.unwrap();
-    core.create_at_path("document2.md").await.unwrap();
-    let mut tx = core.begin_tx().await;
-    let db = tx.db();
-    let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
-    let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
-    let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
-    let new_name = SecretFileName::from_str("document2.md", &key, &parent).unwrap();
-    let mut doc = tree.find(&doc.id).unwrap().clone();
-    doc.timestamped_value.value.name = new_name;
-    tree.stage(Some(doc)).promote().unwrap();
-
-    tx.end();
-
-    assert_matches!(core.test_repo_integrity().await, Err(PathConflict(_)));
-}
-
-#[tokio::test]
-async fn test_empty_file() {
-    let core = test_core_with_account().await;
-    let doc = core.create_at_path("document.txt").await.unwrap();
-    core.write_document(doc.id, &[]).await.unwrap();
-    let warnings = core.test_repo_integrity().await;
-
-    assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([EmptyFile(_)]));
-}
-
-#[tokio::test]
-async fn test_invalid_utf8() {
-    let core = test_core_with_account().await;
-    let doc = core.create_at_path("document.txt").await.unwrap();
-    core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
-        .await
-        .unwrap();
-    let warnings = core.test_repo_integrity().await;
-    assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([InvalidUTF8(_)]));
-}
-
-#[tokio::test]
-async fn test_invalid_utf8_ignores_non_utf_file_extensions() {
-    let core = test_core_with_account().await;
-    let doc = core.create_at_path("document.png").await.unwrap();
-    core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
-        .await
-        .unwrap();
-    let warnings = core.test_repo_integrity().await;
-    assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([]));
-}
+// #[tokio::test]
+// async fn test_invalid_file_name_slash() {
+//     let core = test_core_with_account().await;
+//     let doc = core.create_at_path("document1.md").await.unwrap();
+//     let mut tx = core.begin_tx().await;
+//     let db = tx.db();
+//     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
+//     let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+//     let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
+//     let new_name = SecretFileName::from_str("te/st", &key, &parent).unwrap();
+//     let mut doc = tree.find(&doc.id).unwrap().clone();
+//     doc.timestamped_value.value.name = new_name;
+//     tree.stage(Some(doc)).promote().unwrap();
+// 
+//     tx.end();
+// 
+//     assert_matches!(core.test_repo_integrity().await, Err(FileNameContainsSlash(_)));
+// }
+// 
+// #[tokio::test]
+// async fn empty_filename() {
+//     let core = test_core_with_account().await;
+//     let doc = core.create_at_path("document1.md").await.unwrap();
+//     let mut tx = core.begin_tx().await;
+//     let db = tx.db();
+//     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
+//     let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+//     let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
+//     let new_name = SecretFileName::from_str("", &key, &parent).unwrap();
+//     let mut doc = tree.find(&doc.id).unwrap().clone();
+//     doc.timestamped_value.value.name = new_name;
+//     tree.stage(Some(doc)).promote().unwrap();
+// 
+//     tx.end();
+// 
+//     assert_matches!(core.test_repo_integrity().await, Err(FileNameEmpty(_)));
+// }
+// 
+// #[tokio::test]
+// async fn test_cycle() {
+//     let core = test_core_with_account().await;
+//     core.create_at_path("folder1/folder2/document1.md")
+//         .await
+//         .unwrap();
+//     let parent = core.get_by_path("folder1").await.unwrap().id;
+//     core.begin_tx()
+//         .await
+//         .db()
+//         .local_metadata
+//         .get()
+//         .get(&parent)
+//         .unwrap();
+//     let mut parent = core
+//         .begin_tx()
+//         .await
+//         .db()
+//         .local_metadata
+//         .get()
+//         .get(&parent)
+//         .unwrap()
+//         .clone();
+//     let child = core.get_by_path("folder1/folder2").await.unwrap();
+//     parent.timestamped_value.value.parent = child.id;
+//     core.begin_tx()
+//         .await
+//         .db()
+//         .local_metadata
+//         .insert(*parent.id(), parent)
+//         .unwrap();
+//     assert_matches!(core.test_repo_integrity().await, Err(CycleDetected(_)));
+// }
+// 
+// #[tokio::test]
+// async fn test_documents_treated_as_folders() {
+//     let core = test_core_with_account().await;
+//     core.create_at_path("folder1/folder2/document1.md")
+//         .await
+//         .unwrap();
+//     let parent = core.get_by_path("folder1").await.unwrap();
+//     let mut parent = core
+//         .begin_tx()
+//         .await
+//         .db()
+//         .local_metadata
+//         .get()
+//         .get(&parent.id)
+//         .unwrap()
+//         .clone();
+//     parent.timestamped_value.value.file_type = Document;
+//     core.begin_tx()
+//         .await
+//         .db()
+//         .local_metadata
+//         .insert(*parent.id(), parent)
+//         .unwrap();
+//     assert_matches!(core.test_repo_integrity().await, Err(DocumentTreatedAsFolder(_)));
+// }
+// 
+// #[tokio::test]
+// async fn test_name_conflict() {
+//     let core = test_core_with_account().await;
+//     let doc = core.create_at_path("document1.md").await.unwrap();
+//     core.create_at_path("document2.md").await.unwrap();
+//     let mut tx = core.begin_tx().await;
+//     let db = tx.db();
+//     let mut tree = db.base_metadata.stage(&mut db.local_metadata).to_lazy();
+//     let key = tree.decrypt_key(&doc.id, &core.keychain).unwrap();
+//     let parent = tree.decrypt_key(&doc.parent, &core.keychain).unwrap();
+//     let new_name = SecretFileName::from_str("document2.md", &key, &parent).unwrap();
+//     let mut doc = tree.find(&doc.id).unwrap().clone();
+//     doc.timestamped_value.value.name = new_name;
+//     tree.stage(Some(doc)).promote().unwrap();
+// 
+//     tx.end();
+// 
+//     assert_matches!(core.test_repo_integrity().await, Err(PathConflict(_)));
+// }
+// 
+// #[tokio::test]
+// async fn test_empty_file() {
+//     let core = test_core_with_account().await;
+//     let doc = core.create_at_path("document.txt").await.unwrap();
+//     core.write_document(doc.id, &[]).await.unwrap();
+//     let warnings = core.test_repo_integrity().await;
+// 
+//     assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([EmptyFile(_)]));
+// }
+// 
+// #[tokio::test]
+// async fn test_invalid_utf8() {
+//     let core = test_core_with_account().await;
+//     let doc = core.create_at_path("document.txt").await.unwrap();
+//     core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
+//         .await
+//         .unwrap();
+//     let warnings = core.test_repo_integrity().await;
+//     assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([InvalidUTF8(_)]));
+// }
+// 
+// #[tokio::test]
+// async fn test_invalid_utf8_ignores_non_utf_file_extensions() {
+//     let core = test_core_with_account().await;
+//     let doc = core.create_at_path("document.png").await.unwrap();
+//     core.write_document(doc.id, rand::thread_rng().gen::<[u8; 32]>().as_ref())
+//         .await
+//         .unwrap();
+//     let warnings = core.test_repo_integrity().await;
+//     assert_matches!(warnings.as_ref().map(|w| &w[..]), Ok([]));
+// }

--- a/libs/lb/lb-rs/tests/path_service_tests.rs
+++ b/libs/lb/lb-rs/tests/path_service_tests.rs
@@ -1,6 +1,7 @@
 use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::file_metadata::FileType;
 use lb_rs::model::path_ops::Filter::{DocumentsOnly, FoldersOnly, LeafNodesOnly};
+use lb_rs::model::ValidationFailure;
 use test_utils::*;
 
 #[tokio::test]
@@ -67,7 +68,7 @@ async fn create_at_path_path_taken() {
     let core = test_core_with_account().await;
     core.create_at_path("/folder/document").await.unwrap();
     let result = core.create_at_path("/folder/document").await;
-    assert_matches!(result.unwrap_err().kind, LbErrKind::PathTaken);
+    assert_matches!(result.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::PathConflict(_)));
 }
 
 #[tokio::test]
@@ -75,7 +76,7 @@ async fn create_at_path_not_folder() {
     let core = test_core_with_account().await;
     core.create_at_path("/not-folder").await.unwrap();
     let result = core.create_at_path("/not-folder/document").await;
-    assert_matches!(result.unwrap_err().kind, LbErrKind::FileNotFolder);
+    assert_matches!(result.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(_)));
 }
 
 #[tokio::test]

--- a/libs/lb/lb-rs/tests/path_service_tests.rs
+++ b/libs/lb/lb-rs/tests/path_service_tests.rs
@@ -68,7 +68,10 @@ async fn create_at_path_path_taken() {
     let core = test_core_with_account().await;
     core.create_at_path("/folder/document").await.unwrap();
     let result = core.create_at_path("/folder/document").await;
-    assert_matches!(result.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::PathConflict(_)));
+    assert_matches!(
+        result.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::PathConflict(_))
+    );
 }
 
 #[tokio::test]
@@ -76,7 +79,10 @@ async fn create_at_path_not_folder() {
     let core = test_core_with_account().await;
     core.create_at_path("/not-folder").await.unwrap();
     let result = core.create_at_path("/not-folder/document").await;
-    assert_matches!(result.unwrap_err().kind, LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(_)));
+    assert_matches!(
+        result.unwrap_err().kind,
+        LbErrKind::Validation(ValidationFailure::NonFolderWithChildren(_))
+    );
 }
 
 #[tokio::test]

--- a/libs/lb/lb-rs/tests/sync_fuzzer.rs
+++ b/libs/lb/lb-rs/tests/sync_fuzzer.rs
@@ -133,7 +133,10 @@ impl Actions {
                         let move_file_result = client.move_file(&file.id, &new_parent.id).await;
                         match move_file_result {
                             Ok(()) => {}
-                            Err(LbErr { kind: LbErrKind::Validation(ValidationFailure::Cycle(_)), .. }) => {}
+                            Err(LbErr {
+                                kind: LbErrKind::Validation(ValidationFailure::Cycle(_)),
+                                ..
+                            }) => {}
                             _ => panic!(
                                 "Unexpected error while moving file: {:#?}",
                                 move_file_result

--- a/libs/lb/lb-rs/tests/sync_fuzzer.rs
+++ b/libs/lb/lb-rs/tests/sync_fuzzer.rs
@@ -5,6 +5,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use lb_rs::model::errors::{LbErr, LbErrKind};
 use lb_rs::model::file::File;
 use lb_rs::model::file_metadata::FileType::{Document, Folder};
+use lb_rs::model::ValidationFailure;
 use lb_rs::Lb;
 use rand::distributions::{Alphanumeric, Distribution, Standard};
 use rand::rngs::StdRng;
@@ -132,7 +133,7 @@ impl Actions {
                         let move_file_result = client.move_file(&file.id, &new_parent.id).await;
                         match move_file_result {
                             Ok(()) => {}
-                            Err(LbErr { kind: LbErrKind::FolderMovedIntoSelf, .. }) => {}
+                            Err(LbErr { kind: LbErrKind::Validation(ValidationFailure::Cycle(_)), .. }) => {}
                             _ => panic!(
                                 "Unexpected error while moving file: {:#?}",
                                 move_file_result

--- a/libs/lb/lb-rs/tests/tree_tests.rs
+++ b/libs/lb/lb-rs/tests/tree_tests.rs
@@ -1,14 +1,14 @@
 use lb_rs::model::account::Account;
+use lb_rs::model::errors::LbResult;
 use lb_rs::model::file_like::FileLike;
 use lb_rs::model::file_metadata::FileMetadata;
 use lb_rs::model::staged::StagedTreeLikeMut;
 use lb_rs::model::tree_like::{TreeLike, TreeLikeMut};
-use lb_rs::model::SharedResult;
 use test_utils::*;
 use uuid::Uuid;
 
 #[tokio::test]
-async fn tree_test() -> SharedResult<()> {
+async fn tree_test() -> LbResult<()> {
     let account = &Account::new(random_name(), url());
     let file1 = FileMetadata::create_root(account)?;
     let file2 = FileMetadata::create_root(account)?;
@@ -34,7 +34,7 @@ async fn tree_test() -> SharedResult<()> {
 }
 
 #[tokio::test]
-async fn test_stage_insert_reset() -> SharedResult<()> {
+async fn test_stage_insert_reset() -> LbResult<()> {
     let account = &Account::new(random_name(), url());
     let file1 = FileMetadata::create_root(account)?;
     let mut file2 = FileMetadata::create_root(account)?;
@@ -63,7 +63,7 @@ async fn test_stage_insert_reset() -> SharedResult<()> {
 }
 
 #[tokio::test]
-async fn test_stage_reset() -> SharedResult<()> {
+async fn test_stage_reset() -> LbResult<()> {
     let account = &Account::new(random_name(), url());
     let file1 = FileMetadata::create_root(account)?;
     let file2 = FileMetadata::create_root(account)?;

--- a/libs/lb/lb-rs/tests/validate_tests.rs
+++ b/libs/lb/lb-rs/tests/validate_tests.rs
@@ -3,7 +3,7 @@ use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::file::ShareMode;
 use lb_rs::model::file_metadata::{FileType, Owner};
 use lb_rs::model::tree_like::TreeLike;
-use lb_rs::model::{symkey, SharedErrorKind, ValidationFailure};
+use lb_rs::model::{symkey, ValidationFailure};
 use test_utils::*;
 use uuid::Uuid;
 

--- a/libs/lb/lb-rs/tests/validate_tests.rs
+++ b/libs/lb/lb-rs/tests/validate_tests.rs
@@ -1,4 +1,5 @@
 use lb_rs::model::access_info::{UserAccessInfo, UserAccessMode};
+use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::file::ShareMode;
 use lb_rs::model::file_metadata::{FileType, Owner};
 use lb_rs::model::tree_like::TreeLike;
@@ -38,7 +39,7 @@ async fn create_two_files_with_same_path() {
     let result = tree.validate(Owner(account.public_key()));
     assert_matches!(
         result.unwrap_err().kind,
-        SharedErrorKind::ValidationFailure(ValidationFailure::PathConflict(_))
+        LbErrKind::Validation(ValidationFailure::PathConflict(_))
     );
 }
 
@@ -94,6 +95,6 @@ async fn directly_shared_link() {
     let result = tree.validate(Owner(accounts[1].public_key()));
     assert_matches!(
         result.unwrap_err().kind,
-        SharedErrorKind::ValidationFailure(ValidationFailure::SharedLink { .. })
+        LbErrKind::Validation(ValidationFailure::SharedLink { .. })
     );
 }

--- a/server/src/error_handler.rs
+++ b/server/src/error_handler.rs
@@ -10,6 +10,7 @@ use base64::DecodeError;
 use db_rs::DbError;
 use jsonwebtoken::errors::ErrorKind;
 use lb_rs::model::api::*;
+use lb_rs::model::errors::{DiffError, LbErr, LbErrKind};
 use lb_rs::model::{SharedError, SharedErrorKind};
 use std::fmt::Debug;
 use std::io::Error;
@@ -39,18 +40,18 @@ impl<T: Debug> From<serde_json::Error> for ServerError<T> {
     }
 }
 
-impl From<SharedError> for ServerError<CancelSubscriptionError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<CancelSubscriptionError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
-impl From<SharedError> for ServerError<AdminGetAccountInfoError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<AdminGetAccountInfoError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
-impl From<SharedError> for ServerError<GetUsageError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<GetUsageError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
@@ -267,8 +268,8 @@ impl From<ServerError<LockBillingWorkflowError>> for ServerError<AdminSetUserTie
     }
 }
 
-impl From<SharedError> for ServerError<DeleteAccountHelperError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<DeleteAccountHelperError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
@@ -295,76 +296,76 @@ impl From<ServerError<DeleteAccountHelperError>> for ServerError<AdminDisappearA
     }
 }
 
-impl From<SharedError> for ServerError<AdminValidateAccountError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<AdminValidateAccountError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<AdminValidateServerError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<AdminValidateServerError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<AdminFileInfoError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<AdminFileInfoError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<AdminDisappearFileError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<AdminDisappearFileError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<UpsertError> {
-    fn from(err: SharedError) -> Self {
-        // panic!("{err}");
+impl From<LbErr> for ServerError<UpsertError> {
+    fn from(err: LbErr) -> Self {
         use lb_rs::model::api::UpsertError::*;
         match err.kind {
-            SharedErrorKind::OldVersionIncorrect => ClientError(OldVersionIncorrect),
-            SharedErrorKind::OldFileNotFound => ClientError(OldFileNotFound),
-            SharedErrorKind::OldVersionRequired => ClientError(OldVersionRequired),
-            SharedErrorKind::InsufficientPermission => ClientError(NotPermissioned),
-            SharedErrorKind::DiffMalformed => ClientError(DiffMalformed),
-            SharedErrorKind::HmacModificationInvalid => ClientError(HmacModificationInvalid),
-            SharedErrorKind::DeletedFileUpdated(_) => ClientError(DeletedFileUpdated),
-            SharedErrorKind::RootModificationInvalid => ClientError(RootModificationInvalid),
-            SharedErrorKind::ValidationFailure(fail) => ClientError(Validation(fail)),
-            SharedErrorKind::Unexpected(msg) => InternalError(String::from(msg)),
+            LbErrKind::Diff(diff) => match diff {
+                DiffError::OldVersionIncorrect => ClientError(OldVersionIncorrect),
+                DiffError::OldFileNotFound => ClientError(OldFileNotFound),
+                DiffError::OldVersionRequired => ClientError(OldVersionRequired),
+                DiffError::DiffMalformed => ClientError(DiffMalformed),
+                DiffError::HmacModificationInvalid => ClientError(HmacModificationInvalid),
+            },
+            LbErrKind::InsufficientPermission => ClientError(NotPermissioned),
+            LbErrKind::Validation(fail) => ClientError(Validation(fail)),
+            LbErrKind::RootModificationInvalid => ClientError(RootModificationInvalid),
+            LbErrKind::Unexpected(msg) => InternalError(String::from(msg)),
             _ => internal!("{:?}", err),
         }
     }
 }
 
-impl From<SharedError> for ServerError<ChangeDocError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<ChangeDocError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<MetricsError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<MetricsError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<GetDocumentError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<GetDocumentError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<GetFileIdsError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<GetFileIdsError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }
 
-impl From<SharedError> for ServerError<GetUpdatesError> {
-    fn from(err: SharedError) -> Self {
+impl From<LbErr> for ServerError<GetUpdatesError> {
+    fn from(err: LbErr) -> Self {
         internal!("{:?}", err)
     }
 }

--- a/server/src/error_handler.rs
+++ b/server/src/error_handler.rs
@@ -11,7 +11,6 @@ use db_rs::DbError;
 use jsonwebtoken::errors::ErrorKind;
 use lb_rs::model::api::*;
 use lb_rs::model::errors::{DiffError, LbErr, LbErrKind};
-use lb_rs::model::{SharedError, SharedErrorKind};
 use std::fmt::Debug;
 use std::io::Error;
 use std::sync::PoisonError;
@@ -334,7 +333,7 @@ impl From<LbErr> for ServerError<UpsertError> {
             LbErrKind::InsufficientPermission => ClientError(NotPermissioned),
             LbErrKind::Validation(fail) => ClientError(Validation(fail)),
             LbErrKind::RootModificationInvalid => ClientError(RootModificationInvalid),
-            LbErrKind::Unexpected(msg) => InternalError(String::from(msg)),
+            LbErrKind::Unexpected(msg) => InternalError(msg),
             _ => internal!("{:?}", err),
         }
     }

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -11,6 +11,7 @@ use db_rs::Db;
 use lb_rs::model::api::UpsertError;
 use lb_rs::model::api::*;
 use lb_rs::model::clock::get_time;
+use lb_rs::model::errors::{LbErrKind, LbResult};
 use lb_rs::model::file_like::FileLike;
 use lb_rs::model::file_metadata::{Diff, Owner};
 use lb_rs::model::server_file::{IntoServerFile, ServerFile};
@@ -633,7 +634,7 @@ where
 
     pub fn validate_account_helper(
         &self, db: &mut ServerDb, owner: Owner,
-    ) -> SharedResult<AdminValidateAccount> {
+    ) -> LbResult<AdminValidateAccount> {
         let mut result = AdminValidateAccount::default();
 
         let mut tree = ServerTree::new(
@@ -667,7 +668,7 @@ where
         match validation_res {
             Ok(_) => {}
             Err(err) => match err.kind {
-                SharedErrorKind::ValidationFailure(validation) => {
+                LbErrKind::Validation(validation) => {
                     result.tree_validation_failures.push(validation)
                 }
                 _ => {

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -17,7 +17,6 @@ use lb_rs::model::file_metadata::{Diff, Owner};
 use lb_rs::model::server_file::{IntoServerFile, ServerFile};
 use lb_rs::model::server_tree::ServerTree;
 use lb_rs::model::tree_like::TreeLike;
-use lb_rs::model::{SharedErrorKind, SharedResult};
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::ops::DerefMut;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use lb_rs::model::api::{ErrorWrapper, Request, RequestWrapper};
-use lb_rs::model::{pubkey, SharedError};
+use lb_rs::model::pubkey;
 use libsecp256k1::PublicKey;
 use semver::Version;
 use serde::{Deserialize, Serialize};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,6 +3,7 @@ use billing::google_play_client::GooglePlayClient;
 use billing::stripe_client::StripeClient;
 use document_service::DocumentService;
 use lb_rs::model::clock;
+use lb_rs::model::errors::LbResult;
 use std::env;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -80,7 +81,7 @@ pub fn handle_version_header<Req: Request>(
 
 pub fn verify_auth<TRequest>(
     config: &config::Config, request: &RequestWrapper<TRequest>,
-) -> Result<(), SharedError>
+) -> LbResult<()>
 where
     TRequest: Request + Serialize,
 {

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -9,6 +9,7 @@ use crate::{handle_version_header, router_service, verify_auth, ServerError, Ser
 use lazy_static::lazy_static;
 use lb_rs::model::api::*;
 use lb_rs::model::api::{ErrorWrapper, Request, RequestWrapper};
+use lb_rs::model::errors::{LbErrKind, SignError};
 use lb_rs::model::SharedErrorKind;
 use prometheus::{
     register_counter_vec, register_histogram_vec, CounterVec, HistogramVec, TextEncoder,
@@ -479,7 +480,8 @@ where
     })?;
 
     verify_auth(config, &request).map_err(|err| match err.kind {
-        SharedErrorKind::SignatureExpired(_) | SharedErrorKind::SignatureInTheFuture(_) => {
+        LbErrKind::Sign(SignError::SignatureExpired(_))
+        | LbErrKind::Sign(SignError::SignatureInTheFuture(_)) => {
             warn!("expired auth");
             ErrorWrapper::<Req::Error>::ExpiredAuth
         }

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -10,7 +10,6 @@ use lazy_static::lazy_static;
 use lb_rs::model::api::*;
 use lb_rs::model::api::{ErrorWrapper, Request, RequestWrapper};
 use lb_rs::model::errors::{LbErrKind, SignError};
-use lb_rs::model::SharedErrorKind;
 use prometheus::{
     register_counter_vec, register_histogram_vec, CounterVec, HistogramVec, TextEncoder,
 };


### PR DESCRIPTION
We've been gradually refining the way we've done errors to better suit our needs. This PR is the latest refinement in our error handling journey.

In this PR we eliminate the idea of "SharedError". Enabled by prior bodies of work such as [unifying](#2796) and [cleaned up](#3381) the various facets of core.

Now contributors to core only need to be aware of one type of error - `LbErr` which does all the fancy things we want from our error type:
- an expressive `.kind` field for structured error handling
- a display implementation for all errors
- backtraces and logging

This pr also provides some clarity on when to `Unexpected`: if anyone in the stack (including tests) wants to know if this error occurred - give it a type in `.kind`, otherwise yeet it into `Unexpected`.

This pr also drives some refinements to the process of "Unexpecting" an error.

We had two flavors of unexpecting an error:

```rust
impl From<DbError> for SharedError {
    fn from(value: DbError) -> Self {
        SharedErrorKind::Db(format!("db error: {:?}", value)).into()
    }
}
```

```rust
    let message = &Message::parse_slice(&digest).map_err(|err| {
        LbErrKind::Unexpected(format!(
            "unexpected failure to produce a message after hashing: {err:?}"
        ))
    })?;
```

The first one is ergonomic but if you don't realize what you're doing, you're going to create some ugly messages in the UI.

The second one is annoying as hell.

They're both attempts to add some vague context to make it easier to know what's going on. Sometimes there's this situation:

```rust
lib.do1().map_err(One)?;
lib.do2().map_err(Two)?;

pub enum Err {
  One(LibErr),
  Two(LibErr),
}
```

Here `One` and `Two` serve basically as markers for what scenario the error was encountered in. Sometimes the `String` in errors serve a similar purpose.

We've tried some experiments with backtraces, and these work okay in some situations, but `Location::caller()` works significantly more reliably. Naive usage of this leads to the call location being useless:
- either showing `mod/error.rs` for all error situation
- showing the standard library (inside `map_err` for instance)

This PR solves this by utilizing [`#[track_caller]`](https://doc.rust-lang.org/std/panic/struct.Location.html#method.caller) on a function implemented on `Result<T, E: Debug>`:

```rust
pub trait Unexpected<T> {
    fn map_unexpected(self) -> LbResult<T>;
}

impl<T, E: std::fmt::Debug> Unexpected<T> for Result<T, E> {
    #[track_caller]
    fn map_unexpected(self) -> LbResult<T> {
        let location = Location::caller();
        self.map_err(|err| {
            LbErrKind::Unexpected(format!(
                "unexpected error at {}:{} {err:?}",
                location.file(),
                location.line(),
            ))
            .into()
        })
    }
}

let serialized = bincode::serialize(&timestamped).map_unexpected()?;
```

This makes it:
- easy but explicit to just yeet an error into Unexpected from some other crate
- captures an accurate location
- cleans up a bunch of errors literally no one cares about

fixes #3340 