### PR TITLE
cli & linux: respect API_URL in more situations

### DIFF
--- a/clients/cli/src/account.rs
+++ b/clients/cli/src/account.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use cli_rs::cli_error::{CliError, CliResult};
 
 use is_terminal::IsTerminal;
+use lb_rs::DEFAULT_API_LOCATION;
 use lb_rs::model::api::{PaymentMethod, PaymentPlatform, StripeAccountTier};
 use lb_rs::model::work_unit::WorkUnit;
 
@@ -20,7 +21,7 @@ pub async fn new(username: String, api_url: ApiUrl) -> CliResult<()> {
 }
 
 #[tokio::main]
-pub async fn import() -> CliResult<()> {
+pub async fn import(api_url: ApiUrl) -> CliResult<()> {
     let lb = &core().await?;
     if io::stdin().is_terminal() {
         return Err(CliError::from("to import an existing lockbook account, pipe your account string into this command, e.g.:\npbpaste | lockbook account import".to_string()));
@@ -33,7 +34,7 @@ pub async fn import() -> CliResult<()> {
     account_string = account_string.trim().to_string();
 
     println!("importing account...");
-    lb.import_account(&account_string, None).await?;
+    lb.import_account(&account_string, Some(&api_url.0)).await?;
 
     println!("account imported! next, try to sync by running: lockbook sync");
 
@@ -180,7 +181,7 @@ pub struct ApiUrl(String);
 
 impl Default for ApiUrl {
     fn default() -> Self {
-        Self(std::env::var("API_URL").unwrap_or("https://api.prod.lockbook.net".to_string()))
+        Self(std::env::var("API_URL").unwrap_or(DEFAULT_API_LOCATION.to_string()))
     }
 }
 

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -47,7 +47,12 @@ fn run() -> CliResult<()> {
                 )
                 .subcommand(
                     Command::name("import").description("import an existing account by piping in the account string")
-                        .handler(account::import)
+                        .input(Flag::<ApiUrl>::new("api_url")
+                        .description("location of the lockbook server you're trying to use. If not provided will check the API_URL env var, and then fall back to https://api.prod.lockbook.net"))
+
+                        .handler(|api_url| {
+                            account::import(api_url.get())
+                        })
                 )
                 .subcommand(
                     Command::name("export").description("reveal your account's private key")

--- a/clients/egui/src/onboard.rs
+++ b/clients/egui/src/onboard.rs
@@ -548,7 +548,10 @@ You can view your key again in the settings."#
         let ctx = ctx.clone();
 
         thread::spawn(move || {
-            if let Err(err) = core.import_account(&key, None) {
+            let api_url =
+                std::env::var("API_URL").unwrap_or_else(|_| DEFAULT_API_LOCATION.to_string());
+
+            if let Err(err) = core.import_account(&key, Some(&api_url)) {
                 tx.send(Update::AccountImported(Some(err))).unwrap();
                 ctx.request_repaint();
                 return;


### PR DESCRIPTION
the people desire self hosting, this makes sure that self hosting will work as expected when people want to point a client at a different server. CLI & Linux.