### PR TITLE
ws: generalize ios undo/redo api to canvas

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -822,9 +822,9 @@ pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
 pub unsafe extern "C" fn undo_redo(obj: *mut c_void, redo: bool) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     if redo {
-        obj.renderer.context.push_markdown_event(Event::Redo);
+        obj.renderer.context.push_event(workspace_rs::Event::Redo);
     } else {
-        obj.renderer.context.push_markdown_event(Event::Undo);
+        obj.renderer.context.push_event(workspace_rs::Event::Undo);
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -67,7 +67,10 @@ impl<'ast> Editor {
                         }
                     }
                 }
-                _ => {}
+                crate::Event::PredictedTouch { .. } => {}
+                crate::Event::KineticPan { .. } => {}
+                crate::Event::Undo => result.push(Event::Undo),
+                crate::Event::Redo => result.push(Event::Redo),
             }
         }
         result

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -279,6 +279,8 @@ pub enum Event {
     Paste { content: Vec<ClipContent>, position: egui::Pos2 },
     PredictedTouch { id: egui::TouchId, force: Option<f32>, pos: egui::Pos2 },
     KineticPan { x: f32, y: f32 },
+    Undo,
+    Redo,
 }
 
 #[derive(Debug, Clone)]

--- a/libs/content/workspace/src/tab/svg_editor/gesture_handler.rs
+++ b/libs/content/workspace/src/tab/svg_editor/gesture_handler.rs
@@ -4,6 +4,7 @@ use egui::TouchPhase;
 use resvg::usvg::Transform;
 use tracing::trace;
 
+use crate::tab::ExtendedInput as _;
 use crate::tab::svg_editor::toolbar::{MINI_MAP_WIDTH, Toolbar};
 use crate::tab::svg_editor::util::get_pan;
 
@@ -66,6 +67,13 @@ impl GestureHandler {
                 self.handle_event(e, gesture_ctx)
             }
         });
+        for e in ui.ctx().read_events() {
+            match e {
+                crate::Event::Undo => gesture_ctx.history.undo(gesture_ctx.buffer),
+                crate::Event::Redo => gesture_ctx.history.redo(gesture_ctx.buffer),
+                _ => {}
+            };
+        }
         self.change_viewport(ui, gesture_ctx, hide_overlay);
     }
 


### PR DESCRIPTION
Instead of producing a markdown event, the ios undo/redo api now produces a workspace event (new variants) which are handled by markdown and canvas both. Other platforms have no equivalent.

QA:
- [x] multi-finger tap undo/redo in canvas
- [x] shake and keyboard undo in markdown