### PR TITLE
editor/egui: focus fixes

### DIFF
--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -1053,13 +1053,11 @@ impl FileTree {
             if ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                 resp.rename_request = Some((id, self.rename_buffer.clone()));
                 self.rename_target = None;
-                ui.memory_mut(|m| m.request_focus(file_tree_id));
             }
 
             // release focus to cancel ('esc' or click elsewhere)
             if rename_resp.lost_focus() {
                 self.rename_target = None;
-                ui.memory_mut(|m| m.request_focus(file_tree_id));
             }
 
             return resp; // note: early return

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -973,7 +973,7 @@ impl FileTree {
                 });
 
                 if file_resp.clicked() {
-                    ui.memory_mut(|m| m.request_focus(suggested_docs_id));
+                    ui.memory_mut(|m| m.surrender_focus(suggested_docs_id));
                     self.selected.clear();
                     self.cut.clear();
                     self.cursor = Some(self.suggested_docs_folder_id);
@@ -1177,10 +1177,13 @@ impl FileTree {
                 } else {
                     self.collapse(&[id]);
                 }
+
+                ui.memory_mut(|m| m.surrender_focus(file_tree_id));
+            } else {
+                ui.memory_mut(|m| m.request_focus(file_tree_id));
             }
 
             self.cut.clear();
-            ui.memory_mut(|m| m.request_focus(file_tree_id));
             self.cursor = Some(id);
             ui.ctx().request_repaint();
         }

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -615,12 +615,7 @@ impl Workspace {
                                         self.tabs[i].rename = Some(active_name);
                                     } else {
                                         self.tabs[i].rename = None;
-                                        self.current_tab = i;
-                                        self.current_tab_changed = true;
-                                        self.ctx.send_viewport_cmd(ViewportCommand::Title(
-                                            self.tab_title(&self.tabs[i]),
-                                        ));
-                                        self.out.selected_file = self.tabs[i].id();
+                                        self.make_current(i);
                                     }
                                 }
                                 TabLabelResponse::Closed => {
@@ -758,7 +753,7 @@ impl Workspace {
         let new = old + change;
         if new >= 0 && new < self.tabs.len() as i32 {
             self.tabs.swap(old as usize, new as usize);
-            self.current_tab = new as usize;
+            self.make_current(new as usize);
         }
 
         // tab navigation

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -748,12 +748,13 @@ impl Workspace {
                 0
             }
         });
-
-        let old = self.current_tab as i32;
-        let new = old + change;
-        if new >= 0 && new < self.tabs.len() as i32 {
-            self.tabs.swap(old as usize, new as usize);
-            self.make_current(new as usize);
+        if change != 0 {
+            let old = self.current_tab as i32;
+            let new = old + change;
+            if new >= 0 && new < self.tabs.len() as i32 {
+                self.tabs.swap(old as usize, new as usize);
+                self.make_current(new as usize);
+            }
         }
 
         // tab navigation

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -203,7 +203,7 @@ impl Editor {
         Id::new(self.file_id)
     }
 
-    pub fn focus(&mut self, ctx: &Context) {
+    pub fn focus(&self, ctx: &Context) {
         ctx.memory_mut(|m| {
             m.request_focus(self.id());
         });

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -84,7 +84,15 @@ pub struct Response {
 pub struct LoadRequest {
     pub id: Uuid,
     pub is_new_file: bool,
+
+    // indicates whether the completed load should replace a tab or be merged
+    // into one; unclear if we can just check for existing tabs when complete
     pub tab_created: bool,
+
+    // indicates whether the completed load should make the tab current; this is
+    // what focuses the tab and the tab must be shown every frame to hold focus
+    // todo: hold focus for loading tabs and all the rest in one proper place
+    pub make_current: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -216,6 +216,10 @@ impl Workspace {
             self.ctx
                 .send_viewport_cmd(ViewportCommand::Title(self.tab_title(&self.tabs[i])));
 
+            if let Some(md) = self.current_tab_markdown() {
+                md.focus(&self.ctx);
+            }
+
             true
         } else {
             false


### PR DESCRIPTION
- Fixes an issue when clicking the egui file tree where the file tree withheld focus from the opened file
- Fixes an issue where egui file tree renames would always focus the file tree when done instead of the editor
- Fixes an issue where changing the current tab would not update which tab is focused
    - Files opened with the `make_current` flag are now made current only when the load completes
    - This makes the fix simpler because loading state tabs don't manage focus, which needs to be actively held every frame


https://github.com/user-attachments/assets/eb058a0f-b205-4d1c-b216-5bda3d19bc40

