### PR TITLE
apple, linux, windows, android: fix color weirdness

### DIFF
--- a/libs/content/egui_wgpu_renderer/src/lib.rs
+++ b/libs/content/egui_wgpu_renderer/src/lib.rs
@@ -4,8 +4,8 @@ use egui::{PlatformOutput, ViewportIdMap, ViewportOutput};
 use egui_wgpu::{Renderer, ScreenDescriptor};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use wgpu::{
-    Adapter, CompositeAlphaMode, Device, Instance, Queue, Surface,
-    SurfaceTargetUnsafe, TextureDescriptor, TextureFormat, TextureUsages,
+    Adapter, CompositeAlphaMode, Device, Instance, Queue, Surface, SurfaceTargetUnsafe,
+    TextureDescriptor, TextureFormat, TextureUsages,
 };
 
 pub struct RendererState<'w> {


### PR DESCRIPTION
- fixes instances of colors being deep fried (fixes #4065)
- fixes instances of colors being wrong, or alpha operations not taking place properly (highlighter, and other canvas opacity things)