### PR TITLE
iOS: handle images pasted properly

### DIFF
--- a/clients/apple/iOS/Widgets/CameraView.swift
+++ b/clients/apple/iOS/Widgets/CameraView.swift
@@ -37,7 +37,7 @@ struct CameraView: UIViewControllerRepresentable {
                 .InfoKey: Any]
         ) {
             guard let image = info[.originalImage] as? UIImage,
-                let data = image.normalizedImage()?.jpegData(
+                let data = image.normalizedImage().jpegData(
                     compressionQuality: 1.0
                 )
             else {
@@ -55,24 +55,6 @@ struct CameraView: UIViewControllerRepresentable {
 
         func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
             parent.homeState.sheetInfo = nil
-        }
-    }
-}
-
-extension UIImage {
-    // The camera's native orientation is landscape (with correction in EXIF metadata)
-    // Workspace doesn't handle EXIF data, so this function automatically corrects the orientation
-    func normalizedImage() -> UIImage? {
-        if imageOrientation == .up { return self }
-
-        let format = UIGraphicsImageRendererFormat.default()
-        format.scale = self.scale
-        format.opaque = false
-
-        let renderer = UIGraphicsImageRenderer(size: self.size, format: format)
-
-        return renderer.image { context in
-            self.draw(in: CGRect(origin: .zero, size: self.size))
         }
     }
 }

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Util.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Util.swift
@@ -26,6 +26,29 @@ extension NSCursor {
 }
 #endif
 
+#if os(iOS)
+import UIKit
+
+extension UIImage {
+    // The camera's native orientation is landscape (with correction in EXIF metadata)
+    // Workspace doesn't handle EXIF data, so this function automatically corrects the orientation
+    public func normalizedImage() -> UIImage {
+        if imageOrientation == .up { return self }
+
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = self.scale
+        format.opaque = false
+
+        let renderer = UIGraphicsImageRenderer(size: self.size, format: format)
+
+        return renderer.image { context in
+            self.draw(in: CGRect(origin: .zero, size: self.size))
+        }
+    }
+}
+
+#endif
+
 func textFromPtr(s: UnsafeMutablePointer<CChar>!) -> String {
     if s == nil {
         return ""

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1656,6 +1656,7 @@
                     clipboard_send_file(wsHandle, url.path(percentEncoded: false), isPaste)
                 }
             case .image(let image):
+                let image = image.normalizedImage()
                 if let data = image.pngData() ?? image.jpegData(compressionQuality: 1.0) {
                     workspaceInput?.pasteImage(data: data, isPaste: isPaste)
                 }


### PR DESCRIPTION
- relocated @smailbarkouch's `normalize()` function
- eliminated the `Optional`
- call it on iOS image import

before / after

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/2ec152a9-4818-4b2a-975e-56a93eb74b40" />
