### PR TITLE
md: disable setext headings

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -276,6 +276,7 @@ impl Editor {
         let arena = Arena::new();
         let mut options = Options::default();
         options.parse.smart = true;
+        options.parse.ignore_setext = true;
         options.extension.alerts = true;
         options.extension.autolink = true;
         options.extension.description_lists = false; // todo: is this a good way to power workspace-wide term definitions?

--- a/libs/lb/lb-rs/src/service/account.rs
+++ b/libs/lb/lb-rs/src/service/account.rs
@@ -253,18 +253,6 @@ To create a heading, add up to six `#`'s plus a space before your text. More `#`
 > ##### Heading 5
 > ###### Heading 6
 
-You can also create a heading using an underline composed of `=`'s (Heading 1) or `-`'s (Heading 2) on the following line.
-```md
-Heading 1
-===
-Heading 2
----
-```
-> Heading 1
-> ===
-> Heading 2
-> ---
-
 ## Lists
 Create a list item by adding `- `, `+ `, or `* ` for a bulleted list, `1. ` for a numbered list, or `- [ ] `, `+ [ ] `, or `* [ ] ` for a task list at the start of the line. The added characters are called the *list marker*.
 ```md


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/3729

note that:
```md
h
-
```
is now a single-cell table instead. Perhaps this is not the solution we want.