### PR TITLE
Infra: Migrating version bumping to self hosted runners

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -13,15 +13,13 @@ on:
           - major
 jobs:
   bump:
-    runs-on: macos-latest
+    runs-on: [self-hosted, ci]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CARGO_HOME: /home/parth/lockbook-ci-cache/home
+      CARGO_TARGET_DIR: /home/parth/lockbook-ci-cache/target
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
       - name: run bump script
         run: |
           cargo run -p releaser -- bump-versions ${{ github.event.inputs.bump_type }}


### PR DESCRIPTION
This is a starting point to see what else needs to be done, This may work already since parth user bypasses branch protection rules