### PR TITLE
apple: fix macOS progress spinner color

### DIFF
--- a/clients/apple/Shared/Widgets/SyncButton.swift
+++ b/clients/apple/Shared/Widgets/SyncButton.swift
@@ -26,7 +26,7 @@ struct SyncButton: View {
                         .padding(.trailing, 1)
                         .modifier(SyncButtonProgressBarSize())
                         .tint(.white)
-                        // hack to get light mode version of progress spinner on macOS
+                        // hack to get the dark mode version of progress spinner on macOS
                         .colorScheme(.dark)
                         
                 }).padding(.vertical, 5)

--- a/clients/apple/Shared/Widgets/SyncButton.swift
+++ b/clients/apple/Shared/Widgets/SyncButton.swift
@@ -26,6 +26,8 @@ struct SyncButton: View {
                         .padding(.trailing, 1)
                         .modifier(SyncButtonProgressBarSize())
                         .tint(.white)
+                        // hack to get light mode version of progress spinner on macOS
+                        .colorScheme(.dark)
                         
                 }).padding(.vertical, 5)
             } else {


### PR DESCRIPTION
When syncing, the SyncButton shows a spinner. That spinner was hard to see since it was black, I made it white.