### PR TITLE
removed minidom and lbeditor dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,14 +4161,12 @@ dependencies = [
  "egui",
  "egui-notify",
  "egui-winit",
- "egui_editor",
  "egui_extras",
  "egui_wgpu_backend",
  "env_logger",
  "image 0.24.9",
  "lb-fonts",
  "lb-rs",
- "minidom",
  "pdfium-render",
  "rfd",
  "serde",
@@ -4448,14 +4446,6 @@ checksum = "25a3333bb1609500601edc766a39b4c1772874a4ce26022f4d866854dc020c41"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "minidom"
-version = "0.15.3"
-source = "git+https://github.com/lockbook/minidom#101e20650f435f9601ecff7ee70fcdf8c95e6892"
-dependencies = [
- "rxml",
 ]
 
 [[package]]
@@ -6120,23 +6110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rxml"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98f186c7a2f3abbffb802984b7f1dfd65dac8be1aafdaabbca4137f53f0dff7"
-dependencies = [
- "bytes",
- "rxml_validation",
- "smartstring",
-]
-
-[[package]]
-name = "rxml_validation"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a197350ece202f19a166d1ad6d9d6de145e1d2a8ef47db299abe164dbd7530"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6537,17 +6510,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
 ]
 
 [[package]]

--- a/clients/egui/Cargo.toml
+++ b/clients/egui/Cargo.toml
@@ -24,8 +24,6 @@ image = { version = "0.24", default-features = false, features = [
 ] }
 lb = { package = "lb-rs", path = "../../libs/lb/lb-rs", default-features = false }
 lb-fonts = { git = "https://github.com/lockbook/lb-fonts" }
-lbeditor = { package = "egui_editor", path = "../../libs/content/editor/egui_editor" }
-minidom = { git = "https://github.com/lockbook/minidom" }
 pdfium-render = "0.8.5"
 rfd = "0.11.4"
 serde = { version = "1.0.140", features = ["derive"] }


### PR DESCRIPTION
`cargo check --tests -p lockbook-egui`
![image](https://github.com/user-attachments/assets/9f3fdd21-b2fd-415b-ab72-8e886df0568e)
I don't see anything related to these two dependencies in the specified package in cargo.toml should be safe to remove
