### PR TITLE
ws: reduce landing page cpu

### DIFF
--- a/libs/content/workspace/src/file_cache.rs
+++ b/libs/content/workspace/src/file_cache.rs
@@ -24,6 +24,11 @@ pub struct FileCache {
     pub shared: Vec<File>,
     pub suggested: Vec<Uuid>,
     pub size_bytes_recursive: HashMap<Uuid, u64>,
+    pub last_modified_recursive: HashMap<Uuid, u64>,
+    pub last_modified_by_recursive: HashMap<Uuid, String>,
+    /// Max last_modified across all files. Used as a cache invalidation key
+    /// by the landing page sort cache — changes whenever the file tree changes.
+    pub last_modified: u64,
 }
 
 impl FileCache {
@@ -46,6 +51,9 @@ impl FileCache {
             shared: vec![],
             suggested: vec![],
             size_bytes_recursive: Default::default(),
+            last_modified_recursive: Default::default(),
+            last_modified_by_recursive: Default::default(),
+            last_modified: 0,
         }
     }
 
@@ -57,26 +65,61 @@ impl FileCache {
         let shared = lb.get_pending_share_files()?;
 
         let mut size_recursive = HashMap::new();
+        let mut modified_recursive = HashMap::new();
+        let mut modified_by_recursive = HashMap::new();
         for file in files.iter().chain(shared.iter()) {
+            let all_ids = files
+                .descendents(file.id)
+                .iter()
+                .chain(shared.descendents(file.id).iter())
+                .map(|f| f.id)
+                .chain(iter::once(file.id))
+                .collect::<Vec<_>>();
+
             size_recursive.insert(
                 file.id,
-                files
-                    .descendents(file.id)
+                all_ids
                     .iter()
-                    .chain(shared.descendents(file.id).iter())
-                    .map(|f| f.id)
-                    .chain(iter::once(file.id))
                     .filter_map(|id| {
                         files
-                            .get_by_id(id)
-                            .or_else(|| shared.get_by_id(id))
+                            .get_by_id(*id)
+                            .or_else(|| shared.get_by_id(*id))
                             .map(|f| f.size_bytes)
                     })
                     .sum::<_>(),
             );
+
+            let most_recent = all_ids
+                .iter()
+                .filter_map(|id| files.get_by_id(*id).or_else(|| shared.get_by_id(*id)))
+                .max_by_key(|f| f.last_modified);
+
+            modified_recursive.insert(file.id, most_recent.map(|f| f.last_modified).unwrap_or(0));
+            modified_by_recursive.insert(
+                file.id,
+                most_recent
+                    .map(|f| f.last_modified_by.clone())
+                    .unwrap_or_default(),
+            );
         }
 
-        Ok(Self { root, files, suggested, shared, size_bytes_recursive: size_recursive })
+        let last_modified = files
+            .iter()
+            .chain(shared.iter())
+            .map(|f| f.last_modified)
+            .max()
+            .unwrap_or(0);
+
+        Ok(Self {
+            root,
+            files,
+            suggested,
+            shared,
+            size_bytes_recursive: size_recursive,
+            last_modified_recursive: modified_recursive,
+            last_modified_by_recursive: modified_by_recursive,
+            last_modified,
+        })
     }
 
     pub fn usage_portion(&self, id: Uuid) -> f32 {
@@ -85,13 +128,10 @@ impl FileCache {
     }
 
     pub fn last_modified_recursive(&self, id: Uuid) -> u64 {
-        self.descendents(id)
-            .iter()
-            .map(|f| f.id)
-            .chain(iter::once(id))
-            .map(|id| self.get_by_id(id).unwrap().last_modified)
-            .max()
-            .unwrap()
+        self.last_modified_recursive
+            .get(&id)
+            .copied()
+            .unwrap_or_else(|| self.get_by_id(id).map(|f| f.last_modified).unwrap_or(0))
     }
 
     /// Iterates all known files: the user's own tree plus pending shares.
@@ -189,14 +229,14 @@ impl FileCache {
     }
 
     pub fn last_modified_by_recursive(&self, id: Uuid) -> &str {
-        let last_modified_id = self
-            .descendents(id)
-            .iter()
-            .map(|f| f.id)
-            .chain(iter::once(id))
-            .max_by_key(|id| self.get_by_id(*id).unwrap().last_modified)
-            .unwrap();
-        &self.get_by_id(last_modified_id).unwrap().last_modified_by
+        self.last_modified_by_recursive
+            .get(&id)
+            .map(|s| s.as_str())
+            .unwrap_or_else(|| {
+                self.get_by_id(id)
+                    .map(|f| f.last_modified_by.as_str())
+                    .unwrap_or("")
+            })
     }
 }
 

--- a/libs/content/workspace/src/file_cache.rs
+++ b/libs/content/workspace/src/file_cache.rs
@@ -84,21 +84,6 @@ impl FileCache {
             / self.size_bytes_recursive[&self.get_by_id(id).unwrap().parent] as f32
     }
 
-    /// returns the uncompressed, recursive size of a file scaled relative to
-    /// peers so that the biggest sibling is 1.0
-    pub fn usage_portion_scaled(&self, id: Uuid, peers: &[&File]) -> f32 {
-        let current_usage = self.size_bytes_recursive[&id];
-
-        let max_sibling_usage = peers
-            .iter()
-            .map(|peer| self.size_bytes_recursive[&peer.id])
-            .chain(std::iter::once(current_usage))
-            .max()
-            .unwrap_or(1);
-
-        current_usage as f32 / max_sibling_usage as f32
-    }
-
     pub fn last_modified_recursive(&self, id: Uuid) -> u64 {
         self.descendents(id)
             .iter()

--- a/libs/content/workspace/src/landing.rs
+++ b/libs/content/workspace/src/landing.rs
@@ -18,7 +18,7 @@ use crate::theme::palette_v2::ThemeExt as _;
 use crate::widgets::{GlyphonLabel, GlyphonTextEdit, IconButton};
 use crate::workspace::Workspace;
 
-#[derive(Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct LandingPage {
     search_term: String,
     doc_types: Vec<DocType>,
@@ -27,6 +27,25 @@ pub struct LandingPage {
     sort: Sort,
     sort_asc: bool,
     flatten_tree: bool,
+
+    #[serde(skip)]
+    cached_file_ids: Vec<Uuid>,
+    #[serde(skip)]
+    cache_generation: u64,
+    #[serde(skip)]
+    cache_snapshot: Option<Box<LandingPage>>,
+}
+
+impl PartialEq for LandingPage {
+    fn eq(&self, other: &Self) -> bool {
+        self.search_term == other.search_term
+            && self.doc_types == other.doc_types
+            && self.collaborators == other.collaborators
+            && self.only_me == other.only_me
+            && self.sort == other.sort
+            && self.sort_asc == other.sort_asc
+            && self.flatten_tree == other.flatten_tree
+    }
 }
 
 impl Default for LandingPage {
@@ -39,6 +58,9 @@ impl Default for LandingPage {
             sort: Default::default(),
             sort_asc: true,
             flatten_tree: true,
+            cached_file_ids: Vec::new(),
+            cache_generation: 0,
+            cache_snapshot: None,
         }
     }
 }
@@ -516,7 +538,20 @@ impl Workspace {
         response
     }
 
-    fn filtered_sorted_files<'a>(&self, files: &'a FileCache, account: &Account) -> Vec<&'a File> {
+    fn filtered_sorted_files<'a>(
+        &mut self, files: &'a FileCache, account: &Account,
+    ) -> Vec<&'a File> {
+        if self.landing_page.cache_generation == files.last_modified
+            && self.landing_page.cache_snapshot.as_deref() == Some(&self.landing_page)
+        {
+            return self
+                .landing_page
+                .cached_file_ids
+                .iter()
+                .filter_map(|id| files.get_by_id(*id).or_else(|| files.shared.get_by_id(*id)))
+                .collect();
+        }
+
         let folder = files.get_by_id(self.effective_focused_parent()).unwrap();
 
         // Filter
@@ -637,6 +672,10 @@ impl Workspace {
             descendents.reverse()
         }
 
+        self.landing_page.cached_file_ids = descendents.iter().map(|f| f.id).collect();
+        self.landing_page.cache_generation = files.last_modified;
+        self.landing_page.cache_snapshot = Some(Box::new(self.landing_page.clone()));
+
         descendents
     }
 
@@ -647,8 +686,8 @@ impl Workspace {
         let files_arc = Arc::clone(&self.files);
         let files_guard = files_arc.read().unwrap();
         let files = &*files_guard;
-        let account = &self.account;
-        let descendents = self.filtered_sorted_files(files, account);
+        let account = self.account.clone();
+        let descendents = self.filtered_sorted_files(files, &account);
 
         // Show
         if !descendents.is_empty() {

--- a/libs/content/workspace/src/landing.rs
+++ b/libs/content/workspace/src/landing.rs
@@ -794,6 +794,12 @@ impl Workspace {
 
                         ui.end_row();
 
+                        let max_usage = descendents
+                            .iter()
+                            .filter_map(|f| files.size_bytes_recursive.get(&f.id).copied())
+                            .max()
+                            .unwrap_or(1) as f32;
+
                         let mut current_time_category = "";
                         let mut child_idx = 0;
                         while child_idx < descendents.len() {
@@ -1190,8 +1196,8 @@ impl Workspace {
                                     Vec2::new(available_width, ui.available_height()),
                                 );
 
-                                let target_width = rect.width()
-                                    * files.usage_portion_scaled(child.id, &descendents);
+                                let usage = files.size_bytes_recursive[&child.id] as f32;
+                                let target_width = rect.width() * (usage / max_usage);
                                 let excess_width = rect.width() - target_width;
                                 rect.max.x -= excess_width;
 

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -69,16 +69,6 @@ impl Workspace {
             cache.lock().unwrap().end_frame();
         }
 
-        // todo: remove before merge
-        let fps = 1.0 / ui.input(|i| i.stable_dt);
-        ui.ctx().debug_painter().text(
-            ui.ctx().screen_rect().right_bottom() + egui::vec2(-10., -10.),
-            egui::Align2::RIGHT_BOTTOM,
-            format!("{fps:.0} fps"),
-            egui::FontId::monospace(14.),
-            egui::Color32::from_rgb(255, 100, 100),
-        );
-
         mem::take(&mut self.out)
     }
 

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -69,6 +69,16 @@ impl Workspace {
             cache.lock().unwrap().end_frame();
         }
 
+        // todo: remove before merge
+        let fps = 1.0 / ui.input(|i| i.stable_dt);
+        ui.ctx().debug_painter().text(
+            ui.ctx().screen_rect().right_bottom() + egui::vec2(-10., -10.),
+            egui::Align2::RIGHT_BOTTOM,
+            format!("{fps:.0} fps"),
+            egui::FontId::monospace(14.),
+            egui::Color32::from_rgb(255, 100, 100),
+        );
+
         mem::take(&mut self.out)
     }
 


### PR DESCRIPTION
Noticeably reduces landing page cpu usage, removing top 2 bottlenecks raised by tooling:
* computing relative usage for each file, which computes recursive usage for all files, each frame
* sorting files each frame