### PR TITLE
lockbook-windows: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,12 +355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "array-init"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,10 +4290,8 @@ dependencies = [
 name = "lockbook-windows"
 version = "0.9.22"
 dependencies = [
- "array-init",
  "clipboard-win 4.5.0",
  "egui",
- "egui_editor",
  "egui_wgpu_backend",
  "env_logger",
  "image 0.24.9",

--- a/clients/windows/Cargo.toml
+++ b/clients/windows/Cargo.toml
@@ -4,14 +4,12 @@ version = "0.9.22"
 edition = "2021"
 
 [target.'cfg(windows)'.dependencies]
-array-init = "2.0.0"
 clipboard-win = "4.5.0"
 egui = "0.28.1"
 egui_wgpu_backend = "0.30"
 env_logger = "0.10"
 image = "0.24.7"
 lb = { package = "lb-rs", path = "../../libs/lb/lb-rs" }
-lbeditor = { package = "egui_editor", path = "../../libs/content/editor/egui_editor" }
 lbeguiapp = { package = "lockbook-egui", path = "../egui", default-features = false, features = [
     "egui_wgpu_backend",
 ] }


### PR DESCRIPTION
`cargo check --all-targets`
![image](https://github.com/user-attachments/assets/6afebe85-96f0-4714-a357-82eced31757b)
