### PR TITLE
md: don't automatically create a link when pasting in an existing link

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
@@ -105,10 +105,12 @@ impl<'ast> Editor {
 
                 // ...unless we're already in a link
                 for descendant in root.descendants() {
-                    if matches!(descendant.data().value, NodeValue::Link(_))
-                        && self
-                            .node_range(descendant)
-                            .intersects(&self.buffer.current.selection, false)
+                    if matches!(
+                        descendant.data().value,
+                        NodeValue::Link(_) | NodeValue::WikiLink(_) | NodeValue::Image(_)
+                    ) && self
+                        .node_range(descendant)
+                        .intersects(&self.buffer.current.selection, false)
                     {
                         link_paste = false;
                         break;


### PR DESCRIPTION
builds on https://github.com/lockbook/lockbook/pull/4213/changes