### PR TITLE
editor: fix multiline text paste crash

### DIFF
--- a/libs/lb/lb-rs/src/model/text/unicode_segs.rs
+++ b/libs/lb/lb-rs/src/model/text/unicode_segs.rs
@@ -36,7 +36,13 @@ impl UnicodeSegs {
             return DocCharOffset(0);
         }
 
-        DocCharOffset(self.grapheme_indexes.binary_search(&i).unwrap())
+        match self.grapheme_indexes.binary_search(&i) {
+            Ok(index) => DocCharOffset(index),
+            Err(_) => {
+                eprintln!("Error: DocByteOffset not found in grapheme_indexes: {:?}", i);
+                DocCharOffset(0)
+            }
+        }
     }
 
     pub fn range_to_char(


### PR DESCRIPTION
Some multiline text that contains leading whitespaces causes the app to crash when pasted in the markdown editor
fixes: #3412