### PR TITLE
editor: reveal fold buttons on hover

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -99,7 +99,8 @@ impl<'ast> Editor {
         // todo: factor (copied for headings)
         // todo: proper hit-testing (this ignores anything covering the space)
         let fold_button_space = annotation_space.translate(Vec2::X * -INDENT);
-        let show_fold_button = hovered
+        let show_fold_button = self.touch_mode
+            || hovered
             || fold_button_space.contains(ui.input(|i| i.pointer.latest_pos().unwrap_or_default()));
         if !show_fold_button {
             return;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -166,7 +166,8 @@ impl<'ast> Editor {
         let fold_button_size = (self.row_height(node) * 0.6).min(INDENT / 2.);
 
         // todo: proper hit-testing (this ignores anything covering the space)
-        let show_fold_button = resp.hovered
+        let show_fold_button = self.touch_mode
+            || resp.hovered
             || fold_button_space.contains(ui.input(|i| i.pointer.latest_pos().unwrap_or_default()));
         if !show_fold_button {
             return;


### PR DESCRIPTION

https://github.com/user-attachments/assets/95257f8f-cbf6-4edc-9fc8-44d65121ca7e

The code for fold buttons remains untidy as I'm still figuring out how this ought to work. The conditions for revealing the fold button are:
* Is the button itself hovered?
* For headings, is the heading text hovered?
* For list items, is the region where children nodes are rendered hovered?

This is what was simplest to implement and I'd like to see how it goes. One shortcoming here is that I haven't worked out the hit-testing i.e. the fold button could still be revealed if the hovered location is behind a modal like settings. To fix this, I should use the hit-testing system, but if I did that the text itself (in a list item) would cover the much of the area where the children nodes are rendered and prevent hovers from registering. I think the target state is for block nodes to return responses indicating hover/click/etc the way inline nodes do, and for headings to use this pattern as well, if I can solve the hit-testing problem.