### PR TITLE
iOS: adjust tab sheet spacing

### DIFF
--- a/clients/apple/iOS/Screens/TabsSheet.swift
+++ b/clients/apple/iOS/Screens/TabsSheet.swift
@@ -77,7 +77,6 @@ struct TabsSheet: View {
                                     ) : nil
                             )
                             .padding(.horizontal)
-                            .padding(.vertical, 2)
                         }
                     )
                 }


### PR DESCRIPTION
A bit too much spacing between tab items - so reducing the padding