### PR TITLE
md: shareable file cache

### DIFF
--- a/libs/content/workspace/src/landing.rs
+++ b/libs/content/workspace/src/landing.rs
@@ -104,7 +104,9 @@ impl Workspace {
                 });
         });
 
-        let Some(files) = &self.files else {
+        let files_arc = Arc::clone(&self.files);
+        let files_guard = files_arc.read().unwrap();
+        let Some(files) = files_guard.as_ref() else {
             ui.ctx().request_repaint_after(Duration::from_millis(8));
             return;
         };
@@ -137,7 +139,9 @@ impl Workspace {
     fn show_heading(&mut self, ui: &mut egui::Ui) -> Response {
         let mut response = Response::default();
 
-        let Some(files) = &self.files else {
+        let files_arc = Arc::clone(&self.files);
+        let files_guard = files_arc.read().unwrap();
+        let Some(files) = files_guard.as_ref() else {
             ui.ctx().request_repaint_after(Duration::from_millis(8));
             return response;
         };
@@ -190,7 +194,9 @@ impl Workspace {
     fn show_filters(&mut self, ui: &mut egui::Ui) -> Response {
         let mut response = Response::default();
 
-        let (Some(files), Some(account)) = (&self.files, &self.account) else {
+        let files_arc = Arc::clone(&self.files);
+        let files_guard = files_arc.read().unwrap();
+        let (Some(files), Some(account)) = (files_guard.as_ref(), &self.account) else {
             ui.ctx().request_repaint_after(Duration::from_millis(8));
             return response;
         };
@@ -603,7 +609,9 @@ impl Workspace {
     fn show_files(&mut self, ui: &mut egui::Ui) -> Response {
         let mut response = Response::default();
 
-        let (Some(files), Some(account)) = (&self.files, &self.account) else {
+        let files_arc = Arc::clone(&self.files);
+        let files_guard = files_arc.read().unwrap();
+        let (Some(files), Some(account)) = (files_guard.as_ref(), &self.account) else {
             ui.ctx().request_repaint_after(Duration::from_millis(8));
             return response;
         };

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -2,9 +2,10 @@ use glyphon::FontSystem;
 use std::collections::HashMap;
 use std::io::{BufReader, Cursor};
 use std::mem;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use web_time::Instant;
 
+use crate::file_cache::FileCache;
 use bounds::Bounds;
 use colored::Colorize as _;
 use comrak::nodes::AstNode;
@@ -64,6 +65,7 @@ pub struct Editor {
     pub ctx: Context,
     pub persistence: WsPersistentStore,
     pub font_system: Arc<Mutex<FontSystem>>,
+    pub files: Arc<RwLock<Option<FileCache>>>,
     pub layout: MdLayout,
 
     // theme
@@ -146,6 +148,7 @@ pub struct MdResources {
     pub core: Lb,
     pub persistence: WsPersistentStore,
     pub font_system: Arc<Mutex<FontSystem>>,
+    pub files: Arc<RwLock<Option<FileCache>>>,
 }
 
 pub struct MdConfig {
@@ -205,7 +208,7 @@ impl Editor {
     pub fn new(
         md: &str, file_id: Uuid, hmac: Option<DocumentHmac>, res: MdResources, cfg: MdConfig,
     ) -> Self {
-        let MdResources { ctx, core, persistence, font_system } = res;
+        let MdResources { ctx, core, persistence, font_system, files } = res;
         let MdConfig { plaintext_mode, readonly } = cfg;
 
         let dark_mode = ctx.style().visuals.dark_mode;
@@ -226,6 +229,7 @@ impl Editor {
             ctx,
             persistence,
             font_system,
+            files,
 
             dark_mode,
             syntax_set,
@@ -291,6 +295,7 @@ impl Editor {
                     format!("/tmp/{}", Uuid::new_v4()).into(),
                 ),
                 font_system: Arc::new(Mutex::new(crate::make_font_system())),
+                files: Arc::new(RwLock::new(None)),
             },
             MdConfig { plaintext_mode: false, readonly: false },
         )

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -352,7 +352,9 @@ impl Workspace {
     }
 
     pub fn tab_title(&self, tab: &Tab) -> String {
-        match (tab.id(), &self.files) {
+        let files_arc = std::sync::Arc::clone(&self.files);
+        let files_guard = files_arc.read().unwrap();
+        match (tab.id(), files_guard.as_ref()) {
             (Some(id), Some(files)) => {
                 if let Some(file) = files.files.iter().chain(&files.shared).find(|f| f.id == id) {
                     file.name.clone()

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -49,7 +49,7 @@ pub struct Workspace {
 
     // Files and task status
     pub tasks: TaskManager,
-    pub files: Option<FileCache>,
+    pub files: Arc<RwLock<Option<FileCache>>>,
     pub last_save_all: Option<Instant>,
     pub last_sync_completed: Option<Instant>,
 
@@ -81,7 +81,7 @@ impl Workspace {
         let writable_dir = core.get_config().writeable_path;
         let writeable_dir = Path::new(&writable_dir);
         let writeable_path = writeable_dir.join("ws_persistence.json");
-        let files = FileCache::new(core).log_and_ignore();
+        let files = Arc::new(RwLock::new(FileCache::new(core).log_and_ignore()));
 
         let cfg = WsPersistentStore::new(core.recent_panic().unwrap_or(true), writeable_path);
         ctx.set_zoom_factor(cfg.get_zoom_factor());
@@ -339,8 +339,10 @@ impl Workspace {
         match self.lb_rx.try_recv() {
             Ok(evt) => match evt {
                 Event::MetadataChanged => {
-                    self.files = FileCache::new(&self.core).log_and_ignore();
-                    if let Some(files) = &self.files {
+                    *self.files.write().unwrap() = FileCache::new(&self.core).log_and_ignore();
+                    let files_arc = Arc::clone(&self.files);
+                    let files_guard = files_arc.read().unwrap();
+                    if let Some(files) = files_guard.as_ref() {
                         let mut tabs_to_delete = vec![];
                         for tab in &self.tabs {
                             if let Some(id) = tab.id() {
@@ -493,6 +495,7 @@ impl Workspace {
                                             core: core.clone(),
                                             persistence: self.cfg.clone(),
                                             font_system: self.font_system.clone(),
+                                            files: Arc::clone(&self.files),
                                         },
                                         MdConfig {
                                             plaintext_mode: ext != "md",
@@ -706,7 +709,9 @@ impl Workspace {
 
     pub fn effective_focused_parent(&self) -> Uuid {
         let get_by_id_cached_read_through = |id| {
-            if let Some(files) = &self.files {
+            let files_arc = Arc::clone(&self.files);
+            let files_guard = files_arc.read().unwrap();
+            if let Some(files) = files_guard.as_ref() {
                 files.files.get_by_id(id).cloned()
             } else {
                 self.core.get_file_by_id(id).ok()
@@ -726,7 +731,9 @@ impl Workspace {
                 return current_tab;
             }
 
-            if let Some(files) = &self.files {
+            let files_arc = Arc::clone(&self.files);
+            let files_guard = files_arc.read().unwrap();
+            if let Some(files) = files_guard.as_ref() {
                 files.root.clone()
             } else {
                 self.core.get_root().unwrap()

--- a/public-site/trunk/src/app.rs
+++ b/public-site/trunk/src/app.rs
@@ -94,6 +94,7 @@ impl eframe::App for LbWebApp {
                             core: self.workspace.core.clone(),
                             persistence: self.workspace.cfg.clone(),
                             font_system: Arc::new(Mutex::new(workspace_rs::make_font_system())),
+                            files: Arc::new(std::sync::RwLock::new(None)),
                         },
                         MdConfig { plaintext_mode: false, readonly: false },
                     ));


### PR DESCRIPTION
This puts workspace's file cache in an `Arc<RwLock<_>>` so it can be shared e.g. with the editor