### PR TITLE
lb: add praful as a beta user

### DIFF
--- a/libs/lb/lb-rs/src/model/account.rs
+++ b/libs/lb/lb-rs/src/model/account.rs
@@ -29,6 +29,7 @@ pub const BETA_USERS: &[&str] = &[
     "chetna",
     "chefbowyer",
     "raayan",
+    "praful",
 ];
 
 pub type Username = String;


### PR DESCRIPTION
Hey,

we added some infra to automatically send crash reports when a beta_user experiences a crash. This PR adds your name to the list of beta_users, which allows us to sync your debug_info for analysis while you use the app.

You can see what information is collected by exploring this file: https://github.com/lockbook/lockbook/blob/master/libs/lb/lb-rs/src/service/debug.rs

The most valuable thing we get is that we get notified everytime your app crashes. You can audit the current implementation here: https://github.com/lockbook/lockbook/pull/4114.

Feel free to close this PR if this makes you uncomfortable (just leave a message).