### PR TITLE
ws: refined forward back buttons

### DIFF
--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -580,6 +580,11 @@ impl Workspace {
         let cursor = ui
             .horizontal(|ui| {
                 if IconButton::new(Icon::ARROW_LEFT)
+                    .disabled(
+                        self.current_tab()
+                            .map(|tab| tab.back.is_empty())
+                            .unwrap_or_default(),
+                    )
                     .size(37.)
                     .tooltip("Go Back")
                     .show(ui)
@@ -588,6 +593,11 @@ impl Workspace {
                     back = true;
                 }
                 if IconButton::new(Icon::ARROW_RIGHT)
+                    .disabled(
+                        self.current_tab()
+                            .map(|tab| tab.forward.is_empty())
+                            .unwrap_or_default(),
+                    )
                     .size(37.)
                     .tooltip("Go Forward")
                     .show(ui)


### PR DESCRIPTION
@tvanderstad added the ability to navigate forward and back in #3650, this PR makes it more obvious when there is actually history to use for navigation. Making the buttons take up less visual attention when they're not clickable.

This is what they look like now:
<img width="236" height="138" alt="image" src="https://github.com/user-attachments/assets/a365e221-91b2-43da-a78f-271331b0d385" />
