### PR TITLE
ws: factor tab cache

### DIFF
--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -404,8 +404,10 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_unfocusTitle(
 ) {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
 
-    if let Some(tab) = obj.workspace.current_tab_mut() {
-        tab.rename = None;
+    if let Some(dest) = obj.workspace.current_tab.clone() {
+        if let Some(slot) = obj.workspace.tab_strip.iter_mut().find(|s| s.dest == dest) {
+            slot.rename = None;
+        }
     }
 }
 

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -303,14 +303,14 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_closeDoc(
 
     if let Some(tab_id) = obj
         .workspace
-        .tabs
+        .tab_strip
         .iter()
-        .position(|tab| tab.id() == Some(id))
+        .position(|s| s.dest.id() == id)
     {
         obj.workspace.close_tab(tab_id);
     } else {
-        for i in 0..obj.workspace.tabs.len() {
-            obj.workspace.close_tab(i);
+        while !obj.workspace.tab_strip.is_empty() {
+            obj.workspace.close_tab(0);
         }
     }
 }
@@ -321,8 +321,8 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_closeAllTabs(
 ) {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
 
-    for i in 0..obj.workspace.tabs.len() {
-        obj.workspace.close_tab(i);
+    while !obj.workspace.tab_strip.is_empty() {
+        obj.workspace.close_tab(0);
     }
 }
 
@@ -341,7 +341,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getTabs(
 ) -> jobjectArray {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
 
-    let ids = obj.workspace.tabs.iter().filter_map(|t| t.id());
+    let ids = obj.workspace.tab_strip.iter().map(|s| s.dest.id());
 
     let string_class = env.find_class("java/lang/String").unwrap();
 

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -215,9 +215,9 @@ pub unsafe extern "C" fn close_tab(obj: *mut c_void, id: *const c_char) {
 
     if let Some(tab_id) = obj
         .workspace
-        .tabs
+        .tab_strip
         .iter()
-        .position(|tab| tab.id() == Some(id))
+        .position(|s| s.dest.id() == id)
     {
         obj.workspace.close_tab(tab_id);
     }

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -961,8 +961,10 @@ pub unsafe extern "C" fn set_pencil_only_drawing(obj: *mut c_void, val: bool) {
 pub unsafe extern "C" fn unfocus_title(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    if let Some(tab) = obj.workspace.current_tab_mut() {
-        tab.rename = None;
+    if let Some(dest) = obj.workspace.current_tab.clone() {
+        if let Some(slot) = obj.workspace.tab_strip.iter_mut().find(|s| s.dest == dest) {
+            slot.rename = None;
+        }
     }
 }
 

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -381,7 +381,7 @@ pub unsafe extern "C" fn touches_predicted(obj: *mut c_void, id: u64, x: f32, y:
 pub unsafe extern "C" fn tab_count(obj: *mut c_void) -> i64 {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    obj.workspace.tabs.len() as i64
+    obj.workspace.tab_strip.len() as i64
 }
 
 /// # Safety
@@ -789,10 +789,9 @@ pub unsafe extern "C" fn get_tabs_ids(obj: *mut c_void) -> TabsIds {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let ids: Vec<CUuid> = obj
         .workspace
-        .tabs
+        .tab_strip
         .iter()
-        .flat_map(|tab| tab.id())
-        .map(|id| id.into())
+        .map(|s| s.dest.id().into())
         .collect();
 
     TabsIds { size: ids.len() as i32, ids: Box::into_raw(ids.into_boxed_slice()) as *const CUuid }
@@ -949,7 +948,7 @@ pub unsafe extern "C" fn toggle_drawing_tool_between_eraser(obj: *mut c_void) {
 pub unsafe extern "C" fn set_pencil_only_drawing(obj: *mut c_void, val: bool) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    obj.workspace.tabs.iter_mut().for_each(|t| {
+    obj.workspace.tabs.values_mut().for_each(|t| {
         if let ContentState::Open(TabContent::Svg(svg)) = &mut t.content {
             svg.settings.pencil_only_drawing = val
         }
@@ -982,8 +981,15 @@ pub unsafe extern "C" fn show_hide_tabs(obj: *mut c_void, show: bool) {
 pub unsafe extern "C" fn close_active_tab(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    if !obj.workspace.tabs.is_empty() {
-        obj.workspace.close_tab(obj.workspace.current_tab)
+    if !obj.workspace.tab_strip.is_empty() {
+        if let Some(idx) = obj
+            .workspace
+            .current_tab
+            .as_ref()
+            .and_then(|d| obj.workspace.tab_strip.iter().position(|s| s.dest == *d))
+        {
+            obj.workspace.close_tab(idx);
+        }
     }
 }
 
@@ -993,8 +999,8 @@ pub unsafe extern "C" fn close_active_tab(obj: *mut c_void) {
 pub unsafe extern "C" fn close_all_tabs(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
 
-    for i in 0..obj.workspace.tabs.len() {
-        obj.workspace.close_tab(i);
+    while !obj.workspace.tab_strip.is_empty() {
+        obj.workspace.close_tab(0);
     }
 }
 

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -32,6 +32,10 @@ impl Workspace {
             cache.lock().unwrap().begin_frame();
         }
         self.images.begin_frame();
+        self.tabs.begin_frame();
+        for slot in &self.tab_strip {
+            self.tabs.promote(&slot.dest);
+        }
 
         if self.ctx.input(|inp| !inp.raw.events.is_empty()) {
             self.core.app_foregrounded();
@@ -55,7 +59,7 @@ impl Workspace {
             self.landing_page_first_frame = true;
         }
         if self.out.tabs_changed || self.current_tab_changed {
-            self.cfg.set_tabs(&self.tabs, self.current_tab);
+            self.cfg.set_tabs(&self.tab_strip, &self.current_tab);
         }
 
         let zoom = self.ctx.zoom_factor();
@@ -70,6 +74,7 @@ impl Workspace {
             cache.lock().unwrap().end_frame();
         }
         self.images.end_frame();
+        self.tabs.end_frame();
 
         mem::take(&mut self.out)
     }
@@ -236,9 +241,11 @@ impl Workspace {
                     .show(ui, |ui| {
                         if IconButton::new(Icon::ARROW_LEFT)
                             .disabled(
-                                self.current_tab()
-                                    .map(|tab| tab.back.is_empty())
-                                    .unwrap_or_default(),
+                                self.current_tab
+                                    .as_ref()
+                                    .and_then(|d| self.tab_strip.iter().find(|s| &s.dest == d))
+                                    .map(|s| s.back.is_empty())
+                                    .unwrap_or(true),
                             )
                             .size(37.)
                             .tooltip("Go Back")
@@ -249,9 +256,11 @@ impl Workspace {
                         }
                         if IconButton::new(Icon::ARROW_RIGHT)
                             .disabled(
-                                self.current_tab()
-                                    .map(|tab| tab.forward.is_empty())
-                                    .unwrap_or_default(),
+                                self.current_tab
+                                    .as_ref()
+                                    .and_then(|d| self.tab_strip.iter().find(|s| &s.dest == d))
+                                    .map(|s| s.forward.is_empty())
+                                    .unwrap_or(true),
                             )
                             .size(37.)
                             .tooltip("Go Forward")
@@ -265,32 +274,32 @@ impl Workspace {
                             .max_width(ui.available_width())
                             .show(ui, |ui| {
                                 let mut responses = HashMap::new();
-                                for i in 0..self.tabs.len() {
-                                    if self.tabs[i].is_preview {
-                                        continue;
-                                    }
-                                    if let Some(resp) = self.tab_label(
-                                        ui,
-                                        i,
-                                        self.current_tab == i,
-                                        active_tab_changed,
-                                    ) {
+                                for i in 0..self.tab_strip.len() {
+                                    let dest = &self.tab_strip[i].dest;
+                                    let is_current = self.current_tab.as_ref() == Some(dest);
+                                    if let Some(resp) =
+                                        self.tab_label(ui, i, is_current, active_tab_changed)
+                                    {
                                         responses.insert(i, resp);
                                     }
                                 }
 
                                 // handle responses after showing all tabs because closing a tab invalidates tab indexes
                                 for (i, resp) in responses {
+                                    let dest = self.tab_strip[i].dest.clone();
                                     match resp {
                                         TabLabelResponse::Clicked => {
-                                            if self.current_tab == i {
+                                            let is_current =
+                                                self.current_tab.as_ref() == Some(&dest);
+                                            if is_current {
                                                 // we should rename the file.
 
                                                 self.out.tab_title_clicked = true;
-                                                let active_name = self.tab_title(&self.tabs[i]);
-                                                self.tabs[i].rename = Some(active_name);
+                                                let tab = self.tabs.get(&dest).unwrap();
+                                                let active_name = self.tab_title(tab);
+                                                self.tab_strip[i].rename = Some(active_name);
                                             } else {
-                                                self.tabs[i].rename = None;
+                                                self.tab_strip[i].rename = None;
                                                 self.make_current(i);
                                             }
                                         }
@@ -298,19 +307,18 @@ impl Workspace {
                                             self.close_tab(i);
                                         }
                                         TabLabelResponse::Renamed(name) => {
-                                            self.tabs[i].rename = None;
-                                            if let Some(id) = self.tabs[i].id() {
-                                                self.rename_file((id, name.clone()), true);
-                                            }
+                                            self.tab_strip[i].rename = None;
+                                            let id = dest.id();
+                                            self.rename_file((id, name.clone()), true);
                                         }
                                         TabLabelResponse::Reordered { src, mut dst } => {
                                             let current = self.current_tab_id();
 
-                                            let tab = self.tabs.remove(src);
+                                            let d = self.tab_strip.remove(src);
                                             if src < dst {
                                                 dst -= 1;
                                             }
-                                            self.tabs.insert(dst, tab);
+                                            self.tab_strip.insert(dst, d);
 
                                             if let Some(current) = current {
                                                 self.make_current_by_id(current);
@@ -383,7 +391,13 @@ impl Workspace {
             .ctx
             .input_mut(|i| i.consume_key_exact(COMMAND, egui::Key::S))
         {
-            self.save_tab(self.current_tab);
+            if let Some(idx) = self
+                .current_tab
+                .as_ref()
+                .and_then(|d| self.tab_strip.iter().position(|s| s.dest == *d))
+            {
+                self.save_tab(idx);
+            }
         }
 
         // Ctrl-M to open mind map
@@ -400,7 +414,13 @@ impl Workspace {
             .input_mut(|i| i.consume_key_exact(COMMAND, egui::Key::W))
         {
             if !self.is_empty() {
-                self.close_tab(self.current_tab);
+                if let Some(idx) = self
+                    .current_tab
+                    .as_ref()
+                    .and_then(|d| self.tab_strip.iter().position(|s| s.dest == *d))
+                {
+                    self.close_tab(idx);
+                }
                 self.ctx.send_viewport_cmd(ViewportCommand::Title(
                     self.current_tab_title().unwrap_or("Lockbook".to_owned()),
                 ));
@@ -418,8 +438,8 @@ impl Workspace {
             .input_mut(|i| i.consume_key_exact(COMMAND | SHIFT, egui::Key::W))
             && !self.is_empty()
         {
-            for i in 0..self.tabs.len() {
-                self.close_tab(i);
+            while !self.tab_strip.is_empty() {
+                self.close_tab(0);
             }
 
             self.out.selected_file = None;
@@ -451,11 +471,16 @@ impl Workspace {
             }
         });
         if change != 0 {
-            let old = self.current_tab as i32;
-            let new = old + change;
-            if new >= 0 && new < self.tabs.len() as i32 {
-                self.tabs.swap(old as usize, new as usize);
-                self.make_current(new as usize);
+            let current_idx = self
+                .current_tab
+                .as_ref()
+                .and_then(|d| self.tab_strip.iter().position(|s| s.dest == *d));
+            if let Some(old) = current_idx {
+                let new = old as i32 + change;
+                if new >= 0 && new < self.tab_strip.len() as i32 {
+                    self.tab_strip.swap(old, new as usize);
+                    self.make_current(new as usize);
+                }
             }
         }
 
@@ -463,6 +488,11 @@ impl Workspace {
         let completions_active = self
             .current_tab_markdown()
             .is_some_and(|md| md.emoji_completions.active || md.link_completions.active);
+        let current_idx = self
+            .current_tab
+            .as_ref()
+            .and_then(|d| self.tab_strip.iter().position(|s| s.dest == *d))
+            .unwrap_or(0);
         let mut goto_tab = None;
         self.ctx.input_mut(|input| {
             // Cmd+1 through Cmd+8 to select tab by cardinal index
@@ -470,32 +500,32 @@ impl Workspace {
                 if !completions_active && input.consume_key_exact(COMMAND, key)
                     || (!APPLE && input.consume_key_exact(Modifiers::ALT, key))
                 {
-                    goto_tab = Some(i.min(self.tabs.len()) - 1);
+                    goto_tab = Some(i.min(self.tab_strip.len()) - 1);
                 }
             }
 
             // Cmd+9 to go to last tab
-            if !completions_active && input.consume_key_exact(COMMAND, Key::Num9)
-                || (!APPLE && input.consume_key_exact(Modifiers::ALT, Key::Num9))
+            if (!completions_active && input.consume_key_exact(COMMAND, Key::Num9)
+                || (!APPLE && input.consume_key_exact(Modifiers::ALT, Key::Num9)))
+                && !self.tab_strip.is_empty()
             {
-                goto_tab = Some(self.tabs.len() - 1);
+                goto_tab = Some(self.tab_strip.len() - 1);
             }
 
             // Cmd+Shift+[ or ctrl shift tab to go to previous tab
-            if (APPLE && input.consume_key_exact(COMMAND | SHIFT, Key::OpenCurlyBracket))
-                || (!APPLE && input.consume_key_exact(CTRL | SHIFT, Key::Tab))
+            if ((APPLE && input.consume_key_exact(COMMAND | SHIFT, Key::OpenCurlyBracket))
+                || (!APPLE && input.consume_key_exact(CTRL | SHIFT, Key::Tab)))
+                && current_idx > 0
             {
-                goto_tab = (0..self.current_tab)
-                    .rev()
-                    .find(|&i| !self.tabs[i].is_preview);
+                goto_tab = Some(current_idx - 1);
             }
 
             // Cmd+Shift+] or ctrl tab to go to next tab
-            if (APPLE && input.consume_key_exact(COMMAND | SHIFT, Key::CloseCurlyBracket))
-                || (!APPLE && input.consume_key_exact(CTRL, Key::Tab))
+            if ((APPLE && input.consume_key_exact(COMMAND | SHIFT, Key::CloseCurlyBracket))
+                || (!APPLE && input.consume_key_exact(CTRL, Key::Tab)))
+                && current_idx + 1 < self.tab_strip.len()
             {
-                goto_tab =
-                    (self.current_tab + 1..self.tabs.len()).find(|&i| !self.tabs[i].is_preview);
+                goto_tab = Some(current_idx + 1);
             }
         });
 
@@ -537,6 +567,7 @@ impl Workspace {
     fn tab_label(
         &mut self, ui: &mut egui::Ui, t: usize, is_active: bool, active_tab_changed: bool,
     ) -> Option<TabLabelResponse> {
+        let dest = self.tab_strip[t].dest.clone();
         let mut result = None;
         let icon_size = 15.0;
         let x_icon = Icon::CLOSE.size(icon_size);
@@ -556,15 +587,16 @@ impl Workspace {
 
         let rename_id = egui::Id::new("rename_tab").with(t);
         let mut rename_submitted = false;
-        if let Some(ref mut str) = self.tabs[t].rename {
+        let slot = &mut self.tab_strip[t];
+        if let Some(ref mut str) = slot.rename {
             rename_submitted = GlyphonTextEdit::process_events(ui, rename_id, str);
         }
-        let rename_text_for_sizing = self.tabs[t].rename.clone().unwrap_or_default();
+        let rename_text_for_sizing = slot.rename.clone().unwrap_or_default();
+        let is_renaming = slot.rename.is_some();
         let tab_label = egui::Frame::default()
             .fill(tab_bg)
             .inner_margin(tab_padding)
             .show(ui, |ui| {
-                let is_renaming = self.tabs[t].rename.is_some();
                 ui.scope_builder(UiBuilder::new(), |ui| {
                     let start = ui.available_rect_before_wrap().min;
 
@@ -574,7 +606,11 @@ impl Workspace {
                     let tab_font_size = 14.0;
                     let tab_line_height = 20.0;
                     let tab_max_width = 200.0;
-                    let raw_title = self.tab_title(&self.tabs[t]);
+                    let raw_title = self
+                        .tabs
+                        .get(&dest)
+                        .map(|tab| self.tab_title(tab))
+                        .unwrap_or_else(|| "Unknown".into());
                     let title = DocType::from_name(&raw_title)
                         .display_name(&raw_title)
                         .to_string();
@@ -687,28 +723,28 @@ impl Workspace {
                             .linear_multiply(0.8)
                     };
 
-                    if let Some(ref mut str) = self.tabs[t].rename {
-                        let stem_end = str.rfind('.').unwrap_or(str.len());
-                        let res = ui.put(
-                            text_rect,
-                            GlyphonTextEdit::new(str)
-                                .id(rename_id)
-                                .font_size(14.0)
-                                .select_on_focus(0, stem_end),
-                        );
+                    if is_renaming {
+                        if let Some(ref mut str) = self.tab_strip[t].rename {
+                            let stem_end = str.rfind('.').unwrap_or(str.len());
+                            let res = ui.put(
+                                text_rect,
+                                GlyphonTextEdit::new(str)
+                                    .id(rename_id)
+                                    .font_size(14.0)
+                                    .select_on_focus(0, stem_end),
+                            );
 
-                        if !res.has_focus() && !res.lost_focus() {
-                            // request focus on the first frame
-                            ui.memory_mut(|m| m.request_focus(res.id));
-                        }
+                            if !res.has_focus() && !res.lost_focus() {
+                                ui.memory_mut(|m| m.request_focus(res.id));
+                            }
 
-                        if rename_submitted {
-                            result = Some(TabLabelResponse::Renamed(str.to_owned()));
-                        }
+                            if rename_submitted {
+                                result = Some(TabLabelResponse::Renamed(str.to_owned()));
+                            }
 
-                        // release focus to cancel ('esc' or click elsewhere)
-                        if res.lost_focus() {
-                            self.tabs[t].rename = None;
+                            if res.lost_focus() {
+                                self.tab_strip[t].rename = None;
+                            }
                         }
                     } else {
                         ui.put(
@@ -835,10 +871,15 @@ impl Workspace {
             sep_stroke,
         );
 
+        let last_saved_str = self
+            .tabs
+            .get(&dest)
+            .map(|tab| tab.last_saved.elapsed_human_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        let status_summary = self.tab_status(t).summary();
         tab_label.response.on_hover_ui(|ui| {
-            ui.label(RichText::from(self.tab_status(t).summary()).size(15.0));
-            let last_saved = self.tabs[t].last_saved.elapsed_human_string();
-            ui.label(RichText::from(format!("last saved {last_saved}")).size(12.0));
+            ui.label(RichText::from(status_summary).size(15.0));
+            ui.label(RichText::from(format!("last saved {last_saved_str}")).size(12.0));
             ui.ctx().request_repaint_after_secs(1.0);
         });
 

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -20,7 +20,6 @@ use lb_rs::model::file::File;
 use lb_rs::model::file_metadata::{DocumentHmac, FileType};
 use lb_rs::model::svg;
 use serde::{Deserialize, Serialize};
-use std::ops::IndexMut;
 use std::path::PathBuf;
 use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -44,19 +43,27 @@ impl Destination {
     }
 }
 
+#[derive(Clone)]
+pub struct TabSlot {
+    pub dest: Destination,
+    pub back: Vec<Uuid>,
+    pub forward: Vec<Uuid>,
+    pub rename: Option<String>,
+}
+
+impl TabSlot {
+    pub fn new(dest: Destination) -> Self {
+        Self { dest, back: Vec::new(), forward: Vec::new(), rename: None }
+    }
+}
+
 pub struct Tab {
     pub destination: Destination,
     pub content: ContentState,
-    pub back: Vec<Uuid>,
-    pub forward: Vec<Uuid>,
 
     pub last_changed: Instant,
     pub last_saved: Instant,
-
-    pub rename: Option<String>,
-    pub is_closing: bool,
     pub read_only: bool,
-    pub is_preview: bool,
 }
 
 impl Tab {
@@ -147,9 +154,6 @@ impl Tab {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) -> Response {
-        if self.is_preview {
-            return ui.push_id("preview", |ui| self.show_inner(ui)).inner;
-        }
         self.show_inner(ui)
     }
 
@@ -205,28 +209,6 @@ impl Tab {
         } else {
             self.last_changed > self.last_saved
         }
-    }
-}
-
-pub trait TabsExt: IndexMut<usize, Output = Tab> {
-    fn position_by_id(&self, id: Uuid) -> Option<usize>;
-    fn get_by_id(&self, id: Uuid) -> Option<&Tab> {
-        self.position_by_id(id).map(|pos| &self[pos])
-    }
-    fn get_mut_by_id(&mut self, id: Uuid) -> Option<&mut Tab> {
-        self.position_by_id(id).map(move |pos| &mut self[pos])
-    }
-}
-
-impl TabsExt for [Tab] {
-    fn position_by_id(&self, id: Uuid) -> Option<usize> {
-        self.iter().position(|tab| tab.id() == Some(id))
-    }
-}
-
-impl TabsExt for Vec<Tab> {
-    fn position_by_id(&self, id: Uuid) -> Option<usize> {
-        self.iter().position(|tab| tab.id() == Some(id))
     }
 }
 
@@ -425,7 +407,8 @@ impl TabStatus {
 
 impl Workspace {
     pub fn tab_status(&self, i: usize) -> TabStatus {
-        if let Some(tab) = self.tabs.get(i) {
+        let tab = self.tab_strip.get(i).and_then(|s| self.tabs.get(&s.dest));
+        if let Some(tab) = tab {
             if let Some(id) = tab.id() {
                 if self.tasks.load_in_progress(id) {
                     return TabStatus::LoadInProgress;

--- a/libs/content/workspace/src/task_manager.rs
+++ b/libs/content/workspace/src/task_manager.rs
@@ -11,7 +11,8 @@ use lb_rs::model::file_metadata::DocumentHmac;
 use lb_rs::{Uuid, spawn};
 use tracing::{Level, debug, error, instrument, span, trace, warn};
 
-use crate::tab::{Tab, TabSaveContent, TabsExt as _};
+use crate::tab::{Destination, TabSaveContent};
+use crate::widgets::tab_cache::TabCache;
 
 #[derive(Default)]
 pub struct Tasks {
@@ -80,14 +81,11 @@ pub struct LoadRequest {
     // what focuses the tab and the tab must be shown every frame to hold focus
     // todo: hold focus for loading tabs and all the rest in one proper place
     pub make_current: bool,
-
-    pub is_preview: bool,
 }
 
 #[derive(Clone, Debug)]
 pub struct SaveRequest {
     pub id: Uuid,
-    pub is_preview: bool,
 }
 
 // Timing
@@ -272,7 +270,7 @@ impl TaskManager {
     /// done - so it's the UI's responsibility to check in on it from time-to-time. This is necessary so that the UI
     /// can interject between tasks that are queued and tasks that they are queued behind i.e. to provide the latest
     /// hmac and file content so that a save succeeds.
-    pub fn check_launch(&self, tabs: &[Tab]) {
+    pub fn check_launch(&self, tabs: &TabCache) {
         let mut tasks = self.tasks.lock().unwrap();
 
         // Prioritize loads over saves because when they are both queued, it's likely because a sync pulled updates to
@@ -356,13 +354,8 @@ impl TaskManager {
             let request = queued_save.request.clone();
             let in_progress_save = InProgressSave::new(queued_save);
             let (old_hmac, seq, content) = {
-                // match on is_preview so saves read content/hmac from the correct tab
-                // when two tabs have the same file id
-                let Some(tab) = tabs
-                    .iter()
-                    .find(|t| t.id() == Some(request.id) && t.is_preview == request.is_preview)
-                    .or_else(|| tabs.get_by_id(request.id))
-                else {
+                let key = Destination::File(request.id);
+                let Some(tab) = tabs.get_any(&key) else {
                     error!("could not launch save because its tab does not exist");
                     continue;
                 };

--- a/libs/content/workspace/src/widgets/mod.rs
+++ b/libs/content/workspace/src/widgets/mod.rs
@@ -10,6 +10,7 @@ pub mod progress_bar;
 pub mod separator;
 pub mod subscription;
 pub mod switch;
+pub mod tab_cache;
 
 pub use button::Button;
 pub use button_group::ButtonGroup;

--- a/libs/content/workspace/src/widgets/tab_cache.rs
+++ b/libs/content/workspace/src/widgets/tab_cache.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+
+use crate::tab::{Destination, Tab};
+
+/// Double-buffered tab cache. Tabs accessed during a frame (via promote)
+/// survive; unaccessed tabs are evicted at end_frame unless dirty.
+pub struct TabCache {
+    current: HashMap<Destination, Tab>,
+    previous: HashMap<Destination, Tab>,
+}
+
+impl Default for TabCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TabCache {
+    pub fn new() -> Self {
+        Self { current: HashMap::new(), previous: HashMap::new() }
+    }
+
+    pub fn begin_frame(&mut self) {
+        self.previous = std::mem::take(&mut self.current);
+    }
+
+    /// Dirty tabs are kept alive — their save was already queued at
+    /// close time and needs the tab present for check_launch.
+    pub fn end_frame(&mut self) {
+        let mut keep = Vec::new();
+        for (dest, tab) in self.previous.drain() {
+            if tab.last_changed > tab.last_saved {
+                keep.push((dest, tab));
+            }
+        }
+        for (dest, tab) in keep {
+            self.current.insert(dest, tab);
+        }
+    }
+
+    /// Move a tab from previous into current, keeping it alive this frame.
+    pub fn promote(&mut self, dest: &Destination) {
+        if !self.current.contains_key(dest) {
+            if let Some(tab) = self.previous.remove(dest) {
+                self.current.insert(dest.clone(), tab);
+            }
+        }
+    }
+
+    pub fn get(&self, dest: &Destination) -> Option<&Tab> {
+        self.current.get(dest)
+    }
+
+    pub fn get_mut(&mut self, dest: &Destination) -> Option<&mut Tab> {
+        self.current.get_mut(dest)
+    }
+
+    /// Search both current and previous. Used by check_launch and save
+    /// completion to find tabs that are dirty but not promoted this frame.
+    pub fn get_any(&self, dest: &Destination) -> Option<&Tab> {
+        self.current.get(dest).or_else(|| self.previous.get(dest))
+    }
+
+    pub fn get_any_mut(&mut self, dest: &Destination) -> Option<&mut Tab> {
+        if self.current.contains_key(dest) {
+            self.current.get_mut(dest)
+        } else {
+            self.previous.get_mut(dest)
+        }
+    }
+
+    pub fn insert(&mut self, dest: Destination, tab: Tab) -> Option<Tab> {
+        self.current.insert(dest, tab)
+    }
+
+    pub fn remove(&mut self, dest: &Destination) -> Option<Tab> {
+        self.current
+            .remove(dest)
+            .or_else(|| self.previous.remove(dest))
+    }
+
+    pub fn contains_key(&self, dest: &Destination) -> bool {
+        self.current.contains_key(dest) || self.previous.contains_key(dest)
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &Tab> {
+        self.current.values().chain(self.previous.values())
+    }
+
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut Tab> {
+        self.current.values_mut().chain(self.previous.values_mut())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Destination, &Tab)> {
+        self.current.iter().chain(self.previous.iter())
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Destination, &mut Tab)> {
+        self.current.iter_mut().chain(self.previous.iter_mut())
+    }
+
+    pub fn keys(&self) -> Vec<Destination> {
+        self.current
+            .keys()
+            .chain(self.previous.keys())
+            .cloned()
+            .collect()
+    }
+
+    pub fn retain(&mut self, f: impl FnMut(&Destination, &mut Tab) -> bool) {
+        self.current.retain(f);
+    }
+}

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -31,14 +31,13 @@ use crate::tab::markdown_editor::{
 };
 use crate::tab::pdf_viewer::PdfViewer;
 use crate::tab::svg_editor::{CanvasSettings, SVGEditor};
-use crate::tab::{
-    ContentState, Destination, Tab, TabContent, TabFailure, TabSaveContent, TabsExt as _,
-};
+use crate::tab::{ContentState, Destination, Tab, TabContent, TabFailure, TabSaveContent, TabSlot};
 use crate::task_manager;
 use crate::task_manager::{
     CompletedLoad, CompletedSave, CompletedTiming, LoadRequest, SaveRequest, TaskManager,
 };
 use crate::widgets::image_cache::ImageCache;
+use crate::widgets::tab_cache::TabCache;
 
 #[cfg(not(target_family = "wasm"))]
 use crate::mind_map::show::MindMap;
@@ -47,8 +46,9 @@ use tokio::sync::broadcast::error::TryRecvError;
 
 pub struct Workspace {
     // User activity
-    pub tabs: Vec<Tab>,
-    pub current_tab: usize,
+    pub tabs: TabCache,
+    pub tab_strip: Vec<TabSlot>,
+    pub current_tab: Option<Destination>,
     pub landing_page: LandingPage,
     pub account: Account,
 
@@ -95,8 +95,9 @@ impl Workspace {
         let cfg = WsPersistentStore::new(core.recent_panic().unwrap_or(true), writeable_path);
         ctx.set_zoom_factor(cfg.get_zoom_factor());
         let mut ws = Self {
-            tabs: Default::default(),
-            current_tab: Default::default(),
+            tabs: TabCache::new(),
+            tab_strip: Vec::new(),
+            current_tab: None,
             landing_page: cfg.get_landing_page(),
             account: core.get_account().cloned().expect("failed to get account"),
 
@@ -145,49 +146,85 @@ impl Workspace {
         ws
     }
 
-    pub fn create_tab(&mut self, dest: Destination, content: ContentState, make_current: bool) {
-        let now = Instant::now();
-        let new_tab = Tab {
-            destination: dest,
-            content,
-            back: Vec::new(),
-            forward: Vec::new(),
-            last_changed: now,
-            last_saved: now,
-            rename: None,
-            is_closing: false,
-            read_only: false,
-            is_preview: false,
+    /// Ensure a tab exists for `dest`. Creates it if absent, determining
+    /// content from the destination variant. Does not add to tab_strip or
+    /// make current — callers decide visibility.
+    pub fn open_dest(&mut self, dest: &Destination) {
+        if self.tabs.contains_key(dest) {
+            return;
+        }
+        let id = dest.id();
+        let mut needs_load = false;
+        let content = match dest {
+            Destination::File(id) => {
+                if self.is_image(*id) {
+                    self.image_content(*id)
+                } else {
+                    needs_load = true;
+                    ContentState::Loading(*id)
+                }
+            }
+            #[cfg(not(target_family = "wasm"))]
+            Destination::MindMap(_) => {
+                ContentState::Open(TabContent::MindMap(MindMap::new(&self.core)))
+            }
+            Destination::SpaceInspector(root_id) => {
+                let file = self.files.read().unwrap().get_by_id(*root_id).cloned();
+                ContentState::Open(TabContent::SpaceInspector(SpaceInspector::new(
+                    &self.core,
+                    file,
+                    self.ctx.clone(),
+                )))
+            }
         };
-        self.tabs.push(new_tab);
+        let now = Instant::now();
+        self.tabs.insert(
+            dest.clone(),
+            Tab {
+                destination: dest.clone(),
+                content,
+                last_changed: now,
+                last_saved: now,
+                read_only: false,
+            },
+        );
+        if needs_load {
+            self.tasks
+                .queue_load(LoadRequest { id, tab_created: true, make_current: false });
+        }
+    }
+
+    pub fn create_tab(&mut self, dest: Destination, make_current: bool) {
+        self.open_dest(&dest);
+        if !self.tab_strip.iter().any(|s| s.dest == dest) {
+            self.tab_strip.push(TabSlot::new(dest.clone()));
+        }
         if make_current {
-            self.current_tab = self.tabs.len() - 1;
+            self.current_tab = Some(dest);
             self.current_tab_changed = true;
         }
     }
 
     pub fn get_mut_tab_by_id(&mut self, id: Uuid) -> Option<&mut Tab> {
-        self.tabs.get_mut_by_id(id)
+        let dest = self
+            .tab_strip
+            .iter()
+            .find(|s| s.dest.id() == id)?
+            .dest
+            .clone();
+        self.tabs.get_mut(&dest)
     }
 
     pub fn get_idx_by_id(&mut self, id: Uuid) -> Option<usize> {
-        for (idx, tab) in self.tabs.iter().enumerate() {
-            if let Some(tab_id) = tab.id() {
-                if tab_id == id {
-                    return Some(idx);
-                }
-            }
-        }
-
-        None
+        self.tab_strip.iter().position(|s| s.dest.id() == id)
     }
 
     pub fn is_empty(&self) -> bool {
-        self.tabs.iter().all(|t| t.is_preview)
+        self.tab_strip.is_empty()
     }
 
     pub fn current_tab(&self) -> Option<&Tab> {
-        self.tabs.get(self.current_tab).filter(|t| !t.is_preview)
+        self.current_tab.as_ref().and_then(|d| self.tabs.get(d))
     }
 
     pub fn current_tab_id(&self) -> Option<Uuid> {
@@ -199,81 +236,10 @@ impl Workspace {
     }
 
     pub fn current_tab_mut(&mut self) -> Option<&mut Tab> {
-        self.tabs
-            .get_mut(self.current_tab)
-            .filter(|t| !t.is_preview)
-    }
-
-    // Preview tab lifecycle:
-    // * Create: `open_preview(id)` creates a tab with `ContentState::Loading`
-    // and queues a background load.
-    // * Navigate: calling `open_preview` with a different id closes the
-    // current preview (saving if dirty) and creates a new one.
-    // * Promote: `promote_preview()` sets `is_preview = false`, turning the
-    // preview into a regular tab with no reload.
-    // * Close: `close_preview()` removes the preview. Dirty previews queue
-    // a save and linger as `is_closing` until the save completes.
-    pub fn preview_tab(&self) -> Option<(usize, &Tab)> {
-        self.tabs
-            .iter()
-            .enumerate()
-            .find(|(_, t)| t.is_preview && !t.is_closing)
-    }
-
-    pub fn preview_tab_mut(&mut self) -> Option<(usize, &mut Tab)> {
-        self.tabs
-            .iter_mut()
-            .enumerate()
-            .find(|(_, t)| t.is_preview && !t.is_closing)
-    }
-
-    pub fn open_preview(&mut self, id: Uuid) {
-        let is_document = self
-            .files
-            .read()
-            .unwrap()
-            .get_by_id(id)
-            .is_some_and(|f| f.is_document());
-        if !is_document {
-            return;
-        }
-
-        let current_preview_id = self.preview_tab().and_then(|(_, t)| t.id());
-        if current_preview_id == Some(id) {
-            return;
-        }
-
-        self.close_preview();
-        self.create_tab(Destination::File(id), ContentState::Loading(id), false);
-        let idx = self.tabs.len() - 1;
-        self.tabs[idx].is_preview = true;
-        self.tasks.queue_load(LoadRequest {
-            id,
-            tab_created: true,
-            make_current: false,
-            is_preview: true,
-        });
-    }
-
-    pub fn close_preview(&mut self) {
-        let Some((idx, _)) = self.preview_tab() else { return };
-        if self.tabs[idx].is_dirty(&self.tasks) {
-            self.tabs[idx].is_closing = true;
-            if let Some(id) = self.tabs[idx].id() {
-                self.tasks.queue_save(SaveRequest { id, is_preview: true });
-            }
-        } else {
-            self.tabs.remove(idx);
-            if self.current_tab >= self.tabs.len() && self.current_tab > 0 {
-                self.current_tab -= 1;
-            }
-        }
-    }
-
-    pub fn promote_preview(&mut self) {
-        let Some((idx, tab)) = self.preview_tab_mut() else { return };
-        tab.is_preview = false;
-        self.make_current(idx);
+        self.current_tab
+            .as_ref()
+            .cloned()
+            .and_then(|d| self.tabs.get_mut(&d))
     }
 
     pub fn current_tab_markdown(&self) -> Option<&Markdown> {
@@ -288,29 +254,30 @@ impl Workspace {
     }
 
     pub fn make_current(&mut self, i: usize) -> bool {
-        if i < self.tabs.len() && !self.tabs[i].is_preview {
-            self.current_tab = i;
-            self.current_tab_changed = true;
-            self.tabs[i].is_closing = false;
-            self.out.selected_file = self.tabs[i].id();
-            self.ctx
-                .send_viewport_cmd(ViewportCommand::Title(self.tab_title(&self.tabs[i])));
+        let Some(slot) = self.tab_strip.get(i) else { return false };
+        let dest = slot.dest.clone();
+        if self.tabs.get(&dest).is_none() {
+            return false;
+        };
+        self.current_tab = Some(dest.clone());
+        self.current_tab_changed = true;
+        let tab = self.tabs.get(&dest).unwrap();
+        self.out.selected_file = tab.id();
+        self.ctx
+            .send_viewport_cmd(ViewportCommand::Title(self.tab_title(tab)));
 
-            if let Some(md) = self.current_tab_markdown() {
-                md.focus(&self.ctx);
-            }
-
-            self.ctx.request_repaint();
-
-            true
-        } else {
-            false
+        if let Some(md) = self.current_tab_markdown() {
+            md.focus(&self.ctx);
         }
+
+        self.ctx.request_repaint();
+
+        true
     }
 
     /// Makes the tab with the given id the current tab, if it exists. Returns true if the tab exists.
     pub fn make_current_by_id(&mut self, id: Uuid) -> bool {
-        if let Some(i) = self.tabs.iter().position(|t| t.id() == Some(id)) {
+        if let Some(i) = self.tab_strip.iter().position(|s| s.dest.id() == id) {
             self.make_current(i)
         } else {
             false
@@ -318,18 +285,27 @@ impl Workspace {
     }
 
     pub fn save_all_tabs(&mut self) {
-        for i in 0..self.tabs.len() {
-            self.save_tab(i);
+        let slots: Vec<_> = self.tab_strip.clone();
+        for slot in &slots {
+            let dest = &slot.dest;
+            if let Some(tab) = self.tabs.get(dest) {
+                if let Some(id) = tab.id() {
+                    if tab.is_dirty(&self.tasks) {
+                        self.tasks.queue_save(SaveRequest { id });
+                    }
+                }
+            }
         }
         self.last_save_all = Some(Instant::now());
     }
 
     pub fn save_tab(&mut self, i: usize) {
-        if let Some(tab) = self.tabs.get_mut(i) {
+        let Some(slot) = self.tab_strip.get(i) else { return };
+        let dest = slot.dest.clone();
+        if let Some(tab) = self.tabs.get(&dest) {
             if let Some(id) = tab.id() {
                 if tab.is_dirty(&self.tasks) {
-                    self.tasks
-                        .queue_save(SaveRequest { id, is_preview: tab.is_preview });
+                    self.tasks.queue_save(SaveRequest { id });
                 }
             }
         }
@@ -350,113 +326,108 @@ impl Workspace {
 
     pub fn open_file(&mut self, id: Uuid, make_current: bool, in_new_tab: bool) {
         let dest = Destination::File(id);
-        let mut create_tab = || {
-            if let Some(pos) = self.tabs.iter().position(|t| t.id() == Some(id)) {
-                if make_current {
-                    self.make_current(pos);
-                }
-                return false;
-            }
-            if in_new_tab {
-                return true;
-            }
-            let Some(current_tab) = self.current_tab_mut() else {
-                return true;
-            };
-            if let Some(id) = current_tab.id() {
-                current_tab.back.push(id);
-                current_tab.forward.clear();
-            }
-            current_tab.content = ContentState::Loading(id);
-            current_tab.destination = dest.clone();
-            false
-        };
-        let create_tab = create_tab();
 
-        if self.is_image(id) {
-            let content = self.image_content(id);
-            if create_tab {
-                self.create_tab(dest, content, make_current);
-            } else if let Some(tab) = self.current_tab_mut() {
-                tab.content = content;
+        // already in strip — just focus it
+        if let Some(pos) = self.tab_strip.iter().position(|s| s.dest == dest) {
+            if make_current {
+                self.make_current(pos);
             }
             return;
         }
 
-        if create_tab {
-            self.create_tab(dest, ContentState::Loading(id), make_current);
+        if in_new_tab {
+            self.create_tab(dest, make_current);
+            return;
         }
 
-        self.tasks.queue_load(LoadRequest {
-            id,
-            tab_created: create_tab,
-            make_current,
-            is_preview: false,
-        });
+        // navigate within current tab
+        let Some(old_dest) = self.current_tab.clone() else {
+            self.create_tab(dest, make_current);
+            return;
+        };
+
+        // Find the slot index for the current tab
+        let Some(slot_idx) = self.tab_strip.iter().position(|s| s.dest == old_dest) else {
+            self.create_tab(dest, make_current);
+            return;
+        };
+
+        // Push old dest id to slot's back, clear forward
+        self.tab_strip[slot_idx].back.push(old_dest.id());
+        self.tab_strip[slot_idx].forward.clear();
+        // Update the slot's dest to the new destination
+        self.tab_strip[slot_idx].dest = dest.clone();
+
+        // Ensure the tab exists in cache for the new destination
+        self.open_dest(&dest);
+
+        self.current_tab = Some(dest);
+        self.current_tab_changed = true;
     }
 
     pub fn back(&mut self) {
-        let Some(current_tab) = self.current_tab_mut() else { return };
-        let Some(back_id) = current_tab.back.pop() else { return };
-        let Some(current_id) = current_tab.id() else { return };
-        current_tab.forward.push(current_id);
+        let Some(current_dest) = self.current_tab.clone() else { return };
+        let Some(slot_idx) = self.tab_strip.iter().position(|s| s.dest == current_dest) else {
+            return;
+        };
+        let Some(back_id) = self.tab_strip[slot_idx].back.pop() else { return };
+        self.tab_strip[slot_idx].forward.push(current_dest.id());
 
-        let tab = self.current_tab_mut().unwrap();
-        tab.destination = Destination::File(back_id);
-        if self.is_image(back_id) {
-            self.current_tab_mut().unwrap().content = self.image_content(back_id);
-        } else {
-            self.current_tab_mut().unwrap().content = ContentState::Loading(back_id);
-            self.tasks.queue_load(LoadRequest {
-                id: back_id,
-                tab_created: true,
-                make_current: false,
-                is_preview: false,
-            });
-        }
+        let new_dest = Destination::File(back_id);
+        self.tab_strip[slot_idx].dest = new_dest.clone();
+
+        self.open_dest(&new_dest);
+        self.current_tab = Some(new_dest);
+        self.current_tab_changed = true;
     }
 
     pub fn forward(&mut self) {
-        let Some(current_tab) = self.current_tab_mut() else { return };
-        let Some(forward_id) = current_tab.forward.pop() else { return };
-        let Some(current_id) = current_tab.id() else { return };
-        current_tab.back.push(current_id);
+        let Some(current_dest) = self.current_tab.clone() else { return };
+        let Some(slot_idx) = self.tab_strip.iter().position(|s| s.dest == current_dest) else {
+            return;
+        };
+        let Some(forward_id) = self.tab_strip[slot_idx].forward.pop() else { return };
+        self.tab_strip[slot_idx].back.push(current_dest.id());
 
-        let tab = self.current_tab_mut().unwrap();
-        tab.destination = Destination::File(forward_id);
-        if self.is_image(forward_id) {
-            self.current_tab_mut().unwrap().content = self.image_content(forward_id);
-        } else {
-            self.current_tab_mut().unwrap().content = ContentState::Loading(forward_id);
-            self.tasks.queue_load(LoadRequest {
-                id: forward_id,
-                tab_created: true,
-                make_current: false,
-                is_preview: false,
-            });
-        }
+        let new_dest = Destination::File(forward_id);
+        self.tab_strip[slot_idx].dest = new_dest.clone();
+
+        self.open_dest(&new_dest);
+        self.current_tab = Some(new_dest);
+        self.current_tab_changed = true;
     }
 
     pub fn close_tab(&mut self, i: usize) {
+        let Some(slot) = self.tab_strip.get(i) else { return };
+        let dest = slot.dest.clone();
         #[cfg(not(target_family = "wasm"))]
-        if let ContentState::Open(TabContent::MindMap(mm)) = &mut self.tabs[i].content {
-            mm.stop();
+        if let Some(tab) = self.tabs.get_mut(&dest) {
+            if let ContentState::Open(TabContent::MindMap(mm)) = &mut tab.content {
+                mm.stop();
+            }
         }
 
         self.save_tab(i);
-        self.tabs[i].is_closing = true;
-    }
 
-    pub fn remove_tab(&mut self, i: usize) {
-        if let Some(md) = self.tabs[i].markdown_mut() {
-            md.surrender_focus(&self.ctx);
+        if let Some(tab) = self.tabs.get_mut(&dest) {
+            if let Some(md) = tab.markdown_mut() {
+                md.surrender_focus(&self.ctx);
+            }
         }
 
-        self.tabs.remove(i);
+        // Remove from tab_strip
+        self.tab_strip.remove(i);
         self.out.tabs_changed = true;
 
-        if !self.tabs.is_empty() && (self.current_tab >= self.tabs.len() || i < self.current_tab) {
-            self.current_tab -= 1;
+        // Update current_tab
+        if self.current_tab.as_ref() == Some(&dest) {
+            // Pick a neighbor
+            if self.tab_strip.is_empty() {
+                self.current_tab = None;
+            } else {
+                let new_idx = i.min(self.tab_strip.len() - 1);
+                self.current_tab = Some(self.tab_strip[new_idx].dest.clone());
+            }
         }
         self.current_tab_changed = true;
     }
@@ -477,10 +448,12 @@ impl Workspace {
 
                         if actor == Actor::Sync {
                             self.core.app_foregrounded();
-                            for i in 0..self.tabs.len() {
-                                if self.tabs[i].id() == Some(id) && !self.tabs[i].is_closing {
-                                    self.open_file(id, false, false);
-                                }
+                            let has_open_tab = self
+                                .tab_strip
+                                .iter()
+                                .any(|s| s.dest.id() == id && self.tabs.contains_key(&s.dest));
+                            if has_open_tab {
+                                self.open_file(id, false, false);
                             }
                         }
                     }
@@ -506,17 +479,16 @@ impl Workspace {
             let files_guard = files_arc.read().unwrap();
             let files = &*files_guard;
             let mut tabs_to_delete = vec![];
-            for tab in &self.tabs {
-                if let Some(id) = tab.id() {
-                    if files.get_by_id(id).is_none() {
-                        tabs_to_delete.push(id);
-                    }
+            for slot in &self.tab_strip {
+                let id = slot.dest.id();
+                if files.get_by_id(id).is_none() {
+                    tabs_to_delete.push(id);
                 }
             }
 
             for id in tabs_to_delete {
-                if let Some(idx) = self.get_idx_by_id(id) {
-                    self.remove_tab(idx);
+                if let Some(idx) = self.tab_strip.iter().position(|s| s.dest.id() == id) {
+                    self.close_tab(idx);
                 }
             }
         }
@@ -531,7 +503,7 @@ impl Workspace {
             // scope indentation preserves git history
             {
                 let CompletedLoad {
-                    request: LoadRequest { id, tab_created, make_current, is_preview },
+                    request: LoadRequest { id, tab_created, make_current },
                     content_result,
                     timing: _,
                 } = load;
@@ -540,13 +512,8 @@ impl Workspace {
                 let core = self.core.clone();
                 let show_tabs = self.show_tabs;
 
-                // route to the correct tab when two tabs have the same file id
-                let tab_idx = self
-                    .tabs
-                    .iter()
-                    .position(|t| t.id() == Some(id) && t.is_preview == is_preview)
-                    .or_else(|| self.tabs.position_by_id(id));
-                if let Some(tab) = tab_idx.map(|i| &mut self.tabs[i]) {
+                let key = Destination::File(id);
+                if let Some(tab) = self.tabs.get_mut(&key) {
                     let files_clone = self.files.clone();
                     let files_guard = files_clone.read().unwrap();
 
@@ -648,15 +615,6 @@ impl Workspace {
                                             tablet_or_desktop: show_tabs,
                                         },
                                     )));
-                                if tab.is_preview {
-                                    let md = tab.markdown_mut().unwrap();
-                                    // without initialized, the editor auto-focuses and
-                                    // steals from the search bar
-                                    md.initialized = true;
-                                    // without id_salt, two editors for the same file share
-                                    // an egui ID, causing response/focus/interaction collisions
-                                    md.id_salt = egui::Id::new("preview");
-                                }
                             } else {
                                 let md = tab.markdown_mut().unwrap();
                                 md.buffer.reload(String::from_utf8_lossy(&bytes).into());
@@ -688,20 +646,15 @@ impl Workspace {
             {
                 {
                     let CompletedSave {
-                        request: SaveRequest { id, is_preview },
+                        request: SaveRequest { id },
                         seq,
                         content,
                         new_hmac_result,
                         timing: CompletedTiming { queued_at: _, started_at, completed_at: _ },
                     } = save;
 
-                    // route to the correct tab when two tabs have the same file id
-                    let tab_idx = self
-                        .tabs
-                        .iter()
-                        .position(|t| t.id() == Some(id) && t.is_preview == is_preview)
-                        .or_else(|| self.tabs.position_by_id(id));
-                    if let Some(tab) = tab_idx.map(|i| &mut self.tabs[i]) {
+                    let key = Destination::File(id);
+                    if let Some(tab) = self.tabs.get_any_mut(&key) {
                         match new_hmac_result {
                             Ok(hmac) => {
                                 tab.last_saved = started_at;
@@ -715,21 +668,6 @@ impl Workspace {
                                         svg.open_file_hmac = Some(hmac);
                                         svg.opened_content = *content;
                                     }
-                                }
-
-                                // reload sibling tab so edits appear in both views
-                                let has_sibling = self.tabs.iter().any(|t| {
-                                    t.id() == Some(id)
-                                        && t.is_preview != is_preview
-                                        && !t.is_closing
-                                });
-                                if has_sibling {
-                                    self.tasks.queue_load(LoadRequest {
-                                        id,
-                                        tab_created: false,
-                                        make_current: false,
-                                        is_preview: !is_preview,
-                                    });
                                 }
                             }
                             Err(err) => {
@@ -775,34 +713,6 @@ impl Workspace {
         let start = Instant::now();
         self.tasks.check_launch(&self.tabs);
         start.warn_after("processing task launch", Duration::from_millis(100));
-
-        // background work: cleanup
-        let mut removed_tabs = 0;
-        for i in 0..self.tabs.len() {
-            let i = i - removed_tabs;
-            let tab = &self.tabs[i];
-            if tab.is_closing
-                && !tab
-                    .id()
-                    .map(|id| self.tasks.load_or_save_queued(id))
-                    .unwrap_or_default()
-                && !tab
-                    .id()
-                    .map(|id| self.tasks.load_or_save_in_progress(id))
-                    .unwrap_or_default()
-            {
-                self.remove_tab(i);
-                removed_tabs += 1;
-
-                let title = match self.current_tab() {
-                    Some(tab) => self.tab_title(tab),
-                    None => "Lockbook".to_owned(),
-                };
-                self.ctx.send_viewport_cmd(ViewportCommand::Title(title));
-
-                self.out.selected_file = self.current_tab().and_then(|tab| tab.id());
-            }
-        }
     }
 
     pub fn create_doc_at(&mut self, is_drawing: bool, parent: Uuid) {
@@ -885,16 +795,16 @@ impl Workspace {
 
     /// Opens or focuses the tab for the mind map
     #[cfg(not(target_family = "wasm"))]
-    pub fn upsert_mind_map(&mut self, core: Lb) {
-        if let Some(i) = self.tabs.iter().position(|t| t.mind_map().is_some()) {
+    pub fn upsert_mind_map(&mut self, _core: Lb) {
+        if let Some(i) = self
+            .tab_strip
+            .iter()
+            .position(|s| matches!(s.dest, Destination::MindMap(_)))
+        {
             self.make_current(i);
         } else {
-            let root_id = core.get_root().map(|r| r.id).unwrap_or_default();
-            self.create_tab(
-                Destination::MindMap(root_id),
-                ContentState::Open(TabContent::MindMap(MindMap::new(&core))),
-                true,
-            );
+            let root_id = self.core.get_root().map(|r| r.id).unwrap_or_default();
+            self.create_tab(Destination::MindMap(root_id), true);
         };
     }
     #[cfg(target_family = "wasm")]
@@ -902,24 +812,18 @@ impl Workspace {
         warn!("Mind map is not supported on wasm targets");
     }
 
-    /// Opens the tab for space inspector, closing any existing space inspectors (?)
-    pub fn start_space_inspector(&mut self, core: Lb, folder: Option<File>) {
-        if let Some(i) = self.tabs.iter().position(|t| t.space_inspector().is_some()) {
+    pub fn start_space_inspector(&mut self, _core: Lb, folder: Option<File>) {
+        if let Some(i) = self
+            .tab_strip
+            .iter()
+            .position(|s| matches!(s.dest, Destination::SpaceInspector(_)))
+        {
             self.close_tab(i);
         }
         let root_id = folder
-            .as_ref()
             .map(|f| f.id)
-            .unwrap_or_else(|| core.get_root().map(|r| r.id).unwrap_or_default());
-        self.create_tab(
-            Destination::SpaceInspector(root_id),
-            ContentState::Open(TabContent::SpaceInspector(SpaceInspector::new(
-                &core,
-                folder,
-                self.ctx.clone(),
-            ))),
-            true,
-        );
+            .unwrap_or_else(|| self.core.get_root().map(|r| r.id).unwrap_or_default());
+        self.create_tab(Destination::SpaceInspector(root_id), true);
     }
 
     pub fn rename_file(&mut self, req: (Uuid, String), by_user: bool) {
@@ -941,7 +845,12 @@ impl Workspace {
 
     pub fn file_renamed(&mut self, id: Uuid, new_name: String) {
         let mut different_file_type = false;
-        if let Some(tab) = self.tabs.get_by_id(id) {
+        let dest = self
+            .tab_strip
+            .iter()
+            .find(|s| s.dest.id() == id)
+            .map(|s| s.dest.clone());
+        if let Some(tab) = dest.as_ref().and_then(|d| self.tabs.get(d)) {
             different_file_type = !NameComponents::from(&new_name)
                 .extension
                 .eq(&NameComponents::from(&self.tab_title(tab)).extension);
@@ -1045,20 +954,14 @@ impl WsPersistentStore {
     }
 
     // todo: store non-file (mind map) tabs?
-    pub fn set_tabs(&mut self, tabs: &[Tab], current_tab_index: usize) {
+    pub fn set_tabs(&mut self, tab_strip: &[TabSlot], current_tab: &Option<Destination>) {
         let mut data_lock = self.data.write().unwrap();
-        data_lock.open_tabs = tabs
+        data_lock.open_tabs = tab_strip
             .iter()
-            .filter(|t| !t.is_preview)
-            .flat_map(|t| t.id())
+            .filter(|s| matches!(s.dest, Destination::File(_)))
+            .map(|s| s.dest.id())
             .collect();
-        if !tabs.is_empty() {
-            if let Some(tab) = tabs.get(current_tab_index) {
-                data_lock.current_tab = tab.id();
-            } else {
-                data_lock.current_tab = tabs[0].id();
-            }
-        }
+        data_lock.current_tab = current_tab.as_ref().map(|d| d.id());
         self.write_to_file();
     }
 


### PR DESCRIPTION
Introduces TabCache which stores tabs and manages their lifecycle.
* The TabCache is a map keyed on `Destination`, an enum that can represent a file id or a non-file tab like Mind Map or Space Inspector
* Tabs are automatically dropped if unused for one frame
* Dirty tabs are automatically saved before being dropped
* The tab strip is now separate: stores visible tab order, tab history, and rename state