### PR TITLE
ws: better tab shortcuts

### DIFF
--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -746,14 +746,12 @@ impl Workspace {
                 } else {
                     0
                 }
+            } else if input.consume_key_exact(CTRL | SHIFT, Key::PageUp) {
+                1
+            } else if input.consume_key_exact(CTRL | SHIFT, Key::PageDown) {
+                -1
             } else {
-                if input.consume_key_exact(CTRL | SHIFT, Key::PageUp) {
-                    1
-                } else if input.consume_key_exact(CTRL | SHIFT, Key::PageDown) {
-                    -1
-                } else {
-                    0
-                }
+                0
             }
         });
 


### PR DESCRIPTION
as requested by @steverusso this is a tweak & a new feature.

- on non apple devices, you can now jump to a tab via alt + tab number (in addition to control + number)
- you can now also re-order tabs via the keyboard. on apple the shortcut is <kbd>cmd</kbd> <kbd>ctrl</kbd> <kbd>shift</kbd> <kbd>[</kbd>or<kbd>]</kbd>. on linux the shortcut is <kbd>ctrl</kbd> <kbd>shift</kbd> <kbd>page up</kbd> or<kbd>page down</kbd>.
