### PR TITLE
iOS: add background to floating bottom bar (before iOS 26)

### DIFF
--- a/clients/apple/iOS/Utils/GlassEffectModifier.swift
+++ b/clients/apple/iOS/Utils/GlassEffectModifier.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct GlassEffectModifier: ViewModifier {
     let radius: CGFloat = 20
-    
+
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content


### PR DESCRIPTION
fixes #4077

After:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/c7c0d404-1458-4362-a844-03b85c609a2d" />

Before:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/ad9519e3-1ad3-4de1-a0b2-ecad08ce602e" />

