### PR TITLE
editor: show images above paragraph lines containing them

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
@@ -63,17 +63,19 @@ impl<'ast> Editor {
     }
 
     pub fn show_paragraph(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2) {
-        for descendant in node.descendants() {
-            if let NodeValue::Image(NodeLink { url, .. }) = &descendant.data.borrow().value {
-                self.show_image_block(ui, node, top_left, url);
-                top_left.y += self.height_image(node, url);
-                top_left.y += BLOCK_SPACING;
-            }
-        }
-
         for line in self.node_lines(node).iter() {
             let line = self.bounds.source_lines[line];
             let node_line = self.node_line(node, line);
+
+            for descendant in node.descendants() {
+                if let NodeValue::Image(NodeLink { url, .. }) = &descendant.data.borrow().value {
+                    if !self.node_range(descendant).trim(&node_line).is_empty() {
+                        self.show_image_block(ui, node, top_left, url);
+                        top_left.y += self.height_image(node, url);
+                        top_left.y += BLOCK_SPACING;
+                    }
+                }
+            }
 
             let line_height = self.height_paragraph_line(node, node_line);
 


### PR DESCRIPTION
<img width="1412" height="940" alt="Screenshot 2025-08-20 at 2 46 46 PM" src="https://github.com/user-attachments/assets/66eee56c-d4f3-488f-b35d-15bcc874c0bf" />
