### PR TITLE
canvas: fix minimap hiding

### DIFF
--- a/libs/content/workspace/src/tab/svg_editor/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/mod.rs
@@ -379,9 +379,11 @@ impl SVGEditor {
         }
 
         if !self.has_islands_interaction {
-            self.toolbar
-                .gesture_handler
-                .handle_input(ui, &mut tool_context);
+            self.toolbar.gesture_handler.handle_input(
+                ui,
+                &mut tool_context,
+                self.toolbar.hide_overlay,
+            );
         }
     }
 

--- a/libs/content/workspace/src/tab/svg_editor/renderer.rs
+++ b/libs/content/workspace/src/tab/svg_editor/renderer.rs
@@ -46,6 +46,7 @@ enum RenderOp<'a> {
     ForwordImage(&'a mut Image),
 }
 
+#[derive(Default)]
 pub struct Renderer {
     mesh_cache: HashMap<Uuid, MeshShape>,
     tex_cache: HashMap<Uuid, TextureHandle>,

--- a/libs/content/workspace/src/tab/svg_editor/toolbar/mini_map.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar/mini_map.rs
@@ -4,16 +4,27 @@ use crate::tab::svg_editor::gesture_handler::transform_canvas;
 use crate::tab::svg_editor::renderer::RenderOptions;
 use crate::tab::svg_editor::toolbar::{MINI_MAP_WIDTH, Toolbar, ToolbarContext};
 use crate::tab::svg_editor::util::{get_pan, transform_rect};
+use crate::tab::svg_editor::{CanvasSettings, ViewportSettings};
 const SCROLLBAR_WIDTH: f32 = 15.0;
 
 impl Toolbar {
+    pub fn should_show_mini_map(
+        hide_overlay: bool, settings: &CanvasSettings, viewport_settings: &ViewportSettings,
+    ) -> bool {
+        !hide_overlay
+            && settings.show_mini_map
+            && viewport_settings.is_scroll_mode()
+            && viewport_settings.bounded_rect.is_some()
+    }
+
     pub fn show_mini_map(
         &mut self, ui: &mut egui::Ui, tlbr_ctx: &mut ToolbarContext,
     ) -> (bool, Option<egui::Response>) {
-        if !tlbr_ctx.settings.show_mini_map
-            || !tlbr_ctx.viewport_settings.is_scroll_mode()
-            || tlbr_ctx.viewport_settings.bounded_rect.is_none()
-        {
+        if !Self::should_show_mini_map(
+            self.hide_overlay,
+            tlbr_ctx.settings,
+            tlbr_ctx.viewport_settings,
+        ) {
             return (false, None);
         }
         let bounded_rect = tlbr_ctx.viewport_settings.bounded_rect.unwrap();

--- a/libs/content/workspace/src/tab/svg_editor/toolbar/mod.rs
+++ b/libs/content/workspace/src/tab/svg_editor/toolbar/mod.rs
@@ -32,6 +32,7 @@ const THICKNESS_BTN_WIDTH: f32 = 25.0;
 const SCREEN_PADDING: egui::Pos2 =
     if cfg!(target_os = "android") { egui::pos2(10.0, 50.0) } else { egui::pos2(20.0, 20.0) };
 
+#[derive(Default)]
 pub struct Toolbar {
     pub active_tool: Tool,
     pub pen: Pen,
@@ -101,37 +102,37 @@ impl ViewportSettings {
         hide_overlay: bool,
     ) {
         let is_scroll_mode = self.is_scroll_mode();
-        let new_working_rect = if let Some(bounded_rect) = &mut self.bounded_rect {
+        if let Some(mut new_bounded_rect) = self.bounded_rect {
             if diff_state.is_dirty() && diff_state.transformed.is_none() {
                 if let Some(elements_bounds) = calc_elements_bounds(buffer) {
                     if is_scroll_mode {
-                        bounded_rect.max.y = elements_bounds.max.y
+                        new_bounded_rect.max.y = elements_bounds.max.y
                     } else {
-                        *bounded_rect = elements_bounds;
+                        new_bounded_rect = elements_bounds;
                     }
                 }
             }
 
             let min_x = if self.left_locked {
-                bounded_rect.left().max(self.container_rect.left())
+                new_bounded_rect.left().max(self.container_rect.left())
             } else {
                 self.container_rect.left()
             };
 
             let min_y = if self.top_locked {
-                bounded_rect.top().max(self.container_rect.top())
+                new_bounded_rect.top().max(self.container_rect.top())
             } else {
                 self.container_rect.top()
             };
 
-            let mini_map_width = if settings.show_mini_map && is_scroll_mode && !hide_overlay {
+            let mini_map_width = if Toolbar::should_show_mini_map(hide_overlay, &settings, self) {
                 MINI_MAP_WIDTH
             } else {
                 0.0
             };
 
             let max_x = if self.right_locked {
-                bounded_rect
+                new_bounded_rect
                     .right()
                     .min(self.container_rect.right() - mini_map_width)
             } else {
@@ -139,17 +140,17 @@ impl ViewportSettings {
             };
 
             let max_y = if self.bottom_locked {
-                bounded_rect.bottom().min(self.container_rect.bottom())
+                new_bounded_rect.bottom().min(self.container_rect.bottom())
             } else {
                 self.container_rect.bottom()
             };
 
-            egui::Rect::from_min_max(egui::pos2(min_x, min_y), egui::pos2(max_x, max_y))
+            self.bounded_rect = Some(new_bounded_rect);
+            self.working_rect =
+                egui::Rect::from_min_max(egui::pos2(min_x, min_y), egui::pos2(max_x, max_y));
         } else {
-            self.container_rect
+            self.working_rect = self.container_rect;
         };
-
-        self.working_rect = new_working_rect;
     }
     pub fn is_page_mode(&self) -> bool {
         self.bottom_locked && self.left_locked && self.right_locked && self.top_locked
@@ -398,10 +399,11 @@ impl Toolbar {
             .unwrap_or(egui::Rect::from_min_size(egui::Pos2::default(), egui::vec2(10.0, 10.0)))
             .size();
 
-        let mini_map_width = if tlbr_ctx.settings.show_mini_map
-            && tlbr_ctx.viewport_settings.is_scroll_mode()
-            && !self.hide_overlay
-        {
+        let mini_map_width = if Self::should_show_mini_map(
+            self.hide_overlay,
+            tlbr_ctx.settings,
+            tlbr_ctx.viewport_settings,
+        ) {
             MINI_MAP_WIDTH
         } else {
             0.0


### PR DESCRIPTION
Fixes an issue where pan & pinch on iPad do not work on the region where the minimap would be shown when the minimap is hidden. Does this by extracting and using a new fn `should_show_mini_map`.

QA:
- [x] pan using the minimap
- [x] pan canvas in the minimap area when it's off
- [x] pan canvas in the minimap area when not in notebook mode
- [x] pan canvas in the minimap area when overlay is hidden

side note: it's sensible to only show the minimap in scroll mode but confusing that you can have show minimap on and not see the minimap