### PR TITLE
md: fix advance by line when text wraps on non-whitespace

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/galleys.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/galleys.rs
@@ -71,17 +71,36 @@ impl Editor {
         galley.rect.min.x + rel_x
     }
 
-    /// Returns the offset closest to pos in this galley.
-    pub fn galley_offset(&self, galley: &GalleyInfo, pos: Pos2) -> DocCharOffset {
+    /// Returns the offset closest to pos in this galley, excluding the offset
+    /// after the last glyph.
+    pub fn galley_offset(&self, galley_idx: usize, pos: Pos2) -> DocCharOffset {
+        let galley = &self.galleys.galleys[galley_idx];
         let buffer = galley.buffer.read().unwrap();
-        let glyphs = buffer.layout_runs().next().unwrap().glyphs;
+        let layout_run = buffer.layout_runs().next().unwrap();
+        let glyphs = layout_run.glyphs;
 
         let rel_x = pos.x - galley.rect.min.x;
         let start = self.offset_to_byte(galley.range.start());
 
         let mut rel_offset = 0;
         let mut x = 0.;
-        for glyph in glyphs.iter() {
+
+        // prefer next row
+        let owned_glyphs = if self.galleys.len() > galley_idx + 1 {
+            let next_galley = &self.galleys.galleys[galley_idx + 1];
+            if next_galley.range.start() == galley.range.end() {
+                // when galleys touch, the boundary belongs to the later galley
+                glyphs.len().saturating_sub(1)
+            } else {
+                // doesn't touch next galley
+                glyphs.len()
+            }
+        } else {
+            // no further galleys
+            glyphs.len()
+        };
+
+        for glyph in glyphs.iter().take(owned_glyphs) {
             if x + glyph.w / self.ctx.pixels_per_point() / 2. > rel_x {
                 break;
             }

--- a/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
@@ -72,7 +72,7 @@ impl Editor {
                     let cur_y = cur_galley.rect.min.y;
                     let target_pos = Pos2::new(x_target, cur_y);
 
-                    let new_offset = self.galley_offset(new_galley, target_pos);
+                    let new_offset = self.galley_offset(new_galley_idx, target_pos);
                     let new_x = self.galley_x(new_galley, new_offset);
 
                     let distance = (new_x - x_target).abs(); // closest as in closest to target
@@ -112,7 +112,7 @@ impl Editor {
                     let cur_y = cur_galley.rect.min.y;
                     let target_pos = Pos2::new(x_target, cur_y);
 
-                    let new_offset = self.galley_offset(new_galley, target_pos);
+                    let new_offset = self.galley_offset(new_galley_idx, target_pos);
                     let new_x = self.galley_x(new_galley, new_offset);
 
                     let distance = (new_x - x_target).abs(); // closest as in closest to target

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -1014,7 +1014,7 @@ impl<'ast> Editor {
                 // click an override galley to select the whole thing
                 galley.range
             } else {
-                self.galley_offset(galley, pos).into_range()
+                self.galley_offset(galley_idx, pos).into_range()
             }
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -61,6 +61,17 @@ impl Wrap {
             line.1 = line.1.max(range.1);
         } else {
             self.row_ranges.push(range);
+
+            // prefer next row
+            if row > 0 {
+                if let Some(prev_line) = self.row_ranges.get_mut(row - 1) {
+                    // when two rows' ranges touch, shorten the earlier so that
+                    // the boundary belongs to the later
+                    if prev_line.end() == range.start() {
+                        prev_line.1 -= 1;
+                    }
+                }
+            }
         }
     }
 }
@@ -193,7 +204,6 @@ impl Editor {
             buffer: std::sync::Arc<std::sync::RwLock<glyphon::Buffer>>,
             size: Vec2,
             pos: Pos2,
-            range: (DocCharOffset, DocCharOffset),
         }
         let mut rows: Vec<RowData> = Vec::new();
 
@@ -212,14 +222,21 @@ impl Editor {
                     wrap.row_offset(),
                     wrap.row() as f32 * (font_size + ROW_SPACING) + y_offset,
                 );
+            let rect = Rect::from_min_size(pos, size);
+
+            let row_range = if override_text.is_some() { range } else { first_row_range };
             let advance = if !remaining_text.is_empty() { wrap.row_remaining() } else { size.x };
-            rows.push(RowData {
-                buffer: row,
-                size,
-                pos,
-                range: if override_text.is_some() { range } else { first_row_range },
-            });
+
+            wrap.add_range(row_range);
             wrap.offset += advance;
+            self.galleys.push(GalleyInfo {
+                is_override: override_text.is_some(),
+                range: row_range,
+                buffer: row.clone(),
+                rect,
+                padded,
+            });
+            rows.push(RowData { buffer: row, size, pos });
         }
 
         if !remaining_text.is_empty() {
@@ -257,15 +274,27 @@ impl Editor {
                     wrap.width,
                     &text_format,
                 );
+
                 let size = row.read().unwrap().shaped_size(ppi);
                 let pos = top_left
                     + Vec2::new(
                         wrap.row_offset(),
                         wrap.row() as f32 * (font_size + ROW_SPACING) + y_offset,
                     );
+                let rect = Rect::from_min_size(pos, size);
+
                 let advance = if i < runs_count - 1 { wrap.row_remaining() } else { size.x };
-                rows.push(RowData { buffer: row, size, pos, range: row_range });
+
+                wrap.add_range(row_range);
                 wrap.offset += advance;
+                self.galleys.push(GalleyInfo {
+                    is_override: override_text.is_some(),
+                    range: row_range,
+                    buffer: row.clone(),
+                    rect,
+                    padded,
+                });
+                rows.push(RowData { buffer: row, size, pos });
             }
         }
 
@@ -299,14 +328,6 @@ impl Editor {
                 ));
                 draw_decorations(ui, row.pos, row.size, font_size, &text_format, response.hovered);
             }
-            self.galleys.push(GalleyInfo {
-                is_override: override_text.is_some(),
-                range: row.range,
-                buffer: row.buffer,
-                rect,
-                padded,
-            });
-            wrap.add_range(row.range);
         }
 
         wrap.offset += post_span;


### PR DESCRIPTION
Fixes handling of wrap lines when navigating with up and down arrows or cmd+left/right. Wrap line spans were allowed to touch, meaning when a line wrapped, the start of one line was the same as the end of the previous. Sometimes, advancing up a line would put you at the end of that line, which would put you at the start of the current line, which would not advance you at all. cmd+left/right had related issues where they would detect you to be on the wrong line and advance you to the wrong place on account of that.