### PR TITLE
lb-rs: removed diffy dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,15 +1896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diffy"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
-dependencies = [
- "nu-ansi-term",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,7 +3895,6 @@ dependencies = [
  "crossbeam",
  "db-rs",
  "db-rs-derive",
- "diffy",
  "flate2",
  "futures",
  "glam",

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -23,7 +23,6 @@ basic-human-duration = "0.2.0"
 bezier-rs = "0.2.0"
 bincode = "1.3.3"
 time = "0.3.20"
-diffy = "0.3.0"
 indexmap = { version = "2.5.0", features = ["rayon"] }
 reqwest = { version = "0.11.1", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
`cargo check --tests -p lb-rs`
![image](https://github.com/user-attachments/assets/b98e7485-9f23-4fe1-b211-a722151dda5f)
