### PR TITLE
nfs3: preload fattr3 in readdirplus

### DIFF
--- a/libs/lb-fs/src/cache.rs
+++ b/libs/lb-fs/src/cache.rs
@@ -1,4 +1,4 @@
-use crate::fs_impl::Drive;
+use crate::{fs_impl::Drive, utils::file_id};
 use lb_rs::model::file::File;
 use lb_rs::model::work_unit::WorkUnit;
 use nfs3_server::nfs3_types::nfs3::{fattr3, ftype3, nfstime3};
@@ -17,7 +17,7 @@ impl FileEntry {
         // todo this deserves some scrutiny and cross platform testing
         let mode = if file.is_folder() { 0o755 } else { 0o644 };
 
-        let fileid = file.id.as_u64_pair().0;
+        let fileid = file_id(&file);
         // intereREADDIR3resstingly a number of key read operations rely on this being correct
         let size = if file.is_folder() { 0 } else { size };
 

--- a/libs/lb-fs/src/fs_impl.rs
+++ b/libs/lb-fs/src/fs_impl.rs
@@ -41,7 +41,7 @@ impl Drive {
     ///
     /// The cookie corresponds to the file ID of the last entry returned by a previous `readdir` or
     /// `readdirplus` call.
-    /// A cookie value of `0` indicates that iteration should begin from the start of the 
+    /// A cookie value of `0` indicates that iteration should begin from the start of the
     /// directory.
     ///
     /// Note: The file ID used as a cookie represents half of the file’s UUID.

--- a/libs/lb-fs/src/utils.rs
+++ b/libs/lb-fs/src/utils.rs
@@ -1,5 +1,11 @@
+use lb_rs::model::file::File;
 use nfs3_server::nfs3_types::nfs3::filename3;
 
 pub fn get_string(f: &filename3) -> String {
     String::from_utf8(f.as_ref().to_vec()).expect("Invalid UTF-8")
+}
+
+/// Should be the same as `UuidFileHandle::fileid`.
+pub fn file_id(f: &File) -> u64 {
+    f.id.as_u64_pair().0
 }


### PR DESCRIPTION
In the initial implementation, the iterator locks the `data` mutex on every call to `next`, which is inefficient for such a hot path.

To address this, the iterator has been split into two distinct variants:
- readdir version: works without `fattr3`
- readdirplus version: preloads `fattr3` at construction time to avoid locking during iteration.

I also got rid of manual iteration, and switched to Iterator trait instead.