### PR TITLE
editor: layout fixes

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
@@ -40,6 +40,15 @@ impl<'ast> Editor {
             range.1 = range.1.min(parent_range.1);
         }
 
+        // hack: "A line break (not in a code span or HTML tag) that is preceded
+        // by two or more spaces and does not occur at the end of a block is
+        // parsed as a hard line break" but we prefer to show the spaces since
+        // we render soft breaks as hard breaks (which is up to our discretion).
+        // https://github.github.com/gfm/#hard-line-breaks
+        if let NodeValue::LineBreak = node.data.borrow().value {
+            range.0 = range.1 - 1; // include only the newline
+        }
+
         // hack: GFM spec says "Blank lines preceding or following an indented
         // code block are not included in it" and I have observed the behavior
         // for following lines to be incorrect in e.g. "    f\n".

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/text_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/text_layout.rs
@@ -146,6 +146,7 @@ impl Editor {
         if let Some(first_section) = layout_job.sections.first_mut() {
             first_section.leading_space = wrap.row_offset();
         }
+        layout_job.round_output_size_to_nearest_ui_point = false;
 
         let galley = ui.fonts(|fonts| fonts.layout_job(layout_job));
         let galley_info = GalleyInfo { range, galley, rect: Rect::ZERO, padded: false }; // used for wrap line calculation


### PR DESCRIPTION
* fixes layout of newlines immediately following two+ spaces
* fixes lines that ended within half a pixel of the end of a line creating an unnecessary extra row