### PR TITLE
ios: even less sensitive cursor placement

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -178,7 +178,24 @@
 
         public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
             mtkView.touchesBegan(touches, with: event)
-            
+            self.checkCancelCursorPlacement(touches)
+        }
+
+        public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+            mtkView.touchesMoved(touches, with: event)
+            self.checkCancelCursorPlacement(touches)
+        }
+
+        public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+            mtkView.touchesEnded(touches, with: event)
+            self.checkCancelCursorPlacement(touches)
+        }
+
+        public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+            mtkView.touchesCancelled(touches, with: event)
+        }
+        
+        private func checkCancelCursorPlacement(_ touches: Set<UITouch>) {
             // consumed workspace touches (e.g. tapping to stop a kinetic scroll or toggle a checkbox) preclude cursor placement
             for touch in touches {
                 let location = touch.location(in: self.mtkView)
@@ -190,18 +207,6 @@
                     }
                 }
             }
-        }
-
-        public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-            mtkView.touchesMoved(touches, with: event)
-        }
-
-        public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-            mtkView.touchesEnded(touches, with: event)
-        }
-
-        public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
-            mtkView.touchesCancelled(touches, with: event)
         }
 
         public func beginFloatingCursor(at point: CGPoint) {


### PR DESCRIPTION
Fixes https://github.com/lockbook/lockbook/issues/4106 by canceling cursor placement if the markdown scroll area has velocity at any point during a touch rather than just at the beginning of the touch.

QA:
- [x] stop scroll momentum with a touch
- [x] start scroll momentum with a short flick
- [x] reverse direction of scroll momentum with a short flick