### PR TITLE
md: fix link tapping issues on mobile

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -66,7 +66,7 @@ impl<'ast> Editor {
                 self.node_range(node).end().into_range(),
                 self.text_format(node.parent().unwrap()),
                 Some(" "),
-                Sense::click(),
+                Sense::focusable_noninteractive(),
             );
             response |= self.show_override_section(
                 ui,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -298,11 +298,15 @@ impl Editor {
         let mut response = Response::default();
         for row in &rows {
             let rect = Rect::from_min_size(row.pos, row.size);
-            let interact_rect = if padded { rect.expand(self.layout.inline_padding) } else { rect };
+            let interact_rect =
+                rect.expand2(Vec2::new(self.layout.inline_padding, self.layout.row_spacing / 2.));
             let id = ui.id().with((row.pos.x.to_bits(), row.pos.y.to_bits()));
             let egui_resp = ui.interact(interact_rect, id, sense);
             response.hovered |= egui_resp.hovered();
             response.clicked |= egui_resp.clicked();
+            if sense == Sense::click() {
+                self.touch_consuming_rects.push(interact_rect);
+            }
         }
 
         // render


### PR DESCRIPTION
* adds rects for clickable inlines to touch consuming rects so that clicking a clickable inline does not also place the cursor
* expands the clickable rect for inlines to make link buttons easier to tap