### PR TITLE
android: don't hide bottom navigation bar on ime on mobile

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/MainScreenActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/MainScreenActivity.kt
@@ -323,7 +323,7 @@ class MainScreenActivity : AppCompatActivity(), BottomNavProvider {
                 }
             }
             is UpdateMainScreenUI.HideBottomViewNavigation -> {
-                if (!binding.slidingPaneLayout.isSlideable){
+                if (!binding.slidingPaneLayout.isSlideable) {
                     binding.bottomNavigation.visibility = View.GONE
                 }
             }


### PR DESCRIPTION
this will make it worse for tablet users because they're stuck with a navbar that hides the tab strip, but will solve the bug for mobile users where the navbar disappears on renaming/creating/searching a file. 

mobile is prioritized over tablet due to market size share, but in the future i'll implement a proper fix through a side navbar on tablet screens. 