### PR TITLE
md: cursor must be strictly inside inline syntax to reveal it

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
@@ -416,7 +416,7 @@ impl<'ast> Editor {
     /// generally need additional consideration for optional indentation etc.
     pub fn node_intersects_selection(&self, node: &'ast AstNode<'ast>) -> bool {
         self.node_range(node)
-            .intersects(&self.buffer.current.selection, true)
+            .intersects(&self.buffer.current.selection, false)
     }
 
     pub fn node_contains_selection(&self, node: &'ast AstNode<'ast>) -> bool {


### PR DESCRIPTION
I'd like to try this change, which pushes the editor in more of a rich text direction by capturing syntax more often. Without the change, the cursor at end of `**bold**|` reveals the syntax - with the change, it doesn't.

This makes completing a link or emoji shortcode more satisfying, which is what makes now the time.