### PR TITLE
canvas: replace egui's pinch gesture recognizer with that of swfit

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -396,6 +396,15 @@ pub unsafe extern "C" fn pan(obj: *mut c_void, scroll_x: f32, scroll_y: f32) {
         .push_event(workspace_rs::Event::KineticPan { x: scroll_x, y: scroll_y });
 }
 
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
+pub unsafe extern "C" fn zoom(obj: *mut c_void, scale: f32) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    obj.raw_input.events.push(egui::Event::Zoom(scale));
+}
+
 /// https://developer.apple.com/documentation/uikit/uiresponder/1621142-touchesbegan
 #[no_mangle]
 pub extern "C" fn text_range(start: CTextPosition, end: CTextPosition) -> CTextRange {

--- a/libs/content/workspace/src/tab/svg_editor/util.rs
+++ b/libs/content/workspace/src/tab/svg_editor/util.rs
@@ -135,6 +135,10 @@ pub fn get_pan(ui: &mut egui::Ui) -> Option<egui::Vec2> {
         }
     }
 
+    if cfg!(target_os = "ios") {
+        return None;
+    }
+
     ui.input(|r| {
         if r.smooth_scroll_delta.x.abs() > 0.0 || r.smooth_scroll_delta.y.abs() > 0.0 {
             Some(r.smooth_scroll_delta)


### PR DESCRIPTION
i've noticed that egui's pinch gesture recognizer is prone to false positives. instances where users places there palm can momentary fire a pinch gesture. 
Swift pinch gesture recognizer is less prone to false positives and has better palm rejection. 