### PR TITLE
android: remove deprecated calculate work

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/model/FilesListViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/FilesListViewModel.kt
@@ -226,14 +226,14 @@ class FilesListViewModel(application: Application) : AndroidViewModel(applicatio
         _notifyUpdateFilesUI.postValue(sidebarInfo)
 
         try {
-            val syncWork = Lb.calculateWork()
-            sidebarInfo.lastSynced = Lb.getTimestampHumanString(syncWork.latestServerTS)
-            sidebarInfo.serverDirtyFilesCount = syncWork.workUnits.filter { !it.isLocalChange }.size
+            // val syncWork = Lb.calculateWork()
+            // sidebarInfo.lastSynced = Lb.getTimestampHumanString(syncWork.latestServerTS)
+            // sidebarInfo.serverDirtyFilesCount = syncWork.workUnits.filter { !it.isLocalChange }.size
 
-            serverChanges = syncWork.workUnits.filter { !it.isLocalChange }.map { it.id }.toHashSet()
-            viewModelScope.launch(Dispatchers.Main) {
-                files.set(fileModel.children.intoViewHolderInfo(localChanges, serverChanges))
-            }
+            // serverChanges = syncWork.workUnits.filter { !it.isLocalChange }.map { it.id }.toHashSet()
+            // viewModelScope.launch(Dispatchers.Main) {
+            //    files.set(fileModel.children.intoViewHolderInfo(localChanges, serverChanges))
+            // }
         } catch (err: LbError) {
             if (err.kind != LbEC.ServerUnreachable) {
                 _notifyUpdateFilesUI.postValue(UpdateFilesUI.NotifyError(err))

--- a/clients/android/app/src/main/java/app/lockbook/model/WorkspaceViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/WorkspaceViewModel.kt
@@ -57,17 +57,9 @@ class WorkspaceViewModel : ViewModel() {
     val msg: LiveData<String>
         get() = _msg
 
-    val _refreshFiles = SingleMutableLiveData<Unit>()
-    val refreshFiles: LiveData<Unit>
-        get() = _refreshFiles
-
     val _hideMaterialToolbar = SingleMutableLiveData<Float>()
     val hideMaterialToolbar: LiveData<Float>
         get() = _hideMaterialToolbar
-
-    val _newFolderBtnPressed = SingleMutableLiveData<Unit>()
-    val newFolderBtnPressed: LiveData<Unit>
-        get() = _newFolderBtnPressed
 
     val _tabTitleClicked = SingleMutableLiveData<Unit>()
     val tabTitleClicked: LiveData<Unit>

--- a/clients/android/app/src/main/java/app/lockbook/screen/FilesListFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/FilesListFragment.kt
@@ -193,10 +193,6 @@ class FilesListFragment : Fragment(), FilesFragment {
             updateUI(uiUpdate)
         }
 
-        workspaceModel.refreshFiles.observe(viewLifecycleOwner) {
-            model.reloadFiles()
-        }
-
         workspaceModel.syncCompleted.observe(viewLifecycleOwner) {
             binding.listFilesRefresh.isRefreshing = false
         }

--- a/clients/android/app/src/main/java/app/lockbook/screen/MainScreenActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/MainScreenActivity.kt
@@ -27,7 +27,6 @@ import app.lockbook.databinding.ActivityMainScreenBinding
 import app.lockbook.model.*
 import app.lockbook.ui.*
 import app.lockbook.util.*
-import net.lockbook.Lb
 import java.io.File
 import java.lang.ref.WeakReference
 
@@ -197,10 +196,6 @@ class MainScreenActivity : AppCompatActivity(), BottomNavProvider {
             this
         ) { update ->
             updateMainScreenUI(update)
-        }
-
-        workspaceModel.newFolderBtnPressed.observe(this) {
-            model.launchTransientScreen(TransientScreen.Create(Lb.getRoot().id))
         }
 
         workspaceModel.tabTitleClicked.observe(this) {

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -362,13 +362,6 @@ class WorkspaceView(context: Context, val model: WorkspaceViewModel) : SurfaceVi
                 model._msg.value = status.msg
                 model.lastSyncStatusUpdate = System.currentTimeMillis()
             }
-            if (response.newFolderBtnPressed) {
-                model._newFolderBtnPressed.postValue(Unit)
-            }
-
-            if (response.refreshFiles) {
-                model._refreshFiles.postValue(Unit)
-            }
 
             if (!response.docCreated.isNullUUID()) {
                 model._createFile.postValue(response.docCreated)

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -49,13 +49,6 @@ public data class AndroidResponse(
     @SerialName("doc_created")
     val docCreated: String,
 
-    @SerialName("status_updated")
-    val statusUpdated: Boolean,
-    @SerialName("refresh_files")
-    val refreshFiles: Boolean,
-
-    @SerialName("new_folder_btn_pressed")
-    val newFolderBtnPressed: Boolean,
     @SerialName("tab_title_clicked")
     val tabTitleClicked: Boolean,
     @SerialName("tabs_changed")

--- a/libs/lb/lb-java/lib/src/main/java/net/lockbook/Lb.java
+++ b/libs/lb/lb-java/lib/src/main/java/net/lockbook/Lb.java
@@ -39,7 +39,6 @@ public class Lb {
 
     public static native Usage getUsage() throws LbError;
     public static native Usage.UsageItemMetric getUncompressedUsage() throws LbError;
-    public static native SyncStatus calculateWork() throws LbError;
     public static native String[] getLocalChanges() throws LbError;
     public static native void sync(SyncProgress syncProgress) throws LbError;
     public static native File[] getPendingShares() throws LbError;


### PR DESCRIPTION
this is a quick fix that to make the android app not crash on open. 
what doesn't work: 
- settings: because it uses `getUncompressedUsage`
- sync status doesn't use the subscription api 