### PR TITLE
windows: new clippy warnings

### DIFF
--- a/clients/windows/src/input/file_drop.rs
+++ b/clients/windows/src/input/file_drop.rs
@@ -93,7 +93,10 @@ pub fn handle(app: &mut WgpuLockbook, object: Option<IDataObject>) -> bool {
 
                 // for unknown reasons, if I don't cast the HGLOBAL to an HDROP and query the file count, the next call to object.GetData fails
                 // (this applies even if the format isn't CF_HDROP)
-                let hdrop = HDROP(unsafe { std::mem::transmute(hglobal) });
+                let hdrop = HDROP(unsafe {
+                    std::mem::transmute::<windows::Win32::Foundation::HGLOBAL, isize>(hglobal)
+                });
+
                 let file_count = unsafe { DragQueryFileW(hdrop, 0xFFFFFFFF, None) };
                 if format == CF_HDROP {
                     for i in 0..file_count {

--- a/clients/windows/src/input/message.rs
+++ b/clients/windows/src/input/message.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use windows::{
     Win32::Foundation::*, Win32::UI::Input::KeyboardAndMouse::*, Win32::UI::WindowsAndMessaging::*,
 };
@@ -21,6 +19,8 @@ impl From<LPARAM> for Point<u16> {
 /// Windows message parsed to properly interpret or ignore wparam and lparam (but not to redefine any structs defined
 /// in winapi) for clarity and exhaustive matching.
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
+
 pub enum Message<'a> {
     Unknown { msg: u32 },
     Unhandled { const_name: &'static str },
@@ -95,7 +95,11 @@ impl<'a> Message<'a> {
             WM_COPY => Message::Unhandled { const_name: "WM_COPY" },
             WM_COPYDATA => Message::Unhandled { const_name: "WM_COPYDATA" },
             WM_CREATE => Message::NoDeps(MessageNoDeps::Create {
-                create_struct: unsafe { mem::transmute(lparam) },
+                create_struct: unsafe {
+                    std::mem::transmute::<windows::Win32::Foundation::LPARAM, &CREATESTRUCTA>(
+                        lparam,
+                    )
+                },
             }),
             WM_CTLCOLORBTN => Message::Unhandled { const_name: "WM_CTLCOLORBTN" },
             WM_CTLCOLORDLG => Message::Unhandled { const_name: "WM_CTLCOLORDLG" },


### PR DESCRIPTION
- Tried to annotate types for transmute()
- Removed an unused import
- added #[allow(dead_code)] for Message struct to suppress unused struct fields warnings  