### PR TITLE
workspace: synchronously add new files to file cache

### DIFF
--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -593,8 +593,10 @@ impl Workspace {
             .create_file(new_file.to_name().as_str(), &focused_parent, FileType::Document)
             .map_err(|err| format!("{:?}", err));
 
-        self.out.file_created = Some(result);
-        self.tasks.queue_file_cache_refresh();
+        self.out.file_created = Some(result.clone());
+        if let (Some(cache), Ok(file)) = (&mut self.files, result) {
+            cache.files.push(file);
+        }
         self.ctx.request_repaint();
     }
 


### PR DESCRIPTION
This prevents the tab from being "unknown" in the time between when a file is created and when the file cache is refreshed.

Fix verified on iOS and on egui on macOS