### PR TITLE
lb-rs: fix search crash

### DIFF
--- a/libs/lb/lb-rs/src/subscribers/search.rs
+++ b/libs/lb/lb-rs/src/subscribers/search.rs
@@ -241,12 +241,15 @@ impl Lb {
                 continue;
             };
 
-            let Ok(doc) = String::from_utf8(self.read_document(file.id, false).await.unwrap())
-            else {
+            let Ok(doc) = self.read_document(file.id, false).await else {
                 continue;
             };
 
             if doc.len() > CONTENT_MAX_LEN_BYTES {
+                continue;
+            };
+
+            let Ok(doc) = String::from_utf8(doc) else {
                 continue;
             };
 


### PR DESCRIPTION
fixes #4188 

we're embracing some out of date-ness here, but if a document gets deleted from sync the loop that maintains the tantivy index will fail (for no good reason).

this is the sort of bug I only find out about because of the debug info reporter (@ad-tra @tvanderstad)