### PR TITLE
md: factor mdrender

### DIFF
--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -427,7 +427,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getAllText(
         }
     };
 
-    env.new_string(&markdown.buffer.current.text)
+    env.new_string(&markdown.renderer.buffer.current.text)
         .expect("Couldn't create JString from rust string!")
         .into_raw()
 }
@@ -440,7 +440,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getSelection(
 
     let resp = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => {
-            let (start, end) = markdown.buffer.current.selection;
+            let (start, end) = markdown.renderer.buffer.current.selection;
             JTextRange { none: false, start: start.0, end: end.0 }
         }
         None => JTextRange { none: true, start: 0, end: 0 },
@@ -476,7 +476,13 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getTextLength(
         None => return -1,
     };
 
-    markdown.buffer.current.segs.last_cursor_position().0 as jint
+    markdown
+        .renderer
+        .buffer
+        .current
+        .segs
+        .last_cursor_position()
+        .0 as jint
 }
 
 #[no_mangle]
@@ -493,7 +499,9 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_clear(
     obj.renderer.context.push_markdown_event(Event::Replace {
         region: Region::BetweenLocations {
             start: Location::DocCharOffset(DocCharOffset(0)),
-            end: Location::DocCharOffset(markdown.buffer.current.segs.last_cursor_position()),
+            end: Location::DocCharOffset(
+                markdown.renderer.buffer.current.segs.last_cursor_position(),
+            ),
         },
         text: "".to_string(),
         advance_cursor: false,
@@ -557,7 +565,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_append(
         Err(err) => format!("error: {err:?}"),
     };
 
-    let loc = Location::DocCharOffset(markdown.buffer.current.segs.last_cursor_position());
+    let loc = Location::DocCharOffset(markdown.renderer.buffer.current.segs.last_cursor_position());
 
     obj.renderer.context.push_markdown_event(Event::Replace {
         region: Region::BetweenLocations { start: loc, end: loc },
@@ -583,7 +591,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getTextInRange(
     };
 
     let selection = (DocCharOffset(start as usize), DocCharOffset(end as usize));
-    env.new_string(&markdown.buffer[selection])
+    env.new_string(&markdown.renderer.buffer[selection])
         .expect("Couldn't create JString from rust string!")
         .into_raw()
 }
@@ -604,8 +612,9 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getBuffer(
         }
     };
 
-    let selection = (DocCharOffset(0), markdown.buffer.current.segs.last_cursor_position());
-    env.new_string(&markdown.buffer[selection])
+    let selection =
+        (DocCharOffset(0), markdown.renderer.buffer.current.segs.last_cursor_position());
+    env.new_string(&markdown.renderer.buffer[selection])
         .expect("Couldn't create JString from rust string!")
         .into_raw()
 }
@@ -621,7 +630,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_selectAll(
         None => return,
     };
 
-    let segs = &markdown.buffer.current.segs;
+    let segs = &markdown.renderer.buffer.current.segs;
 
     obj.renderer.context.push_markdown_event(Event::Select {
         region: Region::BetweenLocations {

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn has_text(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.buffer.is_empty()
+    !markdown.renderer.buffer.is_empty()
 }
 
 /// # Safety
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *
 
     let range: Option<(DocCharOffset, DocCharOffset)> = range.into();
     if let Some(range) = range {
-        CString::new(&markdown.buffer[range])
+        CString::new(&markdown.renderer.buffer[range])
             .expect("Could not Rust String -> C String")
             .into_raw()
     } else {
@@ -155,8 +155,11 @@ pub unsafe extern "C" fn get_selected(obj: *mut c_void) -> CTextRange {
 
     CTextRange {
         none: false,
-        start: CTextPosition { pos: markdown.buffer.current.selection.start().0, none: false },
-        end: CTextPosition { pos: markdown.buffer.current.selection.end().0, none: false },
+        start: CTextPosition {
+            pos: markdown.renderer.buffer.current.selection.start().0,
+            none: false,
+        },
+        end: CTextPosition { pos: markdown.renderer.buffer.current.selection.end().0, none: false },
     }
 }
 
@@ -248,7 +251,13 @@ pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
         None => return CTextPosition::default(),
     };
 
-    markdown.buffer.current.segs.last_cursor_position().into()
+    markdown
+        .renderer
+        .buffer
+        .current
+        .segs
+        .last_cursor_position()
+        .into()
 }
 
 /// # Safety
@@ -465,7 +474,7 @@ pub unsafe extern "C" fn position_offset(
 
     let start: Option<DocCharOffset> = start.into();
     if let Some(start) = start {
-        let last_cursor_position = markdown.buffer.current.segs.last_cursor_position();
+        let last_cursor_position = markdown.renderer.buffer.current.segs.last_cursor_position();
 
         let result = if offset < 0 && -offset > start.0 as i32 {
             DocCharOffset::default()
@@ -695,7 +704,7 @@ pub unsafe extern "C" fn get_text(obj: *mut c_void) -> *const c_char {
         None => return null(),
     };
 
-    let value = markdown.buffer.current.text.as_str();
+    let value = markdown.renderer.buffer.current.text.as_str();
 
     CString::new(value)
         .expect("Could not Rust String -> C String")
@@ -836,7 +845,7 @@ pub unsafe extern "C" fn can_undo(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.readonly && markdown.buffer.can_undo()
+    !markdown.readonly && markdown.renderer.buffer.can_undo()
 }
 
 /// # Safety
@@ -849,7 +858,7 @@ pub unsafe extern "C" fn can_redo(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.readonly && markdown.buffer.can_redo()
+    !markdown.readonly && markdown.renderer.buffer.can_redo()
 }
 
 /// # Safety

--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -1,4 +1,4 @@
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use comrak::nodes::{LineColumn, Sourcepos};
 use lb_rs::model::text::offset_types::{DocByteOffset, DocCharOffset, RangeExt};
 use std::cmp::Ordering;
@@ -49,7 +49,7 @@ pub struct Bounds {
     pub inline_paragraphs: Paragraphs,
 }
 
-impl Editor {
+impl MdRender {
     pub fn calc_source_lines(&mut self) {
         self.bounds.source_lines.clear();
 
@@ -596,7 +596,7 @@ impl<'r, const N: usize> Iterator for RangeJoinIter<'r, N> {
     }
 }
 
-impl Editor {
+impl MdRender {
     pub fn print_bounds(&self) {
         self.print_words_bounds();
         self.print_wrap_lines_bounds();
@@ -638,7 +638,7 @@ mod test {
     use lb_rs::model::text::offset_types::DocCharOffset;
 
     use super::Bounds;
-    use crate::tab::markdown_editor::Editor;
+    use crate::tab::markdown_editor::MdRender;
     use crate::tab::markdown_editor::bounds::{BoundExt as _, RangesExt as _};
     use crate::tab::markdown_editor::input::Bound;
 
@@ -1604,7 +1604,7 @@ mod test {
     #[test]
     fn sourcepos_to_range_fenced_code_block() {
         let text = "```\nfn main() {}\n```";
-        let mut md = Editor::test(text);
+        let mut md = MdRender::test(text);
         md.calc_source_lines();
 
         let sourcepos = Sourcepos {
@@ -1620,7 +1620,7 @@ mod test {
     #[test]
     fn sourcepos_to_range_unclosed_fenced_code_block() {
         let text = "```\n";
-        let mut md = Editor::test(text);
+        let mut md = MdRender::test(text);
         md.calc_source_lines();
 
         let sourcepos = Sourcepos {

--- a/libs/content/workspace/src/tab/markdown_editor/galleys.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/galleys.rs
@@ -3,7 +3,7 @@ use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 use std::ops::Index;
 use std::sync::{Arc, RwLock};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::bounds::RangesExt as _;
 
 #[derive(Default)]
@@ -52,27 +52,26 @@ impl Galleys {
     }
 }
 
-impl Editor {
+impl MdRender {
     /// Returns the document offset range for which galleys must exist,
     /// covering the selection ± 1 source line so that arrow-key navigation
     /// across the viewport edge has a galley to land on.
-    pub fn galley_required_ranges(&self) -> Vec<(DocCharOffset, DocCharOffset)> {
+    pub fn galley_required_ranges(
+        &self, in_progress_selection: Option<(DocCharOffset, DocCharOffset)>,
+        find_match: Option<(DocCharOffset, DocCharOffset)>,
+    ) -> Vec<(DocCharOffset, DocCharOffset)> {
         if self.bounds.source_lines.is_empty() {
             return Vec::new();
         }
 
         let mut ranges = Vec::new();
 
-        let selection = self
-            .in_progress_selection
-            .unwrap_or(self.buffer.current.selection);
+        let selection = in_progress_selection.unwrap_or(self.buffer.current.selection);
         ranges.push(self.source_line_range(selection));
 
         // also require galleys for the current find match so scroll_to_find_match works
-        if let Some(idx) = self.find.current_match {
-            if let Some(&match_range) = self.find.matches.get(idx) {
-                ranges.push(self.source_line_range(match_range));
-            }
+        if let Some(match_range) = find_match {
+            ranges.push(self.source_line_range(match_range));
         }
 
         ranges

--- a/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
@@ -12,8 +12,10 @@ impl Editor {
     ) -> DocCharOffset {
         let maybe_x_target_value = mem::take(&mut self.cursor.x_target);
         match advance {
-            Advance::To(bound) => offset.advance_to_bound(bound, backwards, &self.bounds),
-            Advance::Next(bound) => offset.advance_to_next_bound(bound, backwards, &self.bounds),
+            Advance::To(bound) => offset.advance_to_bound(bound, backwards, &self.renderer.bounds),
+            Advance::Next(bound) => {
+                offset.advance_to_next_bound(bound, backwards, &self.renderer.bounds)
+            }
             Advance::By(Increment::Char) => {
                 let mut result = offset;
                 if backwards {
@@ -22,7 +24,7 @@ impl Editor {
                     }
                 } else {
                     result += 1;
-                    result = result.min(self.buffer.current.segs.last_cursor_position());
+                    result = result.min(self.renderer.buffer.current.segs.last_cursor_position());
                 }
                 result
             }
@@ -34,7 +36,9 @@ impl Editor {
                     };
                     let x_target = maybe_x_target_value.unwrap_or(result_x);
                     result = self.advance_by_line(result, x_target, backwards);
-                    if result != 0 && result != self.buffer.current.segs.last_cursor_position() {
+                    if result != 0
+                        && result != self.renderer.buffer.current.segs.last_cursor_position()
+                    {
                         self.cursor.x_target = Some(x_target);
                     }
                 }
@@ -46,17 +50,17 @@ impl Editor {
     fn advance_by_line(
         &self, offset: DocCharOffset, x_target: f32, backwards: bool,
     ) -> DocCharOffset {
-        let Some(cur_galley_idx) = self.galleys.galley_at_offset(offset) else {
+        let Some(cur_galley_idx) = self.renderer.galleys.galley_at_offset(offset) else {
             return offset;
         };
-        let cur_galley = &self.galleys[cur_galley_idx];
+        let cur_galley = &self.renderer.galleys[cur_galley_idx];
         if backwards {
             // jump to the closest galley above that's not above another galley that's above
             let mut closest_offset: Option<DocCharOffset> = None;
             let mut closest_distance = f32::INFINITY;
             let mut row_above_top: Option<f32> = None;
             for new_galley_idx in (0..cur_galley_idx).rev() {
-                let new_galley = &self.galleys[new_galley_idx];
+                let new_galley = &self.renderer.galleys[new_galley_idx];
                 let new_galley_is_above = new_galley.rect.bottom() < cur_galley.rect.top();
                 let new_galley_too_above = if let Some(row_above_top) = row_above_top {
                     new_galley.rect.bottom() < row_above_top
@@ -72,8 +76,8 @@ impl Editor {
                     let cur_y = cur_galley.rect.min.y;
                     let target_pos = Pos2::new(x_target, cur_y);
 
-                    let new_offset = self.galley_offset(new_galley_idx, target_pos);
-                    let new_x = self.galley_x(new_galley, new_offset);
+                    let new_offset = self.renderer.galley_offset(new_galley_idx, target_pos);
+                    let new_x = self.renderer.galley_x(new_galley, new_offset);
 
                     let distance = (new_x - x_target).abs(); // closest as in closest to target
 
@@ -95,8 +99,8 @@ impl Editor {
             let mut closest_offset: Option<DocCharOffset> = None;
             let mut closest_distance = f32::INFINITY;
             let mut row_below_bottom: Option<f32> = None;
-            for new_galley_idx in cur_galley_idx + 1..self.galleys.len() {
-                let new_galley = &self.galleys[new_galley_idx];
+            for new_galley_idx in cur_galley_idx + 1..self.renderer.galleys.len() {
+                let new_galley = &self.renderer.galleys[new_galley_idx];
                 let new_galley_is_below = new_galley.rect.top() > cur_galley.rect.bottom();
                 let new_galley_too_below = if let Some(row_below_bottom) = row_below_bottom {
                     new_galley.rect.top() > row_below_bottom
@@ -112,8 +116,8 @@ impl Editor {
                     let cur_y = cur_galley.rect.min.y;
                     let target_pos = Pos2::new(x_target, cur_y);
 
-                    let new_offset = self.galley_offset(new_galley_idx, target_pos);
-                    let new_x = self.galley_x(new_galley, new_offset);
+                    let new_offset = self.renderer.galley_offset(new_galley_idx, target_pos);
+                    let new_x = self.renderer.galley_x(new_galley, new_offset);
 
                     let distance = (new_x - x_target).abs(); // closest as in closest to target
 
@@ -132,14 +136,15 @@ impl Editor {
             if let Some(closest_offset) = closest_offset {
                 closest_offset
             } else if !self
+                .renderer
                 .bounds
                 .source_lines
                 .find_containing(offset, true, true)
-                .contains(self.bounds.source_lines.len() - 1, true, false)
+                .contains(self.renderer.bounds.source_lines.len() - 1, true, false)
             {
                 // if we're in the last galley but not the last source line it's
                 // because the lasy galley is hidden (perhaps by a folded node)
-                self.buffer.current.segs.last_cursor_position()
+                self.renderer.buffer.current.segs.last_cursor_position()
             } else {
                 offset
             }
@@ -148,8 +153,8 @@ impl Editor {
 
     /// returns the x coordinate of the absolute position of `self` in `galley`
     fn x(&self, offset: DocCharOffset) -> Option<f32> {
-        let cur_galley_idx = self.galleys.galley_at_offset(offset)?;
-        let cur_galley = &self.galleys[cur_galley_idx];
-        Some(self.galley_x(cur_galley, offset))
+        let cur_galley_idx = self.renderer.galleys.galley_at_offset(offset)?;
+        let cur_galley = &self.renderer.galleys[cur_galley_idx];
+        Some(self.renderer.galley_x(cur_galley, offset))
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
@@ -85,7 +85,7 @@ impl<'ast> Editor {
                 // with text selected, pasting a link turns selected text into a
                 // markdown link...
                 let mut link_paste = false;
-                if !self.buffer.current.selection.is_empty() {
+                if !self.renderer.buffer.current.selection.is_empty() {
                     // use comrak's auto-link detector
                     let arena = comrak::Arena::new();
                     let mut options = comrak::Options::default();
@@ -109,8 +109,9 @@ impl<'ast> Editor {
                         descendant.data().value,
                         NodeValue::Link(_) | NodeValue::WikiLink(_) | NodeValue::Image(_)
                     ) && self
+                        .renderer
                         .node_range(descendant)
-                        .intersects(&self.buffer.current.selection, false)
+                        .intersects(&self.renderer.buffer.current.selection, false)
                     {
                         link_paste = false;
                         break;
@@ -152,7 +153,8 @@ impl<'ast> Editor {
             egui::Event::Key { key: Key::Enter, pressed: true, modifiers, .. }
                 if !cfg!(target_os = "ios") && modifiers.command =>
             {
-                self.open_links_in_selection(root, &self.ctx);
+                self.renderer
+                    .open_links_in_selection(root, &self.renderer.ctx);
                 None
             }
             egui::Event::Key { key: Key::Enter, pressed: true, modifiers, .. }

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -32,7 +32,7 @@ impl Editor {
         let mut result = Vec::new();
 
         // todo: binary search
-        for galley_info in self.galleys.galleys.iter().rev() {
+        for galley_info in self.renderer.galleys.galleys.iter().rev() {
             let GalleyInfo { range: galley_range, mut rect, padded, .. } = galley_info;
             if galley_range.end() < range.start() {
                 break;
@@ -41,14 +41,14 @@ impl Editor {
             }
 
             if galley_range.contains_inclusive(range.start()) {
-                rect.min.x = self.galley_x(galley_info, range.start());
+                rect.min.x = self.renderer.galley_x(galley_info, range.start());
             }
             if galley_range.contains_inclusive(range.end()) {
-                rect.max.x = self.galley_x(galley_info, range.end());
+                rect.max.x = self.renderer.galley_x(galley_info, range.end());
             }
 
             if rect.area() > 0.001 && *padded {
-                rect = rect.expand2(self.layout.inline_padding * Vec2::X);
+                rect = rect.expand2(self.renderer.layout.inline_padding * Vec2::X);
             }
 
             result.push(rect);
@@ -71,11 +71,11 @@ impl Editor {
     }
 
     pub fn show_selection_handles(&mut self, ui: &mut Ui) {
-        let theme = self.ctx.get_lb_theme();
+        let theme = self.renderer.ctx.get_lb_theme();
         let color = theme.fg().get_color(theme.prefs().primary);
         let selection = self
             .in_progress_selection
-            .unwrap_or(self.buffer.current.selection);
+            .unwrap_or(self.renderer.buffer.current.selection);
         let selection_start_line = self.cursor_line(selection.0);
         let selection_end_line = self.cursor_line(selection.1);
 
@@ -84,7 +84,7 @@ impl Editor {
         // draw selection handles
         // handles invisible but still draggable when selection is empty
         // we must allocate handles to check if they were dragged last frame
-        if !self.buffer.current.selection.is_empty() {
+        if !self.renderer.buffer.current.selection.is_empty() {
             if let Some(selection_start_line) = selection_start_line {
                 let selection_start_center = Pos2 {
                     x: selection_start_line[1].x - radius,
@@ -154,7 +154,7 @@ impl Editor {
                     start: Location::Pos(
                         ui.input(|i| i.pointer.interact_pos().unwrap_or_default() - 10. * Vec2::Y),
                     ),
-                    end: Location::DocCharOffset(self.buffer.current.selection.1),
+                    end: Location::DocCharOffset(self.renderer.buffer.current.selection.1),
                 };
                 self.in_progress_selection = Some(self.region_to_range(region));
             }
@@ -178,7 +178,7 @@ impl Editor {
                 }
             } else if end_response.dragged() {
                 let region = Region::BetweenLocations {
-                    start: Location::DocCharOffset(self.buffer.current.selection.0),
+                    start: Location::DocCharOffset(self.renderer.buffer.current.selection.0),
                     end: Location::Pos(
                         ui.input(|i| i.pointer.interact_pos().unwrap_or_default() - 10. * Vec2::Y),
                     ),
@@ -191,7 +191,7 @@ impl Editor {
     pub fn scroll_to_cursor(&self, ui: &mut Ui) {
         let selection = self
             .in_progress_selection
-            .unwrap_or(self.buffer.current.selection);
+            .unwrap_or(self.renderer.buffer.current.selection);
 
         if let Some([top, bot]) = self.cursor_line(selection.1) {
             let rect = Rect::from_min_max(top, bot);
@@ -200,10 +200,13 @@ impl Editor {
     }
 
     pub fn cursor_line(&self, offset: DocCharOffset) -> Option<[Pos2; 2]> {
-        let galley_idx = self.galleys.galley_at_offset(offset)?;
-        let galley = &self.galleys[galley_idx];
-        let x = self.galley_x(galley, offset);
-        let y_range = galley.rect.y_range().expand(self.layout.row_spacing / 2.);
+        let galley_idx = self.renderer.galleys.galley_at_offset(offset)?;
+        let galley = &self.renderer.galleys[galley_idx];
+        let x = self.renderer.galley_x(galley, offset);
+        let y_range = galley
+            .rect
+            .y_range()
+            .expand(self.renderer.layout.row_spacing / 2.);
         Some([Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }])
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -31,8 +31,8 @@ impl<'ast> Editor {
         for event in self.get_pointer_events(ctx) {
             response |= self.calc_operations(ctx, root, event, &mut ops);
         }
-        self.buffer.queue(ops);
-        response |= self.buffer.update();
+        self.renderer.buffer.queue(ops);
+        response |= self.renderer.buffer.update();
         response
     }
 
@@ -52,7 +52,7 @@ impl<'ast> Editor {
                                 let file = tab::import_image(&self.core, self.file_id, &data);
 
                                 let rel_path = {
-                                    let guard = self.files.read().unwrap();
+                                    let guard = self.renderer.files.read().unwrap();
                                     let parent = guard.get_by_id(self.file_id).unwrap().parent;
                                     let mut augmented = guard.files.clone();
                                     if augmented.get_by_id(file.parent).is_none() {
@@ -178,12 +178,12 @@ impl<'ast> Editor {
                     // position based on text range of word that will be selected
                     let offset = self.location_to_char_offset(location);
                     let range = offset
-                        .range_bound(Bound::Word, true, true, &self.bounds)
+                        .range_bound(Bound::Word, true, true, &self.renderer.bounds)
                         .unwrap_or((offset, offset));
                     ctx.set_context_menu(self.context_menu_pos(range).unwrap_or(pos));
 
                     Region::BoundAt { bound: Bound::Word, location, backwards: true }
-                } else if self.buffer.current.selection.is_empty() {
+                } else if self.renderer.buffer.current.selection.is_empty() {
                     // double click behavior
                     Region::BoundAt { bound: Bound::Word, location, backwards: true }
                 } else {
@@ -196,9 +196,15 @@ impl<'ast> Editor {
                 // android native context menu: tapped selection
                 if cfg!(target_os = "android") {
                     let offset = self.pos_to_char_offset(pos);
-                    if self.buffer.current.selection.contains(offset, true, true) {
+                    if self
+                        .renderer
+                        .buffer
+                        .current
+                        .selection
+                        .contains(offset, true, true)
+                    {
                         ctx.set_context_menu(
-                            self.context_menu_pos(self.buffer.current.selection)
+                            self.context_menu_pos(self.renderer.buffer.current.selection)
                                 .unwrap_or(pos),
                         );
                         return Vec::new();
@@ -253,9 +259,13 @@ impl<'ast> Editor {
 
     fn context_menu_pos(&self, range: (DocCharOffset, DocCharOffset)) -> Option<Pos2> {
         // find the first line of the selection
-        let lines = self.bounds.wrap_lines.find_intersecting(range, false);
+        let lines = self
+            .renderer
+            .bounds
+            .wrap_lines
+            .find_intersecting(range, false);
         let first_line = lines.iter().next()?;
-        let mut line = self.bounds.wrap_lines[first_line];
+        let mut line = self.renderer.bounds.wrap_lines[first_line];
         if line.0 < range.start() {
             line.0 = range.start();
         }

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -2,7 +2,6 @@ use crate::tab::markdown_editor::Editor;
 use crate::tab::markdown_editor::bounds::{BoundExt as _, RangesExt as _};
 use crate::tab::markdown_editor::galleys::Galleys;
 use crate::tab::markdown_editor::input::{Event, Increment};
-use crate::tab::markdown_editor::widget::inline::html_inline::FOLD_TAG;
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use comrak::nodes::{
     AstNode, LineColumn, ListType, NodeAlert, NodeHeading, NodeLink, NodeList, NodeShortCode,
@@ -31,7 +30,7 @@ impl<'ast> Editor {
         &mut self, ctx: &egui::Context, root: &'ast AstNode<'ast>, event: Event,
         operations: &mut Vec<Operation>,
     ) -> buffer::Response {
-        let current_selection = self.buffer.current.selection;
+        let current_selection = self.renderer.buffer.current.selection;
         let mut response = buffer::Response::default();
         match event {
             Event::Select { region } => {
@@ -54,17 +53,23 @@ impl<'ast> Editor {
                 // insert/extend/terminate container blocks
                 let mut handled = || {
                     // selection must be empty
-                    let Some(offset) = self.selection_offset() else {
+                    let Some(offset) = self.renderer.selection_offset() else {
                         return false;
                     };
 
-                    let container = self.deepest_container_block_at_offset(root, offset);
-                    let line = self.line_at_offset(offset);
-                    let line_content = self.line_content(container, line);
-                    let own_prefix = self.line_own_prefix(container, line);
+                    let container = self
+                        .renderer
+                        .deepest_container_block_at_offset(root, offset);
+                    let line = self.renderer.line_at_offset(offset);
+                    let line_content = self.renderer.line_content(container, line);
+                    let own_prefix = self.renderer.line_own_prefix(container, line);
 
                     let in_code_block = matches!(
-                        self.leaf_block_at_offset(root, offset).data.borrow().value,
+                        self.renderer
+                            .leaf_block_at_offset(root, offset)
+                            .data
+                            .borrow()
+                            .value,
                         NodeValue::CodeBlock(_)
                     );
 
@@ -74,7 +79,7 @@ impl<'ast> Editor {
                             range: current_selection,
                             text: "\n".into(),
                         }));
-                        if let Some(extension_prefix) = self.extension_prefix(container) {
+                        if let Some(extension_prefix) = self.renderer.extension_prefix(container) {
                             operations.push(Operation::Replace(Replace {
                                 range: current_selection,
                                 text: extension_prefix,
@@ -98,7 +103,7 @@ impl<'ast> Editor {
                             range: current_selection,
                             text: "\n".into(),
                         }));
-                        if let Some(insertion_prefix) = self.insertion_prefix(container) {
+                        if let Some(insertion_prefix) = self.renderer.insertion_prefix(container) {
                             operations.push(Operation::Replace(Replace {
                                 range: current_selection,
                                 text: insertion_prefix,
@@ -108,18 +113,18 @@ impl<'ast> Editor {
 
                     // code block auto-indentation
                     if in_code_block {
-                        let line_content_start = self.offset_to_byte(line_content.start());
+                        let line_content_start = self.renderer.offset_to_byte(line_content.start());
                         let indentation_len = RelByteOffset(
-                            self.buffer[line_content].len()
-                                - self.buffer[line_content].trim_start().len(),
+                            self.renderer.buffer[line_content].len()
+                                - self.renderer.buffer[line_content].trim_start().len(),
                         );
                         let indentation =
                             (line_content_start, line_content_start + indentation_len);
-                        let indentation = self.range_to_char(indentation);
+                        let indentation = self.renderer.range_to_char(indentation);
 
                         operations.push(Operation::Replace(Replace {
                             range: current_selection,
-                            text: self.buffer[indentation].to_string(),
+                            text: self.renderer.buffer[indentation].to_string(),
                         }));
                     }
 
@@ -151,14 +156,16 @@ impl<'ast> Editor {
                     }
 
                     // selection must be empty
-                    let Some(offset) = self.selection_offset() else {
+                    let Some(offset) = self.renderer.selection_offset() else {
                         return false;
                     };
 
-                    let container = self.deepest_container_block_at_offset(root, offset);
-                    let line = self.line_at_offset(offset);
-                    let own_prefix = self.line_own_prefix(container, line);
-                    let content = self.line_content(container, line);
+                    let container = self
+                        .renderer
+                        .deepest_container_block_at_offset(root, offset);
+                    let line = self.renderer.line_at_offset(offset);
+                    let own_prefix = self.renderer.line_own_prefix(container, line);
+                    let content = self.renderer.line_content(container, line);
 
                     // selection must be at content start
                     if offset != content.start() {
@@ -187,11 +194,13 @@ impl<'ast> Editor {
             }
             Event::Indent { deindent } => {
                 let selected_lines = self
+                    .renderer
                     .bounds
                     .source_lines
                     .find_intersecting(current_selection, true);
                 let first_selected_line_idx = selected_lines.0;
-                let first_selected_line = self.bounds.source_lines[first_selected_line_idx];
+                let first_selected_line =
+                    self.renderer.bounds.source_lines[first_selected_line_idx];
 
                 if !deindent {
                     // indent into extension of block on prior line
@@ -202,9 +211,10 @@ impl<'ast> Editor {
                         }
 
                         let prior_line_idx = first_selected_line_idx - 1;
-                        let prior_line = self.bounds.source_lines[prior_line_idx];
-                        let prior_line_deepest_container =
-                            self.deepest_container_block_at_offset(root, prior_line.end());
+                        let prior_line = self.renderer.bounds.source_lines[prior_line_idx];
+                        let prior_line_deepest_container = self
+                            .renderer
+                            .deepest_container_block_at_offset(root, prior_line.end());
 
                         // among blocks on prior line, find the least deep that
                         // has a prefix on the prior line but not on the first
@@ -216,22 +226,24 @@ impl<'ast> Editor {
                         let mut prior_line_container_extension_prefix = None;
                         for prior_line_container in prior_line_deepest_container.ancestors() {
                             let has_prefix_on_prior_line = !self
+                                .renderer
                                 .line_own_prefix(prior_line_container, prior_line)
                                 .is_empty();
-                            let has_prefix_on_first_selected_line = if self
-                                .node_last_line_idx(prior_line_container)
-                                < first_selected_line_idx
-                            {
-                                false
-                            } else {
-                                !self
-                                    .line_own_prefix(prior_line_container, first_selected_line)
-                                    .is_empty()
-                            };
+                            let has_prefix_on_first_selected_line =
+                                if self.renderer.node_last_line_idx(prior_line_container)
+                                    < first_selected_line_idx
+                                {
+                                    false
+                                } else {
+                                    !self
+                                        .renderer
+                                        .line_own_prefix(prior_line_container, first_selected_line)
+                                        .is_empty()
+                                };
 
                             if has_prefix_on_prior_line && !has_prefix_on_first_selected_line {
                                 if let Some(extension_prefix) =
-                                    self.extension_own_prefix(prior_line_container)
+                                    self.renderer.extension_own_prefix(prior_line_container)
                                 {
                                     prior_line_container_extension_prefix = Some(extension_prefix);
                                 }
@@ -250,14 +262,16 @@ impl<'ast> Editor {
                         // non-lazy-continuation lines
                         // todo: more attention to multi-line indentation
                         for line_idx in selected_lines.iter() {
-                            let line = self.bounds.source_lines[line_idx];
-                            let container =
-                                self.deepest_container_block_at_offset(root, line.end());
-                            let container_own_prefix = self.line_own_prefix(container, line);
+                            let line = self.renderer.bounds.source_lines[line_idx];
+                            let container = self
+                                .renderer
+                                .deepest_container_block_at_offset(root, line.end());
+                            let container_own_prefix =
+                                self.renderer.line_own_prefix(container, line);
 
                             let insertion_offset =
-                                if Some(self.buffer[container_own_prefix].to_string())
-                                    == self.extension_own_prefix(container)
+                                if Some(self.renderer.buffer[container_own_prefix].to_string())
+                                    == self.renderer.extension_own_prefix(container)
                                 {
                                     // on what could be a subsequent line of a
                                     // container block, tab to indent the line
@@ -290,17 +304,19 @@ impl<'ast> Editor {
                     let mut handled = || {
                         // all lines must have container ancestor prefix
                         for line_idx in selected_lines.iter() {
-                            let line = self.bounds.source_lines[line_idx];
-                            let container =
-                                self.deepest_container_block_at_offset(root, line.end());
-                            let container_own_prefix = self.line_own_prefix(container, line);
+                            let line = self.renderer.bounds.source_lines[line_idx];
+                            let container = self
+                                .renderer
+                                .deepest_container_block_at_offset(root, line.end());
+                            let container_own_prefix =
+                                self.renderer.line_own_prefix(container, line);
 
                             // on what can only be the first line of a container
                             // block, shift-tab to de-indent the block rather
                             // than its contents
                             let skip_container =
-                                Some(self.buffer[container_own_prefix].to_string())
-                                    != self.extension_own_prefix(container);
+                                Some(self.renderer.buffer[container_own_prefix].to_string())
+                                    != self.renderer.extension_own_prefix(container);
 
                             let mut found_container_ancestor = false;
                             for ancestor in container.ancestors() {
@@ -308,7 +324,8 @@ impl<'ast> Editor {
                                     continue;
                                 }
 
-                                let ancestor_own_prefix = self.line_own_prefix(ancestor, line);
+                                let ancestor_own_prefix =
+                                    self.renderer.line_own_prefix(ancestor, line);
                                 if !ancestor_own_prefix.is_empty() {
                                     found_container_ancestor = true;
                                 }
@@ -320,24 +337,27 @@ impl<'ast> Editor {
 
                         // remove container ancestor prefix from each line
                         for line_idx in selected_lines.iter() {
-                            let line = self.bounds.source_lines[line_idx];
-                            let container =
-                                self.deepest_container_block_at_offset(root, line.end());
-                            let container_own_prefix = self.line_own_prefix(container, line);
+                            let line = self.renderer.bounds.source_lines[line_idx];
+                            let container = self
+                                .renderer
+                                .deepest_container_block_at_offset(root, line.end());
+                            let container_own_prefix =
+                                self.renderer.line_own_prefix(container, line);
 
                             // on what can only be the first line of a container
                             // block, shift-tab to de-indent the block rather
                             // than its contents
                             let skip_container =
-                                Some(self.buffer[container_own_prefix].to_string())
-                                    != self.extension_own_prefix(container);
+                                Some(self.renderer.buffer[container_own_prefix].to_string())
+                                    != self.renderer.extension_own_prefix(container);
 
                             for ancestor in container.ancestors() {
                                 if container.same_node(ancestor) && skip_container {
                                     continue;
                                 }
 
-                                let ancestor_own_prefix = self.line_own_prefix(ancestor, line);
+                                let ancestor_own_prefix =
+                                    self.renderer.line_own_prefix(ancestor, line);
                                 if !ancestor_own_prefix.is_empty() {
                                     operations.push(Operation::Replace(Replace {
                                         range: ancestor_own_prefix,
@@ -368,7 +388,7 @@ impl<'ast> Editor {
                 // use selection start so a match containing the cursor is found
                 let anchor = old_match
                     .map(|m| m.0)
-                    .unwrap_or(self.buffer.current.selection.start());
+                    .unwrap_or(self.renderer.buffer.current.selection.start());
 
                 self.find.term = Some(term.clone());
                 self.find.matches = self.find_all(&term);
@@ -392,10 +412,14 @@ impl<'ast> Editor {
                     .and_then(|idx| self.find.matches.get(idx).copied());
                 if old_match != new_match {
                     if let Some(old) = old_match {
-                        self.layout_cache.invalidate_reveal_change(old, old);
+                        self.renderer
+                            .layout_cache
+                            .invalidate_reveal_change(old, old);
                     }
                     if let Some(new) = new_match {
-                        self.layout_cache.invalidate_reveal_change(new, new);
+                        self.renderer
+                            .layout_cache
+                            .invalidate_reveal_change(new, new);
                     }
                 }
             }
@@ -415,18 +439,22 @@ impl<'ast> Editor {
                     .and_then(|idx| self.find.matches.get(idx).copied());
                 if old_match != new_match {
                     if let Some(old) = old_match {
-                        self.layout_cache.invalidate_reveal_change(old, old);
+                        self.renderer
+                            .layout_cache
+                            .invalidate_reveal_change(old, old);
                     }
                     if let Some(new) = new_match {
-                        self.layout_cache.invalidate_reveal_change(new, new);
+                        self.renderer
+                            .layout_cache
+                            .invalidate_reveal_change(new, new);
                     }
                 }
             }
             Event::Undo => {
-                response |= self.buffer.undo();
+                response |= self.renderer.buffer.undo();
             }
             Event::Redo => {
-                response |= self.buffer.redo();
+                response |= self.renderer.buffer.redo();
             }
             Event::Cut => {
                 let range = if !current_selection.is_empty() {
@@ -435,7 +463,7 @@ impl<'ast> Editor {
                     self.clipboard_current_line()
                 };
 
-                ctx.copy_text(self.buffer[range].into());
+                ctx.copy_text(self.renderer.buffer[range].into());
                 operations.push(Operation::Replace(Replace { range, text: "".into() }));
             }
             Event::Copy => {
@@ -445,10 +473,10 @@ impl<'ast> Editor {
                     self.clipboard_current_line()
                 };
 
-                ctx.copy_text(self.buffer[range].into());
+                ctx.copy_text(self.renderer.buffer[range].into());
             }
             Event::ToggleDebug => {
-                self.debug = !self.debug;
+                self.renderer.debug = !self.renderer.debug;
             }
             Event::IncrementBaseFontSize => {
                 // self.appearance.base_font_size =
@@ -464,17 +492,25 @@ impl<'ast> Editor {
                 let unapply = self.unapply_fold(root);
                 for node in root.descendants() {
                     if matches!(node.data().value, NodeValue::Heading(_))
-                        && self.selected_block(node)
+                        && self.renderer.selected_block(node)
                     {
-                        let siblings = self.sorted_siblings(node);
-                        self.apply_fold(node, self.heading_contents(node, &siblings), unapply);
+                        let siblings = self.renderer.sorted_siblings(node);
+                        self.renderer.apply_fold(
+                            node,
+                            self.renderer.heading_contents(node, &siblings),
+                            unapply,
+                        );
                     }
 
                     if matches!(node.data().value, NodeValue::Item(_) | NodeValue::TaskItem(_))
-                        && self.selected_fold_item(node)
+                        && self.renderer.selected_fold_item(node)
                     {
-                        let siblings = self.sorted_siblings(node);
-                        self.apply_fold(node, self.item_contents(node, &siblings), unapply);
+                        let siblings = self.renderer.sorted_siblings(node);
+                        self.renderer.apply_fold(
+                            node,
+                            self.renderer.item_contents(node, &siblings),
+                            unapply,
+                        );
                     }
                 }
             }
@@ -494,7 +530,7 @@ impl<'ast> Editor {
             _ if style.is_inline() => {
                 let unapply = self.unapply_inline(root, range, &style);
 
-                for inline_paragraph in &self.bounds.inline_paragraphs {
+                for inline_paragraph in &self.renderer.bounds.inline_paragraphs {
                     if inline_paragraph.intersects(&range, true) {
                         let paragraph_range = (
                             range.start().max(inline_paragraph.start()),
@@ -518,7 +554,7 @@ impl<'ast> Editor {
 
                 let mut handled = false;
                 for node in root.descendants() {
-                    if self.selected_block(node) {
+                    if self.renderer.selected_block(node) {
                         handled = true;
 
                         // apply heading to ATX heading: replace existing heading
@@ -529,9 +565,9 @@ impl<'ast> Editor {
                                 ..
                             }) = node.data.borrow().value
                             {
-                                for line_idx in self.node_lines(node).iter() {
-                                    let line = self.bounds.source_lines[line_idx];
-                                    let node_line = self.node_line(node, line);
+                                for line_idx in self.renderer.node_lines(node).iter() {
+                                    let line = self.renderer.bounds.source_lines[line_idx];
+                                    let node_line = self.renderer.node_line(node, line);
 
                                     if level > node_level {
                                         let add_levels = level - node_level;
@@ -545,9 +581,10 @@ impl<'ast> Editor {
                                             node_line.start(),
                                             node_line.start() + RelCharOffset(node_level as _),
                                         );
-                                        if self.buffer.current.segs.last_cursor_position()
+                                        if self.renderer.buffer.current.segs.last_cursor_position()
                                             > range.end()
-                                            && &self.buffer[(range.end(), range.end() + 1)] == " "
+                                            && &self.renderer.buffer[(range.end(), range.end() + 1)]
+                                                == " "
                                         {
                                             range.1 += 1;
                                         }
@@ -569,13 +606,16 @@ impl<'ast> Editor {
                                     }
                                 }
                             } else if NodeValue::Paragraph == node.data.borrow().value {
-                                for line_idx in self.node_lines(node).iter() {
-                                    let line = self.bounds.source_lines[line_idx];
-                                    let node_line = self.node_line(node, line);
+                                for line_idx in self.renderer.node_lines(node).iter() {
+                                    let line = self.renderer.bounds.source_lines[line_idx];
+                                    let node_line = self.renderer.node_line(node, line);
 
                                     // count paragraph soft breaks as node breaks
                                     if node.data.borrow().value == NodeValue::Paragraph
-                                        && !line.intersects(&self.buffer.current.selection, true)
+                                        && !line.intersects(
+                                            &self.renderer.buffer.current.selection,
+                                            true,
+                                        )
                                     {
                                         continue;
                                     }
@@ -594,10 +634,10 @@ impl<'ast> Editor {
                             } else {
                                 node.parent().unwrap()
                             };
-                            for line_idx in self.node_lines(node).iter() {
-                                let line = self.bounds.source_lines[line_idx];
+                            for line_idx in self.renderer.node_lines(node).iter() {
+                                let line = self.renderer.bounds.source_lines[line_idx];
 
-                                let prefix = self.line_own_prefix(target_node, line);
+                                let prefix = self.renderer.line_own_prefix(target_node, line);
 
                                 operations.push(Operation::Replace(Replace {
                                     range: prefix,
@@ -607,18 +647,24 @@ impl<'ast> Editor {
 
                             if !unapply {
                                 let mut first_line = true;
-                                for line_idx in self.node_lines(node).iter() {
-                                    let line = self.bounds.source_lines[line_idx];
+                                for line_idx in self.renderer.node_lines(node).iter() {
+                                    let line = self.renderer.bounds.source_lines[line_idx];
 
                                     // count paragraph soft breaks as node breaks
                                     if node.data.borrow().value == NodeValue::Paragraph
-                                        && !line.intersects(&self.buffer.current.selection, true)
+                                        && !line.intersects(
+                                            &self.renderer.buffer.current.selection,
+                                            true,
+                                        )
                                     {
                                         continue;
                                     }
 
-                                    let range =
-                                        self.line_ancestors_prefix(node, line).end().into_range();
+                                    let range = self
+                                        .renderer
+                                        .line_ancestors_prefix(node, line)
+                                        .end()
+                                        .into_range();
                                     let text = match style {
                                         NodeValue::Heading(_) => unreachable!(),
                                         NodeValue::BlockQuote => "> ",
@@ -708,17 +754,18 @@ impl<'ast> Editor {
                         operations.push(Operation::Replace(Replace { range, text }));
                         operations.push(Operation::Select(current_selection));
                     } else {
-                        let target_node = self.deepest_container_block_at_offset(
+                        let target_node = self.renderer.deepest_container_block_at_offset(
                             root,
-                            self.buffer.current.selection.start(),
+                            self.renderer.buffer.current.selection.start(),
                         );
                         if style == target_node.node_type() {
                             let line_idx = self
+                                .renderer
                                 .range_lines(current_selection.start().into_range())
                                 .start();
-                            let line = self.bounds.source_lines[line_idx];
+                            let line = self.renderer.bounds.source_lines[line_idx];
 
-                            let prefix = self.line_own_prefix(target_node, line);
+                            let prefix = self.renderer.line_own_prefix(target_node, line);
 
                             operations.push(Operation::Replace(Replace {
                                 range: prefix,
@@ -738,7 +785,10 @@ impl<'ast> Editor {
     ) -> bool {
         for node in root.descendants() {
             if &node.node_type() == style
-                && self.node_range(node).contains_range(&range, true, true)
+                && self
+                    .renderer
+                    .node_range(node)
+                    .contains_range(&range, true, true)
             {
                 return true;
             }
@@ -752,7 +802,7 @@ impl<'ast> Editor {
         &self, root: &'ast AstNode<'ast>, range: (DocCharOffset, DocCharOffset), style: &NodeValue,
     ) -> bool {
         let mut unapply = false;
-        for inline_paragraph in &self.bounds.inline_paragraphs {
+        for inline_paragraph in &self.renderer.bounds.inline_paragraphs {
             if inline_paragraph.intersects(&range, true) {
                 let paragraph_range = (
                     range.start().max(inline_paragraph.start()),
@@ -770,7 +820,7 @@ impl<'ast> Editor {
         let mut unapply = false;
         let mut any_selected_blocks = false;
         for node in root.descendants() {
-            if self.selected_block(node) {
+            if self.renderer.selected_block(node) {
                 any_selected_blocks = true;
 
                 let target_node =
@@ -783,7 +833,11 @@ impl<'ast> Editor {
             // selecting sequence of contiguous empty/whitespace-only lines:
             // check for matching container block
             return &self
-                .deepest_container_block_at_offset(root, self.buffer.current.selection.start())
+                .renderer
+                .deepest_container_block_at_offset(
+                    root,
+                    self.renderer.buffer.current.selection.start(),
+                )
                 .node_type()
                 == style;
         }
@@ -796,15 +850,15 @@ impl<'ast> Editor {
         let mut unapply = false;
         for node in root.descendants() {
             if matches!(node.data().value, NodeValue::Heading(_))
-                && self.selected_block(node)
-                && self.fold(node).is_some()
+                && self.renderer.selected_block(node)
+                && self.renderer.fold(node).is_some()
             {
                 unapply = true;
             }
 
             if matches!(node.data().value, NodeValue::Item(_) | NodeValue::TaskItem(_))
-                && self.selected_fold_item(node)
-                && self.fold(node).is_some()
+                && self.renderer.selected_fold_item(node)
+                && self.renderer.fold(node).is_some()
             {
                 unapply = true;
             }
@@ -818,41 +872,7 @@ impl<'ast> Editor {
         &mut self, node: &'ast AstNode<'ast>, contents: (DocCharOffset, DocCharOffset),
         unapply: bool,
     ) {
-        if unapply {
-            println!("UNapply fold to selected heading");
-            if let Some(fold) = self.fold(node) {
-                self.event.internal_events.push(Event::Replace {
-                    region: self.node_range(fold).into(),
-                    text: "".into(),
-                    advance_cursor: false,
-                });
-            }
-        } else {
-            println!("apply fold to selected heading");
-            if let Some(foldable) = self.foldable(node) {
-                self.event.internal_events.push(Event::Replace {
-                    region: self.node_range(foldable).end().into_range().into(),
-                    text: FOLD_TAG.into(),
-                    advance_cursor: false,
-                });
-
-                // when folding a section that intersects the cursor, adjust the selection
-                // this ensures the folded section appears folded / avoids immediate selection reveal
-                let selection = self.buffer.current.selection;
-
-                if contents.intersects(&selection, true)
-                    && !selection.contains_range(&contents, true, true)
-                {
-                    self.event.internal_events.push(Event::Select {
-                        region: (
-                            selection.start().min(contents.start()),
-                            selection.end().min(contents.start()),
-                        )
-                            .into(),
-                    });
-                }
-            }
-        }
+        self.renderer.apply_fold(node, contents, unapply);
     }
 
     /// Applies or unapplies `style` to `cursor`, splitting or joining surrounding styles as necessary.
@@ -860,8 +880,8 @@ impl<'ast> Editor {
         &self, root: &'ast AstNode<'ast>, range: (DocCharOffset, DocCharOffset), style: NodeValue,
         unapply: bool, operations: &mut Vec<Operation>,
     ) {
-        let selection = self.buffer.current.selection;
-        if self.buffer.current.text.is_empty() {
+        let selection = self.renderer.buffer.current.selection;
+        if self.renderer.buffer.current.text.is_empty() {
             self.insert_head(range.start(), style.clone(), operations);
             operations.push(Operation::Select(selection));
             self.insert_tail(range.start(), style, operations);
@@ -872,14 +892,21 @@ impl<'ast> Editor {
         let mut start_node: Option<&'ast AstNode<'ast>> = None;
         for node in root.descendants() {
             if node.node_type() == style
-                && self.node_range(node).contains(range.start(), true, true)
+                && self
+                    .renderer
+                    .node_range(node)
+                    .contains(range.start(), true, true)
             {
                 start_node = Some(node);
             }
         }
         let mut end_node: Option<&'ast AstNode<'ast>> = None;
         for node in root.descendants() {
-            if node.node_type() == style && self.node_range(node).contains(range.end(), true, true)
+            if node.node_type() == style
+                && self
+                    .renderer
+                    .node_range(node)
+                    .contains(range.end(), true, true)
             {
                 end_node = Some(node);
             }
@@ -903,7 +930,7 @@ impl<'ast> Editor {
         if unapply {
             // if unapplying, tail or dehead node containing start to crop styled region to selection
             if let Some(start_node) = start_node {
-                if self.head_range(start_node).unwrap().end() < range.start() {
+                if self.renderer.head_range(start_node).unwrap().end() < range.start() {
                     let offset = self.adjust_for_whitespace(range.start(), true);
                     self.insert_tail(offset, style.clone(), operations);
                 } else {
@@ -916,7 +943,7 @@ impl<'ast> Editor {
 
             // if unapplying, head or detail node containing end to crop styled region to selection
             if let Some(end_node) = end_node {
-                if self.tail_range(end_node).unwrap().start() > range.end() {
+                if self.renderer.tail_range(end_node).unwrap().start() > range.end() {
                     let offset = self.adjust_for_whitespace(range.end(), false);
                     self.insert_head(offset, style.clone(), operations);
                 } else {
@@ -958,7 +985,7 @@ impl<'ast> Editor {
             }
 
             let style_matches = node.node_type() == style;
-            if style_matches && self.node_range(node).intersects(&range, true) {
+            if style_matches && self.renderer.node_range(node).intersects(&range, true) {
                 self.dehead_ast_node(node, operations);
                 self.detail_ast_node(node, operations);
             }
@@ -967,7 +994,7 @@ impl<'ast> Editor {
 
     // todo: self by shared reference
     pub fn region_to_range(&mut self, region: Region) -> (DocCharOffset, DocCharOffset) {
-        let mut current_selection = self.buffer.current.selection;
+        let mut current_selection = self.renderer.buffer.current.selection;
         match region {
             Region::Location(location) => self.location_to_range(location),
             Region::ToLocation(location) => {
@@ -1005,13 +1032,13 @@ impl<'ast> Editor {
             Region::Bound { bound, backwards } => {
                 let offset = current_selection.1;
                 offset
-                    .range_bound(bound, backwards, false, &self.bounds)
+                    .range_bound(bound, backwards, false, &self.renderer.bounds)
                     .unwrap_or((offset, offset))
             }
             Region::BoundAt { bound, location, backwards } => {
                 let offset = self.location_to_char_offset(location);
                 offset
-                    .range_bound(bound, backwards, true, &self.bounds)
+                    .range_bound(bound, backwards, true, &self.renderer.bounds)
                     .unwrap_or((offset, offset))
             }
         }
@@ -1019,7 +1046,7 @@ impl<'ast> Editor {
 
     pub fn location_to_range(&self, location: Location) -> (DocCharOffset, DocCharOffset) {
         match location {
-            Location::CurrentCursor => self.buffer.current.selection,
+            Location::CurrentCursor => self.renderer.buffer.current.selection,
             Location::DocCharOffset(o) => o.into_range(),
             Location::Pos(pos) => self.pos_to_range(pos),
         }
@@ -1030,21 +1057,22 @@ impl<'ast> Editor {
     }
 
     fn clipboard_current_line(&self) -> (DocCharOffset, DocCharOffset) {
-        let current_selection = self.buffer.current.selection;
+        let current_selection = self.renderer.buffer.current.selection;
         let paragraph_idx = self
+            .renderer
             .bounds
             .source_lines
             .find_containing(current_selection.1, true, true)
             .0;
 
-        let mut result = self.bounds.source_lines[paragraph_idx];
+        let mut result = self.renderer.bounds.source_lines[paragraph_idx];
 
         // capture leading newline, if any
         if paragraph_idx != 0 {
-            let line = self.bounds.source_lines[paragraph_idx];
-            let prev_line = self.bounds.source_lines[paragraph_idx - 1];
+            let line = self.renderer.bounds.source_lines[paragraph_idx];
+            let prev_line = self.renderer.bounds.source_lines[paragraph_idx - 1];
             let range_between_lines = (prev_line.1, line.0);
-            let rbl_text = &self.buffer[range_between_lines];
+            let rbl_text = &self.renderer.buffer[range_between_lines];
             if rbl_text.ends_with("\r\n") {
                 result.0 -= 2;
             } else if rbl_text.ends_with('\n') || rbl_text.ends_with('\r') {
@@ -1057,7 +1085,7 @@ impl<'ast> Editor {
 
     // todo: find a better home
     pub fn pos_to_range(&self, pos: Pos2) -> (DocCharOffset, DocCharOffset) {
-        let galleys = &self.galleys;
+        let galleys = &self.renderer.galleys;
         let galley_idx = pos_to_galley(pos, galleys);
         let galley = &galleys[galley_idx];
 
@@ -1068,14 +1096,19 @@ impl<'ast> Editor {
             result.into_range()
         } else if galley_idx == galleys.len() - 1 && pos.y > galley.rect.max.y {
             // every position lower than the final galley's bottom maps to the last cursor position
-            self.buffer.current.segs.last_cursor_position().into_range()
+            self.renderer
+                .buffer
+                .current
+                .segs
+                .last_cursor_position()
+                .into_range()
         } else {
             #[allow(clippy::collapsible_else_if)]
             if galley.is_override {
                 // click an override galley to select the whole thing
                 galley.range
             } else {
-                self.galley_offset(galley_idx, pos).into_range()
+                self.renderer.galley_offset(galley_idx, pos).into_range()
             }
         }
     }
@@ -1123,13 +1156,13 @@ pub fn distance(coord: f32, range: Rangef) -> f32 {
 
 impl<'ast> Editor {
     fn dehead_ast_node(&self, node: &'ast AstNode<'ast>, operations: &mut Vec<Operation>) {
-        if let Some(range) = self.head_range(node) {
+        if let Some(range) = self.renderer.head_range(node) {
             operations.push(Operation::Replace(Replace { range, text: "".into() }));
         }
     }
 
     fn detail_ast_node(&self, node: &'ast AstNode<'ast>, operations: &mut Vec<Operation>) {
-        if let Some(range) = self.tail_range(node) {
+        if let Some(range) = self.renderer.tail_range(node) {
             operations.push(Operation::Replace(Replace { range, text: "".into() }));
         }
     }
@@ -1140,12 +1173,12 @@ impl<'ast> Editor {
                 if offset == 0 {
                     break;
                 }
-                &(&self.buffer)[(offset - 1, offset)]
+                &(&self.renderer.buffer)[(offset - 1, offset)]
             } else {
-                if offset == self.buffer.current.segs.last_cursor_position() {
+                if offset == self.renderer.buffer.current.segs.last_cursor_position() {
                     break;
                 }
-                &(&self.buffer)[(offset, offset + 1)]
+                &(&self.renderer.buffer)[(offset, offset + 1)]
             };
             if c == " " {
                 if tail { offset -= 1 } else { offset += 1 }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -84,80 +84,87 @@ pub struct Response {
     pub find_widget_height: f32,
 }
 
-pub struct Editor {
-    // dependencies
-    pub core: Lb,
-    pub client: HttpClient,
+pub struct MdRender {
+    // context
     pub ctx: Context,
-    pub persistence: WsPersistentStore,
-    pub files: Arc<RwLock<FileCache>>,
-    pub link_resolver: Box<dyn LinkResolver>,
     pub layout: MdLayout,
+    pub dark_mode: bool,
+    pub ext: String,
+    pub touch_mode: bool,
 
-    // theme
-    dark_mode: bool, // supports change detection
+    // document
+    pub bounds: Bounds,
+    pub buffer: Buffer,
 
-    // input
+    // render output
+    pub galleys: Galleys,
+    pub text_areas: Vec<TextBufferArea>,
+    pub render_events: Vec<input::Event>,
+    pub touch_consuming_rects: Vec<Rect>,
+
+    // render input
+    pub in_progress_selection: Option<(DocCharOffset, DocCharOffset)>,
+    pub find_current_match: Option<(DocCharOffset, DocCharOffset)>,
+    pub interactive: bool,
+    pub reveal_ranges: Vec<(DocCharOffset, DocCharOffset)>,
+    pub text_highlight_range: Option<(DocCharOffset, DocCharOffset)>,
+
+    // capabilities
+    pub embeds: Box<dyn EmbedResolver>,
+    pub link_resolver: Box<dyn LinkResolver>,
+    pub client: HttpClient,
+    pub files: Arc<RwLock<FileCache>>,
+
+    // caches
+    pub layout_cache: LayoutCache,
+    pub syntax: SyntaxHighlightCache,
+
+    // viewport
+    pub top_left: Pos2,
+    pub width: f32,
+    pub height: f32,
+
+    // debug
+    pub debug: bool,
+    pub frame_times: [Instant; 10],
+    pub frame_times_idx: usize,
+}
+
+pub struct Editor {
+    pub renderer: MdRender,
+
+    // workspace dependencies
+    pub core: Lb,
+    pub persistence: WsPersistentStore,
+
+    // document identity
     pub file_id: Uuid,
     pub id_salt: Id,
     pub hmac: Option<DocumentHmac>,
     pub initialized: bool,
-    pub ext: String,
-    pub touch_mode: bool,
-    pub phone_mode: bool,
     pub readonly: bool,
+    pub phone_mode: bool,
 
-    // internal systems
-    pub bounds: Bounds,
-    pub buffer: Buffer,
+    // input processing
     pub cursor: CursorState,
     pub event: EventState,
-    pub galleys: Galleys,
-    pub text_areas: Vec<TextBufferArea>,
-
-    pub embeds: Box<dyn EmbedResolver>,
     embeds_last_seen: u64,
-    pub layout_cache: LayoutCache,
 
-    // render inputs (populated by show() before rendering)
-    pub reveal_ranges: Vec<(DocCharOffset, DocCharOffset)>,
-    pub text_highlight_range: Option<(DocCharOffset, DocCharOffset)>,
-
-    // render outputs (consumed by show() after rendering)
-    pub render_events: Vec<input::Event>,
-
-    pub syntax: SyntaxHighlightCache,
-    pub debug: bool,
-    frame_times: [Instant; 10],
-    frame_times_idx: usize,
-    pub touch_consuming_rects: Vec<Rect>, // touches on these will not place the cursor on iOS
-    pub scroll_area_velocity: Vec2,       // if nonzero, touches will not place the cursor on iOS
-
-    // widgets
+    // interaction widgets
     pub toolbar: Toolbar,
     pub find: Find,
     pub emoji_completions: EmojiCompletions,
     pub link_completions: LinkCompletions,
 
     // selection state
-    /// During drag operations, stores the selection that would be applied
-    /// without actually updating the buffer selection (which would affect syntax reveal)
     pub in_progress_selection: Option<(DocCharOffset, DocCharOffset)>,
 
     // misc
+    pub scroll_area_velocity: Vec2,
     pub virtual_keyboard_shown: bool,
     scroll_to_cursor: bool,
     scroll_to_find_match: bool,
     pub unprocessed_scroll: Option<Instant>,
-
-    // layout
-    top_left: Pos2,
-    /// width of the viewport, useful for doc render width and image size
-    /// constraints, populated at frame start
-    width: f32,
-    /// height of the viewport, useful for image size constraints, populated at
-    /// frame start
-    height: f32,
 
     // outputs from drawing a frame need an additional frame to process before reporting
     next_resp: Response,
@@ -266,6 +273,77 @@ pub type HttpClient = reqwest::Client;
 #[cfg(not(target_arch = "wasm32"))]
 pub type HttpClient = reqwest::blocking::Client;
 
+impl MdRender {
+    #[cfg(test)]
+    pub(crate) fn test(md: &str) -> Self {
+        let ctx = Context::default();
+        Self {
+            ctx,
+            layout: MdLayout::desktop(),
+            dark_mode: false,
+            ext: "md".into(),
+            touch_mode: false,
+            bounds: Default::default(),
+            buffer: md.into(),
+            galleys: Default::default(),
+            text_areas: Default::default(),
+            render_events: Vec::new(),
+            touch_consuming_rects: Default::default(),
+            reveal_ranges: Vec::new(),
+            text_highlight_range: None,
+            in_progress_selection: None,
+            find_current_match: None,
+            interactive: false,
+            embeds: Box::new(()),
+            link_resolver: Box::new(()),
+            client: Default::default(),
+            files: Arc::new(RwLock::new(FileCache::empty())),
+            layout_cache: Default::default(),
+            syntax: Default::default(),
+            top_left: Default::default(),
+            width: Default::default(),
+            height: Default::default(),
+            debug: false,
+            frame_times: [Instant::now(); 10],
+            frame_times_idx: 0,
+        }
+    }
+
+    pub fn plaintext_mode(&self) -> bool {
+        self.ext.to_lowercase() != "md"
+    }
+
+    pub fn comrak_options() -> Options<'static> {
+        let mut options = Options::default();
+        options.parse.smart = true;
+        options.parse.ignore_setext = true;
+        options.extension.alerts = true;
+        options.extension.autolink = true;
+        options.extension.description_lists = false; // todo: is this a good way to power workspace-wide term definitions?
+        options.extension.footnotes = false;
+        options.extension.front_matter_delimiter = Some("---".to_string());
+        options.extension.greentext = false;
+        options.extension.header_ids = None; // intended for HTML renderers
+        options.extension.highlight = true;
+        options.extension.math_code = true; // rendered as code for now
+        options.extension.math_dollars = true; // rendered as code for now
+        options.extension.multiline_block_quotes = false; // todo
+        options.extension.shortcodes = true;
+        options.extension.spoiler = true;
+        options.extension.strikethrough = true;
+        options.extension.subscript = true;
+        options.extension.superscript = true;
+        options.extension.table = true;
+        options.extension.tagfilter = false; // intended for HTML renderers
+        options.extension.tasklist = true;
+        options.extension.underline = true;
+        options.extension.wikilinks_title_after_pipe = true; // matches obsidian
+        options.extension.wikilinks_title_before_pipe = false; // would not match obsidian
+        options.render.escaped_char_spans = true;
+        options
+    }
+}
+
 impl Editor {
     pub fn new(
         md: &str, file_id: Uuid, hmac: Option<DocumentHmac>, res: MdResources, cfg: MdConfig,
@@ -280,62 +358,74 @@ impl Editor {
 
         let client: HttpClient = Default::default();
 
-        Self {
-            core,
-            client,
+        let renderer = MdRender {
             ctx,
-            persistence,
-            files,
-            link_resolver,
-
+            layout,
             dark_mode,
+            ext,
+            touch_mode,
+
+            bounds: Default::default(),
+            buffer: md.into(),
+
+            galleys: Default::default(),
+            text_areas: Default::default(),
+            render_events: Vec::new(),
+            touch_consuming_rects: Default::default(),
+
+            in_progress_selection: None,
+            find_current_match: None,
+            interactive: false,
+            reveal_ranges: Vec::new(),
+            text_highlight_range: None,
+
+            embeds,
+            link_resolver,
+            client,
+            files,
+
+            layout_cache: Default::default(),
+            syntax: Default::default(),
+
+            top_left: Default::default(),
+            width: Default::default(),
+            height: Default::default(),
+
+            debug: false,
+            frame_times: [Instant::now(); 10],
+            frame_times_idx: 0,
+        };
+
+        Self {
+            renderer,
+
+            core,
+            persistence,
+
+            file_id,
+            id_salt: Id::NULL,
+            hmac,
+            initialized: Default::default(),
+            readonly,
+            phone_mode,
+
+            cursor: Default::default(),
+            event: Default::default(),
+            embeds_last_seen: 0,
 
             toolbar: Default::default(),
             find: Default::default(),
             emoji_completions: Default::default(),
             link_completions: Default::default(),
 
-            readonly,
-            file_id,
-            id_salt: Id::NULL,
-            hmac,
-            initialized: Default::default(),
-            ext,
-            touch_mode,
-            phone_mode,
-            layout,
-
-            bounds: Default::default(),
-            buffer: md.into(),
-            cursor: Default::default(),
-            event: Default::default(),
-            galleys: Default::default(),
-
-            embeds,
-            embeds_last_seen: 0,
-            layout_cache: Default::default(),
-            reveal_ranges: Vec::new(),
-            text_highlight_range: None,
-            render_events: Vec::new(),
-            syntax: Default::default(),
-            debug: false,
-            frame_times: [Instant::now(); 10],
-            frame_times_idx: 0,
-            touch_consuming_rects: Default::default(),
-            scroll_area_velocity: Default::default(),
-            text_areas: Default::default(),
-
             in_progress_selection: None,
 
+            scroll_area_velocity: Default::default(),
             // this is used to toggle the mobile toolbar
             virtual_keyboard_shown: cfg!(target_os = "android"),
             scroll_to_cursor: Default::default(),
             scroll_to_find_match: Default::default(),
             unprocessed_scroll: Default::default(),
-
-            top_left: Default::default(),
-            width: Default::default(),
-            height: Default::default(),
 
             next_resp: Default::default(),
         }
@@ -407,63 +497,37 @@ impl Editor {
     }
 
     pub fn plaintext_mode(&self) -> bool {
-        self.ext.to_lowercase() != "md"
-    }
-
-    fn comrak_options() -> Options<'static> {
-        let mut options = Options::default();
-        options.parse.smart = true;
-        options.parse.ignore_setext = true;
-        options.extension.alerts = true;
-        options.extension.autolink = true;
-        options.extension.description_lists = false; // todo: is this a good way to power workspace-wide term definitions?
-        options.extension.footnotes = false;
-        options.extension.front_matter_delimiter = Some("---".to_string());
-        options.extension.greentext = false;
-        options.extension.header_ids = None; // intended for HTML renderers
-        options.extension.highlight = true;
-        options.extension.math_code = true; // rendered as code for now
-        options.extension.math_dollars = true; // rendered as code for now
-        options.extension.multiline_block_quotes = false; // todo
-        options.extension.shortcodes = true;
-        options.extension.spoiler = true;
-        options.extension.strikethrough = true;
-        options.extension.subscript = true;
-        options.extension.superscript = true;
-        options.extension.table = true;
-        options.extension.tagfilter = false; // intended for HTML renderers
-        options.extension.tasklist = true;
-        options.extension.underline = true;
-        options.extension.wikilinks_title_after_pipe = true; // matches obsidian
-        options.extension.wikilinks_title_before_pipe = false; // would not match obsidian
-        options.render.escaped_char_spans = true;
-        options
+        self.renderer.plaintext_mode()
     }
 
     pub fn show(&mut self, ui: &mut Ui) -> Response {
         let mut resp: Response = mem::take(&mut self.next_resp);
 
         let height = ui.available_size().y.round();
-        let width = ui.max_rect().width().min(self.layout.max_width).round();
-        let height_updated = self.height != height;
-        let width_updated = self.width != width;
-        self.height = height;
-        self.width = width;
+        let width = ui
+            .max_rect()
+            .width()
+            .min(self.renderer.layout.max_width)
+            .round();
+        let height_updated = self.renderer.height != height;
+        let width_updated = self.renderer.width != width;
+        self.renderer.height = height;
+        self.renderer.width = width;
 
         let dark_mode = ui.style().visuals.dark_mode;
-        if dark_mode != self.dark_mode {
-            self.syntax.clear();
-            self.dark_mode = dark_mode;
+        if dark_mode != self.renderer.dark_mode {
+            self.renderer.syntax.clear();
+            self.renderer.dark_mode = dark_mode;
         }
 
-        self.calc_source_lines();
+        self.renderer.calc_source_lines();
 
         let start = web_time::Instant::now();
 
         let arena = Arena::new();
-        let options = Self::comrak_options();
+        let options = MdRender::comrak_options();
 
-        let text_with_newline = self.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
+        let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
         let mut root = comrak::parse_document(&arena, &text_with_newline, &options);
 
         let ast_elapsed = start.elapsed();
@@ -482,20 +546,20 @@ impl Editor {
         let start = web_time::Instant::now();
 
         // process events
-        let prior_selection = self.buffer.current.selection;
+        let prior_selection = self.renderer.buffer.current.selection;
         let embeds_updated = {
-            let current = self.embeds.last_modified();
+            let current = self.renderer.embeds.last_modified();
             let changed = current != self.embeds_last_seen;
             self.embeds_last_seen = current;
             changed
         };
 
         self.emoji_completions
-            .update_active_state(&self.buffer, &self.bounds.inline_paragraphs);
+            .update_active_state(&self.renderer.buffer, &self.renderer.bounds.inline_paragraphs);
         self.link_completions.update_active_state(
-            &self.buffer,
-            &self.bounds.inline_paragraphs,
-            &self.files,
+            &self.renderer.buffer,
+            &self.renderer.bounds.inline_paragraphs,
+            &self.renderer.files,
             self.file_id,
         );
         let buffer_resp = self.process_events(ui.ctx(), root);
@@ -505,17 +569,17 @@ impl Editor {
             resp.text_updated = true;
 
             // need to re-parse ast to compute bounds which are referenced by mobile virtual keyboard between frames
-            let text_with_newline = self.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
+            let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
             root = comrak::parse_document(&arena, &text_with_newline, &options);
 
-            self.bounds.inline_paragraphs.clear();
-            self.layout_cache.invalidate_text_change();
+            self.renderer.bounds.inline_paragraphs.clear();
+            self.renderer.layout_cache.invalidate_text_change();
 
-            self.calc_source_lines();
-            self.compute_bounds(root);
-            self.bounds.inline_paragraphs.sort();
+            self.renderer.calc_source_lines();
+            self.renderer.compute_bounds(root);
+            self.renderer.bounds.inline_paragraphs.sort();
 
-            self.calc_words();
+            self.renderer.calc_words();
 
             // recompute find matches when text changes
             if let Some(term) = &self.find.term {
@@ -535,31 +599,38 @@ impl Editor {
         resp.selection_updated = prior_selection
             != self
                 .in_progress_selection
-                .unwrap_or(self.buffer.current.selection);
+                .unwrap_or(self.renderer.buffer.current.selection);
 
         // populate render inputs
-        self.reveal_ranges.clear();
+        self.renderer.in_progress_selection = self.in_progress_selection;
+        self.renderer.find_current_match = self
+            .find
+            .current_match
+            .and_then(|idx| self.find.matches.get(idx).copied());
+        self.renderer.reveal_ranges.clear();
         if !self.readonly && self.focused(ui.ctx()) {
-            self.reveal_ranges.push(self.buffer.current.selection);
+            self.renderer
+                .reveal_ranges
+                .push(self.renderer.buffer.current.selection);
         }
         if let Some(idx) = self.find.current_match {
             if let Some(&range) = self.find.matches.get(idx) {
-                self.reveal_ranges.push(range);
+                self.renderer.reveal_ranges.push(range);
             }
         }
-        self.text_highlight_range = self
+        self.renderer.text_highlight_range = self
             .emoji_completions
             .search_term_range
             .or(self.link_completions.search_term_range);
 
         ui.painter()
-            .rect_filled(ui.max_rect(), 0., self.ctx.get_lb_theme().neutral_bg());
-        self.apply_theme(ui);
+            .rect_filled(ui.max_rect(), 0., self.renderer.ctx.get_lb_theme().neutral_bg());
+        self.renderer.apply_theme(ui);
         ui.spacing_mut().item_spacing.x = 0.;
 
         let scroll_area_id = ui
             .vertical(|ui| {
-                let scroll_area_id = if self.touch_mode {
+                let scroll_area_id = if self.renderer.touch_mode {
                     self.show_find_centered(ui);
 
                     // ...then show editor content (or toolbar settings)...
@@ -585,9 +656,9 @@ impl Editor {
 
                                 if !self.toolbar.menu_open {
                                     // these are computed during render
-                                    self.galleys.galleys.clear();
-                                    self.bounds.wrap_lines.clear();
-                                    self.touch_consuming_rects.clear();
+                                    self.renderer.galleys.galleys.clear();
+                                    self.renderer.bounds.wrap_lines.clear();
+                                    self.renderer.touch_consuming_rects.clear();
 
                                     // show editor
                                     let scroll_area_id = ui.id().with(egui::Id::new(self.file_id));
@@ -639,9 +710,9 @@ impl Editor {
                     self.show_find_centered(ui);
 
                     // these are computed during render
-                    self.galleys.galleys.clear();
-                    self.bounds.wrap_lines.clear();
-                    self.touch_consuming_rects.clear();
+                    self.renderer.galleys.galleys.clear();
+                    self.renderer.bounds.wrap_lines.clear();
+                    self.renderer.touch_consuming_rects.clear();
 
                     // ...then show editor content
                     let scroll_area_output = self.show_scrollable_editor(ui, root);
@@ -675,20 +746,26 @@ impl Editor {
                     // frame
                     let (start, end) = persisted.selection;
                     let selection = (
-                        start.clamp(0.into(), self.buffer.current.segs.last_cursor_position()),
-                        end.clamp(0.into(), self.buffer.current.segs.last_cursor_position()),
+                        start.clamp(
+                            0.into(),
+                            self.renderer.buffer.current.segs.last_cursor_position(),
+                        ),
+                        end.clamp(
+                            0.into(),
+                            self.renderer.buffer.current.segs.last_cursor_position(),
+                        ),
                     );
-                    self.buffer.queue(vec![
+                    self.renderer.buffer.queue(vec![
                         lb_rs::model::text::operation_types::Operation::Select(selection),
                     ]);
-                    self.buffer.update();
+                    self.renderer.buffer.update();
                 }
 
                 scroll_area_id
             })
             .inner;
 
-        let text_areas = std::mem::take(&mut self.text_areas);
+        let text_areas = std::mem::take(&mut self.renderer.text_areas);
         if !text_areas.is_empty() {
             ui.painter()
                 .add(egui_wgpu_renderer::egui_wgpu::Callback::new_paint_callback(
@@ -699,12 +776,12 @@ impl Editor {
         self.show_emoji_completions(ui);
         self.show_link_completions(ui);
 
-        self.syntax.garbage_collect();
+        self.renderer.syntax.garbage_collect();
 
         let render_elapsed = start.elapsed();
 
-        if self.debug {
-            self.show_debug_fps(ui);
+        if self.renderer.debug {
+            self.renderer.show_debug_fps(ui);
         }
 
         if PRINT {
@@ -713,7 +790,7 @@ impl Editor {
                 "--------------------------------------------------------------------------------"
                     .bright_black()
             );
-            println!("document: {:?}", self.buffer.current.text);
+            println!("document: {:?}", self.renderer.buffer.current.text);
             println!(
                 "{}",
                 "--------------------------------------------------------------------------------"
@@ -731,18 +808,20 @@ impl Editor {
         }
 
         // post-frame bookkeeping
-        let all_selected = self.buffer.current.selection == (0.into(), self.last_cursor_position());
+        let all_selected = self.renderer.buffer.current.selection
+            == (0.into(), self.renderer.last_cursor_position());
         if embeds_updated || height_updated || width_updated {
             if embeds_updated {
                 self.unprocessed_scroll = Some(Instant::now());
             }
-            self.layout_cache.clear();
+            self.renderer.layout_cache.clear();
             ui.ctx().request_repaint();
         } else if resp.selection_updated {
             let new_selection = self
                 .in_progress_selection
-                .unwrap_or(self.buffer.current.selection);
-            self.layout_cache
+                .unwrap_or(self.renderer.buffer.current.selection);
+            self.renderer
+                .layout_cache
                 .invalidate_reveal_change(prior_selection, new_selection);
             ui.ctx().request_repaint();
         }
@@ -750,7 +829,7 @@ impl Editor {
             self.scroll_to_cursor = true;
             ui.ctx().request_repaint();
         }
-        if self.initialized && self.touch_mode && height_updated {
+        if self.initialized && self.renderer.touch_mode && height_updated {
             self.scroll_to_cursor = true;
             ui.ctx().request_repaint();
         }
@@ -758,7 +837,9 @@ impl Editor {
             self.unprocessed_scroll = Some(Instant::now());
             ui.ctx().request_repaint();
         }
-        self.event.internal_events.append(&mut self.render_events);
+        self.event
+            .internal_events
+            .append(&mut self.renderer.render_events);
         if !self.event.internal_events.is_empty() {
             ui.ctx().request_repaint();
         }
@@ -770,10 +851,10 @@ impl Editor {
                 .markdown
                 .file
                 .entry(self.file_id)
-                .and_modify(|f| f.selection = self.buffer.current.selection)
+                .and_modify(|f| f.selection = self.renderer.buffer.current.selection)
                 .or_insert(MdFilePersistence {
                     scroll_offset: Default::default(),
-                    selection: self.buffer.current.selection,
+                    selection: self.renderer.buffer.current.selection,
                     image_dims: Default::default(),
                 });
             persistence_updated = true;
@@ -786,7 +867,7 @@ impl Editor {
                     let state: Option<scroll_area::State> = ui.data(|d| d.get_temp(scroll_area_id));
                     let scroll_offset = if let Some(state) = state { state.offset.y } else { 0. };
 
-                    let image_dims = self.embeds.image_dims();
+                    let image_dims = self.renderer.embeds.image_dims();
                     let mut persistence = self.persistence.data.write().unwrap();
                     persistence
                         .markdown
@@ -829,7 +910,8 @@ impl Editor {
     }
 
     pub fn will_consume_touch(&self, pos: Pos2) -> bool {
-        self.touch_consuming_rects
+        self.renderer
+            .touch_consuming_rects
             .iter()
             .any(|rect| rect.contains(pos))
             || self.scroll_area_velocity.abs().max_elem() > 0.
@@ -845,13 +927,13 @@ impl Editor {
             Margin::symmetric(0, 15)
         };
         ScrollArea::vertical()
-            .scroll_source(if self.touch_mode {
+            .scroll_source(if self.renderer.touch_mode {
                 ScrollSource::ALL
             } else {
                 ScrollSource::SCROLL_BAR | ScrollSource::MOUSE_WHEEL
             })
             .id_salt(self.file_id)
-            .scroll_bar_visibility(if self.touch_mode {
+            .scroll_bar_visibility(if self.renderer.touch_mode {
                 ScrollBarVisibility::AlwaysVisible
             } else {
                 ScrollBarVisibility::VisibleWhenNeeded
@@ -865,12 +947,12 @@ impl Editor {
                             let scroll_view_height = ui.max_rect().height();
                             ui.allocate_space(Vec2 { x: ui.available_width(), y: 0. });
 
-                            let padding = (ui.available_width() - self.width) / 2.;
+                            let padding = (ui.available_width() - self.renderer.width) / 2.;
 
-                            self.top_left =
-                                ui.max_rect().min + (padding + self.layout.margin) * Vec2::X;
+                            self.renderer.top_left = ui.max_rect().min
+                                + (padding + self.renderer.layout.margin) * Vec2::X;
                             let height = {
-                                let document_height = self.height(root, &[root]);
+                                let document_height = self.renderer.height(root, &[root]);
                                 let unfilled_space = if document_height < scroll_view_height {
                                     scroll_view_height - document_height
                                 } else {
@@ -881,8 +963,11 @@ impl Editor {
                                 document_height + unfilled_space.max(end_of_text_padding)
                             };
                             let rect = Rect::from_min_size(
-                                self.top_left,
-                                Vec2::new(self.width - 2. * self.layout.margin, height),
+                                self.renderer.top_left,
+                                Vec2::new(
+                                    self.renderer.width - 2. * self.renderer.layout.margin,
+                                    height,
+                                ),
                             );
 
                             ui.ctx().check_for_id_clash(self.id(), rect, ""); // registers this widget so it's not forgotten by next frame
@@ -890,7 +975,7 @@ impl Editor {
                             let response = ui.interact(
                                 rect,
                                 self.id(),
-                                if self.touch_mode {
+                                if self.renderer.touch_mode {
                                     Sense::click()
                                 } else {
                                     Sense::click_and_drag()
@@ -910,18 +995,19 @@ impl Editor {
                             ui.advance_cursor_after_rect(rect);
 
                             ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
-                                self.show_block(ui, root, self.top_left, &[root]);
+                                self.renderer
+                                    .show_block(ui, root, self.renderer.top_left, &[root]);
                             });
                         });
                 });
-                self.galleys.galleys.sort_by_key(|g| g.range);
+                self.renderer.galleys.galleys.sort_by_key(|g| g.range);
 
                 // show selection
                 if ui.ctx().os() != OperatingSystem::IOS {
                     let selection = self
                         .in_progress_selection
-                        .unwrap_or(self.buffer.current.selection);
-                    let theme = self.ctx.get_lb_theme();
+                        .unwrap_or(self.renderer.buffer.current.selection);
+                    let theme = self.renderer.ctx.get_lb_theme();
                     let color = theme.bg().get_color(theme.prefs().primary);
                     self.show_range(ui, selection, color.lerp_to_gamma(theme.neutral_bg(), 0.7));
                     self.show_offset(ui, selection.1, color);
@@ -941,7 +1027,7 @@ impl Editor {
 
                 // show find match highlights
                 if !self.find.matches.is_empty() {
-                    let theme = self.ctx.get_lb_theme();
+                    let theme = self.renderer.ctx.get_lb_theme();
                     let highlight_color = theme.neutral_bg_tertiary();
                     let current_color = theme.fg().yellow.lerp_to_gamma(theme.neutral_bg(), 0.5);
                     for (i, &match_range) in self.find.matches.iter().enumerate() {
@@ -968,15 +1054,18 @@ impl Editor {
 
     fn show_find_centered(&mut self, ui: &mut Ui) {
         let available = ui.available_width();
-        let content_width =
-            if self.touch_mode { self.width } else { self.toolbar_width().min(self.width) };
+        let content_width = if self.renderer.touch_mode {
+            self.renderer.width
+        } else {
+            self.toolbar_width().min(self.renderer.width)
+        };
         let content_left = ui.max_rect().left() + (available - content_width) / 2.;
         let top = ui.cursor().min.y;
         let find_rect =
             Rect::from_min_size(egui::pos2(content_left, top), egui::vec2(content_width, 0.));
         let scope_resp = ui.scope_builder(egui::UiBuilder::new().max_rect(find_rect), |ui| {
             self.find
-                .show(&self.buffer, self.virtual_keyboard_shown, ui)
+                .show(&self.renderer.buffer, self.virtual_keyboard_shown, ui)
         });
         let find_resp = scope_resp.inner;
         let rendered_rect = scope_resp.response.rect;
@@ -1020,7 +1109,7 @@ impl Editor {
         if resp.closed {
             self.find.matches.clear();
             self.find.current_match = None;
-            self.layout_cache.clear();
+            self.renderer.layout_cache.clear();
         }
     }
 
@@ -1313,7 +1402,7 @@ mod test {
         /// Workspace.enterFrame() — runs a full headless egui frame through
         /// Editor::show(), processing all pending events.
         fn enter_frame(&mut self) {
-            let ctx = self.editor.ctx.clone();
+            let ctx = self.editor.renderer.ctx.clone();
             let pending = std::mem::take(&mut self.pending);
             let _ = ctx.run(RawInput::default(), |ctx| {
                 ctx.set_lb_theme(Theme::default(Mode::Dark));
@@ -1328,11 +1417,11 @@ mod test {
         }
 
         fn get_text(&self) -> &str {
-            &self.editor.buffer.current.text
+            &self.editor.renderer.buffer.current.text
         }
 
         fn get_selection(&self) -> (usize, usize) {
-            let sel = self.editor.buffer.current.selection;
+            let sel = self.editor.renderer.buffer.current.selection;
             (sel.0.0, sel.1.0)
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/output/ui_text_input_tokenizer.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/output/ui_text_input_tokenizer.rs
@@ -32,12 +32,12 @@ impl UITextInputTokenizer for Editor {
         &self, text_position: DocCharOffset, at_boundary: Bound, in_backward_direction: bool,
     ) -> bool {
         let ranges = match at_boundary {
-            Bound::Word => &self.bounds.words,
-            Bound::Line => &self.bounds.wrap_lines,
-            Bound::Paragraph => &self.bounds.source_lines,
+            Bound::Word => &self.renderer.bounds.words,
+            Bound::Line => &self.renderer.bounds.wrap_lines,
+            Bound::Paragraph => &self.renderer.bounds.source_lines,
             Bound::Doc => {
                 return text_position == DocCharOffset(0)
-                    || text_position == self.buffer.current.segs.last_cursor_position();
+                    || text_position == self.renderer.buffer.current.segs.last_cursor_position();
             }
         };
         match text_position.bound_case(ranges) {
@@ -75,9 +75,9 @@ impl UITextInputTokenizer for Editor {
         &self, text_position: DocCharOffset, within_text_unit: Bound, in_backward_direction: bool,
     ) -> bool {
         let ranges = match within_text_unit {
-            Bound::Word => &self.bounds.words,
-            Bound::Line => &self.bounds.wrap_lines,
-            Bound::Paragraph => &self.bounds.source_lines,
+            Bound::Word => &self.renderer.bounds.words,
+            Bound::Line => &self.renderer.bounds.wrap_lines,
+            Bound::Paragraph => &self.renderer.bounds.source_lines,
             Bound::Doc => {
                 return true;
             }
@@ -110,14 +110,18 @@ impl UITextInputTokenizer for Editor {
     fn position_from(
         &self, text_position: DocCharOffset, to_boundary: Bound, in_backward_direction: bool,
     ) -> Option<DocCharOffset> {
-        Some(text_position.advance_to_next_bound(to_boundary, in_backward_direction, &self.bounds))
+        Some(text_position.advance_to_next_bound(
+            to_boundary,
+            in_backward_direction,
+            &self.renderer.bounds,
+        ))
     }
 
     fn range_enclosing_position(
         &self, text_position: DocCharOffset, with_granularity: Bound, in_backward_direction: bool,
     ) -> Option<(DocCharOffset, DocCharOffset)> {
         let ranges = match with_granularity {
-            Bound::Word => &self.bounds.words,
+            Bound::Word => &self.renderer.bounds.words,
             Bound::Line => {
                 // note: lines handled as words
                 //
@@ -129,9 +133,9 @@ impl UITextInputTokenizer for Editor {
                 // the returned ranges until it receives a nil value, which is more consistent with a text granularity
                 // that is non-contiguous the way words are and lines are not. This seems to be what it takes to get
                 // the correct undeline behavior after autocorrecting a word.
-                &self.bounds.words
+                &self.renderer.bounds.words
             }
-            Bound::Paragraph => &self.bounds.source_lines,
+            Bound::Paragraph => &self.renderer.bounds.source_lines,
             Bound::Doc => {
                 unimplemented!()
             }

--- a/libs/content/workspace/src/tab/markdown_editor/theme.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/theme.rs
@@ -1,10 +1,10 @@
 use egui::style::{WidgetVisuals, Widgets};
 use egui::{Stroke, Ui};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::theme::palette_v2::ThemeExt;
 
-impl Editor {
+impl MdRender {
     // todo: all egui needs to be themed this way and this should be removed
     pub fn apply_theme(&self, ui: &mut Ui) {
         let theme = self.ctx.get_lb_theme();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
@@ -6,11 +6,11 @@ use lb_rs::model::text::offset_types::{
     DocCharOffset, IntoRangeExt as _, RangeExt as _, RangeIterExt as _, RelCharOffset,
 };
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
 use crate::theme::icons::Icon;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_alert(&self, parent: &AstNode<'_>, node_alert: &NodeAlert) -> Format {
         let parent_text_format = self.text_format(parent);
         Format {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
@@ -2,12 +2,12 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Rect, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeIterExt as _, RelCharOffset};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Format;
 
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_block_quote(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { color: self.ctx.get_lb_theme().neutral_fg_secondary(), ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
@@ -5,11 +5,11 @@ use lb_rs::model::text::offset_types::{IntoRangeExt as _, RangeExt as _, RangeIt
 use syntect::easy::HighlightLines;
 
 use crate::show::syntax_ext_for;
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_document(&self) -> Format {
         Format {
             family: FontFamily::Sans,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/footnote_definition.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/footnote_definition.rs
@@ -3,12 +3,12 @@ use egui::text::LayoutJob;
 use egui::{FontFamily, FontId, Pos2, Rect, TextFormat, Ui, Vec2};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt, RelCharOffset};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Format;
 
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_footnote_definition(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { color: self.ctx.get_lb_theme().neutral_fg_secondary(), ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -5,13 +5,13 @@ use lb_rs::model::text::offset_types::{
 };
 
 use crate::TextBufferArea;
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{BufferExt as _, FontFamily};
 
 use crate::theme::palette_v2::ThemeExt as _;
 
 // https://github.github.com/gfm/#list-items
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn height_item(&self, node: &'ast AstNode<'ast>) -> f32 {
         let any_children = node.children().next().is_some();
         if any_children {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -4,7 +4,7 @@ use lb_rs::model::text::offset_types::{
     DocCharOffset, IntoRangeExt, RangeExt as _, RangeIterExt as _, RelCharOffset,
 };
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
 pub(crate) mod alert;
 pub(crate) mod block_quote;
@@ -16,7 +16,7 @@ pub(crate) mod table;
 pub(crate) mod table_row;
 pub(crate) mod task_item;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn indent(&self, node: &'ast AstNode<'ast>) -> f32 {
         let value = &node.data.borrow().value;
         let sp = &node.data.borrow().sourcepos;
@@ -96,7 +96,8 @@ impl<'ast> Editor {
     ) {
         let children = self.sorted_children(node);
 
-        let required_ranges = self.galley_required_ranges();
+        let required_ranges =
+            self.galley_required_ranges(self.in_progress_selection, self.find_current_match);
         let viewport = ui.clip_rect();
         let buffer = viewport.height();
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Rect, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::{RangeExt, RangeIterExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn height_table(&self, node: &'ast AstNode<'ast>) -> f32 {
         if self.reveal_table(node) {
             let mut height = 0.;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table_row.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table_row.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Rangef, Rect, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::RangeExt;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Format;
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_table_row(&self, parent: &AstNode<'_>, is_header_row: bool) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { bold: is_header_row, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -2,10 +2,10 @@ use comrak::nodes::{AstNode, NodeTaskItem};
 use egui::{CursorIcon, Pos2, Rect, Sense, Shape, Stroke, StrokeKind, Ui, Vec2};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _, RelCharOffset};
 
-use crate::tab::markdown_editor::{Editor, Event};
+use crate::tab::markdown_editor::{Event, MdRender};
 use crate::theme::palette_v2::ThemeExt;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn height_task_item(&self, node: &'ast AstNode<'ast>) -> f32 {
         self.height_item(node)
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
@@ -8,12 +8,12 @@ use lb_rs::model::text::offset_types::{DocCharOffset, IntoRangeExt, RangeExt as 
 use syntect::easy::HighlightLines;
 use syntect::highlighting::Style;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
 
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_code_block(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { family: FontFamily::Mono, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/front_matter.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/front_matter.rs
@@ -1,9 +1,9 @@
 use comrak::nodes::{AstNode, NodeCodeBlock};
 use egui::{Pos2, Ui};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     fn frontmatter_as_code_block() -> NodeCodeBlock {
         NodeCodeBlock {
             fenced: true,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -4,14 +4,14 @@ use lb_rs::model::text::offset_types::{
     DocCharOffset, IntoRangeExt as _, RangeExt as _, RangeIterExt as _,
 };
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 
 use crate::theme::icons::Icon;
 use crate::theme::palette_v2::ThemeExt as _;
 use crate::widgets::IconButton;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn heading_row_height(&self, level: u8) -> f32 {
         self.layout.row_height
             * match level {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/html_block.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/html_block.rs
@@ -1,10 +1,10 @@
 use comrak::nodes::{AstNode, NodeCodeBlock};
 use egui::{Pos2, Ui};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Format;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_html_block(&self, parent: &AstNode<'_>) -> Format {
         self.text_format_code_block(parent)
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/mod.rs
@@ -1,7 +1,7 @@
 use comrak::nodes::AstNode;
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _, RangeIterExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
 pub(crate) mod code_block;
 pub(crate) mod front_matter;
@@ -11,7 +11,7 @@ pub(crate) mod paragraph;
 pub(crate) mod table_cell;
 pub(crate) mod thematic_break;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     /// Returns 5 ranges representing the pre-node range, pre-first-child section,
     /// inter-children section, post-last-child section, and post-node range.
     #[allow(clippy::type_complexity)]

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
@@ -2,9 +2,9 @@ use comrak::nodes::{AstNode, NodeLink, NodeValue};
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt, RangeIterExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn height_paragraph(&self, node: &'ast AstNode<'ast>) -> f32 {
         let mut result = 0.;
         for descendant in node.descendants() {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/table_cell.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/table_cell.rs
@@ -1,9 +1,9 @@
 use comrak::nodes::{AstNode, NodeLink, NodeValue};
 use egui::{Pos2, Ui, Vec2};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn height_table_cell(&self, node: &'ast AstNode<'ast>) -> f32 {
         let width = self.width(node) - 2.0 * self.layout.block_padding;
         let mut wrap = self.new_wrap(width);

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/thematic_break.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/thematic_break.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Rect, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::{IntoRangeExt as _, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn height_thematic_break(&self) -> f32 {
         self.layout.row_height
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -8,19 +8,19 @@ use comrak::nodes::{AstNode, NodeHeading, NodeLink, NodeValue};
 use egui::ahash::HashMap;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{
-    DocCharOffset, RangeExt as _, RangeIterExt as _, RelCharOffset,
+    DocCharOffset, IntoRangeExt as _, RangeExt as _, RangeIterExt as _, RelCharOffset,
 };
 
-use crate::tab::markdown_editor::Editor;
 use crate::tab::markdown_editor::bounds::RangesExt as _;
 use crate::tab::markdown_editor::widget::inline::html_inline::FOLD_TAG;
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
+use crate::tab::markdown_editor::{Event, MdRender};
 
 pub(crate) mod container;
 pub(crate) mod leaf;
 pub(crate) mod spacing;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn width(&self, node: &'ast AstNode<'ast>) -> f32 {
         let parent = || node.parent().unwrap();
         let parent_width = || self.width(parent());
@@ -440,6 +440,46 @@ impl<'ast> Editor {
         None
     }
 
+    #[allow(clippy::collapsible_else_if)]
+    pub fn apply_fold(
+        &mut self, node: &'ast AstNode<'ast>, contents: (DocCharOffset, DocCharOffset),
+        unapply: bool,
+    ) {
+        if unapply {
+            if let Some(fold) = self.fold(node) {
+                self.render_events.push(Event::Replace {
+                    region: self.node_range(fold).into(),
+                    text: "".into(),
+                    advance_cursor: false,
+                });
+            }
+        } else {
+            if let Some(foldable) = self.foldable(node) {
+                self.render_events.push(Event::Replace {
+                    region: self.node_range(foldable).end().into_range().into(),
+                    text: FOLD_TAG.into(),
+                    advance_cursor: false,
+                });
+
+                // when folding a section that intersects the cursor, adjust the selection
+                // this ensures the folded section appears folded / avoids immediate selection reveal
+                let selection = self.buffer.current.selection;
+
+                if contents.intersects(&selection, true)
+                    && !selection.contains_range(&contents, true, true)
+                {
+                    self.render_events.push(Event::Select {
+                        region: (
+                            selection.start().min(contents.start()),
+                            selection.end().min(contents.start()),
+                        )
+                            .into(),
+                    });
+                }
+            }
+        }
+    }
+
     /// Returns the node that this node is folding, if there is one
     pub fn foldee(&self, node: &'ast AstNode<'ast>) -> Option<&'ast AstNode<'ast>> {
         let mut root = node;
@@ -660,7 +700,7 @@ impl LayoutCache {
     }
 }
 
-impl Editor {
+impl MdRender {
     /// Look up or shape a glyphon buffer for the given text and formatting.
     /// Delegates to the shared GlyphonCache so the same shaped buffer is reused
     /// across frames (and across widgets). The editor-specific concern here is
@@ -743,7 +783,7 @@ impl Editor {
     }
 }
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn get_cached_node_height(&self, node: &'ast AstNode<'ast>) -> Option<f32> {
         let range = self.node_range(node);
         self.layout_cache

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
@@ -4,9 +4,9 @@ use comrak::nodes::{AstNode, NodeValue};
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     /// Converts an optional source line index range to a doc char offset range.
     pub fn spacing_range(
         &self, line_range: &Option<Range<usize>>,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/debug.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/debug.rs
@@ -2,10 +2,10 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Rect, Ui, Vec2};
 use web_time::Instant;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl Editor {
+impl MdRender {
     pub fn show_debug_fps(&mut self, ui: &mut Ui) {
         let now = Instant::now();
         self.frame_times[self.frame_times_idx] = now;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
@@ -261,10 +261,11 @@ impl Editor {
             return;
         }
 
-        let Some((colon_offset, replace_end)) = detect_query(&self.buffer) else {
+        let Some((colon_offset, replace_end)) = detect_query(&self.renderer.buffer) else {
             return;
         };
-        let Some(query) = query_from_range(&self.buffer, (colon_offset, replace_end)) else {
+        let Some(query) = query_from_range(&self.renderer.buffer, (colon_offset, replace_end))
+        else {
             return;
         };
 
@@ -374,8 +375,8 @@ impl Editor {
                 let span_refs: Vec<(&str, bool)> =
                     s.iter().map(|(t, b)| (t.as_str(), *b)).collect();
                 let mut label = GlyphonLabel::new_rich(span_refs, text_color)
-                    .font_size(self.layout.completion_font_size)
-                    .line_height(self.layout.completion_line_height);
+                    .font_size(self.renderer.layout.completion_font_size)
+                    .line_height(self.renderer.layout.completion_line_height);
                 if let Some(hint) = hints.get(i) {
                     label = label.hint(hint, hint_color);
                 }
@@ -385,7 +386,7 @@ impl Editor {
 
         // -- Position popup --------------------------------------------------------
         let popup_width = max_width + POPUP_PADDING;
-        let popup_height = results.len() as f32 * self.layout.completion_row_height;
+        let popup_height = results.len() as f32 * self.renderer.layout.completion_row_height;
         let screen_rect = ui.ctx().screen_rect();
         let popup_y = if cursor_top.y - popup_height >= screen_rect.min.y {
             cursor_top.y - popup_height
@@ -396,16 +397,16 @@ impl Editor {
             Pos2::new(cursor_top.x, popup_y),
             Vec2::new(popup_width, popup_height),
         );
-        self.touch_consuming_rects.push(popup_rect);
+        self.renderer.touch_consuming_rects.push(popup_rect);
 
         let row_rects: Vec<Rect> = (0..results.len())
             .map(|i| {
                 Rect::from_min_size(
                     Pos2::new(
                         popup_rect.min.x,
-                        popup_rect.min.y + i as f32 * self.layout.completion_row_height,
+                        popup_rect.min.y + i as f32 * self.renderer.layout.completion_row_height,
                     ),
-                    Vec2::new(popup_width, self.layout.completion_row_height),
+                    Vec2::new(popup_width, self.renderer.layout.completion_row_height),
                 )
             })
             .collect();
@@ -421,7 +422,7 @@ impl Editor {
         }
 
         // -- Draw backgrounds ------------------------------------------------------
-        self.draw_completion_popup(
+        self.renderer.draw_completion_popup(
             ui,
             popup_rect,
             &row_rects,
@@ -438,14 +439,14 @@ impl Editor {
             let text_top = rect.min.y + 4.0;
             let content_rect = Rect::from_min_size(
                 Pos2::new(rect.min.x + 8.0, text_top),
-                Vec2::new(popup_width - 16.0, self.layout.completion_line_height),
+                Vec2::new(popup_width - 16.0, self.renderer.layout.completion_line_height),
             );
 
             let span_refs: Vec<(&str, bool)> =
                 spans.iter().map(|(t, b)| (t.as_str(), *b)).collect();
             let mut label = GlyphonLabel::new_rich(span_refs, text_color)
-                .font_size(self.layout.completion_font_size)
-                .line_height(self.layout.completion_line_height);
+                .font_size(self.renderer.layout.completion_font_size)
+                .line_height(self.renderer.layout.completion_line_height);
             if let Some(hint) = hints.get(idx) {
                 label = label.hint(hint, hint_color);
             }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
@@ -320,8 +320,8 @@ impl Editor {
         if term.is_empty() {
             return Vec::new();
         }
-        let text = &self.buffer.current.text;
-        let segs = &self.buffer.current.segs;
+        let text = &self.renderer.buffer.current.text;
+        let segs = &self.renderer.buffer.current.segs;
 
         if self.find.regex {
             return self.find_all_regex(term);
@@ -352,8 +352,8 @@ impl Editor {
     }
 
     fn find_all_regex(&self, term: &str) -> Vec<(DocCharOffset, DocCharOffset)> {
-        let text = &self.buffer.current.text;
-        let segs = &self.buffer.current.segs;
+        let text = &self.renderer.buffer.current.text;
+        let segs = &self.renderer.buffer.current.segs;
 
         let pattern =
             if self.find.whole_word { format!(r"\b(?:{})\b", term) } else { term.to_string() };
@@ -396,7 +396,7 @@ impl Editor {
             return false;
         }
 
-        let cursor_pos = self.buffer.current.selection.1;
+        let cursor_pos = self.renderer.buffer.current.selection.1;
         let new_idx = if forward {
             match self.find.current_match {
                 Some(idx) => (idx + 1) % self.find.matches.len(),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/code.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/code.rs
@@ -2,12 +2,12 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, IntoRangeExt as _, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_code(&self, parent: &AstNode<'_>) -> Format {
         let theme = self.ctx.get_lb_theme();
         Format {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/emph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/emph.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_emph(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { italic: true, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/escaped.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/escaped.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_escaped(&self, parent: &AstNode<'_>) -> Format {
         self.text_format(parent)
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/escaped_tag.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/escaped_tag.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_escaped_tag(&self, parent: &AstNode<'_>) -> Format {
         self.text_format(parent)
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/footnote_reference.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/footnote_reference.rs
@@ -2,12 +2,12 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Sense, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, IntoRangeExt as _, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_footnote_reference(&self, parent: &AstNode<'_>) -> Format {
         Format {
             color: self.ctx.get_lb_theme().neutral_fg_secondary(),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/highlight.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/highlight.rs
@@ -2,12 +2,12 @@ use comrak::nodes::AstNode;
 use egui::{Color32, Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 use crate::theme::palette_v2::ThemeExt;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn background_color_highlight(&self) -> Color32 {
         self.ctx.get_lb_theme().bg().yellow.gamma_multiply(0.35)
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/html_inline.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/html_inline.rs
@@ -2,14 +2,14 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 use crate::theme::palette_v2::ThemeExt as _;
 
 pub const FOLD_TAG: &str = "<!-- {\"fold\":true} -->";
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_html_inline(&self, parent: &AstNode<'_>) -> Format {
         Format {
             color: self.ctx.get_lb_theme().neutral_fg_secondary(),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -4,12 +4,12 @@ use comrak::nodes::{AstNode, NodeLink};
 use egui::{self, Pos2, Rect, Ui, Vec2};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Wrap;
 
-impl Editor {
+impl MdRender {
     pub fn warm_images<'a>(&self, node: &'a comrak::nodes::AstNode<'a>) {
         for descendant in node.descendants() {
             let url = match &descendant.data.borrow().value {
@@ -21,7 +21,7 @@ impl Editor {
     }
 }
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn span_image(
         &self, node: &'ast AstNode<'ast>, wrap: &Wrap, range: (DocCharOffset, DocCharOffset),
     ) -> f32 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/line_break.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/line_break.rs
@@ -1,11 +1,11 @@
 use comrak::nodes::AstNode;
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Wrap;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn span_line_break(
         &self, node: &'ast AstNode<'ast>, wrap: &Wrap, range: (DocCharOffset, DocCharOffset),
     ) -> f32 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use crate::file_cache::{FilesExt as _, ResolvedLink};
 use crate::show::DocType;
 use crate::tab::ExtendedOutput as _;
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::block::TitleState;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format, Wrap};
@@ -24,7 +24,7 @@ enum DestinationTitle {
 
 pub use crate::resolvers::LinkState;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_link(&self, parent: &AstNode<'_>, state: LinkState) -> Format {
         let parent_text_format = self.text_format(parent);
         let theme = self.ctx.get_lb_theme();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/math.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/math.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_math(&self, parent: &AstNode<'_>) -> Format {
         self.text_format_code(parent)
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
@@ -2,7 +2,7 @@ use comrak::nodes::{AstNode, NodeFootnoteReference, NodeValue};
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, IntoRangeExt, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Wrap;
 
 pub(crate) mod code;
@@ -40,7 +40,7 @@ impl std::ops::BitOrAssign for Response {
     }
 }
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn span(
         &self, node: &'ast AstNode<'ast>, wrap: &Wrap, range: (DocCharOffset, DocCharOffset),
     ) -> f32 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/short_code.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/short_code.rs
@@ -2,11 +2,11 @@ use comrak::nodes::{AstNode, NodeShortCode};
 use egui::{Pos2, Sense, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_short_code(&self, parent: &AstNode<'_>) -> Format {
         self.text_format(parent)
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/soft_break.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/soft_break.rs
@@ -1,11 +1,11 @@
 use comrak::nodes::AstNode;
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Wrap;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn span_soft_break(
         &self, node: &'ast AstNode<'ast>, wrap: &Wrap, range: (DocCharOffset, DocCharOffset),
     ) -> f32 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/spoilered_text.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/spoilered_text.rs
@@ -2,12 +2,12 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_spoilered_text(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/strikethrough.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/strikethrough.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_strikethrough(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { strikethrough: true, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/strong.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/strong.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_strong(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { bold: true, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/subscript.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/subscript.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_subscript(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { subscript: true, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/superscript.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/superscript.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_superscript(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { superscript: true, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/text.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/text.rs
@@ -2,12 +2,12 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Sense, Ui};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 use crate::theme::palette_v2::ThemeExt as _;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn span_text(
         &self, node: &'ast AstNode<'ast>, wrap: &Wrap, range: (DocCharOffset, DocCharOffset),
     ) -> f32 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/underline.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/underline.rs
@@ -2,11 +2,11 @@ use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::DocCharOffset;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Wrap};
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn text_format_underline(&self, parent: &AstNode<'_>) -> Format {
         let parent_text_format = self.text_format(parent);
         Format { underline: true, ..parent_text_format }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
@@ -4,11 +4,11 @@ use lb_rs::Uuid;
 use lb_rs::model::text::offset_types::DocCharOffset;
 
 use crate::tab::ExtendedOutput as _;
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::Response;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Wrap;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     pub fn span_wikilink(
         &self, node: &'ast AstNode<'ast>, wrap: &Wrap, range: (DocCharOffset, DocCharOffset),
     ) -> f32 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
@@ -566,17 +566,17 @@ impl Editor {
             return;
         }
 
-        let Some(((bracket_start, replace_end), mode)) = detect_any(&self.buffer) else {
+        let Some(((bracket_start, replace_end), mode)) = detect_any(&self.renderer.buffer) else {
             return;
         };
-        let qr = query_range(&self.buffer, (bracket_start, replace_end), mode);
-        let query = self.buffer[qr].to_string();
+        let qr = query_range(&self.renderer.buffer, (bracket_start, replace_end), mode);
+        let query = self.renderer.buffer[qr].to_string();
 
         if self.link_completions.suppressed.as_deref() == Some(query.as_str()) {
             return;
         }
 
-        let cache = self.files.read().unwrap();
+        let cache = self.renderer.files.read().unwrap();
         let mut results = search(&cache, self.file_id, &query, mode);
         drop(cache);
         if results.is_empty() {
@@ -672,8 +672,8 @@ impl Editor {
             .enumerate()
             .map(|(i, r)| {
                 let mut label = GlyphonLabel::new(&r.name, text_color)
-                    .font_size(self.layout.completion_font_size)
-                    .line_height(self.layout.completion_line_height);
+                    .font_size(self.renderer.layout.completion_font_size)
+                    .line_height(self.renderer.layout.completion_line_height);
                 if let Some(shortcut) = shortcuts.get(i) {
                     label = label.hint(shortcut, hint_color);
                 }
@@ -683,8 +683,8 @@ impl Editor {
 
         let measure_path = |text: &str| -> f32 {
             GlyphonLabel::new(text, hint_color)
-                .font_size(self.layout.completion_font_size - 2.0)
-                .line_height(self.layout.completion_line_height)
+                .font_size(self.renderer.layout.completion_font_size - 2.0)
+                .line_height(self.renderer.layout.completion_line_height)
                 .measure(ui)
                 .x
         };
@@ -708,7 +708,7 @@ impl Editor {
             })
             .fold(0.0_f32, f32::max);
 
-        let popup_height = results.len() as f32 * self.layout.completion_row_height;
+        let popup_height = results.len() as f32 * self.renderer.layout.completion_row_height;
         let screen_rect = ui.ctx().screen_rect();
         let popup_y = if cursor_top.y - popup_height >= screen_rect.min.y {
             cursor_top.y - popup_height
@@ -719,16 +719,16 @@ impl Editor {
             Pos2::new(cursor_top.x, popup_y),
             Vec2::new(popup_width, popup_height),
         );
-        self.touch_consuming_rects.push(popup_rect);
+        self.renderer.touch_consuming_rects.push(popup_rect);
 
         let row_rects: Vec<Rect> = (0..results.len())
             .map(|i| {
                 Rect::from_min_size(
                     Pos2::new(
                         popup_rect.min.x,
-                        popup_rect.min.y + i as f32 * self.layout.completion_row_height,
+                        popup_rect.min.y + i as f32 * self.renderer.layout.completion_row_height,
                     ),
-                    Vec2::new(popup_width, self.layout.completion_row_height),
+                    Vec2::new(popup_width, self.renderer.layout.completion_row_height),
                 )
             })
             .collect();
@@ -744,7 +744,7 @@ impl Editor {
         }
 
         // -- Draw backgrounds ------------------------------------------------------
-        self.draw_completion_popup(
+        self.renderer.draw_completion_popup(
             ui,
             popup_rect,
             &row_rects,
@@ -761,7 +761,7 @@ impl Editor {
             let text_top = rect.min.y + 4.0;
             let content_rect = Rect::from_min_size(
                 Pos2::new(rect.min.x + 8.0, text_top),
-                Vec2::new(popup_width - 16.0, self.layout.completion_line_height),
+                Vec2::new(popup_width - 16.0, self.renderer.layout.completion_line_height),
             );
 
             // Name (bold on matched chars) + shortcut hint (e.g. ⌘1).
@@ -770,8 +770,8 @@ impl Editor {
             let span_refs: Vec<(&str, bool)> =
                 spans.iter().map(|(t, b)| (t.as_str(), *b)).collect();
             let mut label = GlyphonLabel::new_rich(span_refs, text_color)
-                .font_size(self.layout.completion_font_size)
-                .line_height(self.layout.completion_line_height);
+                .font_size(self.renderer.layout.completion_font_size)
+                .line_height(self.renderer.layout.completion_line_height);
             if let Some(shortcut) = shortcuts.get(idx) {
                 label = label.hint(shortcut, hint_color);
             }
@@ -789,12 +789,12 @@ impl Editor {
                 })
                 .collect();
             let shaped = GlyphonLabel::new_colored(colored_spans, hint_color)
-                .font_size(self.layout.completion_font_size - 2.0)
-                .line_height(self.layout.completion_line_height)
+                .font_size(self.renderer.layout.completion_font_size - 2.0)
+                .line_height(self.renderer.layout.completion_line_height)
                 .build(ui.ctx());
             let path_rect = Rect::from_min_size(
                 Pos2::new(content_rect.max.x - shortcut_width - 8.0 - shaped.size.x, text_top),
-                Vec2::new(shaped.size.x, self.layout.completion_line_height),
+                Vec2::new(shaped.size.x, self.renderer.layout.completion_line_height),
             );
             text_areas.push(shaped.text_area(path_rect, ui.ctx(), clip_rect));
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
@@ -5,7 +5,7 @@ use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _, RangeIterEx
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
 use crate::theme::palette_v2::ThemeExt as _;
 
-use super::Editor;
+use super::MdRender;
 use super::bounds::RangesExt as _;
 
 pub(crate) mod block;
@@ -17,7 +17,7 @@ pub(crate) mod link_completions;
 pub(crate) mod toolbar;
 pub(crate) mod utils;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     /// Returns the range for the node.
     pub fn node_range(&self, node: &'ast AstNode<'ast>) -> (DocCharOffset, DocCharOffset) {
         // Check cache first

--- a/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
@@ -13,6 +13,7 @@ use lb_rs::model::text::offset_types::{IntoRangeExt, RangeExt as _};
 use lb_rs::model::text::operation_types::Operation;
 use serde::{Deserialize, Serialize};
 
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::NodeValueExt;
 use crate::tab::{ExtendedInput as _, ExtendedOutput as _};
 use crate::theme::icons::Icon;
@@ -148,7 +149,8 @@ impl<'ast> Editor {
             .scroll_bar_visibility(ScrollBarVisibility::AlwaysHidden)
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
-                    ui.visuals_mut().widgets.active.bg_fill = self.ctx.get_lb_theme().fg().blue;
+                    ui.visuals_mut().widgets.active.bg_fill =
+                        self.renderer.ctx.get_lb_theme().fg().blue;
 
                     let is_ios = cfg!(target_os = "ios");
                     let is_mobile = is_ios || cfg!(target_os = "android");
@@ -502,10 +504,11 @@ impl<'ast> Editor {
 
         for node in root.descendants() {
             if let NodeValue::Heading(NodeHeading { level, .. }) = &node.data.borrow().value {
-                if self
-                    .node_range(node)
-                    .contains_range(&self.buffer.current.selection, true, true)
-                {
+                if self.renderer.node_range(node).contains_range(
+                    &self.renderer.buffer.current.selection,
+                    true,
+                    true,
+                ) {
                     current_heading_level = *level;
                     applied = true;
                     break;
@@ -538,7 +541,7 @@ impl<'ast> Editor {
         &self, icon: Icon, style: NodeValue, root: &'ast AstNode<'ast>, ui: &mut Ui,
     ) -> Option<Event> {
         let applied = if style.is_inline() {
-            self.inline_styled(root, self.buffer.current.selection, &style)
+            self.inline_styled(root, self.renderer.buffer.current.selection, &style)
         } else {
             self.unapply_block(root, &style)
         };
@@ -572,11 +575,11 @@ impl<'ast> Editor {
                     Frame::canvas(ui.style())
                         .inner_margin(margin)
                         .stroke(Stroke::NONE)
-                        .fill(self.ctx.get_lb_theme().neutral_bg())
+                        .fill(self.renderer.ctx.get_lb_theme().neutral_bg())
                         .show(ui, |ui| {
                             // setup
                             ui.visuals_mut().widgets.active.bg_fill =
-                                self.ctx.get_lb_theme().fg().blue;
+                                self.renderer.ctx.get_lb_theme().fg().blue;
 
                             let is_ios = cfg!(target_os = "ios");
 
@@ -584,22 +587,24 @@ impl<'ast> Editor {
 
                             let scroll_view_height = ui.max_rect().height();
                             ui.allocate_space(Vec2 { x: ui.available_width(), y: 0. });
-                            let padding = (ui.available_width() - self.width) / 2.;
+                            let padding = (ui.available_width() - self.renderer.width) / 2.;
 
                             let mut top_left =
                                 ui.max_rect().min + (padding + MENU_MARGIN) * Vec2::X;
-                            let md_width = self.width - 2. * MENU_MARGIN;
+                            let md_width = self.renderer.width - 2. * MENU_MARGIN;
 
                             // store values
-                            let source_lines = mem::take(&mut self.bounds.source_lines);
-                            let buffer = mem::take(&mut self.buffer);
-                            let inline_paragraphs = mem::take(&mut self.bounds.inline_paragraphs);
+                            let source_lines = mem::take(&mut self.renderer.bounds.source_lines);
+                            let buffer = mem::take(&mut self.renderer.buffer);
+                            let inline_paragraphs =
+                                mem::take(&mut self.renderer.bounds.inline_paragraphs);
 
-                            let galleys = mem::take(&mut self.galleys.galleys);
-                            let wrap_lines = mem::take(&mut self.bounds.wrap_lines);
-                            let touch_consuming_rects = mem::take(&mut self.touch_consuming_rects);
+                            let galleys = mem::take(&mut self.renderer.galleys.galleys);
+                            let wrap_lines = mem::take(&mut self.renderer.bounds.wrap_lines);
+                            let touch_consuming_rects =
+                                mem::take(&mut self.renderer.touch_consuming_rects);
 
-                            self.layout_cache.clear();
+                            self.renderer.layout_cache.clear();
 
                             // page title
                             ui.add_space(MENU_SPACE);
@@ -1007,19 +1012,22 @@ impl<'ast> Editor {
                             } else {
                                 0.
                             };
-                            let rect = Rect::from_min_size(top_left, Vec2::new(self.width, height));
+                            let rect = Rect::from_min_size(
+                                top_left,
+                                Vec2::new(self.renderer.width, height),
+                            );
 
                             ui.advance_cursor_after_rect(rect);
 
                             // restore stored values
-                            self.buffer = buffer;
-                            self.bounds.source_lines = source_lines;
-                            self.bounds.inline_paragraphs = inline_paragraphs;
-                            self.calc_words();
+                            self.renderer.buffer = buffer;
+                            self.renderer.bounds.source_lines = source_lines;
+                            self.renderer.bounds.inline_paragraphs = inline_paragraphs;
+                            self.renderer.calc_words();
 
-                            self.galleys.galleys = galleys;
-                            self.bounds.wrap_lines = wrap_lines;
-                            self.touch_consuming_rects = touch_consuming_rects;
+                            self.renderer.galleys.galleys = galleys;
+                            self.renderer.bounds.wrap_lines = wrap_lines;
+                            self.renderer.touch_consuming_rects = touch_consuming_rects;
                         });
                 });
             });
@@ -1054,65 +1062,75 @@ impl<'ast> Editor {
     }
 
     pub fn markdown_label_height(&mut self, md: &str) -> f32 {
-        self.buffer = md.into();
+        self.renderer.buffer = md.into();
 
         // place cursor (affects capture)
-        self.buffer.queue(vec![Operation::Select(
-            self.buffer.current.segs.last_cursor_position().into_range(),
+        self.renderer.buffer.queue(vec![Operation::Select(
+            self.renderer
+                .buffer
+                .current
+                .segs
+                .last_cursor_position()
+                .into_range(),
         )]);
-        self.buffer.update();
+        self.renderer.buffer.update();
 
         // parse
         let arena = Arena::new();
-        let options = Self::comrak_options();
-        let text_with_newline = self.buffer.current.text.to_string() + "\n";
+        let options = MdRender::comrak_options();
+        let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n";
         let root = comrak::parse_document(&arena, &text_with_newline, &options);
 
         // pre-render work
-        self.calc_source_lines();
-        self.compute_bounds(root);
-        self.bounds.inline_paragraphs.sort();
-        self.calc_words();
+        self.renderer.calc_source_lines();
+        self.renderer.compute_bounds(root);
+        self.renderer.bounds.inline_paragraphs.sort();
+        self.renderer.calc_words();
 
-        let height = self.height(root, &[root]);
+        let height = self.renderer.height(root, &[root]);
 
-        self.layout_cache.clear();
+        self.renderer.layout_cache.clear();
 
         height
     }
 
     pub fn markdown_label(&mut self, ui: &mut Ui, top_left: Pos2, width: f32, md: &str) {
-        self.buffer = md.into();
+        self.renderer.buffer = md.into();
 
         // place cursor (affects capture)
-        self.buffer.queue(vec![Operation::Select(
-            self.buffer.current.segs.last_cursor_position().into_range(),
+        self.renderer.buffer.queue(vec![Operation::Select(
+            self.renderer
+                .buffer
+                .current
+                .segs
+                .last_cursor_position()
+                .into_range(),
         )]);
-        self.buffer.update();
+        self.renderer.buffer.update();
 
         // parse
         let arena = Arena::new();
-        let options = Self::comrak_options();
-        let text_with_newline = self.buffer.current.text.to_string() + "\n";
+        let options = MdRender::comrak_options();
+        let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n";
         let root = comrak::parse_document(&arena, &text_with_newline, &options);
 
         // pre-render work
-        self.calc_source_lines();
-        self.compute_bounds(root);
-        self.bounds.inline_paragraphs.sort();
-        self.calc_words();
+        self.renderer.calc_source_lines();
+        self.renderer.compute_bounds(root);
+        self.renderer.bounds.inline_paragraphs.sort();
+        self.renderer.calc_words();
 
-        let height = self.height(root, &[root]);
+        let height = self.renderer.height(root, &[root]);
         let rect = Rect::from_min_size(top_left, Vec2::new(width, height));
 
-        self.show_block(
+        self.renderer.show_block(
             &mut ui.new_child(UiBuilder::new().max_rect(rect).layout(*ui.layout())),
             root,
             top_left,
             &[root],
         );
 
-        self.layout_cache.clear();
+        self.renderer.layout_cache.clear();
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/mod.rs
@@ -1,12 +1,12 @@
 use comrak::nodes::{AstNode, NodeValue};
 use lb_rs::model::text::offset_types::{DocByteOffset, DocCharOffset, RangeExt as _, RangeIterExt};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::bounds::RangesExt as _;
 
 pub(crate) mod wrap_layout;
 
-impl<'ast> Editor {
+impl<'ast> MdRender {
     // wrappers because I'm tired of writing ".buffer.current.segs" all the time
     pub fn offset_to_byte(&self, i: DocCharOffset) -> DocByteOffset {
         self.buffer.current.segs.offset_to_byte(i)
@@ -330,27 +330,19 @@ impl<'ast> NodeValueExt for AstNode<'ast> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     #[test]
     fn range_lines_char_no_newline() {
         let text = "*";
-        let md = Editor::test(text);
-
+        let md = crate::tab::markdown_editor::MdRender::test(text);
         let lines = md.range_split_newlines((0.into(), text.len().into()));
-
-        // Should produce 1 range for the entire text since there's no newline
         assert_eq!(lines, vec![(0.into(), 1.into())]);
     }
 
     #[test]
     fn range_lines_char_newline() {
         let text = "*\n";
-        let md = Editor::test(text);
-
+        let md = crate::tab::markdown_editor::MdRender::test(text);
         let lines = md.range_split_newlines((0.into(), text.len().into()));
-
-        // Should produce 2 ranges - one for "*" and one for empty line after "\n"
         assert_eq!(lines, vec![(0.into(), 1.into()), (2.into(), 2.into())]);
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -3,7 +3,7 @@ use egui::{Pos2, Rect, Sense, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
 use crate::TextBufferArea;
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdRender;
 
 struct SplitRow {
     text: String,
@@ -81,7 +81,7 @@ impl Wrap {
     }
 }
 
-impl Editor {
+impl MdRender {
     pub fn new_wrap(&self, width: f32) -> Wrap {
         Wrap::new(width, self.layout.row_height, self.layout.row_spacing)
     }

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -81,7 +81,7 @@ impl Tab {
 
     pub fn seq(&self) -> usize {
         match &self.content {
-            ContentState::Open(TabContent::Markdown(md)) => md.buffer.current.seq,
+            ContentState::Open(TabContent::Markdown(md)) => md.renderer.buffer.current.seq,
             _ => 0,
         }
     }
@@ -267,7 +267,7 @@ impl TabContent {
 
     pub fn seq(&self) -> usize {
         match self {
-            TabContent::Markdown(md) => md.buffer.current.seq,
+            TabContent::Markdown(md) => md.renderer.buffer.current.seq,
             _ => 0,
         }
     }
@@ -277,7 +277,7 @@ impl TabContent {
     pub fn clone_content(&self) -> Option<TabSaveContent> {
         match self {
             TabContent::Markdown(md) => {
-                Some(TabSaveContent::String(md.buffer.current.text.clone()))
+                Some(TabSaveContent::String(md.renderer.buffer.current.text.clone()))
             }
             TabContent::Svg(svg) => Some(TabSaveContent::Svg(Box::new(svg.buffer.clone()))),
             _ => None,

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -624,7 +624,9 @@ impl Workspace {
                                     )));
                             } else {
                                 let md = tab.markdown_mut().unwrap();
-                                md.buffer.reload(String::from_utf8_lossy(&bytes).into());
+                                md.renderer
+                                    .buffer
+                                    .reload(String::from_utf8_lossy(&bytes).into());
                                 md.hmac = maybe_hmac;
                             }
                         }
@@ -668,7 +670,7 @@ impl Workspace {
                                 if let Some(md) = tab.markdown_mut() {
                                     if let TabSaveContent::String(content) = content {
                                         md.hmac = Some(hmac);
-                                        md.buffer.saved(seq, content);
+                                        md.renderer.buffer.saved(seq, content);
                                     }
                                 } else if let Some(svg) = tab.svg_mut() {
                                     if let TabSaveContent::Svg(content) = content {


### PR DESCRIPTION
* moves render-supporting fields into a new MdRender substruct of the editor
* places that now depend only on renderer get `impl Editor` -> `impl MdRender`
* places that still depend on editor get `self.field` -> `self.renderer.field`