### PR TITLE
editor: fix opening iOS context menu after autocorrected word

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -462,9 +462,7 @@ pub unsafe extern "C" fn is_position_at_bound(
     let text_position = pos.pos.into();
     let at_boundary = granularity.into();
 
-    markdown
-        .bounds
-        .is_position_at_boundary(text_position, at_boundary, backwards)
+    markdown.is_position_at_boundary(text_position, at_boundary, backwards)
 }
 
 /// # Safety
@@ -484,9 +482,7 @@ pub unsafe extern "C" fn is_position_within_bound(
     let text_position = pos.pos.into();
     let at_boundary = granularity.into();
 
-    markdown
-        .bounds
-        .is_position_within_text_unit(text_position, at_boundary, backwards)
+    markdown.is_position_within_text_unit(text_position, at_boundary, backwards)
 }
 
 /// # Safety
@@ -507,7 +503,6 @@ pub unsafe extern "C" fn bound_from_position(
     let to_boundary = granularity.into();
 
     markdown
-        .bounds
         .position_from(text_position, to_boundary, backwards)
         .into()
 }
@@ -529,10 +524,7 @@ pub unsafe extern "C" fn bound_at_position(
     let text_position = pos.pos.into();
     let with_granularity = granularity.into();
 
-    let result =
-        markdown
-            .bounds
-            .range_enclosing_position(text_position, with_granularity, backwards);
+    let result = markdown.range_enclosing_position(text_position, with_granularity, backwards);
 
     result.into()
 }

--- a/libs/content/workspace/src/tab/markdown_editor/output/ui_text_input_tokenizer.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/output/ui_text_input_tokenizer.rs
@@ -1,4 +1,5 @@
-use crate::tab::markdown_editor::bounds::{BoundCase, BoundExt as _, Bounds};
+use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::bounds::{BoundCase, BoundExt as _};
 use crate::tab::markdown_editor::input::Bound;
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
@@ -26,7 +27,7 @@ pub trait UITextInputTokenizer {
     ) -> Option<(DocCharOffset, DocCharOffset)>;
 }
 
-impl UITextInputTokenizer for Bounds {
+impl UITextInputTokenizer for Editor {
     fn is_position_at_boundary(
         &self, text_position: DocCharOffset, at_boundary: Bound, in_backward_direction: bool,
     ) -> bool {
@@ -34,12 +35,19 @@ impl UITextInputTokenizer for Bounds {
             Bound::Char => {
                 return true;
             }
-            Bound::Word => &self.words,
-            Bound::Line => &self.wrap_lines,
-            Bound::Paragraph => &self.paragraphs,
+            Bound::Word => &self.bounds.words,
+            Bound::Line => &self.bounds.wrap_lines,
+            Bound::Paragraph => &self.bounds.paragraphs,
             Bound::Doc => {
                 return text_position == DocCharOffset(0)
-                    || text_position == self.paragraphs.last().copied().unwrap_or_default().end();
+                    || text_position
+                        == self
+                            .bounds
+                            .paragraphs
+                            .last()
+                            .copied()
+                            .unwrap_or_default()
+                            .end();
             }
         };
         match text_position.bound_case(ranges) {
@@ -80,9 +88,9 @@ impl UITextInputTokenizer for Bounds {
             Bound::Char => {
                 return true;
             }
-            Bound::Word => &self.words,
-            Bound::Line => &self.wrap_lines,
-            Bound::Paragraph => &self.paragraphs,
+            Bound::Word => &self.bounds.words,
+            Bound::Line => &self.bounds.wrap_lines,
+            Bound::Paragraph => &self.bounds.paragraphs,
             Bound::Doc => {
                 return true;
             }
@@ -115,7 +123,7 @@ impl UITextInputTokenizer for Bounds {
     fn position_from(
         &self, text_position: DocCharOffset, to_boundary: Bound, in_backward_direction: bool,
     ) -> Option<DocCharOffset> {
-        Some(text_position.advance_to_next_bound(to_boundary, in_backward_direction, self))
+        Some(text_position.advance_to_next_bound(to_boundary, in_backward_direction, &self.bounds))
     }
 
     fn range_enclosing_position(
@@ -125,7 +133,7 @@ impl UITextInputTokenizer for Bounds {
             Bound::Char => {
                 unimplemented!()
             }
-            Bound::Word => &self.words,
+            Bound::Word => &self.bounds.words,
             Bound::Line => {
                 // note: lines handled as words
                 //
@@ -137,14 +145,14 @@ impl UITextInputTokenizer for Bounds {
                 // the returned ranges until it receives a nil value, which is more consistent with a text granularity
                 // that is non-contiguous the way words are and lines are not. This seems to be what it takes to get
                 // the correct undeline behavior after autocorrecting a word.
-                &self.words
+                &self.bounds.words
             }
-            Bound::Paragraph => &self.paragraphs,
+            Bound::Paragraph => &self.bounds.paragraphs,
             Bound::Doc => {
                 unimplemented!()
             }
         };
-        match text_position.bound_case(ranges) {
+        let result = match text_position.bound_case(ranges) {
             BoundCase::NoRanges => None,
             BoundCase::AtFirstRangeStart { first_range, .. } => {
                 if in_backward_direction {
@@ -180,6 +188,14 @@ impl UITextInputTokenizer for Bounds {
                 }
             }
             BoundCase::BetweenRanges { .. } => None,
+        };
+        if let Some(result) = result {
+            // this can happen if we are beyond the last range e.g. asking about word at a position after a document's trailing space
+            if !result.contains(text_position, !in_backward_direction, in_backward_direction) {
+                return None;
+            }
         }
+
+        result
     }
 }


### PR DESCRIPTION
fixes an issue raised in [discord](https://discord.com/channels/1014184997751619664/1026208854280777789/1409333850248577066)

<details>

https://github.com/user-attachments/assets/1a1e9dae-58dc-4357-bd6b-edd8a7199607
</details>