### PR TITLE
linux: don't crash when opening a broken url

### DIFF
--- a/clients/linux/src/output/open_url.rs
+++ b/clients/linux/src/output/open_url.rs
@@ -2,6 +2,6 @@ use egui::output::OpenUrl;
 
 pub fn handle(open_url: Option<OpenUrl>) {
     if let Some(open_url) = open_url {
-        open::that(open_url.url).unwrap();
+        let _ = open::that(open_url.url);
     }
 }


### PR DESCRIPTION
fixes an issue raised in [support](https://discord.com/channels/1014184997751619664/1405884030934716458/1405884030934716458)