### PR TITLE
apple: show out of space sheet more often

### DIFF
--- a/clients/apple/Shared/Screens/OutOfSpaceAlert.swift
+++ b/clients/apple/Shared/Screens/OutOfSpaceAlert.swift
@@ -3,26 +3,91 @@ import SwiftUI
 struct OutOfSpaceAlert: ViewModifier {
     @EnvironmentObject var homeState: HomeState
     
-    #if os(macOS)
-    @Environment(\.openWindow) private var openWindow
-    #endif
-    
+    @AppStorage("hideOutOfSpaceSheet") private var hideOutOfSpaceSheet: Bool = false
+
     func body(content: Content) -> some View {
         content
-            .alert("You have run out of space", isPresented: $homeState.showOutOfSpaceAlert) {
-                Button("Upgrade account") {
-                    #if os(iOS)
-                    homeState.showUpgradeAccount = true
-                    #else
-                    openWindow(id: "upgrade-account")
-                    #endif
+            .sheet(isPresented: Binding(
+                get: { homeState.showOutOfSpaceAlert },
+                set: { newValue in
+                    if !newValue {
+                        homeState.dismissOutOfSpaceAlert()
+                    }
                 }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("Purchase premium to access more space")
+            )) {
+                OutOfSpaceSheet()
             }
-            .navigationDestination(isPresented: $homeState.showUpgradeAccount) {
-                UpgradeAccountView(settingsModel: SettingsViewModel())
+    }
+}
+
+struct OutOfSpaceSheet: View {
+    #if os(macOS)
+        @Environment(\.openWindow) private var openWindow
+    #endif
+
+    @EnvironmentObject var homeState: HomeState
+
+    @AppStorage("hideOutOfSpaceSheet") private var hideOutOfSpaceSheet: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("You are out of storage")
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .padding(.bottom)
+
+                Text("Syncing is paused because your account is out of storage.")
+
+                Text("To resume syncing, clear some data or **upgrade to premium**.")
+
+                Text("Premium gives you **30 GB of secure, encrypted storage** - perfect for all your notes, files, and memories.")
             }
+            .multilineTextAlignment(.leading)
+
+            Spacer()
+            
+            Toggle(isOn: $hideOutOfSpaceSheet) {
+                Text("Don’t show this again")
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+            }
+            .toggleStyle(iOSCheckboxToggleStyle())
+            .padding(.vertical, 8)
+
+            VStack(spacing: 12) {
+                Button {
+                    #if os(iOS)
+                        homeState.showUpgradeAccount = true
+                        homeState.sidebarState = .closed
+                    #else
+                        openWindow(id: "upgrade-account")
+                    #endif
+                    homeState.dismissOutOfSpaceAlert()
+                } label: {
+                    Text("Upgrade to Premium")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 30)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.bottom, 6)
+
+                Button {
+                    homeState.dismissOutOfSpaceAlert()
+                } label: {
+                    Text("Ignore for now")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 30)
+                }
+                .buttonStyle(.bordered)
+                .padding(.bottom)
+            }
+        }
+        .padding(.top, 35)
+        .padding(.horizontal, 25)
+        .padding(.bottom)
+        .presentationDetents([.fraction(0.70)])
     }
 }

--- a/clients/apple/Shared/State/HomeState.swift
+++ b/clients/apple/Shared/State/HomeState.swift
@@ -23,6 +23,11 @@ class HomeState: ObservableObject {
     @Published var isSidebarFloating: Bool = false
     #endif
     
+    @Published var showTabsSheet: Bool = false
+
+    @Published private(set) var showOutOfSpaceAlert: Bool = false
+    @AppStorage("hideOutOfSpaceSheet") private var hideOutOfSpaceSheet: Bool = false
+    
     var splitViewVisibility: Binding<NavigationSplitViewVisibility> {
         Binding(
             get: {
@@ -45,9 +50,6 @@ class HomeState: ObservableObject {
             }
         )
     }
-    
-    @Published var showTabsSheet: Bool = false
-    @Published var showOutOfSpaceAlert: Bool = false
     
     var cancellables: Set<AnyCancellable> = []
     
@@ -89,6 +91,22 @@ class HomeState: ObservableObject {
             }
         }
         .store(in: &cancellables)
+        
+        AppState.lb.events.$status.sink { [weak self] status in
+            if status.outOfSpace {
+                self?.triggerOutOfSpaceAlert()
+            }
+        }
+        .store(in: &cancellables)
+    }
+    
+    func triggerOutOfSpaceAlert() {
+        guard !hideOutOfSpaceSheet else { return }
+        showOutOfSpaceAlert = true
+    }
+
+    func dismissOutOfSpaceAlert() {
+        showOutOfSpaceAlert = false
     }
     
     func closeWorkspaceBlockingScreens() {

--- a/clients/apple/Shared/Widgets/SyncButton.swift
+++ b/clients/apple/Shared/Widgets/SyncButton.swift
@@ -17,7 +17,7 @@ struct SyncButton: View {
             if syncButtonStatus == .updateRequired {
                 AppState.shared.error = .custom(title: "Your Lockbook is out of date", msg: "Update to the latest version to sync")
             } else if syncButtonStatus == .outOfSpace {
-                homeState.showOutOfSpaceAlert = true
+                homeState.triggerOutOfSpaceAlert()
             }
             
             

--- a/clients/apple/iOS/Screens/HomeView.swift
+++ b/clients/apple/iOS/Screens/HomeView.swift
@@ -152,6 +152,9 @@ struct HomeView: View {
             .navigationDestination(isPresented: $homeState.showSettings) {
                 SettingsView(model: settingsModel)
             }
+            .navigationDestination(isPresented: $homeState.showUpgradeAccount) {
+                UpgradeAccountView(settingsModel: SettingsViewModel())
+            }
     }
 
     func syncFloatingState(splitView: UISplitViewController) {
@@ -222,7 +225,7 @@ struct FilesHomeView: View {
                 .refreshable {
                     if AppState.lb.events.status.outOfSpace {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                            homeState.showOutOfSpaceAlert = true
+                            homeState.triggerOutOfSpaceAlert()
                         }
                     }
                     


### PR DESCRIPTION
This PR does three things:
1. Update the out of space alert to be more user friendly
2. Show the sheet whenever there is no space (not just from a manual sync)
3. Allow the user to dismiss the alert forever
After:
<img width="1578" height="1044" alt="image" src="https://github.com/user-attachments/assets/b95f8cc0-4112-4c90-beda-82d3d0d00ede" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/efcbe1b3-1674-4ca5-ad45-57514ea36cfa" />

Before:

<img width="168" height="163" alt="image" src="https://github.com/user-attachments/assets/7b949a20-2715-44ff-b8ef-e2f420d2ef8f" />

<img width="191" height="139" alt="image" src="https://github.com/user-attachments/assets/7e4dbb56-1c8c-4822-a5b6-1120da4cd8f9" />

