### PR TITLE
workspace: persist active tab when closing earlier tab

### DIFF
--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -318,7 +318,7 @@ impl Workspace {
         self.tabs.remove(i);
         self.out.tabs_changed = true;
 
-        if !self.tabs.is_empty() && self.current_tab >= self.tabs.len() {
+        if !self.tabs.is_empty() && (self.current_tab >= self.tabs.len() || i < self.current_tab) {
             self.current_tab -= 1;
         }
         self.current_tab_changed = true;


### PR DESCRIPTION
Fixes an obscure tab closing bug. If you close an earlier tab - then your active tab will shift up

After
<video src="https://github.com/user-attachments/assets/dfaad8ed-129d-497c-b6ed-314009833435" controls></video>

Before
<video src="https://github.com/user-attachments/assets/25cec8a4-cf88-4a77-852e-ab6ede60f926" controls></video>