### PR TITLE
lb-rs: add steve to beta_users

### DIFF
--- a/libs/lb/lb-rs/src/model/account.rs
+++ b/libs/lb/lb-rs/src/model/account.rs
@@ -16,7 +16,7 @@ pub const MAX_USERNAME_LENGTH: usize = 32;
 /// their name to this list. Certainly telemetry in lockbook will always be opt in but the
 /// mechanism of consent may evolve over time.
 pub const BETA_USERS: &[&str] =
-    &["parth", "travis", "smail", "adam", "krish", "aravd", "luca", "krishma"];
+    &["parth", "travis", "smail", "adam", "krish", "aravd", "luca", "krishma", "steve"];
 
 pub type Username = String;
 pub type ApiUrl = String;


### PR DESCRIPTION
we added some infra to automatically send crash reports when a `beta_user` experiences a crash. This PR adds your name to the list of `beta_user`s, which allows us to sync your `debug_info` for analysis while you use the app.

You can see what information is collected by exploring this file: https://github.com/lockbook/lockbook/blob/master/libs/lb/lb-rs/src/service/debug.rs

The most valuable thing we get is that we get notified everytime your app crashes. You can audit the current implementation here: #4114.

Feel free to close this PR if this makes you uncomfortable (just leave a message).