### PR TITLE
editor: PageUp/PageDown advance by 50 lines

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -470,7 +470,7 @@ pub unsafe extern "C" fn position_offset_in_direction(
         if matches!(direction, CTextLayoutDirection::Right | CTextLayoutDirection::Left) {
             Offset::Next(Bound::Char)
         } else {
-            Offset::By(Increment::Line)
+            Offset::By(Increment::Lines(1))
         };
     let backwards = matches!(direction, CTextLayoutDirection::Left | CTextLayoutDirection::Up);
 

--- a/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
@@ -27,13 +27,15 @@ impl AdvanceExt for DocCharOffset {
         match offset {
             Offset::To(bound) => self.advance_to_bound(bound, backwards, bounds),
             Offset::Next(bound) => self.advance_to_next_bound(bound, backwards, bounds),
-            Offset::By(Increment::Line) => {
-                let x_target = maybe_x_target_value.unwrap_or(self.x(galleys));
-                let result = self.advance_by_line(x_target, backwards, galleys);
-                if self != 0 && self != segs.last_cursor_position() {
-                    *maybe_x_target = Some(x_target);
+            Offset::By(Increment::Lines(n)) => {
+                let mut result = self;
+                for _ in 0..n {
+                    let x_target = maybe_x_target_value.unwrap_or(result.x(galleys));
+                    result = result.advance_by_line(x_target, backwards, galleys);
+                    if result != 0 && result != segs.last_cursor_position() {
+                        *maybe_x_target = Some(x_target);
+                    }
                 }
-
                 result
             }
         }

--- a/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
@@ -24,20 +24,23 @@ impl From<Modifiers> for Offset {
     }
 }
 
+const PAGE_LINES: usize = 50;
+
 impl Editor {
     pub fn translate_egui_keyboard_event(&self, event: egui::Event) -> Option<Event> {
         match event {
             egui::Event::Key { key, pressed: true, modifiers, .. }
-                if matches!(key, Key::ArrowUp | Key::ArrowDown) =>
+                if matches!(key, Key::ArrowUp | Key::ArrowDown | Key::PageUp | Key::PageDown) =>
             {
+                let lines = if matches!(key, Key::PageUp | Key::PageDown) { PAGE_LINES } else { 1 };
                 Some(Event::Select {
                     region: Region::ToOffset {
                         offset: if modifiers.mac_cmd {
                             Offset::To(Bound::Doc)
                         } else {
-                            Offset::By(Increment::Line)
+                            Offset::By(Increment::Lines(lines))
                         },
-                        backwards: key == Key::ArrowUp,
+                        backwards: matches!(key, Key::ArrowUp | Key::PageUp),
                         extend_selection: modifiers.shift,
                     },
                 })

--- a/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
@@ -38,7 +38,7 @@ pub enum Bound {
 /// text unit you can increment or decrement a location by
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Increment {
-    Line,
+    Lines(usize),
 }
 
 /// text location relative to some absolute text location


### PR DESCRIPTION
Using editor on linux noticed there was no PageUp/Down support. 50 is just a random number, I'm sure it could be chosen better.