### PR TITLE
cli: graceful shutdowns and fewer ugly messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cli-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "344fe03b3fcdfd231f17dee5de7727dc2f8a4221fe9d5b75d64cb0150f6fc26b"
+dependencies = [
+ "cli-rs-command-gen",
+ "colored 2.1.0",
+]
+
+[[package]]
 name = "cli-rs-command-gen"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,7 +4164,7 @@ source = "git+https://github.com/lockbook/lb-fonts#54b09038cbc3048f45e7d771a0118
 name = "lb-fs"
 version = "25.9.29"
 dependencies = [
- "cli-rs",
+ "cli-rs 0.2.0",
  "lb-rs",
  "nfs3_server",
  "tokio",
@@ -4314,7 +4324,7 @@ dependencies = [
 name = "lbdev"
 version = "25.9.29"
 dependencies = [
- "cli-rs",
+ "cli-rs 0.1.13",
  "dotenvy",
  "gh_release",
  "google-androidpublisher3",
@@ -4542,7 +4552,7 @@ dependencies = [
 name = "lockbook"
 version = "25.9.29"
 dependencies = [
- "cli-rs",
+ "cli-rs 0.2.0",
  "colored 3.0.0",
  "fs_extra",
  "hotwatch",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "lockbook"
 path = "src/main.rs"
 
 [dependencies]
-cli-rs = "0.1.12"
+cli-rs = { version = "0.2.0" }
 lb-rs = { version = "25", path = "../../libs/lb/lb-rs" }
 is-terminal = "0.4.7"
 hotwatch = "0.5.0"

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -214,9 +214,7 @@ fn run() -> CliResult<()> {
                 .handler(sync)
         )
         .with_completions()
-        .parse();
-
-    Ok(())
+        .parse()
 }
 
 fn main() {

--- a/libs/lb-fs/Cargo.toml
+++ b/libs/lb-fs/Cargo.toml
@@ -7,12 +7,11 @@ description = "A Virtual file system implementation for lockbook.net."
 homepage = "https://lockbook.net"
 repository = "https://github.com/lockbook/lockbook/"
 readme = "../../docs/README.md"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 nfs3_server = "0.8"
 tokio = { version = "1.35.1", features = ["signal", "process", "rt-multi-thread"] } 
-cli-rs = "0.1.12"
+cli-rs = { version = "0.2.0" }
 lb-rs = { version = "25", path = "../lb/lb-rs" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/libs/lb-fs/src/main.rs
+++ b/libs/lb-fs/src/main.rs
@@ -1,4 +1,4 @@
-use cli_rs::cli_error::CliResult;
+use cli_rs::cli_error::{CliResult, Exit};
 use cli_rs::command::Command;
 use cli_rs::parser::Cmd;
 use lb_fs::fs_impl::Drive;
@@ -18,7 +18,8 @@ fn main() {
                 .description("start an NFS server and mount it to /tmp/lockbook")
                 .handler(mount),
         )
-        .parse();
+        .parse()
+        .exit()
 }
 
 #[tokio::main]


### PR DESCRIPTION
this is going to improve the experience here #3611.

required code change to cli-rs here: https://github.com/lockbook/cli-rs/commit/824292feb5687599e297d247235875fdd2dad2c0

which changed it to not exit internally rather propagate errors up.

our previous strategy made it so `Drop`s were never called on the way up for the CLI which resulted in a good bit of ugliness. This fixes that. 