### PR TITLE
all: update rust version 0.85.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.1"


### PR DESCRIPTION
Upgrading rust seems to work fine
running 
cargo +nightly udeps --all-targets --all-features
panics because i don't have "LB_TARGET" env variable set locally 
