### PR TITLE
editor: automatically paste links as markdown links when there is selected text

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
@@ -1,5 +1,6 @@
-use crate::tab::markdown_editor;
+use crate::tab::markdown_editor::{self, Editor};
 use egui::{self, Key, Modifiers};
+use lb_rs::model::text::offset_types::RangeExt as _;
 use markdown_editor::input::{Bound, Event, Increment, Offset, Region};
 use markdown_editor::style::{BlockNode, InlineNode, ListItem, MarkdownNode};
 use pulldown_cmark::{HeadingLevel, LinkType};
@@ -23,207 +24,239 @@ impl From<Modifiers> for Offset {
     }
 }
 
-/// Translates UI events into editor events. Editor events are interpreted based on the state of the buffer when
-/// they're applied, so this translation makes no use of the editor's current state.
-pub fn translate_egui_keyboard_event(event: egui::Event) -> Option<Event> {
-    match event {
-        egui::Event::Key { key, pressed: true, modifiers, .. }
-            if matches!(key, Key::ArrowUp | Key::ArrowDown) =>
-        {
-            Some(Event::Select {
-                region: Region::ToOffset {
-                    offset: if modifiers.mac_cmd {
-                        Offset::To(Bound::Doc)
-                    } else {
-                        Offset::By(Increment::Line)
-                    },
-                    backwards: key == Key::ArrowUp,
-                    extend_selection: modifiers.shift,
-                },
-            })
-        }
-        egui::Event::Key { key, pressed: true, modifiers, .. }
-            if matches!(key, Key::ArrowRight | Key::ArrowLeft | Key::Home | Key::End) =>
-        {
-            Some(Event::Select {
-                region: Region::ToOffset {
-                    offset: if matches!(key, Key::Home | Key::End) {
-                        if modifiers.command {
+impl Editor {
+    pub fn translate_egui_keyboard_event(&self, event: egui::Event) -> Option<Event> {
+        match event {
+            egui::Event::Key { key, pressed: true, modifiers, .. }
+                if matches!(key, Key::ArrowUp | Key::ArrowDown) =>
+            {
+                Some(Event::Select {
+                    region: Region::ToOffset {
+                        offset: if modifiers.mac_cmd {
                             Offset::To(Bound::Doc)
                         } else {
-                            Offset::To(Bound::Line)
-                        }
-                    } else {
-                        Offset::from(modifiers)
+                            Offset::By(Increment::Line)
+                        },
+                        backwards: key == Key::ArrowUp,
+                        extend_selection: modifiers.shift,
                     },
-                    backwards: matches!(key, Key::ArrowLeft | Key::Home),
-                    extend_selection: modifiers.shift,
-                },
-            })
-        }
-        egui::Event::Text(text) | egui::Event::Paste(text) => Some(Event::Replace {
-            region: Region::Selection,
-            text: text.clone(),
-            advance_cursor: true,
-        }),
-        egui::Event::Key { key, pressed: true, modifiers, .. }
-            if matches!(key, Key::Backspace | Key::Delete) =>
-        {
-            Some(Event::Delete {
-                region: Region::SelectionOrOffset {
-                    offset: Offset::from(modifiers),
-                    backwards: key == Key::Backspace,
-                },
-            })
-        }
-        egui::Event::Key { key: Key::Enter, pressed: true, modifiers, .. }
-            if !cfg!(target_os = "ios") =>
-        {
-            Some(Event::Newline { shift: modifiers.shift })
-        }
-        egui::Event::Key { key: Key::Tab, pressed: true, modifiers, .. } if !modifiers.alt => {
-            if !modifiers.shift && cfg!(target_os = "ios") {
-                return None;
+                })
             }
-
-            Some(Event::Indent { deindent: modifiers.shift })
-        }
-        egui::Event::Key { key: Key::A, pressed: true, modifiers, .. }
-            if modifiers.command && !cfg!(target_os = "ios") =>
-        {
-            Some(Event::Select { region: Region::Bound { bound: Bound::Doc, backwards: true } })
-        }
-        egui::Event::Cut => Some(Event::Cut),
-        egui::Event::Key { key: Key::X, pressed: true, modifiers, .. }
-            if modifiers.command && !modifiers.shift && !cfg!(target_os = "ios") =>
-        {
-            Some(Event::Cut)
-        }
-        egui::Event::Copy => Some(Event::Copy),
-        egui::Event::Key { key: Key::C, pressed: true, modifiers, .. }
-            if modifiers.command && !modifiers.shift && !cfg!(target_os = "ios") =>
-        {
-            Some(Event::Copy)
-        }
-        egui::Event::Key { key: Key::Z, pressed: true, modifiers, .. }
-            if modifiers.command && !cfg!(target_os = "ios") =>
-        {
-            if !modifiers.shift {
-                Some(Event::Undo)
-            } else {
-                Some(Event::Redo)
+            egui::Event::Key { key, pressed: true, modifiers, .. }
+                if matches!(key, Key::ArrowRight | Key::ArrowLeft | Key::Home | Key::End) =>
+            {
+                Some(Event::Select {
+                    region: Region::ToOffset {
+                        offset: if matches!(key, Key::Home | Key::End) {
+                            if modifiers.command {
+                                Offset::To(Bound::Doc)
+                            } else {
+                                Offset::To(Bound::Line)
+                            }
+                        } else {
+                            Offset::from(modifiers)
+                        },
+                        backwards: matches!(key, Key::ArrowLeft | Key::Home),
+                        extend_selection: modifiers.shift,
+                    },
+                })
             }
-        }
-        egui::Event::Key { key: Key::B, pressed: true, modifiers, .. } if modifiers.command => {
-            Some(Event::ToggleStyle {
+            egui::Event::Paste(text) => {
+                // with text selected, pasting a link turns selected text into a
+                // markdown link
+                let mut link_paste = false;
+                if !self.buffer.current.selection.is_empty() {
+                    // use comrak's auto-link detector
+                    let arena = comrak::Arena::new();
+                    let mut options = comrak::Options::default();
+                    options.extension.autolink = true;
+                    let text_with_newline = text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
+                    let root = comrak::parse_document(&arena, &text_with_newline, &options);
+                    for node in root.descendants() {
+                        let value = &node.data.borrow().value;
+                        if let comrak::nodes::NodeValue::Link(node_link) = value {
+                            if node_link.url == text {
+                                link_paste = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if link_paste {
+                    Some(Event::Link { region: Region::Selection, url: text.clone() })
+                } else {
+                    Some(Event::Replace {
+                        region: Region::Selection,
+                        text: text.clone(),
+                        advance_cursor: true,
+                    })
+                }
+            }
+            egui::Event::Text(text) => Some(Event::Replace {
                 region: Region::Selection,
-                style: MarkdownNode::Inline(InlineNode::Bold),
-            })
-        }
-        egui::Event::Key { key: Key::I, pressed: true, modifiers, .. } if modifiers.command => {
-            Some(Event::ToggleStyle {
-                region: Region::Selection,
-                style: MarkdownNode::Inline(InlineNode::Italic),
-            })
-        }
-        egui::Event::Key { key: Key::C, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.shift =>
-        {
-            if !modifiers.alt {
+                text: text.clone(),
+                advance_cursor: true,
+            }),
+            egui::Event::Key { key, pressed: true, modifiers, .. }
+                if matches!(key, Key::Backspace | Key::Delete) =>
+            {
+                Some(Event::Delete {
+                    region: Region::SelectionOrOffset {
+                        offset: Offset::from(modifiers),
+                        backwards: key == Key::Backspace,
+                    },
+                })
+            }
+            egui::Event::Key { key: Key::Enter, pressed: true, modifiers, .. }
+                if !cfg!(target_os = "ios") =>
+            {
+                Some(Event::Newline { shift: modifiers.shift })
+            }
+            egui::Event::Key { key: Key::Tab, pressed: true, modifiers, .. } if !modifiers.alt => {
+                if !modifiers.shift && cfg!(target_os = "ios") {
+                    None
+                } else {
+                    Some(Event::Indent { deindent: modifiers.shift })
+                }
+            }
+            egui::Event::Key { key: Key::A, pressed: true, modifiers, .. }
+                if modifiers.command && !cfg!(target_os = "ios") =>
+            {
+                Some(Event::Select { region: Region::Bound { bound: Bound::Doc, backwards: true } })
+            }
+            egui::Event::Cut => Some(Event::Cut),
+            egui::Event::Key { key: Key::X, pressed: true, modifiers, .. }
+                if modifiers.command && !modifiers.shift && !cfg!(target_os = "ios") =>
+            {
+                Some(Event::Cut)
+            }
+            egui::Event::Copy => Some(Event::Copy),
+            egui::Event::Key { key: Key::C, pressed: true, modifiers, .. }
+                if modifiers.command && !modifiers.shift && !cfg!(target_os = "ios") =>
+            {
+                Some(Event::Copy)
+            }
+            egui::Event::Key { key: Key::Z, pressed: true, modifiers, .. }
+                if modifiers.command && !cfg!(target_os = "ios") =>
+            {
+                if !modifiers.shift {
+                    Some(Event::Undo)
+                } else {
+                    Some(Event::Redo)
+                }
+            }
+            egui::Event::Key { key: Key::B, pressed: true, modifiers, .. } if modifiers.command => {
                 Some(Event::ToggleStyle {
                     region: Region::Selection,
-                    style: MarkdownNode::Inline(InlineNode::Code),
+                    style: MarkdownNode::Inline(InlineNode::Bold),
                 })
-            } else {
-                Some(Event::toggle_block_style(BlockNode::Code("".into())))
             }
+            egui::Event::Key { key: Key::I, pressed: true, modifiers, .. } if modifiers.command => {
+                Some(Event::ToggleStyle {
+                    region: Region::Selection,
+                    style: MarkdownNode::Inline(InlineNode::Italic),
+                })
+            }
+            egui::Event::Key { key: Key::C, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.shift =>
+            {
+                if !modifiers.alt {
+                    Some(Event::ToggleStyle {
+                        region: Region::Selection,
+                        style: MarkdownNode::Inline(InlineNode::Code),
+                    })
+                } else {
+                    Some(Event::toggle_block_style(BlockNode::Code("".into())))
+                }
+            }
+            egui::Event::Key { key: Key::X, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.shift =>
+            {
+                Some(Event::ToggleStyle {
+                    region: Region::Selection,
+                    style: MarkdownNode::Inline(InlineNode::Strikethrough),
+                })
+            }
+            egui::Event::Key { key: Key::K, pressed: true, modifiers, .. } if modifiers.command => {
+                Some(Event::ToggleStyle {
+                    region: Region::Selection,
+                    style: MarkdownNode::Inline(InlineNode::Link(
+                        LinkType::Inline,
+                        "".into(),
+                        "".into(),
+                    )),
+                })
+            }
+            egui::Event::Key { key: Key::Num7, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.shift =>
+            {
+                Some(Event::toggle_block_style(BlockNode::ListItem(ListItem::Numbered(1), 0)))
+            }
+            egui::Event::Key { key: Key::Num8, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.shift =>
+            {
+                Some(Event::toggle_block_style(BlockNode::ListItem(ListItem::Bulleted, 0)))
+            }
+            egui::Event::Key { key: Key::Num9, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.shift =>
+            {
+                Some(Event::toggle_block_style(BlockNode::ListItem(ListItem::Todo(false), 0)))
+            }
+            egui::Event::Key { key: Key::Num1, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H1)))
+            }
+            egui::Event::Key { key: Key::Num2, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H2)))
+            }
+            egui::Event::Key { key: Key::Num3, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H3)))
+            }
+            egui::Event::Key { key: Key::Num4, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H4)))
+            }
+            egui::Event::Key { key: Key::Num5, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H5)))
+            }
+            egui::Event::Key { key: Key::Num6, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H6)))
+            }
+            egui::Event::Key { key: Key::Q, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Quote))
+            }
+            egui::Event::Key { key: Key::R, pressed: true, modifiers, .. }
+                if modifiers.command && modifiers.alt =>
+            {
+                Some(Event::toggle_block_style(BlockNode::Rule))
+            }
+            egui::Event::Key { key: Key::F2, pressed: true, .. } => Some(Event::ToggleDebug),
+            egui::Event::Key { key: Key::Equals, pressed: true, modifiers, .. }
+                if modifiers.command =>
+            {
+                Some(Event::IncrementBaseFontSize)
+            }
+            egui::Event::Key { key: Key::Minus, pressed: true, modifiers, .. }
+                if modifiers.command =>
+            {
+                Some(Event::DecrementBaseFontSize)
+            }
+            _ => None,
         }
-        egui::Event::Key { key: Key::X, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.shift =>
-        {
-            Some(Event::ToggleStyle {
-                region: Region::Selection,
-                style: MarkdownNode::Inline(InlineNode::Strikethrough),
-            })
-        }
-        egui::Event::Key { key: Key::K, pressed: true, modifiers, .. } if modifiers.command => {
-            Some(Event::ToggleStyle {
-                region: Region::Selection,
-                style: MarkdownNode::Inline(InlineNode::Link(
-                    LinkType::Inline,
-                    "".into(),
-                    "".into(),
-                )),
-            })
-        }
-        egui::Event::Key { key: Key::Num7, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.shift =>
-        {
-            Some(Event::toggle_block_style(BlockNode::ListItem(ListItem::Numbered(1), 0)))
-        }
-        egui::Event::Key { key: Key::Num8, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.shift =>
-        {
-            Some(Event::toggle_block_style(BlockNode::ListItem(ListItem::Bulleted, 0)))
-        }
-        egui::Event::Key { key: Key::Num9, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.shift =>
-        {
-            Some(Event::toggle_block_style(BlockNode::ListItem(ListItem::Todo(false), 0)))
-        }
-        egui::Event::Key { key: Key::Num1, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H1)))
-        }
-        egui::Event::Key { key: Key::Num2, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H2)))
-        }
-        egui::Event::Key { key: Key::Num3, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H3)))
-        }
-        egui::Event::Key { key: Key::Num4, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H4)))
-        }
-        egui::Event::Key { key: Key::Num5, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H5)))
-        }
-        egui::Event::Key { key: Key::Num6, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Heading(HeadingLevel::H6)))
-        }
-        egui::Event::Key { key: Key::Q, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Quote))
-        }
-        egui::Event::Key { key: Key::R, pressed: true, modifiers, .. }
-            if modifiers.command && modifiers.alt =>
-        {
-            Some(Event::toggle_block_style(BlockNode::Rule))
-        }
-        egui::Event::Key { key: Key::F2, pressed: true, .. } => Some(Event::ToggleDebug),
-        egui::Event::Key { key: Key::Equals, pressed: true, modifiers, .. }
-            if modifiers.command =>
-        {
-            Some(Event::IncrementBaseFontSize)
-        }
-        egui::Event::Key { key: Key::Minus, pressed: true, modifiers, .. } if modifiers.command => {
-            Some(Event::DecrementBaseFontSize)
-        }
-        _ => None,
     }
 }
-
 impl Event {
     pub fn toggle_block_style(block: BlockNode) -> Self {
         Event::ToggleStyle {

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -11,7 +11,6 @@ use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _, RangeIterEx
 use markdown_editor::Editor;
 use markdown_editor::input::{Event, Region};
 
-use super::canonical::translate_egui_keyboard_event;
 use super::{Bound, Location, mutation};
 
 impl<'ast> Editor {
@@ -81,7 +80,7 @@ impl<'ast> Editor {
                 })
             })
             .into_iter()
-            .filter_map(translate_egui_keyboard_event)
+            .filter_map(|e| self.translate_egui_keyboard_event(e))
             .collect::<Vec<_>>()
         } else {
             Vec::new()

--- a/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
@@ -108,6 +108,7 @@ pub enum Event {
     ToggleDebug,
     IncrementBaseFontSize,
     DecrementBaseFontSize,
+    Link { region: Region, url: String }, // turn the region into a markdown link to the given url
 }
 
 impl From<(DocCharOffset, DocCharOffset)> for Region {

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -14,7 +14,7 @@ use lb_rs::model::text::offset_types::{
     ToRangeExt as _,
 };
 use lb_rs::model::text::operation_types::{Operation, Replace};
-use pulldown_cmark::HeadingLevel;
+use pulldown_cmark::{HeadingLevel, LinkType};
 
 use super::advance::AdvanceExt as _;
 use super::{Bound, Location, Offset, Region};
@@ -46,259 +46,21 @@ impl<'ast> Editor {
                 }
             }
             Event::ToggleStyle { region, style } => {
-                let range = self.region_to_range(region);
-
-                match style {
-                    MarkdownNode::Document | MarkdownNode::Paragraph => {}
-                    MarkdownNode::Inline(inline_style) => {
-                        let unapply = self.unapply_inline(root, range, &inline_style);
-
-                        for inline_paragraph in &self.bounds.inline_paragraphs {
-                            if inline_paragraph.intersects(&range, true) {
-                                let paragraph_range = (
-                                    range.start().max(inline_paragraph.start()),
-                                    range.end().min(inline_paragraph.end()),
-                                );
-
-                                self.apply_inline_style(
-                                    root,
-                                    paragraph_range,
-                                    inline_style.clone(),
-                                    unapply,
-                                    operations,
-                                );
-                            }
-                        }
-
-                        // todo: advance cursor
-                    }
-                    MarkdownNode::Block(block_style) => {
-                        let unapply = self.unapply_block(root, &block_style);
-
-                        let mut handled = false;
-                        for node in root.descendants() {
-                            if self.selected_block(node) {
-                                handled = true;
-
-                                // apply heading to ATX heading: replace existing heading
-                                if let BlockNodeType::Heading(style_level) = block_style.node_type()
-                                {
-                                    if let NodeValue::Heading(NodeHeading {
-                                        level: node_level,
-                                        setext: false,
-                                    }) = node.data.borrow().value
-                                    {
-                                        for line_idx in self.node_lines(node).iter() {
-                                            let line = self.bounds.source_lines[line_idx];
-                                            let node_line = self.node_line(node, line);
-
-                                            let style_level = match style_level {
-                                                HeadingLevel::H1 => 1,
-                                                HeadingLevel::H2 => 2,
-                                                HeadingLevel::H3 => 3,
-                                                HeadingLevel::H4 => 4,
-                                                HeadingLevel::H5 => 5,
-                                                HeadingLevel::H6 => 6,
-                                            };
-                                            if style_level > node_level {
-                                                let add_levels = style_level - node_level;
-                                                operations.push(Operation::Replace(Replace {
-                                                    range: node_line.start().into_range(),
-                                                    text: "#".repeat(add_levels as _),
-                                                }));
-                                            } else if style_level == node_level {
-                                                // remove heading
-                                                let mut range = (
-                                                    node_line.start(),
-                                                    node_line.start()
-                                                        + RelCharOffset(node_level as _),
-                                                );
-                                                if self.buffer.current.segs.last_cursor_position()
-                                                    > range.end()
-                                                    && &self.buffer[(range.end(), range.end() + 1)]
-                                                        == " "
-                                                {
-                                                    range.1 += 1;
-                                                }
-
-                                                operations.push(Operation::Replace(Replace {
-                                                    range,
-                                                    text: "".into(),
-                                                }));
-                                            } else {
-                                                let remove_levels = node_level - style_level;
-                                                operations.push(Operation::Replace(Replace {
-                                                    range: (
-                                                        node_line.start(),
-                                                        node_line.start()
-                                                            + RelCharOffset(remove_levels as _),
-                                                    ),
-                                                    text: "".into(),
-                                                }));
-                                            }
-                                        }
-                                    } else if NodeValue::Paragraph == node.data.borrow().value {
-                                        for line_idx in self.node_lines(node).iter() {
-                                            let line = self.bounds.source_lines[line_idx];
-                                            let node_line = self.node_line(node, line);
-
-                                            // count paragraph soft breaks as node breaks
-                                            if node.data.borrow().value == NodeValue::Paragraph
-                                                && !line.intersects(
-                                                    &self.buffer.current.selection,
-                                                    true,
-                                                )
-                                            {
-                                                continue;
-                                            }
-
-                                            operations.push(Operation::Replace(Replace {
-                                                range: node_line.start().into_range(),
-                                                text: "#".repeat(style_level as _) + " ",
-                                            }));
-                                        }
-                                    }
-                                } else {
-                                    // remove target prefix regardless (will often be empty / supports replacements)
-                                    // todo: space between selected nodes?
-                                    let target_node = if node.is_container_block() {
-                                        node
-                                    } else {
-                                        node.parent().unwrap()
-                                    };
-                                    for line_idx in self.node_lines(node).iter() {
-                                        let line = self.bounds.source_lines[line_idx];
-
-                                        let prefix = self.line_own_prefix(target_node, line);
-
-                                        operations.push(Operation::Replace(Replace {
-                                            range: prefix,
-                                            text: "".into(),
-                                        }));
-                                    }
-
-                                    if !unapply {
-                                        let mut first_line = true;
-                                        for line_idx in self.node_lines(node).iter() {
-                                            let line = self.bounds.source_lines[line_idx];
-
-                                            // count paragraph soft breaks as node breaks
-                                            if node.data.borrow().value == NodeValue::Paragraph
-                                                && !line.intersects(
-                                                    &self.buffer.current.selection,
-                                                    true,
-                                                )
-                                            {
-                                                continue;
-                                            }
-
-                                            let range = self
-                                                .line_ancestors_prefix(node, line)
-                                                .end()
-                                                .into_range();
-                                            let text = match block_style {
-                                                BlockNode::Heading(_) => unreachable!(),
-                                                BlockNode::Quote => "> ",
-                                                BlockNode::Code(_) => unimplemented!(), // todo: support inserting lines
-                                                BlockNode::ListItem(ListItem::Bulleted, _) => {
-                                                    if first_line {
-                                                        "* "
-                                                    } else {
-                                                        "  "
-                                                    }
-                                                }
-                                                BlockNode::ListItem(ListItem::Numbered(_), _) => {
-                                                    if first_line {
-                                                        "1. "
-                                                    } else {
-                                                        "   "
-                                                    }
-                                                }
-                                                BlockNode::ListItem(ListItem::Todo(true), _) => {
-                                                    if first_line {
-                                                        "* [x] "
-                                                    } else {
-                                                        "  "
-                                                    }
-                                                }
-                                                BlockNode::ListItem(ListItem::Todo(false), _) => {
-                                                    if first_line {
-                                                        "* [ ] "
-                                                    } else {
-                                                        "  "
-                                                    }
-                                                }
-                                                BlockNode::Rule => unimplemented!(), // todo: kind of just not a priority rn
-                                            }
-                                            .into();
-
-                                            operations
-                                                .push(Operation::Replace(Replace { range, text }));
-
-                                            // count paragraph soft breaks as node breaks
-                                            if node.data.borrow().value != NodeValue::Paragraph {
-                                                first_line = false;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        if !handled {
-                            // selecting sequence of contiguous empty/whitespace-only lines:
-                            // insert or remove matching prefix
-                            if !unapply {
-                                let range = current_selection.start().into_range();
-                                let text = match block_style {
-                                    BlockNode::Heading(heading_level) => {
-                                        // todo: technically this makes a bunch of separate headings
-                                        match heading_level {
-                                            HeadingLevel::H1 => "# ",
-                                            HeadingLevel::H2 => "## ",
-                                            HeadingLevel::H3 => "### ",
-                                            HeadingLevel::H4 => "#### ",
-                                            HeadingLevel::H5 => "##### ",
-                                            HeadingLevel::H6 => "###### ",
-                                        }
-                                    }
-                                    BlockNode::Quote => "> ",
-                                    BlockNode::Code(_) => unimplemented!(), // todo: support inserting lines
-                                    BlockNode::ListItem(ListItem::Bulleted, _) => "* ",
-                                    BlockNode::ListItem(ListItem::Numbered(_), _) => "1. ",
-                                    BlockNode::ListItem(ListItem::Todo(true), _) => "* [x] ",
-                                    BlockNode::ListItem(ListItem::Todo(false), _) => "* [ ] ",
-                                    BlockNode::Rule => unimplemented!(), // todo: kind of just not a priority rn
-                                }
-                                .into();
-
-                                operations.push(Operation::Replace(Replace { range, text }));
-                                operations.push(Operation::Select(current_selection));
-                            } else {
-                                let target_node = self.deepest_container_block_at_offset(
-                                    root,
-                                    self.buffer.current.selection.start(),
-                                );
-                                if block_style
-                                    .node_type()
-                                    .matches(&target_node.data.borrow().value)
-                                {
-                                    let line_idx = self
-                                        .range_lines(current_selection.start().into_range())
-                                        .start();
-                                    let line = self.bounds.source_lines[line_idx];
-
-                                    let prefix = self.line_own_prefix(target_node, line);
-
-                                    operations.push(Operation::Replace(Replace {
-                                        range: prefix,
-                                        text: "".into(),
-                                    }));
-                                }
-                            }
-                        }
-                    }
-                }
+                self.toggle_style(root, region, style, current_selection, operations);
+            }
+            Event::Link { region, url } => {
+                self.toggle_style(
+                    root,
+                    region,
+                    MarkdownNode::Inline(InlineNode::Link(
+                        LinkType::Autolink,
+                        "".into(),
+                        "".into(),
+                    )),
+                    current_selection,
+                    operations,
+                );
+                // ...insert the url, but where?
             }
             Event::Newline { shift } => {
                 // insert/extend/terminate container blocks
@@ -654,6 +416,249 @@ impl<'ast> Editor {
         }
 
         response
+    }
+
+    fn toggle_style(
+        &mut self, root: &'ast AstNode<'ast>, region: Region, style: MarkdownNode,
+        current_selection: (DocCharOffset, DocCharOffset), operations: &mut Vec<Operation>,
+    ) {
+        let range = self.region_to_range(region);
+
+        match style {
+            MarkdownNode::Document | MarkdownNode::Paragraph => {}
+            MarkdownNode::Inline(inline_style) => {
+                let unapply = self.unapply_inline(root, range, &inline_style);
+
+                for inline_paragraph in &self.bounds.inline_paragraphs {
+                    if inline_paragraph.intersects(&range, true) {
+                        let paragraph_range = (
+                            range.start().max(inline_paragraph.start()),
+                            range.end().min(inline_paragraph.end()),
+                        );
+
+                        self.apply_inline_style(
+                            root,
+                            paragraph_range,
+                            inline_style.clone(),
+                            unapply,
+                            operations,
+                        );
+                    }
+                }
+
+                // todo: advance cursor
+            }
+            MarkdownNode::Block(block_style) => {
+                let unapply = self.unapply_block(root, &block_style);
+
+                let mut handled = false;
+                for node in root.descendants() {
+                    if self.selected_block(node) {
+                        handled = true;
+
+                        // apply heading to ATX heading: replace existing heading
+                        if let BlockNodeType::Heading(style_level) = block_style.node_type() {
+                            if let NodeValue::Heading(NodeHeading {
+                                level: node_level,
+                                setext: false,
+                            }) = node.data.borrow().value
+                            {
+                                for line_idx in self.node_lines(node).iter() {
+                                    let line = self.bounds.source_lines[line_idx];
+                                    let node_line = self.node_line(node, line);
+
+                                    let style_level = match style_level {
+                                        HeadingLevel::H1 => 1,
+                                        HeadingLevel::H2 => 2,
+                                        HeadingLevel::H3 => 3,
+                                        HeadingLevel::H4 => 4,
+                                        HeadingLevel::H5 => 5,
+                                        HeadingLevel::H6 => 6,
+                                    };
+                                    if style_level > node_level {
+                                        let add_levels = style_level - node_level;
+                                        operations.push(Operation::Replace(Replace {
+                                            range: node_line.start().into_range(),
+                                            text: "#".repeat(add_levels as _),
+                                        }));
+                                    } else if style_level == node_level {
+                                        // remove heading
+                                        let mut range = (
+                                            node_line.start(),
+                                            node_line.start() + RelCharOffset(node_level as _),
+                                        );
+                                        if self.buffer.current.segs.last_cursor_position()
+                                            > range.end()
+                                            && &self.buffer[(range.end(), range.end() + 1)] == " "
+                                        {
+                                            range.1 += 1;
+                                        }
+
+                                        operations.push(Operation::Replace(Replace {
+                                            range,
+                                            text: "".into(),
+                                        }));
+                                    } else {
+                                        let remove_levels = node_level - style_level;
+                                        operations.push(Operation::Replace(Replace {
+                                            range: (
+                                                node_line.start(),
+                                                node_line.start()
+                                                    + RelCharOffset(remove_levels as _),
+                                            ),
+                                            text: "".into(),
+                                        }));
+                                    }
+                                }
+                            } else if NodeValue::Paragraph == node.data.borrow().value {
+                                for line_idx in self.node_lines(node).iter() {
+                                    let line = self.bounds.source_lines[line_idx];
+                                    let node_line = self.node_line(node, line);
+
+                                    // count paragraph soft breaks as node breaks
+                                    if node.data.borrow().value == NodeValue::Paragraph
+                                        && !line.intersects(&self.buffer.current.selection, true)
+                                    {
+                                        continue;
+                                    }
+
+                                    operations.push(Operation::Replace(Replace {
+                                        range: node_line.start().into_range(),
+                                        text: "#".repeat(style_level as _) + " ",
+                                    }));
+                                }
+                            }
+                        } else {
+                            // remove target prefix regardless (will often be empty / supports replacements)
+                            // todo: space between selected nodes?
+                            let target_node = if node.is_container_block() {
+                                node
+                            } else {
+                                node.parent().unwrap()
+                            };
+                            for line_idx in self.node_lines(node).iter() {
+                                let line = self.bounds.source_lines[line_idx];
+
+                                let prefix = self.line_own_prefix(target_node, line);
+
+                                operations.push(Operation::Replace(Replace {
+                                    range: prefix,
+                                    text: "".into(),
+                                }));
+                            }
+
+                            if !unapply {
+                                let mut first_line = true;
+                                for line_idx in self.node_lines(node).iter() {
+                                    let line = self.bounds.source_lines[line_idx];
+
+                                    // count paragraph soft breaks as node breaks
+                                    if node.data.borrow().value == NodeValue::Paragraph
+                                        && !line.intersects(&self.buffer.current.selection, true)
+                                    {
+                                        continue;
+                                    }
+
+                                    let range =
+                                        self.line_ancestors_prefix(node, line).end().into_range();
+                                    let text = match block_style {
+                                        BlockNode::Heading(_) => unreachable!(),
+                                        BlockNode::Quote => "> ",
+                                        BlockNode::Code(_) => unimplemented!(), // todo: support inserting lines
+                                        BlockNode::ListItem(ListItem::Bulleted, _) => {
+                                            if first_line { "* " } else { "  " }
+                                        }
+                                        BlockNode::ListItem(ListItem::Numbered(_), _) => {
+                                            if first_line {
+                                                "1. "
+                                            } else {
+                                                "   "
+                                            }
+                                        }
+                                        BlockNode::ListItem(ListItem::Todo(true), _) => {
+                                            if first_line {
+                                                "* [x] "
+                                            } else {
+                                                "  "
+                                            }
+                                        }
+                                        BlockNode::ListItem(ListItem::Todo(false), _) => {
+                                            if first_line {
+                                                "* [ ] "
+                                            } else {
+                                                "  "
+                                            }
+                                        }
+                                        BlockNode::Rule => unimplemented!(), // todo: kind of just not a priority rn
+                                    }
+                                    .into();
+
+                                    operations.push(Operation::Replace(Replace { range, text }));
+
+                                    // count paragraph soft breaks as node breaks
+                                    if node.data.borrow().value != NodeValue::Paragraph {
+                                        first_line = false;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !handled {
+                    // selecting sequence of contiguous empty/whitespace-only lines:
+                    // insert or remove matching prefix
+                    if !unapply {
+                        let range = current_selection.start().into_range();
+                        let text = match block_style {
+                            BlockNode::Heading(heading_level) => {
+                                // todo: technically this makes a bunch of separate headings
+                                match heading_level {
+                                    HeadingLevel::H1 => "# ",
+                                    HeadingLevel::H2 => "## ",
+                                    HeadingLevel::H3 => "### ",
+                                    HeadingLevel::H4 => "#### ",
+                                    HeadingLevel::H5 => "##### ",
+                                    HeadingLevel::H6 => "###### ",
+                                }
+                            }
+                            BlockNode::Quote => "> ",
+                            BlockNode::Code(_) => unimplemented!(), // todo: support inserting lines
+                            BlockNode::ListItem(ListItem::Bulleted, _) => "* ",
+                            BlockNode::ListItem(ListItem::Numbered(_), _) => "1. ",
+                            BlockNode::ListItem(ListItem::Todo(true), _) => "* [x] ",
+                            BlockNode::ListItem(ListItem::Todo(false), _) => "* [ ] ",
+                            BlockNode::Rule => unimplemented!(), // todo: kind of just not a priority rn
+                        }
+                        .into();
+
+                        operations.push(Operation::Replace(Replace { range, text }));
+                        operations.push(Operation::Select(current_selection));
+                    } else {
+                        let target_node = self.deepest_container_block_at_offset(
+                            root,
+                            self.buffer.current.selection.start(),
+                        );
+                        if block_style
+                            .node_type()
+                            .matches(&target_node.data.borrow().value)
+                        {
+                            let line_idx = self
+                                .range_lines(current_selection.start().into_range())
+                                .start();
+                            let line = self.bounds.source_lines[line_idx];
+
+                            let prefix = self.line_own_prefix(target_node, line);
+
+                            operations.push(Operation::Replace(Replace {
+                                range: prefix,
+                                text: "".into(),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Returns true if all text in the given range has style `style`


### PR DESCRIPTION
It's not that smart. If you have anything selected and paste a link, it will try to make the selection a link, even if the selection is multiple lines or already contains part of a link or other messy situations like that.

https://github.com/user-attachments/assets/c9c969e7-b85a-4471-beb8-6addbbac8c0a

