### PR TITLE
server: bandwidth controls

### DIFF
--- a/libs/lb/lb-rs/src/model/api.rs
+++ b/libs/lb/lb-rs/src/model/api.rs
@@ -159,6 +159,7 @@ pub struct GetDocumentResponse {
 pub enum GetDocumentError {
     DocumentNotFound,
     NotPermissioned,
+    BandwidthExceeded,
 }
 
 impl Request for GetDocRequest {
@@ -351,6 +352,7 @@ pub enum NewAccountError {
     InvalidUsername,
     FileIdTaken,
     Disabled,
+    RateLimited,
 }
 
 impl Request for NewAccountRequest {

--- a/libs/lb/lb-rs/src/subscribers/search.rs
+++ b/libs/lb/lb-rs/src/subscribers/search.rs
@@ -57,7 +57,7 @@ impl Lb {
     /// Additionally if a path search contains a string, greater than 8 characters long that is
     /// contained within any of the paths in the search index, that result is returned with the
     /// highest score. lb:// style ids are also supported.
-    #[instrument(level = "debug", skip(self), err(Debug))]
+    #[instrument(level = "debug", skip(self, input), err(Debug))]
     pub async fn search(&self, input: &str, cfg: SearchConfig) -> LbResult<Vec<SearchResult>> {
         // show suggested docs if the input string is empty
         if input.is_empty() {

--- a/libs/lb/lb-rs/src/subscribers/search.rs
+++ b/libs/lb/lb-rs/src/subscribers/search.rs
@@ -234,7 +234,10 @@ impl Lb {
                 continue;
             };
 
-            let doc = String::from_utf8(self.read_document(file.id, false).await.unwrap()).unwrap();
+            let Ok(doc) = String::from_utf8(self.read_document(file.id, false).await.unwrap())
+            else {
+                continue;
+            };
 
             if doc.len() > CONTENT_MAX_LEN_BYTES {
                 continue;

--- a/server/src/account_service.rs
+++ b/server/src/account_service.rs
@@ -67,6 +67,8 @@ where
         context.request.username = context.request.username.to_lowercase();
         let request = &context.request;
 
+        tracing::info!("new-account attempt username: {}", request.username);
+
         if !username_is_valid(&request.username) {
             return Err(ClientError(NewAccountError::InvalidUsername));
         }

--- a/server/src/account_service.rs
+++ b/server/src/account_service.rs
@@ -88,11 +88,9 @@ where
         let mut db = self.index_db.lock().await;
         let handle = db.begin_transaction()?;
 
-        if self.config.features.new_account_rate_limit {
-            if let Some(ip) = context.ip {
-                if !self.can_create_account(ip).await {
-                    return Err(ClientError(NewAccountError::RateLimited));
-                }
+        if let Some(ip) = context.ip {
+            if !self.can_create_account(ip).await {
+                return Err(ClientError(NewAccountError::RateLimited));
             }
         }
 

--- a/server/src/account_service.rs
+++ b/server/src/account_service.rs
@@ -54,8 +54,12 @@ where
             root_folder: SignedMeta::from(request.root_folder),
         };
 
-        self.new_account_v2(RequestContext { request, public_key: context.public_key })
-            .await
+        self.new_account_v2(RequestContext {
+            request,
+            public_key: context.public_key,
+            ip: context.ip,
+        })
+        .await
     }
 
     /// Create a new account given a username, public_key, and root folder.

--- a/server/src/billing/billing_model.rs
+++ b/server/src/billing/billing_model.rs
@@ -47,11 +47,13 @@ impl SubscriptionProfile {
         }
     }
 
-    pub fn bandwidth_cap(&self) -> u64 {
-        match self.is_premium() {
+    pub fn bandwidth_cap(&self) -> usize {
+        let cap = match self.is_premium() {
             true => self.data_cap() * 4, // $0.012
             false => self.data_cap(),    // $3.60
-        }
+        };
+
+        cap as usize
     }
 
     pub fn is_premium(&self) -> bool {

--- a/server/src/billing/billing_model.rs
+++ b/server/src/billing/billing_model.rs
@@ -47,6 +47,13 @@ impl SubscriptionProfile {
         }
     }
 
+    pub fn bandwidth_cap(&self) -> u64 {
+        match self.is_premium() {
+            true => self.data_cap() * 4, // $0.012
+            false => self.data_cap(),    // $3.60
+        }
+    }
+
     pub fn is_premium(&self) -> bool {
         self.data_cap() == PREMIUM_TIER_USAGE_SIZE
     }

--- a/server/src/billing/billing_model.rs
+++ b/server/src/billing/billing_model.rs
@@ -47,10 +47,11 @@ impl SubscriptionProfile {
         }
     }
 
+    // the rate was $0.12 / gb when this was written
     pub fn bandwidth_cap(&self) -> usize {
         let cap = match self.is_premium() {
-            true => self.data_cap() * 4, // $0.012
-            false => self.data_cap(),    // $3.60
+            true => self.data_cap(),      // $0.012
+            false => self.data_cap() * 4, // $3.60
         };
 
         cap as usize

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -76,6 +76,7 @@ impl AdminConfig {
 #[derive(Clone, Debug)]
 pub struct FeatureFlags {
     pub new_accounts: bool,
+    pub new_account_rate_limit: bool,
 }
 
 impl FeatureFlags {
@@ -83,6 +84,10 @@ impl FeatureFlags {
         Self {
             new_accounts: env::var("FEATURE_NEW_ACCOUNTS")
                 .unwrap_or_else(|_| "true".to_string())
+                .parse()
+                .unwrap(),
+            new_account_rate_limit: env::var("FEATURE_NEW_ACCOUNT_LIMITS")
+                .unwrap_or_else(|_| "false".to_string())
                 .parse()
                 .unwrap(),
         }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -77,6 +77,7 @@ impl AdminConfig {
 pub struct FeatureFlags {
     pub new_accounts: bool,
     pub new_account_rate_limit: bool,
+    pub bandwidth_controls: bool,
 }
 
 impl FeatureFlags {
@@ -88,6 +89,10 @@ impl FeatureFlags {
                 .unwrap(),
             new_account_rate_limit: env::var("FEATURE_NEW_ACCOUNT_LIMITS")
                 .unwrap_or_else(|_| "false".to_string())
+                .parse()
+                .unwrap(),
+            bandwidth_controls: env::var("FEATURE_BANDWIDTH_CONTROLS")
+                .unwrap_or_else(|_| "true".to_string())
                 .parse()
                 .unwrap(),
         }

--- a/server/src/defense.rs
+++ b/server/src/defense.rs
@@ -95,7 +95,7 @@ where
                 if now - visitor.time > Duration::minutes(1).whole_milliseconds() as u64 {
                     return true;
                 } else {
-                    tracing::warn!("account creation not permitted due to rate limit");
+                    tracing::error!("account creation not permitted due to rate limit");
                     return false;
                 }
             }

--- a/server/src/defense.rs
+++ b/server/src/defense.rs
@@ -53,7 +53,7 @@ impl BandwidthReport {
     pub fn increase_by(&mut self, inc: usize) {
         let now = YearMonth::current();
         match self.monthly_agg.get_mut(&YearMonth::current()) {
-            Some(new) => *new = *new + inc,
+            Some(new) => *new += inc,
             None => {
                 self.monthly_agg.insert(now, inc);
             }
@@ -100,7 +100,7 @@ where
                 }
             }
         }
-        return true;
+        true
     }
 
     pub async fn did_create_account(&self, ip: SocketAddr) {

--- a/server/src/defense.rs
+++ b/server/src/defense.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+
+use google_androidpublisher3::chrono::{Datelike, Local};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BandwidthReport {
+    monthly_agg: HashMap<YearMonth, usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct YearMonth {
+    pub year: i32,
+    pub month: u32,
+}
+
+impl YearMonth {
+    fn current() -> Self {
+        let now = Local::now();
+        Self { year: now.year(), month: now.month() }
+    }
+}
+
+impl BandwidthReport {
+    pub fn current_bandwidth(&self) -> usize {
+        self.monthly_agg
+            .get(&YearMonth::current())
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub fn increase_by(&mut self, inc: usize) {
+        let now = YearMonth::current();
+        match self.monthly_agg.get_mut(&YearMonth::current()) {
+            Some(new) => *new = *new + inc,
+            None => {
+                self.monthly_agg.insert(now, inc);
+            }
+        }
+    }
+}

--- a/server/src/defense.rs
+++ b/server/src/defense.rs
@@ -18,7 +18,7 @@ use crate::{
     document_service::DocumentService,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BandwidthReport {
     monthly_agg: HashMap<YearMonth, usize>,
 }
@@ -36,12 +36,18 @@ impl YearMonth {
     }
 }
 
+pub static SERVER_BANDWIDTH_CAP: usize = 1_000_000_000_000; // 1tb = $120
+
 impl BandwidthReport {
     pub fn current_bandwidth(&self) -> usize {
         self.monthly_agg
             .get(&YearMonth::current())
             .copied()
             .unwrap_or_default()
+    }
+
+    pub fn all_bandwidth(&self) -> usize {
+        self.monthly_agg.values().sum()
     }
 
     pub fn increase_by(&mut self, inc: usize) {

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -696,7 +696,7 @@ where
                     .get(&requester)
                     .cloned()
                     .unwrap_or_default();
-                let bandwidth_cap = db
+                let account_bandwidth_cap = db
                     .accounts
                     .get()
                     .get(&requester)
@@ -705,7 +705,7 @@ where
 
                 if server_wide.current_bandwidth() > SERVER_BANDWIDTH_CAP {
                     error!("Bandwidth caps are now being enforced");
-                    if account_bandwidth.current_bandwidth() > bandwidth_cap {
+                    if account_bandwidth.current_bandwidth() > account_bandwidth_cap {
                         error!("User bandwidth cap exceeded");
                         return Err(ClientError(GetDocumentError::BandwidthExceeded));
                     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,13 +1,15 @@
 use billing::app_store_client::AppStoreClient;
 use billing::google_play_client::GooglePlayClient;
 use billing::stripe_client::StripeClient;
+use defense::IpData;
 use document_service::DocumentService;
 use lb_rs::model::clock;
 use lb_rs::model::errors::LbResult;
 use schema::ServerDb;
+use std::collections::VecDeque;
 use std::env;
 use std::fmt::Debug;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -40,7 +42,7 @@ where
     pub google_play_client: G,
     pub app_store_client: A,
     pub document_service: D,
-    pub recent_ips: Vec<SocketAddr>,
+    pub recent_new_account_ips: Arc<Mutex<VecDeque<IpData>>>,
 }
 
 #[derive(Clone)]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -7,6 +7,7 @@ use lb_rs::model::errors::LbResult;
 use schema::ServerDb;
 use std::env;
 use std::fmt::Debug;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -39,12 +40,14 @@ where
     pub google_play_client: G,
     pub app_store_client: A,
     pub document_service: D,
+    pub recent_ips: Vec<SocketAddr>,
 }
 
 #[derive(Clone)]
 pub struct RequestContext<TRequest> {
     pub request: TRequest,
     pub public_key: PublicKey,
+    pub ip: Option<SocketAddr>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -97,6 +100,7 @@ where
 pub mod account_service;
 pub mod billing;
 pub mod config;
+pub mod defense;
 pub mod document_service;
 pub mod error_handler;
 pub mod file_service;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         google_play_client,
         app_store_client,
         document_service,
-        recent_ips: Default::default(),
+        recent_new_account_ips: Default::default(),
     });
 
     let routes = core_routes(&server_state)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -43,6 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         google_play_client,
         app_store_client,
         document_service,
+        recent_ips: Default::default(),
     });
 
     let routes = core_routes(&server_state)

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -205,7 +205,7 @@ where
             METRICS_STATISTICS.deleted_users.set(deleted_users);
             METRICS_STATISTICS.total_document_bytes.set(total_bytes);
             METRICS_STATISTICS
-                .total_document_bytes
+                .total_egress_bytes
                 .set(server_wide_egress as i64);
             METRICS_STATISTICS
                 .share_feature_users

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -59,6 +59,9 @@ macro_rules! core_req {
                  request: Bytes,
                  version: Option<String>,
                  ip: Option<SocketAddr>| {
+                    if ip.is_none() {
+                        tracing::error!("ip not present in request");
+                    }
                     let span1 = span!(
                         Level::INFO,
                         "matched_request",
@@ -113,9 +116,13 @@ macro_rules! core_req {
                             username = username.as_str(),
                             public_key = req_pk.as_str()
                         );
+                        if ip.is_none() {
+                            tracing::error!("ip not present in request");
+                        }
                         let rc: RequestContext<$Req> = RequestContext {
                             request: request.signed_request.timestamped_value.value,
                             public_key: request.signed_request.public_key,
+                            ip,
                         };
 
                         async move {

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -92,7 +92,6 @@ macro_rules! core_req {
                                 }
                             };
 
-                        debug!("request verified successfully");
                         let req_pk = request.signed_request.public_key;
                         let username = {
                             let db = state.index_db.lock().await;
@@ -121,30 +120,27 @@ macro_rules! core_req {
 
                         async move {
                             let status;
-                            let log;
                             let mut level = tracing::Level::INFO;
                             let to_serialize = match $handler(state, rc).await {
                                 Ok(response) => {
                                     status = warp::http::StatusCode::OK;
-                                    log = "request processed successfully".to_string();
                                     Ok(response)
                                 }
                                 Err(ServerError::ClientError(e)) => {
                                     status = warp::http::StatusCode::BAD_REQUEST;
                                     level = tracing::Level::WARN;
-                                    log =
-                                        format!("request rejected due to a client error: {:?}", e);
                                     Err(ErrorWrapper::Endpoint(e))
                                 }
                                 Err(ServerError::InternalError(e)) => {
                                     status = warp::http::StatusCode::INTERNAL_SERVER_ERROR;
                                     level = tracing::Level::ERROR;
-                                    log = format!("Internal error {}: {}", <$Req>::ROUTE, e);
+                                    tracing::error!("internal: {e}");
                                     Err(ErrorWrapper::InternalError)
                                 }
                             };
                             let response =
                                 warp::reply::with_status(warp::reply::json(&to_serialize), status);
+                            let log = format!("{status} {} {username}", &<$Req>::ROUTE);
                             let latency = timer.stop_and_record();
                             match level {
                                 tracing::Level::INFO => {

--- a/server/src/schema.rs
+++ b/server/src/schema.rs
@@ -1,5 +1,3 @@
-use crate::billing::billing_model::SubscriptionProfile;
-use db_rs::{LookupSet, LookupTable};
 use db_rs_derive::Schema;
 use lb_rs::model::file_metadata::Owner;
 use lb_rs::model::server_meta::ServerMeta;
@@ -32,6 +30,3 @@ pub struct ServerV5 {
     pub file_children: LookupSet<Uuid, Uuid>,
     pub bandwidth_egress: LookupTable<Owner, BandwidthReport>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BandwidthReport {}

--- a/server/src/schema.rs
+++ b/server/src/schema.rs
@@ -30,4 +30,8 @@ pub struct ServerV5 {
     pub owned_files: LookupSet<Owner, Uuid>,
     pub shared_files: LookupSet<Owner, Uuid>,
     pub file_children: LookupSet<Uuid, Uuid>,
+    pub bandwidth_egress: LookupTable<Owner, BandwidthReport>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BandwidthReport {}

--- a/server/src/schema.rs
+++ b/server/src/schema.rs
@@ -1,8 +1,11 @@
+use db_rs::{LookupSet, LookupTable};
 use db_rs_derive::Schema;
 use lb_rs::model::file_metadata::Owner;
 use lb_rs::model::server_meta::ServerMeta;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use crate::{billing::billing_model::SubscriptionProfile, defense::BandwidthReport};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OneKey;

--- a/server/src/schema.rs
+++ b/server/src/schema.rs
@@ -1,4 +1,4 @@
-use db_rs::{LookupSet, LookupTable};
+use db_rs::{LookupSet, LookupTable, Single};
 use db_rs_derive::Schema;
 use lb_rs::model::file_metadata::Owner;
 use lb_rs::model::server_meta::ServerMeta;
@@ -31,5 +31,6 @@ pub struct ServerV5 {
     pub owned_files: LookupSet<Owner, Uuid>,
     pub shared_files: LookupSet<Owner, Uuid>,
     pub file_children: LookupSet<Uuid, Uuid>,
-    pub bandwidth_egress: LookupTable<Owner, BandwidthReport>,
+    pub server_egress: Single<BandwidthReport>,
+    pub egress_by_owner: LookupTable<Owner, BandwidthReport>,
 }


### PR DESCRIPTION
- better logs
- bandwidth monitoring and limits
- you can only create an account from the same IP once per minute

deployment notes:
- `FEATURE_NEW_ACCOUNT_LIMITS` needs to be `true`