### PR TITLE
feat: switch from nfsserve to nfs3_server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 xcuserdata/
 
 *.xcscmblueprint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,7 +4165,6 @@ source = "git+https://github.com/lockbook/lb-fonts#54b09038cbc3048f45e7d771a0118
 name = "lb-fs"
 version = "0.9.26"
 dependencies = [
- "async-trait",
  "cli-rs",
  "lb-rs",
  "nfs3_server",
@@ -5069,9 +5068,9 @@ dependencies = [
 
 [[package]]
 name = "nfs3_server"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93e2860c9cd589872b82eee33288658e20708fa011b5f6839f605a565cb03f1"
+checksum = "2a66ca2d2f16bbdd4d5b04ee9295d06f214860d8c52c12b3d4001eb97e0e954a"
 dependencies = [
  "anyhow",
  "filetime",
@@ -5082,9 +5081,9 @@ dependencies = [
 
 [[package]]
 name = "nfs3_types"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099eabb8e460846ada8cd6e71d4e8f2fa857a6aec7d7b56c40a8b693a4a6a08b"
+checksum = "a1e8a6ffeaf0ce30c1cc73a65bb22bc6cd0dd6fab680850745ab64391a69c2cb"
 dependencies = [
  "nfs3_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -1168,15 +1168,6 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-
-[[package]]
-name = "bytestream"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f720842a717d6afaf69fee2dc69b771edc165f12cc3eb1b0e8eeef53a86454"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "bzip2"
@@ -2634,14 +2625,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.23"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
+ "libredox 0.1.6",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3912,6 +3903,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4166,7 +4168,7 @@ dependencies = [
  "async-trait",
  "cli-rs",
  "lb-rs",
- "nfsserve",
+ "nfs3_server",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4396,6 +4398,17 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.5.1",
 ]
 
 [[package]]
@@ -4910,6 +4923,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "mslnk"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,23 +5057,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "nfsserve"
-version = "0.10.2"
+name = "nfs3_macros"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73615e054238e6bf5e554407b5b23e82fc63616db459057c51b794799eda6fb"
+checksum = "abcb08aad2dd6cc7f34abb2443089021675f72f1c0594f8795d9b8d47aed48b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "nfs3_server"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93e2860c9cd589872b82eee33288658e20708fa011b5f6839f605a565cb03f1"
 dependencies = [
  "anyhow",
- "async-trait",
- "byteorder",
- "bytestream",
  "filetime",
- "futures",
- "num-derive 0.3.3",
- "num-traits",
- "smallvec",
+ "nfs3_types",
  "tokio",
  "tracing",
- "tracing-attributes",
+]
+
+[[package]]
+name = "nfs3_types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099eabb8e460846ada8cd6e71d4e8f2fa857a6aec7d7b56c40a8b693a4a6a08b"
+dependencies = [
+ "nfs3_macros",
 ]
 
 [[package]]
@@ -5119,7 +5156,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -5162,17 +5199,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-derive"
@@ -5518,7 +5544,7 @@ version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
- "libredox",
+ "libredox 0.0.2",
 ]
 
 [[package]]
@@ -6174,9 +6200,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -6299,7 +6325,7 @@ dependencies = [
  "maybe-rayon",
  "new_debug_unreachable",
  "noop_proc_macro",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "once_cell",
  "paste",
@@ -7783,28 +7809,29 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7935,9 +7962,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -7959,9 +7986,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7970,9 +7997,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",

--- a/libs/lb-fs/Cargo.toml
+++ b/libs/lb-fs/Cargo.toml
@@ -10,8 +10,7 @@ readme = "../../docs/README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.77"
-nfs3_server = "0.7"
+nfs3_server = "0.8"
 tokio = { version = "1.35.1", features = ["signal", "process", "rt-multi-thread"] } 
 cli-rs = "0.1.12"
 lb-rs = { version = "0.9", path = "../lb/lb-rs" }

--- a/libs/lb-fs/Cargo.toml
+++ b/libs/lb-fs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lb-fs"
 version = "0.9.26"
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 description = "A Virtual file system implementation for lockbook.net."
 homepage = "https://lockbook.net"
@@ -11,7 +11,7 @@ readme = "../../docs/README.md"
 
 [dependencies]
 async-trait = "0.1.77"
-nfsserve = "0.10.1"
+nfs3_server = "0.7"
 tokio = { version = "1.35.1", features = ["signal", "process", "rt-multi-thread"] } 
 cli-rs = "0.1.12"
 lb-rs = { version = "0.9", path = "../lb/lb-rs" }

--- a/libs/lb-fs/src/cache.rs
+++ b/libs/lb-fs/src/cache.rs
@@ -92,7 +92,7 @@ impl Drive {
 
                 let now = FileEntry::ts_from_u64(FileEntry::now());
 
-                entry.fattr.mtime = now.clone(); // FIXME: this should be copiable
+                entry.fattr.mtime = now;
                 entry.fattr.ctime = now;
 
                 data.insert(entry.file.id.into(), entry);

--- a/libs/lb-fs/src/cache.rs
+++ b/libs/lb-fs/src/cache.rs
@@ -1,7 +1,7 @@
 use crate::fs_impl::Drive;
 use lb_rs::model::file::File;
 use lb_rs::model::work_unit::WorkUnit;
-use nfsserve::nfs::{fattr3, ftype3, nfstime3};
+use nfs3_server::nfs3_types::nfs3::{fattr3, ftype3, nfstime3};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::info;
 
@@ -26,7 +26,7 @@ impl FileEntry {
         let ctime = Self::ts_from_u64(file.last_modified);
 
         let fattr = fattr3 {
-            ftype,
+            type_: ftype,
             mode,
             nlink: 1, // hard links to this file
             uid: 501, // todo: evaluate owner field? not resolved by this lib
@@ -70,7 +70,7 @@ impl Drive {
             let id = file.id;
             let entry =
                 FileEntry::from_file(file, sizes.get(&id).copied().unwrap_or_default() as u64);
-            data.insert(entry.fattr.fileid, entry);
+            data.insert(entry.file.id.into(), entry);
         }
         info!("cache ready");
     }
@@ -92,10 +92,10 @@ impl Drive {
 
                 let now = FileEntry::ts_from_u64(FileEntry::now());
 
-                entry.fattr.mtime = now;
+                entry.fattr.mtime = now.clone(); // FIXME: this should be copiable
                 entry.fattr.ctime = now;
 
-                data.insert(entry.fattr.fileid, entry);
+                data.insert(entry.file.id.into(), entry);
             }
         }
     }

--- a/libs/lb-fs/src/fs_impl.rs
+++ b/libs/lb-fs/src/fs_impl.rs
@@ -45,7 +45,7 @@ impl FileHandle for UuidFileHandle {
     where
         Self: Sized,
     {
-        Uuid::from_slice(bytes).ok().map(|id| Self(id))
+        Uuid::from_slice(bytes).ok().map(Self)
     }
 }
 
@@ -78,7 +78,7 @@ impl Drive {
         &self, dirid: &UuidFileHandle, cookie: u64,
     ) -> Result<Iterator, nfsstat3> {
         let data = self.data.lock().await;
-        let dirid = data.get(&dirid).unwrap().file.id;
+        let dirid = data.get(dirid).unwrap().file.id;
         let mut children = self.lb.get_children(&dirid).await.unwrap();
 
         children.sort_by(|a, b| a.id.cmp(&b.id));
@@ -111,7 +111,7 @@ impl NfsReadFileSystem for Drive {
     async fn lookup(
         &self, dirid: &Self::Handle, filename: &filename3<'_>,
     ) -> Result<Self::Handle, nfsstat3> {
-        let dir = self.data.lock().await.get(&dirid).unwrap().file.clone();
+        let dir = self.data.lock().await.get(dirid).unwrap().file.clone();
 
         if dir.is_document() {
             info!("NOTDIR");
@@ -157,7 +157,7 @@ impl NfsReadFileSystem for Drive {
     ) -> Result<(Vec<u8>, bool), nfsstat3> {
         let offset = offset as usize;
         let count = count as usize;
-        let id = self.data.lock().await.get(&id).unwrap().file.id;
+        let id = self.data.lock().await.get(id).unwrap().file.id;
 
         let doc = self.lb.read_document(id, false).await.unwrap();
 
@@ -202,7 +202,7 @@ impl NfsFileSystem for Drive {
     async fn setattr(&self, id: &Self::Handle, setattr: sattr3) -> Result<fattr3, nfsstat3> {
         let mut data = self.data.lock().await;
         let now = FileEntry::now();
-        let entry = data.get_mut(&id).unwrap();
+        let entry = data.get_mut(id).unwrap();
 
         if let Nfs3Option::Some(new) = setattr.size {
             if entry.fattr.size != new {
@@ -262,7 +262,7 @@ impl NfsFileSystem for Drive {
         let offset = offset as usize;
 
         let mut data = self.data.lock().await;
-        let entry = data.get_mut(&id).unwrap();
+        let entry = data.get_mut(id).unwrap();
         let id = entry.file.id;
 
         let mut doc = self.lb.read_document(id, false).await.unwrap();
@@ -292,7 +292,7 @@ impl NfsFileSystem for Drive {
         &self, dirid: &Self::Handle, filename: &filename3<'_>, attr: sattr3,
     ) -> Result<(Self::Handle, fattr3), nfsstat3> {
         let filename = get_string(filename);
-        let parent = self.data.lock().await.get(&dirid).unwrap().file.id;
+        let parent = self.data.lock().await.get(dirid).unwrap().file.id;
         let file = self
             .lb
             .create_file(&filename, &parent, FileType::Document)
@@ -315,7 +315,7 @@ impl NfsFileSystem for Drive {
         createverf: nfs3_server::nfs3_types::nfs3::createverf3,
     ) -> Result<Self::Handle, nfsstat3> {
         let filename = get_string(filename);
-        let dirid = self.data.lock().await.get(&dirid).unwrap().file.id;
+        let dirid = self.data.lock().await.get(dirid).unwrap().file.id;
         let children = self.lb.get_children(&dirid).await.unwrap();
         for child in children {
             if child.name == filename {
@@ -343,7 +343,7 @@ impl NfsFileSystem for Drive {
         &self, dirid: &Self::Handle, dirname: &filename3<'_>,
     ) -> Result<(Self::Handle, fattr3), nfsstat3> {
         let filename = get_string(dirname);
-        let parent = self.data.lock().await.get(&dirid).unwrap().file.id;
+        let parent = self.data.lock().await.get(dirid).unwrap().file.id;
         let file = self
             .lb
             .create_file(&filename, &parent, FileType::Folder)
@@ -365,7 +365,7 @@ impl NfsFileSystem for Drive {
     #[instrument(skip(self), fields(dirid = dirid.to_string(), filename = get_string(filename)))]
     async fn remove(&self, dirid: &Self::Handle, filename: &filename3<'_>) -> Result<(), nfsstat3> {
         let mut data = self.data.lock().await;
-        let dirid = data.get(&dirid).unwrap().file.id;
+        let dirid = data.get(dirid).unwrap().file.id;
 
         let children = self.lb.get_children(&dirid).await.unwrap();
         let file_name = get_string(filename);
@@ -394,8 +394,8 @@ impl NfsFileSystem for Drive {
         let from_filename = get_string(from_filename);
         let to_filename = get_string(to_filename);
 
-        let from_dirid = data.get(&from_dirid).unwrap().file.id;
-        let to_dirid = data.get(&to_dirid).unwrap().file.id;
+        let from_dirid = data.get(from_dirid).unwrap().file.id;
+        let to_dirid = data.get(to_dirid).unwrap().file.id;
 
         let src_children = self.lb.get_children(&from_dirid).await.unwrap();
 

--- a/libs/lb-fs/src/fs_impl.rs
+++ b/libs/lb-fs/src/fs_impl.rs
@@ -7,7 +7,7 @@ use lb_rs::model::file_metadata::FileType;
 use lb_rs::{Lb, Uuid};
 use nfs3_server::nfs3_types::nfs3::{
     fattr3, fileid3, filename3, nfspath3, nfsstat3, sattr3, set_atime, set_gid3, set_mode3,
-    set_mtime, set_size3, set_uid3,
+    set_mtime, set_size3, set_uid3, Nfs3Option,
 };
 use nfs3_server::vfs::{
     FileHandle, FileHandleU64, NfsFileSystem, NfsReadFileSystem, ReadDirPlusIterator,
@@ -164,104 +164,7 @@ impl NfsReadFileSystem for Drive {
 
 
 
-
-    // #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
-    // async fn create_exclusive(
-    //     &self, dirid: fileid3, filename: &filename3,
-    // ) -> Result<fileid3, nfsstat3> {
-    //     let filename = get_string(filename);
-    //     let dirid = self.data.lock().await.get(&dirid).unwrap().file.id;
-    //     let children = self.lb.get_children(&dirid).await.unwrap();
-    //     for child in children {
-    //         if child.name == filename {
-    //             warn!("exists already");
-    //             return Err(nfsstat3::NFS3ERR_EXIST);
-    //         }
-    //     }
-
-    //     let file = self
-    //         .lb
-    //         .create_file(&filename, &dirid, FileType::Document)
-    //         .await
-    //         .unwrap();
-
-    //     let entry = FileEntry::from_file(file, 0);
-    //     let id = entry.fattr.fileid;
-    //     info!("({}, size={})", fmt(id), entry.fattr.size);
-    //     self.data.lock().await.insert(entry.fattr.fileid, entry);
-
-    //     return Ok(id);
-    // }
-
-    // #[instrument(skip(self), fields(id = fmt(id)))]
-    // async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
-    //     let mut data = self.data.lock().await;
-    //     let now = FileEntry::now();
-    //     let entry = data.get_mut(&id).unwrap();
-
-    //     match setattr.size {
-    //         set_size3::Void => {}
-    //         set_size3::size(new) => {
-    //             if entry.fattr.size != new {
-    //                 let mut doc = self.lb.read_document(entry.file.id, false).await.unwrap();
-    //                 doc.resize(new as usize, 0);
-    //                 self.lb.write_document(entry.file.id, &doc).await.unwrap();
-    //                 entry.fattr.mtime = FileEntry::ts_from_u64(now);
-    //                 entry.fattr.ctime = FileEntry::ts_from_u64(now);
-    //             }
-    //         }
-    //     }
-
-    //     match setattr.atime {
-    //         set_atime::DONT_CHANGE => {}
-    //         set_atime::SET_TO_SERVER_TIME => {
-    //             entry.fattr.atime = FileEntry::ts_from_u64(now);
-    //         }
-    //         set_atime::SET_TO_CLIENT_TIME(ts) => {
-    //             entry.fattr.atime = ts;
-    //         }
-    //     }
-
-    //     match setattr.mtime {
-    //         set_mtime::DONT_CHANGE => {}
-    //         set_mtime::SET_TO_SERVER_TIME => {
-    //             entry.fattr.mtime = FileEntry::ts_from_u64(now);
-    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
-    //         }
-    //         set_mtime::SET_TO_CLIENT_TIME(ts) => {
-    //             entry.fattr.mtime = ts;
-    //             entry.fattr.ctime = ts;
-    //         }
-    //     }
-
-    //     match setattr.uid {
-    //         set_uid3::Void => {}
-    //         set_uid3::uid(uid) => {
-    //             entry.fattr.uid = uid;
-    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
-    //         }
-    //     }
-
-    //     match setattr.gid {
-    //         set_gid3::Void => {}
-    //         set_gid3::gid(gid) => {
-    //             entry.fattr.gid = gid;
-    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
-    //         }
-    //     }
-
-    //     match setattr.mode {
-    //         set_mode3::Void => {}
-    //         set_mode3::mode(mode) => {
-    //             entry.fattr.mode = mode;
-    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
-    //         }
-    //     }
-
-    //     info!("fattr = {:?}", entry.fattr);
-
-    //     return Ok(entry.fattr);
-    // }
+    
 
     // #[instrument(skip(self), fields(id = fmt(id), offset, count))]
     // async fn read(
@@ -288,7 +191,7 @@ impl NfsReadFileSystem for Drive {
     // }
 
     // /// they will provide a start_after of 0 for no id
-    // #[instrument(skip(self), fields(dirid = fmt(dirid), start_after, max_entries))]
+    // #[instrument(skip(self), fields(dirid = dirid.to_string(), start_after, max_entries))]
     // async fn readdir(
     //     &self, dirid: fileid3, start_after: fileid3, max_entries: usize,
     // ) -> Result<ReadDirResult, nfsstat3> {
@@ -339,7 +242,7 @@ impl NfsReadFileSystem for Drive {
     // /// Removes a file.
     // /// If not supported dur to readonly file system
     // /// this should return Err(nfsstat3::NFS3ERR_ROFS)
-    // #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
+    // #[instrument(skip(self), fields(dirid = dirid.to_string(), filename = get_string(filename)))]
     // #[allow(unused)]
     // async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3> {
     //     let mut data = self.data.lock().await;
@@ -441,7 +344,7 @@ impl NfsReadFileSystem for Drive {
     //     return Ok(());
     // }
 
-    // #[instrument(skip(self), fields(dirid = fmt(dirid), dirname = get_string(dirname)))]
+    // #[instrument(skip(self), fields(dirid = dirid.to_string(), dirname = get_string(dirname)))]
     // #[allow(unused)]
     // async fn mkdir(
     //     &self, dirid: fileid3, dirname: &filename3,
@@ -476,8 +379,61 @@ impl NfsReadFileSystem for Drive {
 }
 
 impl NfsFileSystem for Drive {
-    async fn setattr(&self, id: &Self::Handle, setattr: sattr3) -> Result<fattr3, nfsstat3> {
-        todo!()
+    #[instrument(skip(self), fields(id = id.to_string()))]
+    async fn setattr(&self, id: &Self::Handle, setattr: sattr3) -> Result<fattr3, nfsstat3> {        
+        let mut data = self.data.lock().await;
+        let now = FileEntry::now();
+        let entry = data.get_mut(&id).unwrap();
+
+        if let Nfs3Option::Some(new) = setattr.size {
+            if entry.fattr.size != new {
+                let mut doc = self.lb.read_document(entry.file.id, false).await.unwrap();
+                doc.resize(new as usize, 0);
+                self.lb.write_document(entry.file.id, &doc).await.unwrap();
+                entry.fattr.mtime = FileEntry::ts_from_u64(now);
+                entry.fattr.ctime = FileEntry::ts_from_u64(now);
+            }            
+        }
+
+        match setattr.atime {
+            set_atime::DONT_CHANGE => {}
+            set_atime::SET_TO_SERVER_TIME => {
+                entry.fattr.atime = FileEntry::ts_from_u64(now);
+            }
+            set_atime::SET_TO_CLIENT_TIME(ts) => {
+                entry.fattr.atime = ts;
+            }
+        }
+
+        match setattr.mtime {
+            set_mtime::DONT_CHANGE => {}
+            set_mtime::SET_TO_SERVER_TIME => {
+                entry.fattr.mtime = FileEntry::ts_from_u64(now);
+                entry.fattr.ctime = FileEntry::ts_from_u64(now);
+            }
+            set_mtime::SET_TO_CLIENT_TIME(ts) => {
+                entry.fattr.mtime = ts.clone(); // FIXME: this should be copiable
+                entry.fattr.ctime = ts;
+            }
+        }
+
+        if let Nfs3Option::Some(uid) = setattr.uid {
+            entry.fattr.uid = uid;
+            entry.fattr.ctime = FileEntry::ts_from_u64(now);            
+        }
+
+        if let Nfs3Option::Some(gid) = setattr.gid {
+            entry.fattr.gid = gid;
+            entry.fattr.ctime = FileEntry::ts_from_u64(now);
+        }
+
+        if let Nfs3Option::Some(mode) = setattr.mode {
+            entry.fattr.mode = mode;
+            entry.fattr.ctime = FileEntry::ts_from_u64(now);            
+        }
+
+        info!("fattr = {:?}", entry.fattr);
+        Ok(entry.fattr.clone())
     }
 
     #[instrument(skip(self), fields(id = id.to_string(), buffer = buffer.len()))]
@@ -528,15 +484,37 @@ impl NfsFileSystem for Drive {
 
         let file = self.setattr(&id, attr).await.unwrap();
 
-        info!("({}, size={})", file.fileid, file.size);
+        info!("({id}, size={})", file.size);
         Ok((id, file))
     }
 
+    #[instrument(skip(self), fields(dirid = dirid.to_string(), filename = get_string(filename)))]
     async fn create_exclusive(
         &self, dirid: &Self::Handle, filename: &filename3<'_>,
         createverf: nfs3_server::nfs3_types::nfs3::createverf3,
     ) -> Result<Self::Handle, nfsstat3> {
-        todo!()
+        let filename = get_string(filename);
+        let dirid = self.data.lock().await.get(&dirid).unwrap().file.id;
+        let children = self.lb.get_children(&dirid).await.unwrap();
+        for child in children {
+            if child.name == filename {
+                warn!("exists already");
+                return Err(nfsstat3::NFS3ERR_EXIST);
+            }
+        }
+
+        let file = self
+            .lb
+            .create_file(&filename, &dirid, FileType::Document)
+            .await
+            .unwrap();
+
+        let entry = FileEntry::from_file(file, 0);
+        let id = entry.file.id.into();
+        info!("({id}, size={})", entry.fattr.size);
+        self.data.lock().await.insert(id, entry);
+
+        Ok(id)
     }
 
     async fn mkdir(

--- a/libs/lb-fs/src/fs_impl.rs
+++ b/libs/lb-fs/src/fs_impl.rs
@@ -1,17 +1,55 @@
+#![expect(unused)] // FIXME: remove this once all unused code is removed
+
 use crate::cache::FileEntry;
-use crate::utils::{fmt, get_string};
+use crate::utils::{get_string};
 use async_trait::async_trait;
 use lb_rs::model::file_metadata::FileType;
 use lb_rs::{Lb, Uuid};
-use nfsserve::nfs::{
-    fattr3, fileid3, filename3, nfspath3, nfsstat3, nfsstring, sattr3, set_atime, set_gid3,
-    set_mode3, set_mtime, set_size3, set_uid3,
+use nfs3_server::nfs3_types::nfs3::{
+    fattr3, fileid3, filename3, nfspath3, nfsstat3, sattr3, set_atime, set_gid3, set_mode3,
+    set_mtime, set_size3, set_uid3,
 };
-use nfsserve::vfs::{DirEntry, NFSFileSystem, ReadDirResult, VFSCapabilities};
+use nfs3_server::vfs::{
+    FileHandle, FileHandleU64, NfsFileSystem, NfsReadFileSystem, ReadDirPlusIterator,
+    VFSCapabilities,
+};
 use std::collections::HashMap;
+use std::fs::ReadDir;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{info, instrument, warn};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct UuidFileHandle(pub Uuid);
+
+impl std::fmt::Display for UuidFileHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FileHandle for UuidFileHandle {
+    fn len(&self) -> usize {
+        16
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        Uuid::from_slice(bytes).ok().map(|id| Self(id))
+    }
+}
+
+impl From<Uuid> for UuidFileHandle {
+    fn from(id: Uuid) -> Self {
+        Self(id)
+    }
+}
 
 #[derive(Clone)]
 pub struct Drive {
@@ -28,106 +66,21 @@ pub struct Drive {
     /// 1. size computations are expensive in core
     /// 2. nfs needs to update timestamps to specified values
     /// 3. nfs models properties we don't, like file permission bits
-    pub data: Arc<Mutex<HashMap<fileid3, FileEntry>>>,
+    pub data: Arc<Mutex<HashMap<UuidFileHandle, FileEntry>>>,
 }
 
-#[async_trait]
-impl NFSFileSystem for Drive {
+impl NfsReadFileSystem for Drive {
+    type Handle = UuidFileHandle;
+
     #[instrument(skip(self))]
-    fn root_dir(&self) -> fileid3 {
-        let root = self.root;
-        let half = root.as_u64_pair().0;
-
-        info!("ret={root}");
-        half
+    fn root_dir(&self) -> Self::Handle {
+        self.root.into()
     }
 
-    fn capabilities(&self) -> VFSCapabilities {
-        VFSCapabilities::ReadWrite
-    }
-
-    #[instrument(skip(self), fields(id = fmt(id), buffer = buffer.len()))]
-    async fn write(&self, id: fileid3, offset: u64, buffer: &[u8]) -> Result<fattr3, nfsstat3> {
-        let offset = offset as usize;
-
-        let mut data = self.data.lock().await;
-        let entry = data.get_mut(&id).unwrap();
-        let id = entry.file.id;
-
-        let mut doc = self.lb.read_document(id, false).await.unwrap();
-        let mut expanded = false;
-        if offset + buffer.len() > doc.len() {
-            doc.resize(offset + buffer.len(), 0);
-            doc[offset..].copy_from_slice(buffer);
-            expanded = true;
-        } else {
-            for (idx, datum) in buffer.iter().enumerate() {
-                doc[offset + idx] = *datum;
-            }
-        }
-        let doc_size = doc.len();
-        self.lb.write_document(id, &doc).await.unwrap();
-
-        entry.fattr.size = doc_size as u64;
-
-        info!("expanded={expanded}, fattr.size = {}", doc_size);
-
-        Ok(entry.fattr)
-    }
-
-    // todo this should create a file regardless of whether it exists
-    #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
-    async fn create(
-        &self, dirid: fileid3, filename: &filename3, attr: sattr3,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
-        let filename = get_string(filename);
-        let parent = self.data.lock().await.get(&dirid).unwrap().file.id;
-        let file = self
-            .lb
-            .create_file(&filename, &parent, FileType::Document)
-            .await
-            .unwrap();
-
-        let entry = FileEntry::from_file(file, 0);
-        let id = entry.fattr.fileid;
-        self.data.lock().await.insert(entry.fattr.fileid, entry);
-
-        let file = self.setattr(id, attr).await.unwrap();
-
-        info!("({}, size={})", fmt(file.fileid), file.size);
-        Ok((id, file))
-    }
-
-    #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
-    async fn create_exclusive(
-        &self, dirid: fileid3, filename: &filename3,
-    ) -> Result<fileid3, nfsstat3> {
-        let filename = get_string(filename);
-        let dirid = self.data.lock().await.get(&dirid).unwrap().file.id;
-        let children = self.lb.get_children(&dirid).await.unwrap();
-        for child in children {
-            if child.name == filename {
-                warn!("exists already");
-                return Err(nfsstat3::NFS3ERR_EXIST);
-            }
-        }
-
-        let file = self
-            .lb
-            .create_file(&filename, &dirid, FileType::Document)
-            .await
-            .unwrap();
-
-        let entry = FileEntry::from_file(file, 0);
-        let id = entry.fattr.fileid;
-        info!("({}, size={})", fmt(id), entry.fattr.size);
-        self.data.lock().await.insert(entry.fattr.fileid, entry);
-
-        return Ok(id);
-    }
-
-    #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
-    async fn lookup(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3> {
+    #[instrument(skip(self), fields(dirid = dirid.to_string(), filename = get_string(filename)))]
+    async fn lookup(
+        &self, dirid: &Self::Handle, filename: &filename3<'_>,
+    ) -> Result<Self::Handle, nfsstat3> {
         let dir = self.data.lock().await.get(&dirid).unwrap().file.clone();
 
         if dir.is_document() {
@@ -136,24 +89,24 @@ impl NFSFileSystem for Drive {
         }
 
         // if looking for dir/. its the current directory
-        if filename[..] == [b'.'] {
-            info!(". == {}", fmt(dirid));
-            return Ok(dirid);
+        if filename.as_ref() == [b'.'] {
+            info!(". == {dirid}");
+            return Ok(*dirid);
         }
 
         // if looking for dir/.. its the parent directory
-        if filename[..] == [b'.', b'.'] {
+        if filename.as_ref() == [b'.', b'.'] {
             info!(".. == {}", dir.parent);
-            return Ok(dir.parent.as_u64_pair().0);
+            return Ok(dir.parent.into());
         }
 
         let children = self.lb.get_children(&dir.id).await.unwrap();
-        let file_name = String::from_utf8(filename.0.clone()).unwrap();
+        let file_name = get_string(filename);
 
         for child in children {
             if file_name == child.name {
                 info!("{}", child.id);
-                return Ok(child.id.as_u64_pair().0);
+                return Ok(child.id.into());
             }
         }
 
@@ -161,86 +114,14 @@ impl NFSFileSystem for Drive {
         Err(nfsstat3::NFS3ERR_NOENT)
     }
 
-    #[instrument(skip(self), fields(id = fmt(id)))]
-    async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
-        let file = self.data.lock().await.get(&id).unwrap().fattr;
+    async fn getattr(&self, id: &Self::Handle) -> Result<fattr3, nfsstat3> {
+        let file = self.data.lock().await.get(id).unwrap().fattr.clone();
         info!("fattr = {:?}", file);
         Ok(file)
     }
 
-    #[instrument(skip(self), fields(id = fmt(id)))]
-    async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
-        let mut data = self.data.lock().await;
-        let now = FileEntry::now();
-        let entry = data.get_mut(&id).unwrap();
-
-        match setattr.size {
-            set_size3::Void => {}
-            set_size3::size(new) => {
-                if entry.fattr.size != new {
-                    let mut doc = self.lb.read_document(entry.file.id, false).await.unwrap();
-                    doc.resize(new as usize, 0);
-                    self.lb.write_document(entry.file.id, &doc).await.unwrap();
-                    entry.fattr.mtime = FileEntry::ts_from_u64(now);
-                    entry.fattr.ctime = FileEntry::ts_from_u64(now);
-                }
-            }
-        }
-
-        match setattr.atime {
-            set_atime::DONT_CHANGE => {}
-            set_atime::SET_TO_SERVER_TIME => {
-                entry.fattr.atime = FileEntry::ts_from_u64(now);
-            }
-            set_atime::SET_TO_CLIENT_TIME(ts) => {
-                entry.fattr.atime = ts;
-            }
-        }
-
-        match setattr.mtime {
-            set_mtime::DONT_CHANGE => {}
-            set_mtime::SET_TO_SERVER_TIME => {
-                entry.fattr.mtime = FileEntry::ts_from_u64(now);
-                entry.fattr.ctime = FileEntry::ts_from_u64(now);
-            }
-            set_mtime::SET_TO_CLIENT_TIME(ts) => {
-                entry.fattr.mtime = ts;
-                entry.fattr.ctime = ts;
-            }
-        }
-
-        match setattr.uid {
-            set_uid3::Void => {}
-            set_uid3::uid(uid) => {
-                entry.fattr.uid = uid;
-                entry.fattr.ctime = FileEntry::ts_from_u64(now);
-            }
-        }
-
-        match setattr.gid {
-            set_gid3::Void => {}
-            set_gid3::gid(gid) => {
-                entry.fattr.gid = gid;
-                entry.fattr.ctime = FileEntry::ts_from_u64(now);
-            }
-        }
-
-        match setattr.mode {
-            set_mode3::Void => {}
-            set_mode3::mode(mode) => {
-                entry.fattr.mode = mode;
-                entry.fattr.ctime = FileEntry::ts_from_u64(now);
-            }
-        }
-
-        info!("fattr = {:?}", entry.fattr);
-
-        return Ok(entry.fattr);
-    }
-
-    #[instrument(skip(self), fields(id = fmt(id), offset, count))]
     async fn read(
-        &self, id: fileid3, offset: u64, count: u32,
+        &self, id: &Self::Handle, offset: u64, count: u32,
     ) -> Result<(Vec<u8>, bool), nfsstat3> {
         let offset = offset as usize;
         let count = count as usize;
@@ -262,190 +143,491 @@ impl NFSFileSystem for Drive {
         return Ok((doc[offset..offset + count].to_vec(), false));
     }
 
-    /// they will provide a start_after of 0 for no id
-    #[instrument(skip(self), fields(dirid = fmt(dirid), start_after, max_entries))]
     async fn readdir(
-        &self, dirid: fileid3, start_after: fileid3, max_entries: usize,
-    ) -> Result<ReadDirResult, nfsstat3> {
-        let data = self.data.lock().await;
-        let dirid = data.get(&dirid).unwrap().file.id;
-        let mut children = self.lb.get_children(&dirid).await.unwrap();
-
-        children.sort_by(|a, b| a.id.cmp(&b.id));
-
-        // this is how the example does it, we'd never return a fileid3 of 0
-        let mut start_index = 0;
-        if start_after > 0 {
-            for (idx, child) in children.iter().enumerate() {
-                if child.id.as_u64_pair().0 == start_after {
-                    start_index = idx + 1;
-                }
-            }
-        }
-
-        let mut ret = ReadDirResult::default();
-
-        if start_index >= children.len() {
-            ret.end = true;
-            info!("[] done");
-            return Ok(ret);
-        }
-
-        let end_index = if start_index + max_entries >= children.len() {
-            ret.end = true;
-            children.len()
-        } else {
-            start_index + max_entries
-        };
-
-        for child in &children[start_index..end_index] {
-            let fileid = child.id.as_u64_pair().0;
-            let name = nfsstring(child.name.clone().into_bytes());
-            let attr = data.get(&fileid).unwrap().fattr;
-
-            ret.entries.push(DirEntry { fileid, name, attr });
-        }
-
-        info!("|{}| done={}", ret.entries.len(), ret.end);
-
-        Ok(ret)
+        &self, dirid: &Self::Handle, cookie: u64,
+    ) -> Result<impl nfs3_server::vfs::ReadDirIterator, nfsstat3> {
+        Err::<Iterator, _>(nfsstat3::NFS3ERR_IO)
     }
 
-    /// Removes a file.
-    /// If not supported dur to readonly file system
-    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
-    #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
-    #[allow(unused)]
-    async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3> {
-        let mut data = self.data.lock().await;
-        let dirid = data.get(&dirid).unwrap().file.id;
-
-        let children = self.lb.get_children(&dirid).await.unwrap();
-        let file_name = String::from_utf8(filename.0.clone()).unwrap();
-
-        for child in children {
-            if file_name == child.name {
-                info!("deleted");
-                self.lb.delete(&child.id).await;
-                data.remove(&child.id.as_u64_pair().0);
-                return Ok(());
-            }
-        }
-
-        info!("NOENT");
-        return Err(nfsstat3::NFS3ERR_NOENT);
+    async fn readdirplus(
+        &self, dirid: &Self::Handle, cookie: u64,
+    ) -> Result<impl nfs3_server::vfs::ReadDirPlusIterator, nfsstat3> {
+        Err::<Iterator, _>(nfsstat3::NFS3ERR_IO)
     }
 
-    /// either an overwrite rename or move
-    #[instrument(skip(self), fields(from_dirid = fmt(from_dirid), from_filename = get_string(from_filename), to_dirid = fmt(to_dirid), to_filename = get_string(to_filename)))]
-    #[allow(unused)]
-    async fn rename(
-        &self, from_dirid: fileid3, from_filename: &filename3, to_dirid: fileid3,
-        to_filename: &filename3,
-    ) -> Result<(), nfsstat3> {
-        let mut data = self.data.lock().await;
+    async fn readlink(&self, id: &Self::Handle) -> Result<nfspath3<'_>, nfsstat3> {
+        todo!()
+    }
+    // #[instrument(skip(self))]
+    // fn root_dir(&self) -> fileid3 {
+    //     let root = self.root;
+    //     let half = root.as_u64_pair().0;
 
-        let from_filename = String::from_utf8(from_filename.0.clone()).unwrap();
-        let to_filename = String::from_utf8(to_filename.0.clone()).unwrap();
+    //     info!("ret={root}");
+    //     half
+    // }
 
-        let from_dirid = data.get(&from_dirid).unwrap().file.id;
-        let to_dirid = data.get(&to_dirid).unwrap().file.id;
+    // fn capabilities(&self) -> VFSCapabilities {
+    //     VFSCapabilities::ReadWrite
+    // }
 
-        let src_children = self.lb.get_children(&from_dirid).await.unwrap();
+    // #[instrument(skip(self), fields(id = fmt(id), buffer = buffer.len()))]
+    // async fn write(&self, id: fileid3, offset: u64, buffer: &[u8]) -> Result<fattr3, nfsstat3> {
+    //     let offset = offset as usize;
 
-        let mut from_id = None;
-        let mut to_id = None;
-        for child in src_children {
-            if child.name == from_filename {
-                from_id = Some(child.id);
-            }
+    //     let mut data = self.data.lock().await;
+    //     let entry = data.get_mut(&id).unwrap();
+    //     let id = entry.file.id;
 
-            if to_dirid == from_dirid && child.name == to_filename {
-                to_id = Some(child.id);
-            }
-        }
+    //     let mut doc = self.lb.read_document(id, false).await.unwrap();
+    //     let mut expanded = false;
+    //     if offset + buffer.len() > doc.len() {
+    //         doc.resize(offset + buffer.len(), 0);
+    //         doc[offset..].copy_from_slice(buffer);
+    //         expanded = true;
+    //     } else {
+    //         for (idx, datum) in buffer.iter().enumerate() {
+    //             doc[offset + idx] = *datum;
+    //         }
+    //     }
+    //     let doc_size = doc.len();
+    //     self.lb.write_document(id, &doc).await.unwrap();
 
-        if to_dirid != from_dirid {
-            let dst_children = self.lb.get_children(&to_dirid).await.unwrap();
-            for child in dst_children {
-                if child.name == to_filename {
-                    to_id = Some(child.id);
-                }
-            }
-        }
+    //     entry.fattr.size = doc_size as u64;
 
-        let from_id = from_id.unwrap();
+    //     info!("expanded={expanded}, fattr.size = {}", doc_size);
 
-        match to_id {
-            // we are overwriting a file
-            Some(id) => {
-                info!("overwrite {from_id} -> {id}");
-                let from_doc = self.lb.read_document(from_id, false).await.unwrap();
-                info!("|{}|", from_doc.len());
-                let doc_len = from_doc.len() as u64;
-                self.lb.write_document(id, &from_doc).await.unwrap();
-                self.lb.delete(&from_id).await.unwrap();
+    //     Ok(entry.fattr)
+    // }
 
-                let mut entry = data.get_mut(&id.as_u64_pair().0).unwrap();
-                entry.fattr.size = doc_len;
+    // // todo this should create a file regardless of whether it exists
+    // #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
+    // async fn create(
+    //     &self, dirid: fileid3, filename: &filename3, attr: sattr3,
+    // ) -> Result<(fileid3, fattr3), nfsstat3> {
+    //     let filename = get_string(filename);
+    //     let parent = self.data.lock().await.get(&dirid).unwrap().file.id;
+    //     let file = self
+    //         .lb
+    //         .create_file(&filename, &parent, FileType::Document)
+    //         .await
+    //         .unwrap();
 
-                data.remove(&from_id.as_u64_pair().0);
-            }
+    //     let entry = FileEntry::from_file(file, 0);
+    //     let id = entry.fattr.fileid;
+    //     self.data.lock().await.insert(entry.fattr.fileid, entry);
 
-            // we are doing a move and/or rename
-            None => {
-                if from_dirid != to_dirid {
-                    info!("move {} -> {}\t", from_id, to_dirid);
-                    self.lb.move_file(&from_id, &to_dirid).await.unwrap();
-                }
+    //     let file = self.setattr(id, attr).await.unwrap();
 
-                if from_filename != to_filename {
-                    info!("rename {} -> {}\t", from_id, to_filename);
-                    self.lb.rename_file(&from_id, &to_filename).await.unwrap();
-                }
+    //     info!("({}, size={})", fmt(file.fileid), file.size);
+    //     Ok((id, file))
+    // }
 
-                let mut entry = data.get_mut(&from_id.as_u64_pair().0).unwrap();
+    // #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
+    // async fn create_exclusive(
+    //     &self, dirid: fileid3, filename: &filename3,
+    // ) -> Result<fileid3, nfsstat3> {
+    //     let filename = get_string(filename);
+    //     let dirid = self.data.lock().await.get(&dirid).unwrap().file.id;
+    //     let children = self.lb.get_children(&dirid).await.unwrap();
+    //     for child in children {
+    //         if child.name == filename {
+    //             warn!("exists already");
+    //             return Err(nfsstat3::NFS3ERR_EXIST);
+    //         }
+    //     }
 
-                let file = self.lb.get_file_by_id(from_id).await.unwrap();
-                entry.file = file;
+    //     let file = self
+    //         .lb
+    //         .create_file(&filename, &dirid, FileType::Document)
+    //         .await
+    //         .unwrap();
 
-                info!("ok");
-            }
-        }
+    //     let entry = FileEntry::from_file(file, 0);
+    //     let id = entry.fattr.fileid;
+    //     info!("({}, size={})", fmt(id), entry.fattr.size);
+    //     self.data.lock().await.insert(entry.fattr.fileid, entry);
 
-        return Ok(());
+    //     return Ok(id);
+    // }
+
+    // #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
+    // async fn lookup(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3> {
+    //     let dir = self.data.lock().await.get(&dirid).unwrap().file.clone();
+
+    //     if dir.is_document() {
+    //         info!("NOTDIR");
+    //         return Err(nfsstat3::NFS3ERR_NOTDIR);
+    //     }
+
+    //     // if looking for dir/. its the current directory
+    //     if filename[..] == [b'.'] {
+    //         info!(". == {}", fmt(dirid));
+    //         return Ok(dirid);
+    //     }
+
+    //     // if looking for dir/.. its the parent directory
+    //     if filename[..] == [b'.', b'.'] {
+    //         info!(".. == {}", dir.parent);
+    //         return Ok(dir.parent.as_u64_pair().0);
+    //     }
+
+    //     let children = self.lb.get_children(&dir.id).await.unwrap();
+    //     let file_name = String::from_utf8(filename.0.clone()).unwrap();
+
+    //     for child in children {
+    //         if file_name == child.name {
+    //             info!("{}", child.id);
+    //             return Ok(child.id.as_u64_pair().0);
+    //         }
+    //     }
+
+    //     info!("NOENT");
+    //     Err(nfsstat3::NFS3ERR_NOENT)
+    // }
+
+    // #[instrument(skip(self), fields(id = fmt(id)))]
+    // async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
+    //     let file = self.data.lock().await.get(&id).unwrap().fattr;
+    //     info!("fattr = {:?}", file);
+    //     Ok(file)
+    // }
+
+    // #[instrument(skip(self), fields(id = fmt(id)))]
+    // async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
+    //     let mut data = self.data.lock().await;
+    //     let now = FileEntry::now();
+    //     let entry = data.get_mut(&id).unwrap();
+
+    //     match setattr.size {
+    //         set_size3::Void => {}
+    //         set_size3::size(new) => {
+    //             if entry.fattr.size != new {
+    //                 let mut doc = self.lb.read_document(entry.file.id, false).await.unwrap();
+    //                 doc.resize(new as usize, 0);
+    //                 self.lb.write_document(entry.file.id, &doc).await.unwrap();
+    //                 entry.fattr.mtime = FileEntry::ts_from_u64(now);
+    //                 entry.fattr.ctime = FileEntry::ts_from_u64(now);
+    //             }
+    //         }
+    //     }
+
+    //     match setattr.atime {
+    //         set_atime::DONT_CHANGE => {}
+    //         set_atime::SET_TO_SERVER_TIME => {
+    //             entry.fattr.atime = FileEntry::ts_from_u64(now);
+    //         }
+    //         set_atime::SET_TO_CLIENT_TIME(ts) => {
+    //             entry.fattr.atime = ts;
+    //         }
+    //     }
+
+    //     match setattr.mtime {
+    //         set_mtime::DONT_CHANGE => {}
+    //         set_mtime::SET_TO_SERVER_TIME => {
+    //             entry.fattr.mtime = FileEntry::ts_from_u64(now);
+    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
+    //         }
+    //         set_mtime::SET_TO_CLIENT_TIME(ts) => {
+    //             entry.fattr.mtime = ts;
+    //             entry.fattr.ctime = ts;
+    //         }
+    //     }
+
+    //     match setattr.uid {
+    //         set_uid3::Void => {}
+    //         set_uid3::uid(uid) => {
+    //             entry.fattr.uid = uid;
+    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
+    //         }
+    //     }
+
+    //     match setattr.gid {
+    //         set_gid3::Void => {}
+    //         set_gid3::gid(gid) => {
+    //             entry.fattr.gid = gid;
+    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
+    //         }
+    //     }
+
+    //     match setattr.mode {
+    //         set_mode3::Void => {}
+    //         set_mode3::mode(mode) => {
+    //             entry.fattr.mode = mode;
+    //             entry.fattr.ctime = FileEntry::ts_from_u64(now);
+    //         }
+    //     }
+
+    //     info!("fattr = {:?}", entry.fattr);
+
+    //     return Ok(entry.fattr);
+    // }
+
+    // #[instrument(skip(self), fields(id = fmt(id), offset, count))]
+    // async fn read(
+    //     &self, id: fileid3, offset: u64, count: u32,
+    // ) -> Result<(Vec<u8>, bool), nfsstat3> {
+    //     let offset = offset as usize;
+    //     let count = count as usize;
+    //     let id = self.data.lock().await.get(&id).unwrap().file.id;
+
+    //     let doc = self.lb.read_document(id, false).await.unwrap();
+
+    //     if offset >= doc.len() {
+    //         info!("[] EOF");
+    //         return Ok((vec![], true));
+    //     }
+
+    //     if offset + count >= doc.len() {
+    //         info!("|{}| EOF", doc[offset..].len());
+    //         return Ok((doc[offset..].to_vec(), true));
+    //     }
+
+    //     info!("|{}|", count);
+    //     return Ok((doc[offset..offset + count].to_vec(), false));
+    // }
+
+    // /// they will provide a start_after of 0 for no id
+    // #[instrument(skip(self), fields(dirid = fmt(dirid), start_after, max_entries))]
+    // async fn readdir(
+    //     &self, dirid: fileid3, start_after: fileid3, max_entries: usize,
+    // ) -> Result<ReadDirResult, nfsstat3> {
+    //     let data = self.data.lock().await;
+    //     let dirid = data.get(&dirid).unwrap().file.id;
+    //     let mut children = self.lb.get_children(&dirid).await.unwrap();
+
+    //     children.sort_by(|a, b| a.id.cmp(&b.id));
+
+    //     // this is how the example does it, we'd never return a fileid3 of 0
+    //     let mut start_index = 0;
+    //     if start_after > 0 {
+    //         for (idx, child) in children.iter().enumerate() {
+    //             if child.id.as_u64_pair().0 == start_after {
+    //                 start_index = idx + 1;
+    //             }
+    //         }
+    //     }
+
+    //     let mut ret = ReadDirResult::default();
+
+    //     if start_index >= children.len() {
+    //         ret.end = true;
+    //         info!("[] done");
+    //         return Ok(ret);
+    //     }
+
+    //     let end_index = if start_index + max_entries >= children.len() {
+    //         ret.end = true;
+    //         children.len()
+    //     } else {
+    //         start_index + max_entries
+    //     };
+
+    //     for child in &children[start_index..end_index] {
+    //         let fileid = child.id.as_u64_pair().0;
+    //         let name = nfsstring(child.name.clone().into_bytes());
+    //         let attr = data.get(&fileid).unwrap().fattr;
+
+    //         ret.entries.push(DirEntry { fileid, name, attr });
+    //     }
+
+    //     info!("|{}| done={}", ret.entries.len(), ret.end);
+
+    //     Ok(ret)
+    // }
+
+    // /// Removes a file.
+    // /// If not supported dur to readonly file system
+    // /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    // #[instrument(skip(self), fields(dirid = fmt(dirid), filename = get_string(filename)))]
+    // #[allow(unused)]
+    // async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3> {
+    //     let mut data = self.data.lock().await;
+    //     let dirid = data.get(&dirid).unwrap().file.id;
+
+    //     let children = self.lb.get_children(&dirid).await.unwrap();
+    //     let file_name = String::from_utf8(filename.0.clone()).unwrap();
+
+    //     for child in children {
+    //         if file_name == child.name {
+    //             info!("deleted");
+    //             self.lb.delete(&child.id).await;
+    //             data.remove(&child.id.as_u64_pair().0);
+    //             return Ok(());
+    //         }
+    //     }
+
+    //     info!("NOENT");
+    //     return Err(nfsstat3::NFS3ERR_NOENT);
+    // }
+
+    // /// either an overwrite rename or move
+    // #[instrument(skip(self), fields(from_dirid = fmt(from_dirid), from_filename = get_string(from_filename), to_dirid = fmt(to_dirid), to_filename = get_string(to_filename)))]
+    // #[allow(unused)]
+    // async fn rename(
+    //     &self, from_dirid: fileid3, from_filename: &filename3, to_dirid: fileid3,
+    //     to_filename: &filename3,
+    // ) -> Result<(), nfsstat3> {
+    //     let mut data = self.data.lock().await;
+
+    //     let from_filename = String::from_utf8(from_filename.0.clone()).unwrap();
+    //     let to_filename = String::from_utf8(to_filename.0.clone()).unwrap();
+
+    //     let from_dirid = data.get(&from_dirid).unwrap().file.id;
+    //     let to_dirid = data.get(&to_dirid).unwrap().file.id;
+
+    //     let src_children = self.lb.get_children(&from_dirid).await.unwrap();
+
+    //     let mut from_id = None;
+    //     let mut to_id = None;
+    //     for child in src_children {
+    //         if child.name == from_filename {
+    //             from_id = Some(child.id);
+    //         }
+
+    //         if to_dirid == from_dirid && child.name == to_filename {
+    //             to_id = Some(child.id);
+    //         }
+    //     }
+
+    //     if to_dirid != from_dirid {
+    //         let dst_children = self.lb.get_children(&to_dirid).await.unwrap();
+    //         for child in dst_children {
+    //             if child.name == to_filename {
+    //                 to_id = Some(child.id);
+    //             }
+    //         }
+    //     }
+
+    //     let from_id = from_id.unwrap();
+
+    //     match to_id {
+    //         // we are overwriting a file
+    //         Some(id) => {
+    //             info!("overwrite {from_id} -> {id}");
+    //             let from_doc = self.lb.read_document(from_id, false).await.unwrap();
+    //             info!("|{}|", from_doc.len());
+    //             let doc_len = from_doc.len() as u64;
+    //             self.lb.write_document(id, &from_doc).await.unwrap();
+    //             self.lb.delete(&from_id).await.unwrap();
+
+    //             let mut entry = data.get_mut(&id.as_u64_pair().0).unwrap();
+    //             entry.fattr.size = doc_len;
+
+    //             data.remove(&from_id.as_u64_pair().0);
+    //         }
+
+    //         // we are doing a move and/or rename
+    //         None => {
+    //             if from_dirid != to_dirid {
+    //                 info!("move {} -> {}\t", from_id, to_dirid);
+    //                 self.lb.move_file(&from_id, &to_dirid).await.unwrap();
+    //             }
+
+    //             if from_filename != to_filename {
+    //                 info!("rename {} -> {}\t", from_id, to_filename);
+    //                 self.lb.rename_file(&from_id, &to_filename).await.unwrap();
+    //             }
+
+    //             let mut entry = data.get_mut(&from_id.as_u64_pair().0).unwrap();
+
+    //             let file = self.lb.get_file_by_id(from_id).await.unwrap();
+    //             entry.file = file;
+
+    //             info!("ok");
+    //         }
+    //     }
+
+    //     return Ok(());
+    // }
+
+    // #[instrument(skip(self), fields(dirid = fmt(dirid), dirname = get_string(dirname)))]
+    // #[allow(unused)]
+    // async fn mkdir(
+    //     &self, dirid: fileid3, dirname: &filename3,
+    // ) -> Result<(fileid3, fattr3), nfsstat3> {
+    //     let filename = get_string(dirname);
+    //     let parent = self.data.lock().await.get(&dirid).unwrap().file.id;
+    //     let file = self
+    //         .lb
+    //         .create_file(&filename, &parent, FileType::Folder)
+    //         .await
+    //         .unwrap();
+
+    //     let entry = FileEntry::from_file(file, 0);
+    //     let id = entry.fattr.fileid;
+    //     let fattr = entry.fattr;
+    //     self.data.lock().await.insert(entry.fattr.fileid, entry);
+
+    //     info!("({}, fattr={:?})", fmt(id), fattr);
+    //     Ok((id, fattr))
+    // }
+
+    // async fn symlink(
+    //     &self, _dirid: fileid3, _linkname: &filename3, _symlink: &nfspath3, _attr: &sattr3,
+    // ) -> Result<(fileid3, fattr3), nfsstat3> {
+    //     info!("symlink NOTSUPP");
+    //     return Err(nfsstat3::NFS3ERR_NOTSUPP);
+    // }
+    // async fn readlink(&self, _id: fileid3) -> Result<nfspath3, nfsstat3> {
+    //     info!("readklink NOTSUPP");
+    //     return Err(nfsstat3::NFS3ERR_NOTSUPP);
+    // }
+}
+
+impl NfsFileSystem for Drive {
+    async fn setattr(&self, id: &Self::Handle, setattr: sattr3) -> Result<fattr3, nfsstat3> {
+        todo!()
     }
 
-    #[instrument(skip(self), fields(dirid = fmt(dirid), dirname = get_string(dirname)))]
-    #[allow(unused)]
+    async fn write(&self, id: &Self::Handle, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+        todo!()
+    }
+
+    async fn create(
+        &self, dirid: &Self::Handle, filename: &filename3<'_>, attr: sattr3,
+    ) -> Result<(Self::Handle, fattr3), nfsstat3> {
+        todo!()
+    }
+
+    async fn create_exclusive(
+        &self, dirid: &Self::Handle, filename: &filename3<'_>,
+        createverf: nfs3_server::nfs3_types::nfs3::createverf3,
+    ) -> Result<Self::Handle, nfsstat3> {
+        todo!()
+    }
+
     async fn mkdir(
-        &self, dirid: fileid3, dirname: &filename3,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
-        let filename = get_string(dirname);
-        let parent = self.data.lock().await.get(&dirid).unwrap().file.id;
-        let file = self
-            .lb
-            .create_file(&filename, &parent, FileType::Folder)
-            .await
-            .unwrap();
-
-        let entry = FileEntry::from_file(file, 0);
-        let id = entry.fattr.fileid;
-        let fattr = entry.fattr;
-        self.data.lock().await.insert(entry.fattr.fileid, entry);
-
-        info!("({}, fattr={:?})", fmt(id), fattr);
-        Ok((id, fattr))
+        &self, dirid: &Self::Handle, dirname: &filename3<'_>,
+    ) -> Result<(Self::Handle, fattr3), nfsstat3> {
+        todo!()
     }
 
-    async fn symlink(
-        &self, _dirid: fileid3, _linkname: &filename3, _symlink: &nfspath3, _attr: &sattr3,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
-        info!("symlink NOTSUPP");
-        return Err(nfsstat3::NFS3ERR_NOTSUPP);
+    async fn remove(&self, dirid: &Self::Handle, filename: &filename3<'_>) -> Result<(), nfsstat3> {
+        todo!()
     }
-    async fn readlink(&self, _id: fileid3) -> Result<nfspath3, nfsstat3> {
-        info!("readklink NOTSUPP");
-        return Err(nfsstat3::NFS3ERR_NOTSUPP);
+
+    async fn rename<'a>(
+        &self, from_dirid: &Self::Handle, from_filename: &filename3<'a>, to_dirid: &Self::Handle,
+        to_filename: &filename3<'a>,
+    ) -> Result<(), nfsstat3> {
+        todo!()
+    }
+
+    async fn symlink<'a>(
+        &self, dirid: &Self::Handle, linkname: &filename3<'a>, symlink: &nfspath3<'a>,
+        attr: &sattr3,
+    ) -> Result<(Self::Handle, fattr3), nfsstat3> {
+        todo!()
+    }
+}
+
+pub struct Iterator {}
+
+impl ReadDirPlusIterator for Iterator {
+    async fn next(
+        &mut self,
+    ) -> nfs3_server::vfs::NextResult<nfs3_server::vfs::entryplus3<'static>> {
+        todo!()
     }
 }

--- a/libs/lb-fs/src/lib.rs
+++ b/libs/lb-fs/src/lib.rs
@@ -4,7 +4,7 @@ use cli_rs::cli_error::{CliError, CliResult};
 use lb_rs::model::core_config::Config;
 use lb_rs::service::sync::SyncProgress;
 use lb_rs::{Lb, Uuid};
-use nfsserve::tcp::{NFSTcp, NFSTcpListener};
+use nfs3_server::tcp::{NFSTcp, NFSTcpListener};
 use std::io;
 use std::io::IsTerminal;
 use std::process::exit;

--- a/libs/lb-fs/src/utils.rs
+++ b/libs/lb-fs/src/utils.rs
@@ -1,14 +1,5 @@
-use lb_rs::Uuid;
-use nfsserve::nfs::filename3;
-
-pub fn chop(u: Uuid) -> u64 {
-    u.as_u64_pair().0
-}
-
-pub fn fmt(id: u64) -> String {
-    Uuid::from_u64_pair(id, 0).to_string()
-}
+use nfs3_server::nfs3_types::nfs3::filename3;
 
 pub fn get_string(f: &filename3) -> String {
-    String::from_utf8(f.0.clone()).unwrap()
+    String::from_utf8(f.as_ref().to_vec()).expect("Invalid UTF-8")
 }


### PR DESCRIPTION
As discussed in issue #3591, this PR replaces `nfsserve` with `nfs3_server` crate

One notable improvement is that `nfs_fh3` now includes the full UUID for both directories and files. This means there's no longer a need to track separate fileids, and this might be used for potential optimizations down the line. Feel free to explore that further if it’s useful!

Regarding Rust editions, I think you don't need to upgrade `lockbook` crate since `lb-fs` doesn't leak any new types from 2024 edition.

@Parth – I'd really appreciate your help testing this out. Just want to make sure nothing breaks :)

