### PR TITLE
apple: fix release

### DIFF
--- a/clients/apple/Shared/Preview.swift
+++ b/clients/apple/Shared/Preview.swift
@@ -1,44 +1,42 @@
-#if DEBUG
-    import SwiftUI
-    import SwiftWorkspace
+import SwiftUI
+import SwiftWorkspace
 
-    // !!!: ADD NEW OBSERVABLE OBJECTS TO THIS
-    extension View {
-        func withCommonPreviewEnvironment() -> some View {
-            self
-                .environmentObject(BillingState.preview)
-                .environmentObject(FilesViewModel.preview)
-                .environmentObject(HomeState.preview)
-                .environmentObject(PathSearchViewModel.preview)
-                .environmentObject(PendingSharesViewModel.preview)
-                .environmentObject(SelectFolderViewModel.preview)
-                .environmentObject(SettingsViewModel.preview)
-                .environmentObject(SuggestedDocsViewModel.preview)
-                .environmentObject(WorkspaceInputState.preview)
-                .environmentObject(WorkspaceOutputState.preview)
-                .withPlatformSpecificPreviewEnvironment()
-        }
-
-        private func withPlatformSpecificPreviewEnvironment() -> some View {
-            #if os(iOS)
-                return
-                    self
-                    .environmentObject(FileTreeViewModel.preview)
-            #else
-                return self
-            #endif
-        }
+// !!!: ADD NEW OBSERVABLE OBJECTS TO THIS
+extension View {
+    func withCommonPreviewEnvironment() -> some View {
+        self
+            .environmentObject(BillingState.preview)
+            .environmentObject(FilesViewModel.preview)
+            .environmentObject(HomeState.preview)
+            .environmentObject(PathSearchViewModel.preview)
+            .environmentObject(PendingSharesViewModel.preview)
+            .environmentObject(SelectFolderViewModel.preview)
+            .environmentObject(SettingsViewModel.preview)
+            .environmentObject(SuggestedDocsViewModel.preview)
+            .environmentObject(WorkspaceInputState.preview)
+            .environmentObject(WorkspaceOutputState.preview)
+            .withPlatformSpecificPreviewEnvironment()
     }
 
-    extension View {
-        func withMacPreviewSize(width: CGFloat = 400, height: CGFloat = 80)
-            -> some View
-        {
-            #if os(macOS)
-                self.frame(width: width, height: height)
-            #else
+    private func withPlatformSpecificPreviewEnvironment() -> some View {
+        #if os(iOS)
+            return
                 self
-            #endif
-        }
+                .environmentObject(FileTreeViewModel.preview)
+        #else
+            return self
+        #endif
     }
-#endif
+}
+
+extension View {
+    func withMacPreviewSize(width: CGFloat = 400, height: CGFloat = 80)
+        -> some View
+    {
+        #if os(macOS)
+            self.frame(width: width, height: height)
+        #else
+            self
+        #endif
+    }
+}

--- a/clients/apple/Shared/State/BillingState.swift
+++ b/clients/apple/Shared/State/BillingState.swift
@@ -136,10 +136,8 @@ enum PurchaseState {
     case failure
 }
 
-#if DEBUG
-    extension BillingState {
-        static var preview: BillingState {
-            return BillingState()
-        }
+extension BillingState {
+    static var preview: BillingState {
+        return BillingState()
     }
-#endif
+}

--- a/clients/apple/Shared/State/FilesViewModel.swift
+++ b/clients/apple/Shared/State/FilesViewModel.swift
@@ -229,10 +229,8 @@ class FilesViewModel: ObservableObject {
     }
 }
 
-#if DEBUG
-    extension FilesViewModel {
-        static var preview: FilesViewModel {
-            return FilesViewModel()
-        }
+extension FilesViewModel {
+    static var preview: FilesViewModel {
+        return FilesViewModel()
     }
-#endif
+}

--- a/clients/apple/Shared/State/HomeState.swift
+++ b/clients/apple/Shared/State/HomeState.swift
@@ -130,10 +130,8 @@ enum UsageBarDisplayMode: String, Codable, CaseIterable, Identifiable {
     }
 }
 
-#if DEBUG
 extension HomeState {
     static var preview: HomeState {
         return HomeState(workspaceOutput: .preview, filesModel: .preview)
     }
 }
-#endif

--- a/clients/apple/Shared/State/PathSearchViewModel.swift
+++ b/clients/apple/Shared/State/PathSearchViewModel.swift
@@ -89,10 +89,8 @@ class PathSearchViewModel: ObservableObject {
     }
 }
 
-#if DEBUG
 extension PathSearchViewModel {
     static var preview: PathSearchViewModel {
         return PathSearchViewModel(filesModel: .preview, workspaceInput: .preview)
     }
 }
-#endif

--- a/clients/apple/Shared/State/PendingSharesViewModel.swift
+++ b/clients/apple/Shared/State/PendingSharesViewModel.swift
@@ -42,10 +42,8 @@ class PendingSharesViewModel: ObservableObject {
     }
 }
 
-#if DEBUG
 extension PendingSharesViewModel {
     static var preview: PendingSharesViewModel {
         return PendingSharesViewModel()
     }
 }
-#endif

--- a/clients/apple/Shared/State/SelectFolderViewModel.swift
+++ b/clients/apple/Shared/State/SelectFolderViewModel.swift
@@ -121,10 +121,8 @@ enum SelectFolderMode {
 }
 
 
-#if DEBUG
 extension SelectFolderViewModel {
     static var preview: SelectFolderViewModel {
         return SelectFolderViewModel(homeState: .preview, filesModel: .preview)
     }
 }
-#endif

--- a/clients/apple/Shared/State/SettingsViewModel.swift
+++ b/clients/apple/Shared/State/SettingsViewModel.swift
@@ -81,10 +81,8 @@ class SettingsViewModel: ObservableObject {
     }
 }
 
-#if DEBUG
 extension SettingsViewModel {
     static var preview: SettingsViewModel {
         return SettingsViewModel()
     }
 }
-#endif

--- a/clients/apple/Shared/State/SuggestedDocsViewModel.swift
+++ b/clients/apple/Shared/State/SuggestedDocsViewModel.swift
@@ -83,10 +83,8 @@ struct SuggestedDocInfo: Identifiable {
     let lastModified: String
 }
 
-#if DEBUG
 extension SuggestedDocsViewModel {
     static var preview: SuggestedDocsViewModel {
         return SuggestedDocsViewModel(filesModel: .preview)
     }
 }
-#endif

--- a/clients/apple/iOS/State/FileTreeViewModel.swift
+++ b/clients/apple/iOS/State/FileTreeViewModel.swift
@@ -72,10 +72,8 @@ class FileTreeViewModel: ObservableObject {
     }
 }
 
-#if DEBUG
 extension FileTreeViewModel {
     static var preview: FileTreeViewModel {
         return FileTreeViewModel(filesModel: .preview, workspaceInput: .preview, workspaceOutput: .preview)
     }
 }
-#endif

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
@@ -33,9 +33,7 @@ public class WorkspaceInputState: ObservableObject {
         self.coreHandle = coreHandle
     }
 
-    #if DEBUG
-        public init() {}
-    #endif
+    public init() {}
 
     public func openFile(id: UUID) {
         guard let wsHandle else {
@@ -146,16 +144,14 @@ func createTempDir() -> URL? {
     return tempTempURL
 }
 
-#if DEBUG
-    extension WorkspaceInputState {
-        public static var preview: WorkspaceInputState {
-            return WorkspaceInputState()
-        }
+extension WorkspaceInputState {
+    public static var preview: WorkspaceInputState {
+        return WorkspaceInputState()
     }
+}
 
-    extension WorkspaceOutputState {
-        public static var preview: WorkspaceOutputState {
-            return WorkspaceOutputState()
-        }
+extension WorkspaceOutputState {
+    public static var preview: WorkspaceOutputState {
+        return WorkspaceOutputState()
     }
-#endif
+}


### PR DESCRIPTION
Got rid of a bunch of `DEBUG` compilation flags. My original worry was building static previews for release, but in reality, they're only created if accessed. We should guard access in another PR.