### PR TITLE
lb-rs: add raayan beta_users

### DIFF
--- a/libs/lb/lb-rs/src/model/account.rs
+++ b/libs/lb/lb-rs/src/model/account.rs
@@ -28,6 +28,7 @@ pub const BETA_USERS: &[&str] = &[
     "rahul",
     "chetna",
     "chefbowyer",
+    "raayan",
 ];
 
 pub type Username = String;


### PR DESCRIPTION
Hey @raayan,

we added some infra to automatically send crash reports when a `beta_user` experiences a crash. This PR adds your name to the list of `beta_user`s, which allows us to sync your `debug_info` for analysis while you use the app.

You can see what information is collected by exploring this file: https://github.com/lockbook/lockbook/blob/master/libs/lb/lb-rs/src/service/debug.rs

The most valuable thing we get is that we get notified everytime your app crashes. You can audit the current implementation here: #4114.

Feel free to close this PR if this makes you uncomfortable (just leave a message).