### PR TITLE
iOS: move tab sheet close button to trailing edge

### DIFF
--- a/clients/apple/iOS/Screens/TabsSheet.swift
+++ b/clients/apple/iOS/Screens/TabsSheet.swift
@@ -35,18 +35,6 @@ struct TabsSheet: View {
                     },
                     label: {
                         HStack {
-                            Button(
-                                action: {
-                                    self.closeTab(id: info.id)
-                                },
-                                label: {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .foregroundColor(.red)
-                                        .imageScale(.medium)
-                                        .padding(.trailing)
-                                }
-                            )
-
                             Image(
                                 systemName:
                                     FileIconHelper.docNameToSystemImageName(
@@ -65,6 +53,19 @@ struct TabsSheet: View {
                                 .truncationMode(.tail)
 
                             Spacer()
+                            
+                            Button(
+                                action: {
+                                    self.closeTab(id: info.id)
+                                },
+                                label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundColor(.red)
+                                        .imageScale(.medium)
+                                        .padding(.leading)
+                                }
+                            )
+
                         }
                         .padding(.horizontal)
                         .padding(.vertical, 6)


### PR DESCRIPTION
<img width="428" height="808" alt="image" src="https://github.com/user-attachments/assets/7a189e64-d2b4-4509-b0f0-fd8bbfb521e2" />
