### PR TITLE
canvas: fix island check coordinates

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -943,8 +943,7 @@
                 return
             }
 
-            let config = UIEditMenuConfiguration(
-                identifier: nil, sourcePoint: gesture.location(in: self))
+            let config = UIEditMenuConfiguration(identifier: nil, sourcePoint: location)
             menuInteraction.presentEditMenu(with: config)
         }
 


### PR DESCRIPTION
Fixes an issue where tapping in the bottom 10px of a canvas island would also open the edit menu (if there was something in your clipboard that could be pasted).