### PR TITLE
editor: layout fixes

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -414,7 +414,13 @@ impl Editor {
             );
         }
         let prior_selection = self.buffer.current.selection;
-        if !self.initialized || self.process_events(ui.ctx(), root) {
+        let images_updated = {
+            let mut images_updated = self.images.updated.lock().unwrap();
+            let result = *images_updated;
+            *images_updated = false;
+            result
+        };
+        if !self.initialized || self.process_events(ui.ctx(), root) || images_updated {
             self.next_resp.text_updated = true;
 
             // need to re-parse ast to compute bounds which are referenced by mobile virtual keyboard between frames

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/cache.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/cache.rs
@@ -14,6 +14,7 @@ use std::thread;
 #[derive(Clone, Default)]
 pub struct ImageCache {
     pub map: HashMap<String, Arc<Mutex<ImageState>>>,
+    pub updated: Arc<Mutex<bool>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -48,6 +49,7 @@ pub fn calc<'ast>(
                 let client = client.clone();
                 let core = core.clone();
                 let ctx = ui.ctx().clone();
+                let updated = result.updated.clone();
 
                 result.map.insert(url.clone(), image_state.clone());
 
@@ -137,6 +139,8 @@ pub fn calc<'ast>(
                             *image_state.lock().unwrap() = ImageState::Failed(err);
                         }
                     }
+
+                    *updated.lock().unwrap() = true;
 
                     // request a frame when the image is done loading
                     ctx.request_repaint();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/text_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/text_layout.rs
@@ -281,6 +281,7 @@ impl Editor {
         if let Some(first_section) = layout_job.sections.first_mut() {
             first_section.leading_space = tmp_wrap.row_offset();
         }
+        layout_job.round_output_size_to_nearest_ui_point = false;
 
         let galley = self.ctx.fonts(|fonts| fonts.layout_job(layout_job));
         for row in &galley.rows {


### PR DESCRIPTION
fixes an issue where text was wrapping without creating enough space for the next row when the row ended within half a pixel of the right side

<details>
<img width="1140" height="1397" alt="Screenshot 2025-09-03 at 1 29 14 PM" src="https://github.com/user-attachments/assets/b1dec2b8-06b6-4a2a-9c6f-ba3b00013d72" />
</details>

fixes an issue where images were only creating enough space for the loading placeholder even after loading

<details>
<img width="1140" height="1397" alt="Screenshot 2025-09-03 at 1 28 52 PM" src="https://github.com/user-attachments/assets/deaba029-0168-423a-b6f6-554b38666c9f" />
</details>
