### PR TITLE
lb-rs: enum approach for co-operative core processes

### DIFF
--- a/libs/lb/lb-rs/src/blocking.rs
+++ b/libs/lb/lb-rs/src/blocking.rs
@@ -33,14 +33,14 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Lb {
-    lb: crate::Lb,
+    lb: crate::InnerLb,
     rt: Arc<Runtime>,
 }
 
 impl Lb {
     pub fn init(config: Config) -> LbResult<Self> {
         let rt = Arc::new(Runtime::new().unwrap());
-        let lb = rt.block_on(crate::Lb::init(config))?;
+        let lb = rt.block_on(crate::InnerLb::init(config))?;
         Ok(Self { rt, lb })
     }
 

--- a/libs/lb/lb-rs/src/enum_lb.rs
+++ b/libs/lb/lb-rs/src/enum_lb.rs
@@ -1,0 +1,27 @@
+pub enum Lb {
+    ActualLb(InnerLb),
+    ExposedLb(ProxyLb)
+}
+
+impl Lb {
+    pub async fn init(config: Config) -> LbResult<Self> {
+        let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
+
+        match TcpListener::bind(socket) {
+            Ok(listener) => {
+                let inner_lb = InnerLb::init(config).await?;
+                Ok(Lb::ActualLb(inner_lb))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+                Ok(Lb::ExposedLb(ProxyLb{addr: socket}))
+            }
+            Err(error) => Err(LbErrKind::Unexpected(format!("Failed to bind: {error}")).into())
+        }
+    }
+}
+
+use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
+use crate::Config;
+use crate::{LbErrKind, LbResult};
+use crate::inner_lb::InnerLb;
+use crate::proxy_lb::ProxyLb;

--- a/libs/lb/lb-rs/src/enum_lb.rs
+++ b/libs/lb/lb-rs/src/enum_lb.rs
@@ -21,7 +21,21 @@ impl Lb {
 }
 
 impl Lb {
-
+    pub async fn create_account(
+        &mut self,
+        username: &str,
+        api_url: &str,
+        welcome_doc: bool,
+    ) -> LbResult<Account> {
+        match self {
+            Lb::ActualLb(inner) => {
+                inner.create_account(username, api_url, welcome_doc).await
+            }
+            Lb::ExposedLb(proxy) => {
+                proxy.create_account(username, api_url, welcome_doc).await
+            }
+        }
+    }
 }
 
 use std::net::{Ipv4Addr, SocketAddrV4};
@@ -30,3 +44,4 @@ use crate::model::core_config::Config;
 use crate::{LbErrKind, LbResult};
 use crate::inner_lb::InnerLb;
 use crate::proxy_lb::ProxyLb;
+use crate::model::account::Account;

--- a/libs/lb/lb-rs/src/enum_lb.rs
+++ b/libs/lb/lb-rs/src/enum_lb.rs
@@ -7,7 +7,7 @@ impl Lb {
     pub async fn init(config: Config) -> LbResult<Self> {
         let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
 
-        match TcpListener::bind(socket) {
+        match TcpListener::bind(socket).await {
             Ok(listener) => {
                 let inner_lb = InnerLb::init(config).await?;
                 Ok(Lb::ActualLb(inner_lb))
@@ -20,8 +20,13 @@ impl Lb {
     }
 }
 
-use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
-use crate::Config;
+impl Lb {
+
+}
+
+use std::net::{Ipv4Addr, SocketAddrV4};
+use tokio::net::TcpListener;    
+use crate::model::core_config::Config;
 use crate::{LbErrKind, LbResult};
 use crate::inner_lb::InnerLb;
 use crate::proxy_lb::ProxyLb;

--- a/libs/lb/lb-rs/src/inner_lb.rs
+++ b/libs/lb/lb-rs/src/inner_lb.rs
@@ -1,0 +1,53 @@
+#[derive(Clone)]
+pub struct InnerLb {
+    pub config: Config,
+    pub keychain: Keychain,
+    pub db: LbDb,
+    pub docs: AsyncDocs,
+    pub search: SearchIndex,
+    pub client: Network,
+    pub events: EventSubs,
+    pub syncing: Arc<AtomicBool>,
+    pub status: StatusUpdater,
+}
+
+impl InnerLb {
+    #[instrument(level = "info", skip_all, err(Debug))]
+    pub async fn init(config: Config) -> LbResult<Self> {
+        logging::init(&config)?;
+
+        let db = CoreDb::init(db_rs::Config::in_folder(&config.writeable_path))
+            .map_err(|err| LbErrKind::Unexpected(format!("{:#?}", err)))?;
+        let keychain = Keychain::from(db.account.get());
+        let db = Arc::new(RwLock::new(db));
+        let docs = AsyncDocs::from(&config);
+        let client = Network::default();
+        let search = SearchIndex::default();
+        let status = StatusUpdater::default();
+        let syncing = Arc::default();
+        let events = EventSubs::default();
+
+        let result = Self { config, keychain, db, docs, client, search, syncing, events, status };
+
+        result.setup_search();
+        result.setup_status().await?;
+
+        Ok(result)
+    }
+}
+
+use crate::io::CoreDb;
+use crate::service::logging;
+use db_rs::Db;
+use crate::io::docs::AsyncDocs;
+use crate::io::network::Network;
+use crate::io::LbDb;
+use crate::model::core_config::Config;
+use crate::model::errors::{LbErrKind, LbResult};
+use crate::service::events::EventSubs;
+use crate::service::keychain::Keychain;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use crate::subscribers::search::SearchIndex;
+use crate::subscribers::status::StatusUpdater;
+use tokio::sync::RwLock;

--- a/libs/lb/lb-rs/src/io/mod.rs
+++ b/libs/lb/lb-rs/src/io/mod.rs
@@ -12,7 +12,7 @@ use crate::model::account::Account;
 use crate::model::file_metadata::Owner;
 use crate::model::signed_file::SignedFile;
 use crate::service::activity::DocEvent;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use db_rs::{Db, List, LookupTable, Single, TxHandle};
 use db_rs_derive::Schema;
 use std::ops::{Deref, DerefMut};

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -26,6 +26,7 @@ pub mod subscribers;
 pub mod inner_lb;
 pub mod proxy_lb;
 pub mod enum_lb;
+pub mod rpc;
 
 pub fn get_code_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -34,8 +35,8 @@ pub fn get_code_version() -> &'static str {
 pub static DEFAULT_API_LOCATION: &str = "https://api.prod.lockbook.net";
 pub static CORE_CODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub use uuid::Uuid;
-pub use model::errors::{LbErrKind, LbResult};
-pub use model::core_config::Config;
+
 pub use enum_lb::Lb;
 pub use inner_lb::InnerLb;
+pub use uuid::Uuid;
+pub use model::errors::{LbErrKind, LbResult};

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -23,44 +23,8 @@ pub mod io;
 pub mod model;
 pub mod service;
 pub mod subscribers;
-
-#[derive(Clone)]
-pub struct Lb {
-    pub config: Config,
-    pub keychain: Keychain,
-    pub db: LbDb,
-    pub docs: AsyncDocs,
-    pub search: SearchIndex,
-    pub client: Network,
-    pub events: EventSubs,
-    pub syncing: Arc<AtomicBool>,
-    pub status: StatusUpdater,
-}
-
-impl Lb {
-    #[instrument(level = "info", skip_all, err(Debug))]
-    pub async fn init(config: Config) -> LbResult<Self> {
-        logging::init(&config)?;
-
-        let db = CoreDb::init(db_rs::Config::in_folder(&config.writeable_path))
-            .map_err(|err| LbErrKind::Unexpected(format!("{:#?}", err)))?;
-        let keychain = Keychain::from(db.account.get());
-        let db = Arc::new(RwLock::new(db));
-        let docs = AsyncDocs::from(&config);
-        let client = Network::default();
-        let search = SearchIndex::default();
-        let status = StatusUpdater::default();
-        let syncing = Arc::default();
-        let events = EventSubs::default();
-
-        let result = Self { config, keychain, db, docs, client, search, syncing, events, status };
-
-        result.setup_search();
-        result.setup_status().await?;
-
-        Ok(result)
-    }
-}
+pub mod inner_lb;
+pub use inner_lb::InnerLb;
 
 pub fn get_code_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -69,19 +33,6 @@ pub fn get_code_version() -> &'static str {
 pub static DEFAULT_API_LOCATION: &str = "https://api.prod.lockbook.net";
 pub static CORE_CODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-use crate::io::CoreDb;
-use crate::service::logging;
-use db_rs::Db;
-use io::docs::AsyncDocs;
-use io::network::Network;
-use io::LbDb;
-use model::core_config::Config;
-pub use model::errors::{LbErrKind, LbResult};
-use service::events::EventSubs;
-use service::keychain::Keychain;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
-use subscribers::search::SearchIndex;
-use subscribers::status::StatusUpdater;
-use tokio::sync::RwLock;
 pub use uuid::Uuid;
+pub use model::errors::{LbErrKind, LbResult};
+pub use model::core_config::Config;

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -24,7 +24,22 @@ pub mod model;
 pub mod service;
 pub mod subscribers;
 pub mod inner_lb;
-pub use inner_lb::InnerLb;
+pub mod proxy_lb;
+
+pub enum Lb {
+    ActualLb(InnerLb),
+    ExposedLb(ProxyLb)
+}
+
+impl Lb {
+    pub async fn init(config: Config) -> LbResult<Self> {
+        if true { 
+            let inner_lb = InnerLb::init(config).await?;
+            return Ok(Lb::ActualLb(inner_lb));
+        }
+        Ok(Lb::ExposedLb(ProxyLb{}))
+    }
+}
 
 pub fn get_code_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -33,6 +48,8 @@ pub fn get_code_version() -> &'static str {
 pub static DEFAULT_API_LOCATION: &str = "https://api.prod.lockbook.net";
 pub static CORE_CODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+use proxy_lb::ProxyLb;
 pub use uuid::Uuid;
 pub use model::errors::{LbErrKind, LbResult};
 pub use model::core_config::Config;
+pub use inner_lb::InnerLb;

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -25,21 +25,7 @@ pub mod service;
 pub mod subscribers;
 pub mod inner_lb;
 pub mod proxy_lb;
-
-pub enum Lb {
-    ActualLb(InnerLb),
-    ExposedLb(ProxyLb)
-}
-
-impl Lb {
-    pub async fn init(config: Config) -> LbResult<Self> {
-        if true { 
-            let inner_lb = InnerLb::init(config).await?;
-            return Ok(Lb::ActualLb(inner_lb));
-        }
-        Ok(Lb::ExposedLb(ProxyLb{}))
-    }
-}
+pub mod enum_lb;
 
 pub fn get_code_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -48,8 +34,8 @@ pub fn get_code_version() -> &'static str {
 pub static DEFAULT_API_LOCATION: &str = "https://api.prod.lockbook.net";
 pub static CORE_CODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-use proxy_lb::ProxyLb;
 pub use uuid::Uuid;
 pub use model::errors::{LbErrKind, LbResult};
 pub use model::core_config::Config;
+pub use enum_lb::Lb;
 pub use inner_lb::InnerLb;

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -40,3 +40,4 @@ pub use enum_lb::Lb;
 pub use inner_lb::InnerLb;
 pub use uuid::Uuid;
 pub use model::errors::{LbErrKind, LbResult};
+use model::core_config::Config;

--- a/libs/lb/lb-rs/src/proxy_lb.rs
+++ b/libs/lb/lb-rs/src/proxy_lb.rs
@@ -1,5 +1,78 @@
-use std::net::SocketAddrV4;
-
 pub struct ProxyLb {
     pub addr: SocketAddrV4
 }
+
+impl ProxyLb {
+    pub async fn create_account(
+        &self,
+        username: &str,
+        api_url: &str,
+        welcome_doc: bool,
+    ) -> LbResult<Account> {
+        let mut stream = TcpStream::connect(&self.addr)
+            .await
+            .map_err(core_err_unexpected)?;
+
+        let args = bincode::serialize(&(username.to_string(), api_url.to_string(), welcome_doc))
+            .map_err(core_err_unexpected)?;
+
+        call_rpc(&mut stream, "create_account", args).await
+    }
+
+    /* #[instrument(level = "debug", skip(self, key), err(Debug))]
+    pub async fn import_account(&self, key: &str, api_url: Option<&str>) -> LbResult<Account> {
+        
+    }
+
+    pub async fn import_account_private_key_v1(&self, account: Account) -> LbResult<Account> {
+        
+    }
+
+    pub async fn import_account_private_key_v2(
+        &self, private_key: SecretKey, api_url: &str,
+    ) -> LbResult<Account> {
+        
+    }
+
+    pub async fn import_account_phrase(
+        &self, phrase: [&str; 24], api_url: &str,
+    ) -> LbResult<Account> {
+        
+    }
+
+    #[instrument(level = "debug", skip(self), err(Debug))]
+    pub fn export_account_private_key(&self) -> LbResult<String> {
+      
+    }
+
+    pub(crate) fn export_account_private_key_v1(&self) -> LbResult<String> {
+       
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn export_account_private_key_v2(&self) -> LbResult<String> {
+       
+    }
+
+    pub fn export_account_phrase(&self) -> LbResult<String> {
+    }
+
+    pub fn export_account_qr(&self) -> LbResult<Vec<u8>> {
+        
+    }
+
+    #[instrument(level = "debug", skip(self), err(Debug))]
+    pub async fn delete_account(&self) -> LbResult<()> {
+        
+    }
+
+    fn welcome_message(username: &str) -> Vec<u8> {
+       unimplemented!()
+    } */
+}
+
+use crate::{model::errors::core_err_unexpected, LbResult};
+use std::net::{SocketAddrV4};
+use tokio::net::TcpStream;
+use crate::rpc::call_rpc;
+use crate::model::account::Account;

--- a/libs/lb/lb-rs/src/proxy_lb.rs
+++ b/libs/lb/lb-rs/src/proxy_lb.rs
@@ -1,0 +1,3 @@
+pub struct ProxyLb {
+    
+}

--- a/libs/lb/lb-rs/src/proxy_lb.rs
+++ b/libs/lb/lb-rs/src/proxy_lb.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddrV4;
+
 pub struct ProxyLb {
-    
+    pub addr: SocketAddrV4
 }

--- a/libs/lb/lb-rs/src/rpc.rs
+++ b/libs/lb/lb-rs/src/rpc.rs
@@ -1,0 +1,55 @@
+#[derive(Serialize, Deserialize)]
+pub struct RpcRequest {
+    pub method: String,
+    pub args: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RpcResponse<T> {
+    pub result: LbResult<T>,
+}
+
+impl RpcRequest {
+    pub fn new(method: impl Into<String>, args: Vec<u8>) -> Self {
+        Self {
+            method: method.into(),
+            args,
+        }
+    }
+}
+
+pub async fn call_rpc<T>(
+    stream: &mut TcpStream,
+    method: &str,
+    args: Vec<u8>,
+) -> LbResult<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let req = RpcRequest::new(method, args);
+    let encoded = bincode::serialize(&req).map_err(core_err_unexpected)?;
+    let len = encoded.len() as u32;
+
+    let mut full_msg = Vec::with_capacity(4 + encoded.len());
+    full_msg.extend_from_slice(&len.to_be_bytes());
+    full_msg.extend_from_slice(&encoded);
+
+    stream.write_all(&full_msg).await.map_err(core_err_unexpected)?;
+
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await.map_err(core_err_unexpected)?;
+    let resp_len = u32::from_be_bytes(len_buf);
+
+    let mut resp_buf = vec![0u8; resp_len as usize];
+    stream.read_exact(&mut resp_buf).await.map_err(core_err_unexpected)?;
+
+    let resp: RpcResponse<T> = bincode::deserialize(&resp_buf).map_err(core_err_unexpected)?;
+    resp.result
+}
+
+use serde::{Serialize,Deserialize};
+use tokio::net::TcpStream;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use bincode;
+use crate::{LbResult};
+use crate::model::errors::{core_err_unexpected};

--- a/libs/lb/lb-rs/src/service/account.rs
+++ b/libs/lb/lb-rs/src/service/account.rs
@@ -5,7 +5,7 @@ use crate::model::api::{
 use crate::model::errors::{core_err_unexpected, LbErrKind, LbResult};
 use crate::model::file_like::FileLike;
 use crate::model::file_metadata::{FileMetadata, FileType, Owner};
-use crate::{Lb, DEFAULT_API_LOCATION};
+use crate::{InnerLb as Lb, DEFAULT_API_LOCATION};
 use libsecp256k1::SecretKey;
 use qrcode_generator::QrCodeEcc;
 

--- a/libs/lb/lb-rs/src/service/activity.rs
+++ b/libs/lb/lb-rs/src/service/activity.rs
@@ -1,6 +1,6 @@
 use crate::model::errors::LbResult;
 use crate::model::tree_like::TreeLike;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use serde::Deserialize;
 use serde::Serialize;
 use std::cmp;

--- a/libs/lb/lb-rs/src/service/admin.rs
+++ b/libs/lb/lb-rs/src/service/admin.rs
@@ -2,7 +2,7 @@ use crate::io::network::ApiError;
 use crate::model::account::Username;
 use crate::model::api::*;
 use crate::model::errors::{core_err_unexpected, LbErrKind, LbResult};
-use crate::Lb;
+use crate::InnerLb as Lb;
 use uuid::Uuid;
 
 impl Lb {

--- a/libs/lb/lb-rs/src/service/billing.rs
+++ b/libs/lb/lb-rs/src/service/billing.rs
@@ -6,7 +6,7 @@ use crate::model::api::{
     UpgradeAccountStripeError, UpgradeAccountStripeRequest,
 };
 use crate::model::errors::{core_err_unexpected, LbErrKind, LbResult};
-use crate::Lb;
+use crate::InnerLb as Lb;
 
 // todo: when core is responsible for syncing, these should probably trigger syncs and status updates
 impl Lb {

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -1,6 +1,6 @@
 use crate::model::clock;
 use crate::model::errors::LbResult;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use crate::{get_code_version, service::logging::LOG_FILE};
 use basic_human_duration::ChronoHumanDuration;
 use chrono::NaiveDateTime;

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -10,7 +10,7 @@ use crate::model::lazy::LazyTree;
 use crate::model::signed_file::SignedFile;
 use crate::model::tree_like::TreeLike;
 use crate::model::validate;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use uuid::Uuid;
 
 use super::activity;

--- a/libs/lb/lb-rs/src/service/events.rs
+++ b/libs/lb/lb-rs/src/service/events.rs
@@ -2,7 +2,7 @@ pub use tokio::sync::broadcast::{self, Receiver, Sender};
 use tracing::*;
 use uuid::Uuid;
 
-use crate::Lb;
+use crate::InnerLb as Lb;
 
 use super::sync::SyncIncrement;
 

--- a/libs/lb/lb-rs/src/service/file.rs
+++ b/libs/lb/lb-rs/src/service/file.rs
@@ -5,7 +5,7 @@ use crate::model::file_metadata::{FileType, Owner};
 use crate::model::filename::MAX_FILENAME_LENGTH;
 use crate::model::symkey;
 use crate::model::tree_like::TreeLike;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use std::iter;
 use uuid::Uuid;
 

--- a/libs/lb/lb-rs/src/service/import_export.rs
+++ b/libs/lb/lb-rs/src/service/import_export.rs
@@ -2,7 +2,7 @@ use crate::model::errors::{LbErr, LbErrKind, LbResult};
 use crate::model::file::File;
 use crate::model::file_metadata::FileType;
 use crate::model::ValidationFailure;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use std::fs;

--- a/libs/lb/lb-rs/src/service/integrity.rs
+++ b/libs/lb/lb-rs/src/service/integrity.rs
@@ -8,7 +8,7 @@ use crate::model::filename::DocumentType;
 use crate::model::tree_like::TreeLike;
 
 use crate::model::errors::{LbErrKind, LbResult, Warning};
-use crate::Lb;
+use crate::InnerLb as Lb;
 
 impl Lb {
     #[instrument(level = "debug", skip(self), err(Debug))]

--- a/libs/lb/lb-rs/src/service/keychain.rs
+++ b/libs/lb/lb-rs/src/service/keychain.rs
@@ -9,7 +9,7 @@ use crate::{
         crypto::AESKey,
         errors::{LbErrKind, LbResult},
     },
-    Lb,
+    InnerLb as Lb,
 };
 use libsecp256k1::PublicKey;
 use tokio::sync::OnceCell;

--- a/libs/lb/lb-rs/src/service/path.rs
+++ b/libs/lb/lb-rs/src/service/path.rs
@@ -2,7 +2,7 @@ use crate::model::errors::{LbErrKind, LbResult};
 use crate::model::file::File;
 use crate::model::path_ops::Filter;
 use crate::model::tree_like::TreeLike;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use uuid::Uuid;
 
 impl Lb {

--- a/libs/lb/lb-rs/src/service/share.rs
+++ b/libs/lb/lb-rs/src/service/share.rs
@@ -4,7 +4,7 @@ use crate::model::file::{File, ShareMode};
 use crate::model::file_like::FileLike;
 use crate::model::file_metadata::Owner;
 use crate::model::tree_like::TreeLike;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use libsecp256k1::PublicKey;
 use uuid::Uuid;
 

--- a/libs/lb/lb-rs/src/service/sync.rs
+++ b/libs/lb/lb-rs/src/service/sync.rs
@@ -18,7 +18,7 @@ use crate::model::tree_like::TreeLike;
 use crate::model::work_unit::WorkUnit;
 use crate::model::{clock, svg};
 use crate::model::{symkey, ValidationFailure};
-use crate::Lb;
+use crate::InnerLb as Lb;
 pub use basic_human_duration::ChronoHumanDuration;
 use futures::stream;
 use futures::StreamExt;

--- a/libs/lb/lb-rs/src/service/usage.rs
+++ b/libs/lb/lb-rs/src/service/usage.rs
@@ -3,7 +3,7 @@ use crate::model::errors::LbResult;
 use crate::model::file_like::FileLike;
 use crate::model::tree_like::TreeLike;
 use crate::model::usage::{bytes_to_human, get_usage};
-use crate::Lb;
+use crate::InnerLb as Lb;
 use serde::Serialize;
 use std::collections::HashMap;
 use uuid::Uuid;

--- a/libs/lb/lb-rs/src/subscribers/search.rs
+++ b/libs/lb/lb-rs/src/subscribers/search.rs
@@ -2,7 +2,7 @@ use crate::model::errors::{LbResult, Unexpected};
 use crate::model::file::File;
 use crate::service::activity::RankingWeights;
 use crate::service::events::Event;
-use crate::Lb;
+use crate::InnerLb as Lb;
 use serde::Serialize;
 use std::ops::Range;
 use std::sync::atomic::AtomicBool;

--- a/libs/lb/lb-rs/src/subscribers/status.rs
+++ b/libs/lb/lb-rs/src/subscribers/status.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::{
     model::errors::{LbErrKind, LbResult, Unexpected},
     service::{events::Event, sync::SyncIncrement, usage::UsageMetrics},
-    Lb,
+    InnerLb as Lb,
 };
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
The first commits do the following big changes : 

1.  Renamed `Lb` to `InnerLb`. This has the consequence of aliasing imports of Lb in all the `service/*.rs` files 
2. Moved `InnerLb` definition and its `init` definition to its own module.
3. `lib.rs` now only imports the enum as well as the two concrete structs `InnerLb` and `ProxyLb` 
to `use crate::InnerLb as Lb`.
4. the enum itslef is now taking the name `Lb`. Added  `pub use enum_lb::Lb;` so that `lb-rs `clients don't have to adjust their imports.
5. `rpc` module contains two structs to properly define what a request and a response looks like. for now these reside in the module file itself but i think it needs to be moved to the `model` folder in future commits
6. `error.rs`'s LbErr now implements Ser and Deser, **I did ask the AI to do these implementations just demo purposes for now since it's that relevant right now for what I've been working on will probably work on improving them in later commits**
7. For now i went with the approach where each call opens its own tcp connection. thus the definition of `ProxyLb` not containing a connection field used across the whole api.
8. For drafting purposes, I hardcoded a TCP port that `init` will try to connect to, Thinking about moving this in `Config`

The goal of these first commits is to prepare the overall structure.
If this gets approved, future commits will focus on implementing the other apis, further organize the files and at some point implement robust measures such as retrial on error on connections etc...