### PR TITLE
infra: fix crate publishing not triggering

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -19,6 +19,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo run -p releaser -- github-release
+  
   call_publish:
     needs: release
     uses: ./.github/workflows/publish-crate.yml
+    secrets:
+      CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -19,3 +19,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo run -p releaser -- github-release
+  call_publish:
+    needs: release
+    uses: ./.github/workflows/publish-crate.yml

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -16,7 +16,10 @@ on:
         required: false
         type: string
         default: 'lb-rs'
-        
+    secrets:
+      CRATES_IO_API_TOKEN:
+        required: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -9,7 +9,14 @@ on:
         description: 'Name of the crate to publish'
         required: false
         default: 'lb-rs'
-
+  workflow_call:
+    inputs:
+      package:
+        description: 'Name of the crate to publish'
+        required: false
+        type: string
+        default: 'lb-rs'
+        
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/utils/releaser/src/utils.rs
+++ b/utils/releaser/src/utils.rs
@@ -29,7 +29,7 @@ impl CommandRunner for Command {
 }
 
 pub fn lb_repo() -> RepoInfo<'static> {
-    RepoInfo { owner: "lockbook", repo_name: "lockbook" }
+    RepoInfo { owner: "Kousay-Jebir", repo_name: "lockbook" }
 }
 
 pub fn lb_version() -> String {

--- a/utils/releaser/src/utils.rs
+++ b/utils/releaser/src/utils.rs
@@ -29,7 +29,7 @@ impl CommandRunner for Command {
 }
 
 pub fn lb_repo() -> RepoInfo<'static> {
-    RepoInfo { owner: "Kousay-Jebir", repo_name: "lockbook" }
+    RepoInfo { owner: "lockbook", repo_name: "lockbook" }
 }
 
 pub fn lb_version() -> String {


### PR DESCRIPTION
PS: Crate publishing is expected to fail due to the expiration of the cratesio auth token
crate publishing now listens on manual releases (if needed), `workflow_dispatch` and `workflow_call`
Tested on my fork by running the release workflow