### PR TITLE
apple: assorted bug fixes

### DIFF
--- a/clients/apple/iOS/Screens/HomeView.swift
+++ b/clients/apple/iOS/Screens/HomeView.swift
@@ -96,6 +96,25 @@ struct HomeView: View {
                 }
             }
         )
+        .confirmationDialog(
+            "Are you sure? This action cannot be undone.",
+            isPresented: Binding(
+                get: {
+                    filesModel.isMoreThanOneFileInDeletion()
+                },
+                set: { _ in
+                    filesModel.deleteFileConfirmation = nil
+                }
+            ),
+            titleVisibility: .visible,
+            actions: {
+                if let files = filesModel
+                    .deleteFileConfirmation
+                {
+                    DeleteConfirmationButtons(files: files)
+                }
+            }
+        )
         .selectFolderSheets()
         .environmentObject(homeState)
         .environmentObject(settingsModel)

--- a/clients/apple/iOS/Widgets/StatusBarView.swift
+++ b/clients/apple/iOS/Widgets/StatusBarView.swift
@@ -22,6 +22,7 @@ struct StatusBarView: View {
         .modifier(GlassEffectModifier())
         .padding(.bottom, 8)
         .padding(.horizontal)
+        .contentShape(Rectangle())
     }
 
     var selectedFilesOptions: some View {


### PR DESCRIPTION
Add back bulk deletion conformation for iOS, and make the background of the floating status bar clickable (so you can't click a file under it)