### PR TITLE
ios: ws consumed taps preclude cursor placement

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -178,6 +178,18 @@
 
         public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
             mtkView.touchesBegan(touches, with: event)
+            
+            // consumed workspace touches (e.g. tapping to stop a kinetic scroll or toggle a checkbox) preclude cursor placement
+            for touch in touches {
+                let location = touch.location(in: self.mtkView)
+                if will_consume_touch(self.wsHandle, Float(location.x), Float(location.y)) {
+                    for gestureRecognizer in self.gestureRecognizers ?? [] {
+                        if gestureRecognizer.name == "UITextInteractionNameSingleTap" {
+                            gestureRecognizer.state = .failed
+                        }
+                    }
+                }
+            }
         }
 
         public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -936,8 +948,7 @@
 
             // Check if we have any valid actions before presenting
             let location = gesture.location(in: self.mtkView)
-            if canvas_detect_islands_interaction(
-                self.wsHandle, Float(location.x), Float(location.y))
+            if will_consume_touch(self.wsHandle, Float(location.x), Float(location.y))
                 || (!UIPasteboard.general.hasStrings && !UIPasteboard.general.hasImages)
             {
                 return

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -389,21 +389,21 @@ pub unsafe extern "C" fn tab_count(obj: *mut c_void) -> i64 {
 
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
-///
-/// https://developer.apple.com/documentation/uikit/uiresponder/1621142-touchesbegan
 #[no_mangle]
-pub unsafe extern "C" fn canvas_detect_islands_interaction(
-    obj: *mut c_void, x: f32, y: f32,
-) -> bool {
+pub unsafe extern "C" fn will_consume_touch(obj: *mut c_void, x: f32, y: f32) -> bool {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    let mut has_islands_interaction = false;
     if let Some(tab) = obj.workspace.current_tab() {
         if let ContentState::Open(TabContent::Svg(svg)) = &tab.content {
-            has_islands_interaction = svg.detect_islands_interaction(egui::pos2(x, y));
+            svg.detect_islands_interaction(egui::pos2(x, y))
+        } else if let ContentState::Open(TabContent::Markdown(md)) = &tab.content {
+            md.will_consume_touch(egui::pos2(x, y))
+        } else {
+            false
         }
+    } else {
+        false
     }
-    has_islands_interaction
 }
 
 /// # Safety

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -108,6 +108,8 @@ impl<'ast> Editor {
 
         let fold_button_space = annotation_space.translate(Vec2::X * -INDENT);
         let fold_button_size = self.row_height(node) * 0.6;
+        self.touch_consuming_rects.push(fold_button_space);
+
         if let Some(fold) = self.fold(node) {
             ui.allocate_ui_at_rect(fold_button_space, |ui| {
                 let icon = Icon::CHEVRON_RIGHT

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -24,6 +24,7 @@ impl<'ast> Editor {
 
         let annotation_size = Vec2 { x: INDENT, y: row_height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
+        self.touch_consuming_rects.push(annotation_space);
 
         ui.allocate_ui_at_rect(annotation_space, |ui| {
             let mut checked = maybe_check.is_some();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -164,6 +164,7 @@ impl<'ast> Editor {
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
         let fold_button_space = annotation_space.translate(Vec2::X * -INDENT);
         let fold_button_size = (self.row_height(node) * 0.6).min(INDENT / 2.);
+        self.touch_consuming_rects.push(fold_button_space);
 
         // todo: proper hit-testing (this ignores anything covering the space)
         let show_fold_button = self.touch_mode


### PR DESCRIPTION
Fixes an issue where tapping to stop a kinetic scroll or toggle a checkbox would also place the cursor, which would also summon the keyboard.