### PR TITLE
editor: show image error messages

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -122,9 +122,9 @@ impl<'ast> Editor {
                         });
                     });
                 }
-                ImageState::Failed(_) => {
+                ImageState::Failed(message) => {
                     let icon = "\u{f116}";
-                    let caption = "Could not show image";
+                    let caption = format!("Could not show image: {message}");
 
                     let size = self.image_size(Vec2::splat(200.), width);
                     let rect = Rect::from_min_size(top_left, Vec2::new(width, size.y));


### PR DESCRIPTION
<img width="1140" height="755" alt="Screenshot 2025-08-20 at 2 50 46 PM" src="https://github.com/user-attachments/assets/cdefad41-7dae-417d-ab09-68e8d14098fa" />
