### PR TITLE
md: fix height of whitespace-only docs

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
@@ -22,6 +22,24 @@ impl<'ast> Editor {
         }
     }
 
+    pub fn height_document(&self, node: &'ast AstNode<'ast>) -> f32 {
+        let width = self.width(node);
+
+        let any_children = node.children().next().is_some();
+        if any_children && !self.plaintext_mode {
+            self.block_children_height(node)
+        } else {
+            let mut result = 0.;
+            for line_idx in self.node_lines(node).iter() {
+                let line = self.bounds.source_lines[line_idx];
+                result +=
+                    self.height_section(&mut Wrap::new(width), line, self.text_format_syntax(node));
+                result += ROW_SPACING;
+            }
+            result
+        }
+    }
+
     pub fn show_document(
         &mut self, ui: &mut egui::Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
     ) {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -127,7 +127,7 @@ impl<'ast> Editor {
             NodeValue::BlockQuote => self.height_block_quote(node),
             NodeValue::DescriptionItem(_) => unimplemented!("extension disabled"),
             NodeValue::DescriptionList => unimplemented!("extension disabled"),
-            NodeValue::Document => self.block_children_height(node),
+            NodeValue::Document => self.height_document(node),
             NodeValue::FootnoteDefinition(_) => self.height_footnote_definition(node),
             NodeValue::Item(_) => self.height_item(node),
             NodeValue::List(_) => self.block_children_height(node),


### PR DESCRIPTION
you couldn't scroll to the bottom even if that's where your cursor was