### PR TITLE
lb-rs: fix problems with heavy concurrent doc writes

### DIFF
--- a/libs/lb/lb-rs/src/io/docs.rs
+++ b/libs/lb/lb-rs/src/io/docs.rs
@@ -110,6 +110,10 @@ impl AsyncDocs {
                 .and_then(|name| name.to_str())
                 .ok_or(LbErrKind::Unexpected("could not get filename from os".to_string()))?;
 
+            if file_name.contains("pending") {
+                continue;
+            }
+
             let (id_str, hmac_str) = file_name.split_at(36); // UUIDs are 36 characters long in string form
 
             let id = Uuid::parse_str(id_str).map_err(|err| {

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -96,7 +96,7 @@ impl Lb {
 
         let mut status = self.status().await;
         status.space_used = None;
-        let status = format!("{:?}", status);
+        let status = format!("{:status?}");
         let is_syncing = self.syncing.load(Ordering::Relaxed);
 
         Ok(serde_json::to_string_pretty(&DebugInfo {

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -96,7 +96,7 @@ impl Lb {
 
         let mut status = self.status().await;
         status.space_used = None;
-        let status = format!("{:status?}");
+        let status = format!("{status:?}");
         let is_syncing = self.syncing.load(Ordering::Relaxed);
 
         Ok(serde_json::to_string_pretty(&DebugInfo {

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -94,7 +94,9 @@ impl Lb {
             self.collect_panics()
         );
 
-        let status = format!("{:?}", self.status().await);
+        let mut status = self.status().await;
+        status.space_used = None;
+        let status = format!("{:?}", status);
         let is_syncing = self.syncing.load(Ordering::Relaxed);
 
         Ok(serde_json::to_string_pretty(&DebugInfo {

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -45,15 +45,13 @@ impl Lb {
             .local_metadata
             .get()
             .get(&id)
-            .map(|m| m.document_hmac())
-            .flatten()
+            .and_then(|m| m.document_hmac())
             .copied();
         let base_hmac = db
             .base_metadata
             .get()
             .get(&id)
-            .map(|m| m.document_hmac())
-            .flatten()
+            .and_then(|m| m.document_hmac())
             .copied();
 
         let hmac_to_cleanup = if base_hmac != local_hmac { local_hmac } else { None };
@@ -113,15 +111,13 @@ impl Lb {
             .local_metadata
             .get()
             .get(&id)
-            .map(|m| m.document_hmac())
-            .flatten()
+            .and_then(|m| m.document_hmac())
             .copied();
         let base_hmac = db
             .base_metadata
             .get()
             .get(&id)
-            .map(|m| m.document_hmac())
-            .flatten()
+            .and_then(|m| m.document_hmac())
             .copied();
 
         let hmac_to_cleanup = if base_hmac != local_hmac { local_hmac } else { None };

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -28,6 +28,8 @@ impl Lb {
 
         let doc = self.read_document_helper(id, &mut tree).await?;
 
+        drop(tx);
+
         if user_activity {
             self.add_doc_event(activity::DocEvent::Read(id, get_time().0))
                 .await?;

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -28,14 +28,9 @@ impl Lb {
 
         let doc = self.read_document_helper(id, &mut tree).await?;
 
-        let bg_lb = self.clone();
         if user_activity {
-            tokio::spawn(async move {
-                bg_lb
-                    .add_doc_event(activity::DocEvent::Read(id, get_time().0))
-                    .await
-                    .unwrap();
-            });
+            self.add_doc_event(activity::DocEvent::Read(id, get_time().0))
+                .await?;
         }
 
         Ok(doc)
@@ -45,6 +40,23 @@ impl Lb {
     pub async fn write_document(&self, id: Uuid, content: &[u8]) -> LbResult<()> {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
+
+        let local_hmac = db
+            .local_metadata
+            .get()
+            .get(&id)
+            .map(|m| m.document_hmac())
+            .flatten()
+            .copied();
+        let base_hmac = db
+            .base_metadata
+            .get()
+            .get(&id)
+            .map(|m| m.document_hmac())
+            .flatten()
+            .copied();
+
+        let hmac_to_cleanup = if base_hmac != local_hmac { local_hmac } else { None };
 
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
@@ -57,17 +69,14 @@ impl Lb {
         let encrypted_document = tree.update_document(&id, content, &self.keychain)?;
         let hmac = tree.find(&id)?.document_hmac().copied();
         self.docs.insert(id, hmac, &encrypted_document).await?;
+        if hmac != hmac_to_cleanup {
+            self.docs.delete(id, hmac_to_cleanup).await?;
+        }
         tx.end();
 
         self.events.doc_written(id, None);
-        let bg_lb = self.clone();
-        tokio::spawn(async move {
-            bg_lb
-                .add_doc_event(activity::DocEvent::Write(id, get_time().0))
-                .await
-                .unwrap();
-            bg_lb.cleanup().await.unwrap();
-        });
+        self.add_doc_event(activity::DocEvent::Write(id, get_time().0))
+            .await?;
 
         Ok(())
     }
@@ -83,15 +92,11 @@ impl Lb {
 
         let doc = self.read_document_helper(id, &mut tree).await?;
         let hmac = tree.find(&id)?.document_hmac().copied();
+        drop(tx);
 
         if user_activity {
-            let bg_lb = self.clone();
-            tokio::spawn(async move {
-                bg_lb
-                    .add_doc_event(activity::DocEvent::Read(id, get_time().0))
-                    .await
-                    .unwrap();
-            });
+            self.add_doc_event(activity::DocEvent::Read(id, get_time().0))
+                .await?;
         }
 
         Ok((hmac, doc))
@@ -103,6 +108,23 @@ impl Lb {
     ) -> LbResult<DocumentHmac> {
         let mut tx = self.begin_tx().await;
         let db = tx.db();
+
+        let local_hmac = db
+            .local_metadata
+            .get()
+            .get(&id)
+            .map(|m| m.document_hmac())
+            .flatten()
+            .copied();
+        let base_hmac = db
+            .base_metadata
+            .get()
+            .get(&id)
+            .map(|m| m.document_hmac())
+            .flatten()
+            .copied();
+
+        let hmac_to_cleanup = if base_hmac != local_hmac { local_hmac } else { None };
 
         let mut tree = (&db.base_metadata)
             .to_staged(&mut db.local_metadata)
@@ -125,21 +147,17 @@ impl Lb {
         self.docs
             .insert(id, Some(hmac), &encrypted_document)
             .await?;
+        if Some(hmac) != hmac_to_cleanup {
+            self.docs.delete(id, hmac_to_cleanup).await?;
+        }
         tx.end();
 
         // todo: when workspace isn't the only writer, this arg needs to be exposed
         // this will happen when lb-fs is integrated into an app and shares an lb-rs with ws
         // or it will happen when there are multiple co-operative core processes.
         self.events.doc_written(id, Some(Actor::Workspace));
-
-        let bg_lb = self.clone();
-        tokio::spawn(async move {
-            bg_lb
-                .add_doc_event(activity::DocEvent::Write(id, get_time().0))
-                .await
-                .unwrap();
-            bg_lb.cleanup().await.unwrap();
-        });
+        self.add_doc_event(activity::DocEvent::Write(id, get_time().0))
+            .await?;
 
         Ok(hmac)
     }
@@ -164,9 +182,9 @@ impl Lb {
             .filter_map(|f| f.document_hmac().map(|hmac| (*f.id(), *hmac)))
             .collect::<HashSet<_>>();
 
-        drop(tx);
-
         self.docs.retain(file_hmacs).await?;
+
+        drop(tx);
 
         Ok(())
     }


### PR DESCRIPTION
fixes #3607 
fixes #3611 

tightens up the handling of our docs which would buckle under the stress of many concurrent docs.

our cleanup fn was super aggressive, it would delete any file that was unreferenced by a file tree, but the way it managed it's logic it could delete a file that was being added by a mass import or a sync.

this pr more intentionally cleans up files during writes -- it knows what the old file is, and if it needs to be cleaned up (a local overwrite) then it will specifically delete that one file.

it also eliminates a bunch of things that were `tokio::spawn`'d to the background which performed poorly in CLI like environments, this is possible now that the logic is lighter.

and then lastly the logic error was corrected in cleanup allowing it to be invoked aggressively and still be safe (though it would be slower). But now it's only invoked due to a sync.

this all will be revamped soon (#190)