### PR TITLE
Revert "md: cursor must be strictly inside inline syntax to reveal it"

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
@@ -416,7 +416,7 @@ impl<'ast> Editor {
     /// generally need additional consideration for optional indentation etc.
     pub fn node_intersects_selection(&self, node: &'ast AstNode<'ast>) -> bool {
         self.node_range(node)
-            .intersects(&self.buffer.current.selection, false)
+            .intersects(&self.buffer.current.selection, true)
     }
 
     pub fn node_contains_selection(&self, node: &'ast AstNode<'ast>) -> bool {


### PR DESCRIPTION
Reverts lockbook/lockbook#4281, which broke the notion of currently selected block so that toggling a bullet at the end of a paragraph no longer turns it into a list item. It was a nice experiment, I think this configuration is a valid setting and will implement with quality when the time comes.