### PR TITLE
apple: fix url opening double free

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1275,8 +1275,10 @@
             if output.urls_opened.size > 0 {
                 var urls: [URL] = []
                 for i in 0..<Int(output.urls_opened.size) {
+                    // Don't use textFromPtr here — it frees each string, but
+                    // free_urls below frees the strings and the array together.
                     if let ptr = output.urls_opened.urls[i],
-                       let url = URL(string: textFromPtr(s: ptr)),
+                       let url = URL(string: String(cString: ptr)),
                        UIApplication.shared.canOpenURL(url)
                     {
                         urls.append(url)

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
@@ -328,7 +328,9 @@
             if output.urls_opened.size > 0 {
                 var urls: [URL] = []
                 for i in 0 ..< Int(output.urls_opened.size) {
-                    if let ptr = output.urls_opened.urls[i], let url = URL(string: textFromPtr(s: ptr)) {
+                    // Don't use textFromPtr here — it frees each string, but
+                    // free_urls below frees the strings and the array together.
+                    if let ptr = output.urls_opened.urls[i], let url = URL(string: String(cString: ptr)) {
                         urls.append(url)
                     }
                 }


### PR DESCRIPTION
introduced by #4285 - opening multiple links complicated memory management because we have to free an array now too. The change added a function to free the array and inner strings (urls), but a helper I was already using was already freeing the strings.