### PR TITLE
apple: fix billing issues

### DIFF
--- a/clients/apple/Shared/State/BillingState.swift
+++ b/clients/apple/Shared/State/BillingState.swift
@@ -50,7 +50,7 @@ class BillingState: ObservableObject {
             return
         }
         
-        guard case .success(nil) = AppState.lb.getSubscriptionInfo() else {
+        if case .success(.some(let info)) = AppState.lb.getSubscriptionInfo(), info.isPremium() == true {
             return
         }
         

--- a/clients/apple/Shared/State/SettingsViewModel.swift
+++ b/clients/apple/Shared/State/SettingsViewModel.swift
@@ -28,7 +28,7 @@ class SettingsViewModel: ObservableObject {
             DispatchQueue.main.async {
                 switch res {
                 case .success(let info):
-                    self.isPremium = info != nil
+                    self.isPremium = info?.isPremium() ?? false
                 case .failure(let err):
                     AppState.shared.error = .lb(error: err)
                 }

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Billing.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Billing.swift
@@ -39,6 +39,17 @@ public struct SubscriptionInfo {
             platform = .stripe(cardLast4Digits: String(cString: res.stripe.pointee.card_last_4_digits))
         }
     }
+    
+    public func isPremium() -> Bool {
+        switch self.platform {
+        case .stripe(let cardLast4Digits):
+            return true
+        case .googlePlay(let state):
+            return state == .ok || state == .gracePeriod || state == .canceled
+        case .appStore(let state):
+            return state == .ok || state == .gracePeriod
+        }
+    }
 }
 
 public enum PaymentPlatform {

--- a/server/src/billing/billing_service.rs
+++ b/server/src/billing/billing_service.rs
@@ -100,10 +100,13 @@ where
 
         {
             let db = self.index_db.lock().await;
-            if let Some(owner) = db.app_store_ids.get().get(&request.app_account_token) {
-                return Err(ClientError(
-                    UpgradeAccountAppStoreError::AppStoreAccountAlreadyLinked,
-                ));
+            if db
+                .app_store_ids
+                .get()
+                .get(&request.app_account_token)
+                .is_some()
+            {
+                return Err(ClientError(UpgradeAccountAppStoreError::AppStoreAccountAlreadyLinked));
             }
         }
 

--- a/server/src/billing/billing_service.rs
+++ b/server/src/billing/billing_service.rs
@@ -101,19 +101,9 @@ where
         {
             let db = self.index_db.lock().await;
             if let Some(owner) = db.app_store_ids.get().get(&request.app_account_token) {
-                if let Some(other_account) = db.accounts.get().get(owner) {
-                    if let Some(BillingPlatform::AppStore(ref info)) =
-                        other_account.billing_info.billing_platform
-                    {
-                        if info.account_token == request.app_account_token
-                            && other_account.billing_info.is_premium()
-                        {
-                            return Err(ClientError(
-                                UpgradeAccountAppStoreError::AppStoreAccountAlreadyLinked,
-                            ));
-                        }
-                    }
-                }
+                return Err(ClientError(
+                    UpgradeAccountAppStoreError::AppStoreAccountAlreadyLinked,
+                ));
             }
         }
 


### PR DESCRIPTION
Fixes
+ Show billing correctly for apple (if subscription expired, don't show premium)
+ Prevent double spend for subscription id
