### PR TITLE
editor: performance fixes

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -242,8 +242,6 @@ impl Editor {
     }
 
     pub fn show(&mut self, ui: &mut Ui) -> Response {
-        println!("---------- frame ----------");
-
         let resp = mem::take(&mut self.next_resp);
 
         self.height = ui.available_size().y;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -74,11 +74,12 @@ impl<'ast> Editor {
 
     // the height of a block that contains blocks is the sum of the heights of the blocks it contains
     pub fn block_children_height(&self, node: &'ast AstNode<'ast>) -> f32 {
+        let children: Vec<_> = node.children().collect(); // note: does not need to be sorted for height
         let mut height_sum = 0.0;
-        for child in node.children() {
-            height_sum += self.block_pre_spacing_height(child);
+        for child in &children {
+            height_sum += self.block_pre_spacing_height(child, &children);
             height_sum += self.height(child);
-            height_sum += self.block_post_spacing_height(child);
+            height_sum += self.block_post_spacing_height(child, &children);
         }
         height_sum
     }
@@ -90,10 +91,10 @@ impl<'ast> Editor {
         let mut children: Vec<_> = node.children().collect();
         children.sort_by_key(|c| c.data.borrow().sourcepos);
 
-        for child in children {
+        for child in &children {
             // add pre-spacing
-            let pre_spacing = self.block_pre_spacing_height(child);
-            self.show_block_pre_spacing(ui, child, top_left);
+            let pre_spacing = self.block_pre_spacing_height(child, &children);
+            self.show_block_pre_spacing(ui, child, top_left, &children);
             top_left.y += pre_spacing;
 
             // add block
@@ -118,8 +119,8 @@ impl<'ast> Editor {
             top_left.y += child_height;
 
             // add post-spacing
-            let post_spacing = self.block_post_spacing_height(child);
-            self.show_block_post_spacing(ui, child, top_left);
+            let post_spacing = self.block_post_spacing_height(child, &children);
+            self.show_block_post_spacing(ui, child, top_left, &children);
             top_left.y += post_spacing;
         }
     }
@@ -539,15 +540,15 @@ impl<'ast> Editor {
         let mut children: Vec<_> = node.children().collect();
         children.sort_by_key(|c| c.data.borrow().sourcepos);
 
-        for child in children {
+        for child in &children {
             // add pre-spacing bounds
-            self.compute_bounds_block_pre_spacing(child);
+            self.compute_bounds_block_pre_spacing(child, &children);
 
             // add block bounds
             self.compute_bounds(child);
 
             // add post-spacing bounds
-            self.compute_bounds_block_post_spacing(child);
+            self.compute_bounds_block_post_spacing(child, &children);
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -5,7 +5,7 @@ use lb_rs::model::text::offset_types::{
 };
 
 use crate::tab::markdown_editor::Editor;
-use crate::tab::markdown_editor::widget::INDENT;
+use crate::tab::markdown_editor::widget::{INDENT, MARGIN};
 
 pub(crate) mod alert;
 pub(crate) mod block_quote;
@@ -115,7 +115,11 @@ impl<'ast> Editor {
                 }
             }
 
-            self.show_block(ui, child, top_left);
+            let visible =
+                2. * MARGIN <= top_left.y + child_height && 2. * MARGIN + self.height >= top_left.y;
+            if visible {
+                self.show_block(ui, child, top_left);
+            }
             top_left.y += child_height;
 
             // add post-spacing

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -94,7 +94,15 @@ impl<'ast> Editor {
         for child in &children {
             // add pre-spacing
             let pre_spacing = self.block_pre_spacing_height(child, &children);
-            self.show_block_pre_spacing(ui, child, top_left, &children);
+            let pre_spacing_above_viewport = 2. * MARGIN > top_left.y + pre_spacing;
+            let pre_spacing_below_viewport = 2. * MARGIN + self.height < top_left.y;
+            let pre_spacing_visible = !pre_spacing_above_viewport && !pre_spacing_below_viewport;
+            if pre_spacing_visible {
+                self.show_block_pre_spacing(ui, child, top_left, &children);
+            }
+            if pre_spacing_below_viewport {
+                break;
+            }
             top_left.y += pre_spacing;
 
             // add block
@@ -115,16 +123,28 @@ impl<'ast> Editor {
                 }
             }
 
-            let visible =
-                2. * MARGIN <= top_left.y + child_height && 2. * MARGIN + self.height >= top_left.y;
-            if visible {
+            let block_above_viewport = 2. * MARGIN > top_left.y + child_height;
+            let block_below_viewport = 2. * MARGIN + self.height < top_left.y;
+            let block_visible = !block_above_viewport && !block_below_viewport;
+            if block_visible {
                 self.show_block(ui, child, top_left);
+            }
+            if block_below_viewport {
+                break;
             }
             top_left.y += child_height;
 
             // add post-spacing
             let post_spacing = self.block_post_spacing_height(child, &children);
-            self.show_block_post_spacing(ui, child, top_left, &children);
+            let post_spacing_above_viewport = 2. * MARGIN > top_left.y + post_spacing;
+            let post_spacing_below_viewport = 2. * MARGIN + self.height < top_left.y;
+            let post_spacing_visible = !post_spacing_above_viewport && !post_spacing_below_viewport;
+            if post_spacing_visible {
+                self.show_block_post_spacing(ui, child, top_left, &children);
+            }
+            if post_spacing_below_viewport {
+                break;
+            }
             top_left.y += post_spacing;
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table_row.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table_row.rs
@@ -98,7 +98,7 @@ impl<'ast> Editor {
             // draw cell contents
             let mut child_top_left = top_left;
             for table_cell in node.children() {
-                self.show_block(ui, table_cell, child_top_left);
+                self.show_table_cell(ui, table_cell, child_top_left);
                 child_top_left.x += child_width;
             }
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -275,7 +275,7 @@ impl<'ast> Editor {
 
     /// Returns the children of the given node in sourcepos order.
     pub fn sorted_children(&self, node: &'ast AstNode<'ast>) -> Vec<&'ast AstNode<'ast>> {
-        let mut children = Vec::new();
+        let mut children = Vec::with_capacity(node.children().count());
         children.extend(node.children());
         children.sort_by_key(|c| c.data.borrow().sourcepos);
         children

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
@@ -21,7 +21,7 @@ impl<'ast> Editor {
 
         let mut result = 0.;
 
-        let sibling_index = self.sibling_index(node, &siblings);
+        let sibling_index = self.sibling_index(node, siblings);
         let is_first_sibling = sibling_index == 0;
 
         let spacing_first_line = if is_first_sibling {
@@ -73,7 +73,7 @@ impl<'ast> Editor {
         }
         let width = self.width(node);
 
-        let sibling_index = self.sibling_index(node, &siblings);
+        let sibling_index = self.sibling_index(node, siblings);
         let is_first_sibling = sibling_index == 0;
         let spacing_first_line = if is_first_sibling {
             // parent top -> (empty row -> spacing)* -> first sibling top
@@ -129,7 +129,7 @@ impl<'ast> Editor {
 
         let mut result = 0.;
 
-        let sibling_index = self.sibling_index(node, &siblings);
+        let sibling_index = self.sibling_index(node, siblings);
         let is_last_sibling = sibling_index == siblings.len() - 1;
         let node_last_line = self.node_last_line_idx(node);
         if !is_last_sibling {
@@ -169,7 +169,7 @@ impl<'ast> Editor {
         }
         let width = self.width(node);
 
-        let sibling_index = self.sibling_index(node, &siblings);
+        let sibling_index = self.sibling_index(node, siblings);
         let is_last_sibling = sibling_index == siblings.len() - 1;
         let node_last_line = self.node_last_line_idx(node);
         if !is_last_sibling {
@@ -211,7 +211,7 @@ impl<'ast> Editor {
             return;
         }
 
-        let sibling_index = self.sibling_index(node, &siblings);
+        let sibling_index = self.sibling_index(node, siblings);
         let is_first_sibling = sibling_index == 0;
 
         let spacing_first_line = if is_first_sibling {
@@ -252,7 +252,7 @@ impl<'ast> Editor {
             return;
         }
 
-        let sibling_index = self.sibling_index(node, &siblings);
+        let sibling_index = self.sibling_index(node, siblings);
         let is_last_sibling = sibling_index == siblings.len() - 1;
         let node_last_line = self.node_last_line_idx(node);
         if !is_last_sibling {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
@@ -6,7 +6,9 @@ use crate::tab::markdown_editor::widget::BLOCK_SPACING;
 use crate::tab::markdown_editor::widget::utils::text_layout::Wrap;
 
 impl<'ast> Editor {
-    pub fn block_pre_spacing_height(&self, node: &'ast AstNode<'ast>) -> f32 {
+    pub fn block_pre_spacing_height(
+        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
+    ) -> f32 {
         let Some(parent) = node.parent() else {
             // document never spaced
             return 0.;
@@ -19,7 +21,6 @@ impl<'ast> Editor {
 
         let mut result = 0.;
 
-        let siblings = self.sorted_siblings(node);
         let sibling_index = self.sibling_index(node, &siblings);
         let is_first_sibling = sibling_index == 0;
 
@@ -60,6 +61,7 @@ impl<'ast> Editor {
 
     pub fn show_block_pre_spacing(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
+        siblings: &[&'ast AstNode<'ast>],
     ) {
         let Some(parent) = node.parent() else {
             // document never spaced
@@ -71,7 +73,6 @@ impl<'ast> Editor {
         }
         let width = self.width(node);
 
-        let siblings = self.sorted_siblings(node);
         let sibling_index = self.sibling_index(node, &siblings);
         let is_first_sibling = sibling_index == 0;
         let spacing_first_line = if is_first_sibling {
@@ -113,7 +114,9 @@ impl<'ast> Editor {
         }
     }
 
-    pub(crate) fn block_post_spacing_height(&self, node: &'ast AstNode<'ast>) -> f32 {
+    pub(crate) fn block_post_spacing_height(
+        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
+    ) -> f32 {
         let Some(parent) = node.parent() else {
             // document never spaced
             return 0.;
@@ -126,7 +129,6 @@ impl<'ast> Editor {
 
         let mut result = 0.;
 
-        let siblings = self.sorted_siblings(node);
         let sibling_index = self.sibling_index(node, &siblings);
         let is_last_sibling = sibling_index == siblings.len() - 1;
         let node_last_line = self.node_last_line_idx(node);
@@ -155,6 +157,7 @@ impl<'ast> Editor {
 
     pub(crate) fn show_block_post_spacing(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
+        siblings: &[&'ast AstNode<'ast>],
     ) {
         let Some(parent) = node.parent() else {
             // document never spaced
@@ -166,7 +169,6 @@ impl<'ast> Editor {
         }
         let width = self.width(node);
 
-        let siblings = self.sorted_siblings(node);
         let sibling_index = self.sibling_index(node, &siblings);
         let is_last_sibling = sibling_index == siblings.len() - 1;
         let node_last_line = self.node_last_line_idx(node);
@@ -197,7 +199,9 @@ impl<'ast> Editor {
         }
     }
 
-    pub fn compute_bounds_block_pre_spacing(&mut self, node: &'ast AstNode<'ast>) {
+    pub fn compute_bounds_block_pre_spacing(
+        &mut self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
+    ) {
         let Some(parent) = node.parent() else {
             // document never spaced
             return;
@@ -207,7 +211,6 @@ impl<'ast> Editor {
             return;
         }
 
-        let siblings = self.sorted_siblings(node);
         let sibling_index = self.sibling_index(node, &siblings);
         let is_first_sibling = sibling_index == 0;
 
@@ -237,7 +240,9 @@ impl<'ast> Editor {
         }
     }
 
-    pub(crate) fn compute_bounds_block_post_spacing(&mut self, node: &'ast AstNode<'ast>) {
+    pub(crate) fn compute_bounds_block_post_spacing(
+        &mut self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
+    ) {
         let Some(parent) = node.parent() else {
             // document never spaced
             return;
@@ -247,7 +252,6 @@ impl<'ast> Editor {
             return;
         }
 
-        let siblings = self.sorted_siblings(node);
         let sibling_index = self.sibling_index(node, &siblings);
         let is_last_sibling = sibling_index == siblings.len() - 1;
         let node_last_line = self.node_last_line_idx(node);


### PR DESCRIPTION
This raises the max fps from ~5 to 90 for a 750kb document of headings, paragraphs, lists, and code blocks on my M3 Max (and from ~1 to 60 on my iPhone 13 Pro). It reduces significant waste by re-using results of expensive calls or eliminating them entirely. It also only shows blocks that are visible in the viewport.

https://github.com/user-attachments/assets/10cfb987-79d4-445e-ab4c-ae8ae4b72ecd

