### PR TITLE
linux: update metainfo file to fix an error

### DIFF
--- a/utils/dev/flatpak-package/net.lockbook.Lockbook.appdata.xml
+++ b/utils/dev/flatpak-package/net.lockbook.Lockbook.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>net.lockbook.lockbook</id>
+  <id>net.lockbook.Lockbook</id>
 
   <name>Lockbook</name>
   <summary>Lockbook is an open source note taking app.</summary>
@@ -21,7 +21,7 @@
     </p>
   </description>
 
-  <launchable type="desktop-id">lockbook-desktop.desktop</launchable>
+  <launchable type="desktop-id">net.lockbook.Lockbook.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://lockbook.net/linux-screenshot1.png</image>


### PR DESCRIPTION
fix an error on flatpak-build 
```
Renaming net.lockbook.Lockbook.appdata.xml to share/metainfo/net.lockbook.Lockbook.metainfo.xml
Running appstreamcli compose
Only accepting components: net.lockbook.Lockbook, net.lockbook.Lockbook.desktop
Processing directory: /home/amumu/Documents/net.lockbook.Lockbook/.flatpak-builder/rofiles/rofiles-Qvb5Gx/files
Composing metadata...
Run failed, some data was ignored.
Errors were raised during this compose run:
general
  E: filters-but-no-output
Refer to the generated issue report data for details on the individual problems.
Error: ERROR: appstreamcli compose failed: Child process exited with code 1
```