### PR TITLE
lb-fs: handle deleted files better

### DIFF
--- a/libs/lb-fs/src/fs_impl.rs
+++ b/libs/lb-fs/src/fs_impl.rs
@@ -82,7 +82,14 @@ impl NfsReadFileSystem for Drive {
     async fn lookup(
         &self, dirid: &Self::Handle, filename: &filename3<'_>,
     ) -> Result<Self::Handle, nfsstat3> {
-        let dir = self.data.lock().await.get(dirid).unwrap().file.clone();
+        let dir = self
+            .data
+            .lock()
+            .await
+            .get(dirid)
+            .ok_or(nfsstat3::NFS3ERR_STALE)?
+            .file
+            .clone();
 
         if dir.is_document() {
             info!("NOTDIR");
@@ -101,6 +108,7 @@ impl NfsReadFileSystem for Drive {
             return Ok(dir.parent.into());
         }
 
+        // todo this should almost certainly just operate on the cache
         let children = self.lb.get_children(&dir.id).await.unwrap();
         let file_name = get_string(filename);
 
@@ -117,7 +125,14 @@ impl NfsReadFileSystem for Drive {
 
     #[instrument(skip(self), fields(id = id.to_string()))]
     async fn getattr(&self, id: &Self::Handle) -> Result<fattr3, nfsstat3> {
-        let file = self.data.lock().await.get(id).unwrap().fattr.clone();
+        let file = self
+            .data
+            .lock()
+            .await
+            .get(id)
+            .ok_or(nfsstat3::NFS3ERR_STALE)?
+            .fattr
+            .clone();
         info!("fattr = {:?}", file);
         Ok(file)
     }

--- a/libs/lb/lb-rs/src/subscribers/syncer.rs
+++ b/libs/lb/lb-rs/src/subscribers/syncer.rs
@@ -87,8 +87,10 @@ impl Lb {
         pipeline?;
 
         let account = self.get_account()?.clone();
+
+        #[cfg(not(target_family = "wasm"))]
         if account.is_beta() {
-            self.clone().send_debug_info(account);
+            self.send_debug_info(account).await;
         }
 
         Ok(())
@@ -1165,22 +1167,28 @@ impl Lb {
         Ok(id)
     }
 
-    fn send_debug_info(self, account: Account) {
-        #[cfg(not(target_family = "wasm"))]
-        tokio::spawn(async move {
+    #[cfg(not(target_family = "wasm"))]
+    async fn send_debug_info(&self, account: Account) {
+        let debug_info = self
+            .debug_info("none provided - sync".to_string(), false)
+            .await
+            .unwrap();
+
+        if self.config.background_work {
+            let bg_self = self.clone();
+            tokio::spawn(async move {
+                bg_self
+                    .client
+                    .request(&account, UpsertDebugInfoRequest { debug_info })
+                    .await
+                    .unwrap();
+            });
+        } else {
             self.client
-                .request(
-                    &account,
-                    UpsertDebugInfoRequest {
-                        debug_info: self
-                            .debug_info("none provided - sync".to_string(), false)
-                            .await
-                            .unwrap(),
-                    },
-                )
+                .request(&account, UpsertDebugInfoRequest { debug_info })
                 .await
-                .unwrap();
-        });
+                .log_and_ignore();
+        }
     }
 
     async fn read_document_helper<T>(


### PR DESCRIPTION
fixes #4377 
fixes https://github.com/lockbook/lockbook/issues/4328

There were actually a few bad instances of deleting operations going poorly in lb-fs (deletions being synced, not performed by lb-fs).

These fixes the problems I could produce during intentional problem causing. There's probably another pass that should happen over these parts, basically every instance of an unwrap should probably be replaced with `ok_or(STALE)?` and things will just behave better.

fixes #4072 

during #4240 we also simplified the sync status so now this is a non-issue. Surely sync status could always be prettier, but this now isn't "stupid".