### PR TITLE
editor: fix stuck cursor

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/galleys.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/galleys.rs
@@ -40,7 +40,7 @@ impl Galleys {
     }
 
     pub fn galley_at_offset(&self, offset: DocCharOffset) -> usize {
-        for i in 0..self.galleys.len() {
+        for i in (0..self.galleys.len()).rev() {
             let galley = &self.galleys[i];
             if galley.range.contains_inclusive(offset) {
                 return i;

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -176,7 +176,7 @@ impl Editor {
         let galley = &self.galleys[galley_idx];
         let x = cursor_to_pos_abs(galley, cursor).x;
         let y_range = galley.rect.y_range();
-        return [Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }];
+        [Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }]
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -172,21 +172,11 @@ impl Editor {
     }
 
     pub fn cursor_line(&self, offset: DocCharOffset) -> [Pos2; 2] {
-        for galley_info in self.galleys.galleys.iter().rev() {
-            let GalleyInfo { range, galley, rect, .. } = galley_info;
-            if range.contains_inclusive(offset) {
-                let cursor = galley.from_ccursor(CCursor {
-                    index: (offset - range.start()).0,
-                    prefer_next_row: true,
-                });
-                let x = cursor_to_pos_abs(galley_info, cursor).x;
-                let y_range = rect.y_range();
-                return [Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }];
-            }
-        }
-
-        // todo: better error handling
-        Default::default()
+        let (galley_idx, cursor) = self.galleys.galley_and_cursor_by_offset(offset);
+        let galley = &self.galleys[galley_idx];
+        let x = cursor_to_pos_abs(galley, cursor).x;
+        let y_range = galley.rect.y_range();
+        return [Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }];
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/3682

The logic for rendering the cursor and for deciding where it is for the purposes of arrow key navigation were out-of-sync. This PR makes the cursor rendering logic depend on the same logic as arrow key navigation and fixes arrow key navigation by updating it to match the previous cursor rendering logic i.e. preferring a later galley when at a boundary between galleys. This matters when there are two galleys that contain the cursor location and those galleys would render that cursor location in different places, which to my knowledge only happens when text wraps.