### PR TITLE
md: factor mdedit

### DIFF
--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -427,7 +427,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getAllText(
         }
     };
 
-    env.new_string(&markdown.renderer.buffer.current.text)
+    env.new_string(&markdown.edit.renderer.buffer.current.text)
         .expect("Couldn't create JString from rust string!")
         .into_raw()
 }
@@ -440,7 +440,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getSelection(
 
     let resp = match obj.workspace.current_tab_markdown_mut() {
         Some(markdown) => {
-            let (start, end) = markdown.renderer.buffer.current.selection;
+            let (start, end) = markdown.edit.renderer.buffer.current.selection;
             JTextRange { none: false, start: start.0, end: end.0 }
         }
         None => JTextRange { none: true, start: 0, end: 0 },
@@ -477,6 +477,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getTextLength(
     };
 
     markdown
+        .edit
         .renderer
         .buffer
         .current
@@ -500,7 +501,13 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_clear(
         region: Region::BetweenLocations {
             start: Location::DocCharOffset(DocCharOffset(0)),
             end: Location::DocCharOffset(
-                markdown.renderer.buffer.current.segs.last_cursor_position(),
+                markdown
+                    .edit
+                    .renderer
+                    .buffer
+                    .current
+                    .segs
+                    .last_cursor_position(),
             ),
         },
         text: "".to_string(),
@@ -565,7 +572,15 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_append(
         Err(err) => format!("error: {err:?}"),
     };
 
-    let loc = Location::DocCharOffset(markdown.renderer.buffer.current.segs.last_cursor_position());
+    let loc = Location::DocCharOffset(
+        markdown
+            .edit
+            .renderer
+            .buffer
+            .current
+            .segs
+            .last_cursor_position(),
+    );
 
     obj.renderer.context.push_markdown_event(Event::Replace {
         region: Region::BetweenLocations { start: loc, end: loc },
@@ -591,7 +606,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getTextInRange(
     };
 
     let selection = (DocCharOffset(start as usize), DocCharOffset(end as usize));
-    env.new_string(&markdown.renderer.buffer[selection])
+    env.new_string(&markdown.edit.renderer.buffer[selection])
         .expect("Couldn't create JString from rust string!")
         .into_raw()
 }
@@ -612,9 +627,17 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_getBuffer(
         }
     };
 
-    let selection =
-        (DocCharOffset(0), markdown.renderer.buffer.current.segs.last_cursor_position());
-    env.new_string(&markdown.renderer.buffer[selection])
+    let selection = (
+        DocCharOffset(0),
+        markdown
+            .edit
+            .renderer
+            .buffer
+            .current
+            .segs
+            .last_cursor_position(),
+    );
+    env.new_string(&markdown.edit.renderer.buffer[selection])
         .expect("Couldn't create JString from rust string!")
         .into_raw()
 }
@@ -630,7 +653,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_selectAll(
         None => return,
     };
 
-    let segs = &markdown.renderer.buffer.current.segs;
+    let segs = &markdown.edit.renderer.buffer.current.segs;
 
     obj.renderer.context.push_markdown_event(Event::Select {
         region: Region::BetweenLocations {

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn has_text(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.renderer.buffer.is_empty()
+    !markdown.edit.renderer.buffer.is_empty()
 }
 
 /// # Safety
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *
 
     let range: Option<(DocCharOffset, DocCharOffset)> = range.into();
     if let Some(range) = range {
-        CString::new(&markdown.renderer.buffer[range])
+        CString::new(&markdown.edit.renderer.buffer[range])
             .expect("Could not Rust String -> C String")
             .into_raw()
     } else {
@@ -156,10 +156,13 @@ pub unsafe extern "C" fn get_selected(obj: *mut c_void) -> CTextRange {
     CTextRange {
         none: false,
         start: CTextPosition {
-            pos: markdown.renderer.buffer.current.selection.start().0,
+            pos: markdown.edit.renderer.buffer.current.selection.start().0,
             none: false,
         },
-        end: CTextPosition { pos: markdown.renderer.buffer.current.selection.end().0, none: false },
+        end: CTextPosition {
+            pos: markdown.edit.renderer.buffer.current.selection.end().0,
+            none: false,
+        },
     }
 }
 
@@ -252,6 +255,7 @@ pub unsafe extern "C" fn end_of_document(obj: *mut c_void) -> CTextPosition {
     };
 
     markdown
+        .edit
         .renderer
         .buffer
         .current
@@ -474,7 +478,13 @@ pub unsafe extern "C" fn position_offset(
 
     let start: Option<DocCharOffset> = start.into();
     if let Some(start) = start {
-        let last_cursor_position = markdown.renderer.buffer.current.segs.last_cursor_position();
+        let last_cursor_position = markdown
+            .edit
+            .renderer
+            .buffer
+            .current
+            .segs
+            .last_cursor_position();
 
         let result = if offset < 0 && -offset > start.0 as i32 {
             DocCharOffset::default()
@@ -515,7 +525,7 @@ pub unsafe extern "C" fn position_offset_in_direction(
 
     let mut result: DocCharOffset = start.pos.into();
     for _ in 0..offset {
-        result = markdown.advance(result, advance, backwards);
+        result = markdown.edit.advance(result, advance, backwards);
     }
 
     CTextPosition { none: start.none, pos: result.0 }
@@ -542,7 +552,9 @@ pub unsafe extern "C" fn is_position_at_bound(
     let text_position = pos.pos.into();
     let at_boundary = granularity.into();
 
-    markdown.is_position_at_boundary(text_position, at_boundary, backwards)
+    markdown
+        .edit
+        .is_position_at_boundary(text_position, at_boundary, backwards)
 }
 
 /// # Safety
@@ -566,7 +578,9 @@ pub unsafe extern "C" fn is_position_within_bound(
     let text_position = pos.pos.into();
     let at_boundary = granularity.into();
 
-    markdown.is_position_within_text_unit(text_position, at_boundary, backwards)
+    markdown
+        .edit
+        .is_position_within_text_unit(text_position, at_boundary, backwards)
 }
 
 /// # Safety
@@ -590,7 +604,7 @@ pub unsafe extern "C" fn bound_from_position(
         Advance::Next(granularity.into())
     };
 
-    Some(markdown.advance(text_position, advance, backwards)).into()
+    Some(markdown.edit.advance(text_position, advance, backwards)).into()
 }
 
 /// # Safety
@@ -614,7 +628,9 @@ pub unsafe extern "C" fn bound_at_position(
     let text_position = pos.pos.into();
     let with_granularity = granularity.into();
 
-    let result = markdown.range_enclosing_position(text_position, with_granularity, backwards);
+    let result = markdown
+        .edit
+        .range_enclosing_position(text_position, with_granularity, backwards);
 
     result.into()
 }
@@ -642,16 +658,21 @@ pub unsafe extern "C" fn first_rect(obj: *mut c_void, range: CTextRange) -> CRec
         };
         let mut selection_start = range.start();
         let selection_end = range.end();
-        selection_start = markdown.advance(selection_start, Advance::To(Bound::Line), false);
+        selection_start = markdown
+            .edit
+            .advance(selection_start, Advance::To(Bound::Line), false);
         let end_of_selection_start_line = selection_start;
         let end_of_rect = cmp::min(selection_end, end_of_selection_start_line);
         (selection_start, end_of_rect)
     };
 
-    let Some(start_line) = markdown.cursor_line(selection_representing_rect.start()) else {
+    let Some(start_line) = markdown
+        .edit
+        .cursor_line(selection_representing_rect.start())
+    else {
         return CRect::default();
     };
-    let Some(end_line) = markdown.cursor_line(selection_representing_rect.end()) else {
+    let Some(end_line) = markdown.edit.cursor_line(selection_representing_rect.end()) else {
         return CRect::default();
     };
 
@@ -689,8 +710,9 @@ pub unsafe extern "C" fn position_at_point(obj: *mut c_void, point: CPoint) -> C
         None => return CTextPosition::default(),
     };
 
-    let offset =
-        markdown.pos_to_char_offset(obj.renderer.pos_from_points(point.x as f32, point.y as f32));
+    let offset = markdown
+        .edit
+        .pos_to_char_offset(obj.renderer.pos_from_points(point.x as f32, point.y as f32));
 
     CTextPosition { none: false, pos: offset.0 }
 }
@@ -704,7 +726,7 @@ pub unsafe extern "C" fn get_text(obj: *mut c_void) -> *const c_char {
         None => return null(),
     };
 
-    let value = markdown.renderer.buffer.current.text.as_str();
+    let value = markdown.edit.renderer.buffer.current.text.as_str();
 
     CString::new(value)
         .expect("Could not Rust String -> C String")
@@ -721,7 +743,7 @@ pub unsafe extern "C" fn cursor_rect_at_position(obj: *mut c_void, pos: CTextPos
         None => return CRect::default(),
     };
 
-    let Some(line) = markdown.cursor_line(pos.pos.into()) else { return CRect::default() };
+    let Some(line) = markdown.edit.cursor_line(pos.pos.into()) else { return CRect::default() };
 
     CRect {
         min_x: line[0].x as f64,
@@ -766,7 +788,7 @@ pub unsafe extern "C" fn selection_rects(
     };
 
     let mut selection_rects = Vec::new();
-    for rect in markdown.range_rects(range) {
+    for rect in markdown.edit.range_rects(range) {
         selection_rects.push(CRect {
             min_x: rect.min.x as f64,
             min_y: rect.min.y as f64,
@@ -845,7 +867,7 @@ pub unsafe extern "C" fn can_undo(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.readonly && markdown.renderer.buffer.can_undo()
+    !markdown.edit.readonly && markdown.edit.renderer.buffer.can_undo()
 }
 
 /// # Safety
@@ -858,7 +880,7 @@ pub unsafe extern "C" fn can_redo(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.readonly && markdown.renderer.buffer.can_redo()
+    !markdown.edit.readonly && markdown.edit.renderer.buffer.can_redo()
 }
 
 /// # Safety

--- a/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
@@ -1,12 +1,12 @@
 use std::mem;
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdEdit;
 use crate::tab::markdown_editor::bounds::{BoundExt as _, RangesExt as _};
 use crate::tab::markdown_editor::input::{Advance, Increment};
 use egui::Pos2;
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-impl Editor {
+impl MdEdit {
     pub fn advance(
         &mut self, offset: DocCharOffset, advance: Advance, backwards: bool,
     ) -> DocCharOffset {

--- a/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
@@ -1,4 +1,4 @@
-use crate::tab::markdown_editor::{self, Editor};
+use crate::tab::markdown_editor::{self, MdEdit};
 use comrak::nodes::{AstNode, ListType, NodeHeading, NodeLink, NodeList, NodeValue};
 use egui::{self, Key, Modifiers};
 use lb_rs::model::text::offset_types::RangeExt as _;
@@ -25,7 +25,7 @@ impl From<Modifiers> for Advance {
 
 const PAGE_LINES: usize = 50;
 
-impl<'ast> Editor {
+impl<'ast> MdEdit {
     pub fn translate_egui_keyboard_event(
         &self, event: egui::Event, root: &'ast AstNode<'ast>,
     ) -> Option<Event> {

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -3,7 +3,7 @@ use std::mem;
 use egui::{Color32, Pos2, Rangef, Rect, Sense, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
 
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdEdit;
 
 use crate::tab::{ExtendedInput as _, markdown_editor::galleys::GalleyInfo};
 use crate::theme::palette_v2::ThemeExt as _;
@@ -18,7 +18,7 @@ pub struct CursorState {
     pub x_target: Option<f32>,
 }
 
-impl Editor {
+impl MdEdit {
     /// Highlights the provided range with a faded version of the provided accent color.
     pub fn show_range(
         &self, ui: &mut Ui, highlight_range: (DocCharOffset, DocCharOffset), color: Color32,

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -17,25 +17,25 @@ impl<'ast> Editor {
     pub fn process_events(&mut self, ctx: &Context, root: &'ast AstNode<'ast>) -> Response {
         let mut ops = Vec::new();
         let mut response = buffer::Response::default();
-        for event in mem::take(&mut self.event.internal_events) {
-            response |= self.calc_operations(ctx, root, event, &mut ops);
+        for event in mem::take(&mut self.edit.event.internal_events) {
+            response |= self.edit.calc_operations(ctx, root, event, &mut ops);
         }
         for event in self.get_workspace_events(ctx) {
-            response |= self.calc_operations(ctx, root, event, &mut ops);
+            response |= self.edit.calc_operations(ctx, root, event, &mut ops);
         }
         for event in self.get_key_events(ctx, root) {
-            response |= self.calc_operations(ctx, root, event, &mut ops);
+            response |= self.edit.calc_operations(ctx, root, event, &mut ops);
         }
         for event in self.get_pointer_events(ctx) {
-            response |= self.calc_operations(ctx, root, event, &mut ops);
+            response |= self.edit.calc_operations(ctx, root, event, &mut ops);
         }
-        self.renderer.buffer.queue(ops);
-        response |= self.renderer.buffer.update();
+        self.edit.renderer.buffer.queue(ops);
+        response |= self.edit.renderer.buffer.update();
         response
     }
 
     fn get_workspace_events(&self, ctx: &Context) -> Vec<Event> {
-        if self.readonly {
+        if self.edit.readonly {
             return Vec::new();
         }
 
@@ -66,7 +66,7 @@ impl<'ast> Editor {
                 })
             })
             .into_iter()
-            .filter_map(|e| self.translate_egui_keyboard_event(e, root))
+            .filter_map(|e| self.edit.translate_egui_keyboard_event(e, root))
             .collect::<Vec<_>>()
         } else {
             Vec::new()
@@ -96,7 +96,7 @@ impl<'ast> Editor {
 
                         if IconButton::new(Icon::CONTENT_CUT)
                             .tooltip("Cut")
-                            .disabled(self.readonly)
+                            .disabled(self.edit.readonly)
                             .show(ui)
                             .clicked()
                         {
@@ -115,7 +115,7 @@ impl<'ast> Editor {
                         ui.add_space(5.);
                         if IconButton::new(Icon::CONTENT_PASTE)
                             .tooltip("Paste")
-                            .disabled(self.readonly)
+                            .disabled(self.edit.readonly)
                             .show(ui)
                             .clicked()
                         {
@@ -144,14 +144,14 @@ impl<'ast> Editor {
                 if cfg!(target_os = "android") {
                     // android native context menu: multi-tapped for selection
                     // position based on text range of word that will be selected
-                    let offset = self.location_to_char_offset(location);
+                    let offset = self.edit.location_to_char_offset(location);
                     let range = offset
-                        .range_bound(Bound::Word, true, true, &self.renderer.bounds)
+                        .range_bound(Bound::Word, true, true, &self.edit.renderer.bounds)
                         .unwrap_or((offset, offset));
                     ctx.set_context_menu(self.context_menu_pos(range).unwrap_or(pos));
 
                     Region::BoundAt { bound: Bound::Word, location, backwards: true }
-                } else if self.renderer.buffer.current.selection.is_empty() {
+                } else if self.edit.renderer.buffer.current.selection.is_empty() {
                     // double click behavior
                     Region::BoundAt { bound: Bound::Word, location, backwards: true }
                 } else {
@@ -163,8 +163,9 @@ impl<'ast> Editor {
             } else if response.clicked() {
                 // android native context menu: tapped selection
                 if cfg!(target_os = "android") {
-                    let offset = self.pos_to_char_offset(pos);
+                    let offset = self.edit.pos_to_char_offset(pos);
                     if self
+                        .edit
                         .renderer
                         .buffer
                         .current
@@ -172,7 +173,7 @@ impl<'ast> Editor {
                         .contains(offset, true, true)
                     {
                         ctx.set_context_menu(
-                            self.context_menu_pos(self.renderer.buffer.current.selection)
+                            self.context_menu_pos(self.edit.renderer.buffer.current.selection)
                                 .unwrap_or(pos),
                         );
                         return Vec::new();
@@ -184,25 +185,28 @@ impl<'ast> Editor {
                 ctx.set_context_menu(pos);
                 return Vec::new();
             } else if response.drag_stopped() {
-                if let Some(in_progress_selection) = mem::take(&mut self.in_progress_selection) {
+                if let Some(in_progress_selection) = mem::take(&mut self.edit.in_progress_selection)
+                {
                     Region::from(in_progress_selection)
                 } else {
                     return Vec::new();
                 }
             } else if response.dragged() && modifiers.shift {
-                self.in_progress_selection =
-                    Some(self.region_to_range(Region::ToLocation(location)));
+                self.edit.in_progress_selection =
+                    Some(self.edit.region_to_range(Region::ToLocation(location)));
                 return Vec::new();
             } else if response.dragged() {
                 if response.drag_started() {
                     // convert drag origin on first frame so it doesn't update as we auto-scroll
                     let drag_origin = ctx.input(|i| i.pointer.press_origin()).unwrap_or_default();
-                    self.in_progress_selection =
-                        Some(self.region_to_range(Region::Location(Location::Pos(drag_origin))));
+                    self.edit.in_progress_selection = Some(
+                        self.edit
+                            .region_to_range(Region::Location(Location::Pos(drag_origin))),
+                    );
                 }
 
-                let offset = self.location_to_char_offset(location);
-                if let Some(in_progress_selection) = &mut self.in_progress_selection {
+                let offset = self.edit.location_to_char_offset(location);
+                if let Some(in_progress_selection) = &mut self.edit.in_progress_selection {
                     in_progress_selection.1 = offset;
                 }
 
@@ -228,12 +232,13 @@ impl<'ast> Editor {
     fn context_menu_pos(&self, range: (DocCharOffset, DocCharOffset)) -> Option<Pos2> {
         // find the first line of the selection
         let lines = self
+            .edit
             .renderer
             .bounds
             .wrap_lines
             .find_intersecting(range, false);
         let first_line = lines.iter().next()?;
-        let mut line = self.renderer.bounds.wrap_lines[first_line];
+        let mut line = self.edit.renderer.bounds.wrap_lines[first_line];
         if line.0 < range.start() {
             line.0 = range.start();
         }
@@ -242,8 +247,8 @@ impl<'ast> Editor {
         }
 
         // open the context menu in the center of the top of the rect containing the line
-        let start_line = self.cursor_line(line.0)?;
-        let end_line = self.cursor_line(line.1)?;
+        let start_line = self.edit.cursor_line(line.0)?;
+        let end_line = self.edit.cursor_line(line.1)?;
         Some(Pos2 { x: (start_line[1].x + end_line[1].x) / 2., y: start_line[0].y })
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -1,4 +1,4 @@
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdEdit;
 use crate::tab::markdown_editor::bounds::{BoundExt as _, RangesExt as _};
 use crate::tab::markdown_editor::galleys::Galleys;
 use crate::tab::markdown_editor::input::{Event, Increment};
@@ -23,7 +23,7 @@ pub struct EventState {
     pub internal_events: Vec<Event>,
 }
 
-impl<'ast> Editor {
+impl<'ast> MdEdit {
     /// Translates editor events into buffer operations by interpreting them in the context of the current editor state.
     /// Dispatches events that aren't buffer operations. Returns a (text_updated, selection_updated) pair.
     pub fn calc_operations(
@@ -1082,7 +1082,7 @@ pub fn distance(coord: f32, range: Rangef) -> f32 {
     }
 }
 
-impl<'ast> Editor {
+impl<'ast> MdEdit {
     fn dehead_ast_node(&self, node: &'ast AstNode<'ast>, operations: &mut Vec<Operation>) {
         if let Some(range) = self.renderer.head_range(node) {
             operations.push(Operation::Replace(Replace { range, text: "".into() }));

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -136,8 +136,37 @@ pub enum ScrollTarget {
     FindMatch,
 }
 
-pub struct Editor {
+/// Editing primitive — an [`MdRender`] plus the interactive state needed to
+/// mutate it. Self-contained so it can be used standalone (by a chat composer
+/// or a label+input pair) without needing an [`Editor`]'s widgets and
+/// workspace integration.
+pub struct MdEdit {
     pub renderer: MdRender,
+
+    pub cursor: CursorState,
+    pub event: EventState,
+
+    /// Capability flag — whether this editor may mutate the buffer. Preview
+    /// tabs set this to true; every mutation path in `input/canonical.rs`
+    /// early-returns when set.
+    pub readonly: bool,
+
+    /// Transient drag selection — `Some` while a drag is in progress; the
+    /// rendered cursor/selection falls back to the buffer's own selection
+    /// when `None`.
+    pub in_progress_selection: Option<(DocCharOffset, DocCharOffset)>,
+
+    /// Frame-scoped single-target scroll intent, consumed at the end of the
+    /// scroll area callback.
+    pub pending_scroll: Option<ScrollTarget>,
+
+    /// Momentum from the last scroll-area frame; used by `will_consume_touch`
+    /// to block touch cursor placement during momentum scroll.
+    pub scroll_area_velocity: Vec2,
+}
+
+pub struct Editor {
+    pub edit: MdEdit,
 
     // workspace dependencies
     pub core: Lb,
@@ -148,12 +177,8 @@ pub struct Editor {
     pub id_salt: Id,
     pub hmac: Option<DocumentHmac>,
     pub initialized: bool,
-    pub readonly: bool,
     pub phone_mode: bool,
 
-    // input processing
-    pub cursor: CursorState,
-    pub event: EventState,
     embeds_last_seen: u64,
 
     // interaction widgets
@@ -162,14 +187,8 @@ pub struct Editor {
     pub emoji_completions: EmojiCompletions,
     pub link_completions: LinkCompletions,
 
-    // selection state
-    pub in_progress_selection: Option<(DocCharOffset, DocCharOffset)>,
-
     // misc
-    pub scroll_area_velocity: Vec2,
     pub virtual_keyboard_shown: bool,
-
-    pending_scroll: Option<ScrollTarget>,
     pub unprocessed_scroll: Option<Instant>,
 
     // outputs from drawing a frame need an additional frame to process before reporting
@@ -403,7 +422,15 @@ impl Editor {
         };
 
         Self {
-            renderer,
+            edit: MdEdit {
+                renderer,
+                readonly,
+                cursor: Default::default(),
+                event: Default::default(),
+                in_progress_selection: None,
+                pending_scroll: None,
+                scroll_area_velocity: Default::default(),
+            },
 
             core,
             persistence,
@@ -412,11 +439,8 @@ impl Editor {
             id_salt: Id::NULL,
             hmac,
             initialized: Default::default(),
-            readonly,
             phone_mode,
 
-            cursor: Default::default(),
-            event: Default::default(),
             embeds_last_seen: 0,
 
             toolbar: Default::default(),
@@ -424,12 +448,8 @@ impl Editor {
             emoji_completions: Default::default(),
             link_completions: Default::default(),
 
-            in_progress_selection: None,
-
-            scroll_area_velocity: Default::default(),
             // this is used to toggle the mobile toolbar
             virtual_keyboard_shown: cfg!(target_os = "android"),
-            pending_scroll: None,
             unprocessed_scroll: Default::default(),
 
             next_resp: Default::default(),
@@ -502,7 +522,7 @@ impl Editor {
     }
 
     pub fn plaintext_mode(&self) -> bool {
-        self.renderer.plaintext_mode()
+        self.edit.renderer.plaintext_mode()
     }
 
     pub fn show(&mut self, ui: &mut Ui) -> Response {
@@ -512,27 +532,27 @@ impl Editor {
         let width = ui
             .max_rect()
             .width()
-            .min(self.renderer.layout.max_width)
+            .min(self.edit.renderer.layout.max_width)
             .round();
-        let height_updated = self.renderer.height != height;
-        let width_updated = self.renderer.width != width;
-        self.renderer.height = height;
-        self.renderer.width = width;
+        let height_updated = self.edit.renderer.height != height;
+        let width_updated = self.edit.renderer.width != width;
+        self.edit.renderer.height = height;
+        self.edit.renderer.width = width;
 
         let dark_mode = ui.style().visuals.dark_mode;
-        if dark_mode != self.renderer.dark_mode {
-            self.renderer.syntax.clear();
-            self.renderer.dark_mode = dark_mode;
+        if dark_mode != self.edit.renderer.dark_mode {
+            self.edit.renderer.syntax.clear();
+            self.edit.renderer.dark_mode = dark_mode;
         }
 
-        self.renderer.calc_source_lines();
+        self.edit.renderer.calc_source_lines();
 
         let start = web_time::Instant::now();
 
         let arena = Arena::new();
         let options = MdRender::comrak_options();
 
-        let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
+        let text_with_newline = self.edit.renderer.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
         let mut root = comrak::parse_document(&arena, &text_with_newline, &options);
 
         let ast_elapsed = start.elapsed();
@@ -551,20 +571,22 @@ impl Editor {
         let start = web_time::Instant::now();
 
         // process events
-        let prior_selection = self.renderer.buffer.current.selection;
+        let prior_selection = self.edit.renderer.buffer.current.selection;
         let embeds_updated = {
-            let current = self.renderer.embeds.last_modified();
+            let current = self.edit.renderer.embeds.last_modified();
             let changed = current != self.embeds_last_seen;
             self.embeds_last_seen = current;
             changed
         };
 
-        self.emoji_completions
-            .update_active_state(&self.renderer.buffer, &self.renderer.bounds.inline_paragraphs);
+        self.emoji_completions.update_active_state(
+            &self.edit.renderer.buffer,
+            &self.edit.renderer.bounds.inline_paragraphs,
+        );
         self.link_completions.update_active_state(
-            &self.renderer.buffer,
-            &self.renderer.bounds.inline_paragraphs,
-            &self.renderer.files,
+            &self.edit.renderer.buffer,
+            &self.edit.renderer.bounds.inline_paragraphs,
+            &self.edit.renderer.files,
             self.file_id,
         );
 
@@ -573,21 +595,21 @@ impl Editor {
         // handling never sees them while a popup is open. Escape is observed
         // (not consumed) inside handle_input and fires regardless of editor
         // focus, so the popup can always be dismissed.
-        if !self.readonly {
+        if !self.edit.readonly {
             let focused = self.focused(ui.ctx());
             self.emoji_completions.handle_input(
                 ui.ctx(),
-                &self.renderer.buffer,
+                &self.edit.renderer.buffer,
                 focused,
-                &mut self.event.internal_events,
+                &mut self.edit.event.internal_events,
             );
             self.link_completions.handle_input(
                 ui.ctx(),
-                &self.renderer.buffer,
-                &self.renderer.files,
+                &self.edit.renderer.buffer,
+                &self.edit.renderer.files,
                 self.file_id,
                 focused,
-                &mut self.event.internal_events,
+                &mut self.edit.event.internal_events,
             );
         }
 
@@ -598,21 +620,21 @@ impl Editor {
             resp.text_updated = true;
 
             // need to re-parse ast to compute bounds which are referenced by mobile virtual keyboard between frames
-            let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
+            let text_with_newline = self.edit.renderer.buffer.current.text.to_string() + "\n"; // todo: probably not okay but this parser quirky af sometimes
             root = comrak::parse_document(&arena, &text_with_newline, &options);
 
-            self.renderer.bounds.inline_paragraphs.clear();
-            self.renderer.layout_cache.invalidate_text_change();
+            self.edit.renderer.bounds.inline_paragraphs.clear();
+            self.edit.renderer.layout_cache.invalidate_text_change();
 
-            self.renderer.calc_source_lines();
-            self.renderer.compute_bounds(root);
-            self.renderer.bounds.inline_paragraphs.sort();
+            self.edit.renderer.calc_source_lines();
+            self.edit.renderer.compute_bounds(root);
+            self.edit.renderer.bounds.inline_paragraphs.sort();
 
-            self.renderer.calc_words();
+            self.edit.renderer.calc_words();
 
             // recompute find matches when text changes
             if let Some(term) = self.find.term.clone() {
-                self.find.matches = self.find.find_all(&self.renderer.buffer, &term);
+                self.find.matches = self.find.find_all(&self.edit.renderer.buffer, &term);
                 if self.find.matches.is_empty() {
                     self.find.current_match = None;
                 } else if let Some(idx) = self.find.current_match {
@@ -626,38 +648,43 @@ impl Editor {
         }
         resp.selection_updated = prior_selection
             != self
+                .edit
                 .in_progress_selection
-                .unwrap_or(self.renderer.buffer.current.selection);
+                .unwrap_or(self.edit.renderer.buffer.current.selection);
 
         // populate render inputs (find-related inputs are populated later by
         // show_find_centered, after Find::show advances state this frame —
         // otherwise galley_required_ranges/reveal_ranges would lag a frame and
         // scroll_to_find_match would have no galley to scroll to)
-        self.renderer.in_progress_selection = self.in_progress_selection;
-        self.renderer.reveal_ranges.clear();
-        if !self.readonly && self.focused(ui.ctx()) {
-            self.renderer
+        self.edit.renderer.in_progress_selection = self.edit.in_progress_selection;
+        self.edit.renderer.reveal_ranges.clear();
+        if !self.edit.readonly && self.focused(ui.ctx()) {
+            self.edit
+                .renderer
                 .reveal_ranges
-                .push(self.renderer.buffer.current.selection);
+                .push(self.edit.renderer.buffer.current.selection);
         }
-        self.renderer.text_highlight_range = self
+        self.edit.renderer.text_highlight_range = self
             .emoji_completions
             .search_term_range
             .or(self.link_completions.search_term_range);
 
-        ui.painter()
-            .rect_filled(ui.max_rect(), 0., self.renderer.ctx.get_lb_theme().neutral_bg());
-        self.renderer.apply_theme(ui);
+        ui.painter().rect_filled(
+            ui.max_rect(),
+            0.,
+            self.edit.renderer.ctx.get_lb_theme().neutral_bg(),
+        );
+        self.edit.renderer.apply_theme(ui);
         ui.spacing_mut().item_spacing.x = 0.;
 
         let scroll_area_id = ui
             .vertical(|ui| {
-                let scroll_area_id = if self.renderer.touch_mode {
+                let scroll_area_id = if self.edit.renderer.touch_mode {
                     self.show_find_centered(ui);
 
                     // ...then show editor content (or toolbar settings)...
                     let available_width = ui.available_width();
-                    let toolbar_height = if !self.readonly
+                    let toolbar_height = if !self.edit.readonly
                         && (self.virtual_keyboard_shown || self.toolbar.menu_open)
                     {
                         MOBILE_TOOL_BAR_SIZE
@@ -678,9 +705,9 @@ impl Editor {
 
                                 if !self.toolbar.menu_open {
                                     // these are computed during render
-                                    self.renderer.galleys.galleys.clear();
-                                    self.renderer.bounds.wrap_lines.clear();
-                                    self.renderer.touch_consuming_rects.clear();
+                                    self.edit.renderer.galleys.galleys.clear();
+                                    self.edit.renderer.bounds.wrap_lines.clear();
+                                    self.edit.renderer.touch_consuming_rects.clear();
 
                                     // show editor
                                     let scroll_area_id = ui.id().with(egui::Id::new(self.file_id));
@@ -694,7 +721,8 @@ impl Editor {
                                     let scroll_area_output = self.show_scrollable_editor(ui, root);
                                     self.next_resp.scroll_updated =
                                         scroll_area_output.state.offset.y != scroll_area_offset;
-                                    self.scroll_area_velocity = scroll_area_output.state.velocity();
+                                    self.edit.scroll_area_velocity =
+                                        scroll_area_output.state.velocity();
 
                                     Some(scroll_area_id)
                                 } else {
@@ -708,7 +736,9 @@ impl Editor {
                         .inner;
 
                     // ...then show toolbar at the bottom
-                    if !self.readonly && (self.virtual_keyboard_shown || self.toolbar.menu_open) {
+                    if !self.edit.readonly
+                        && (self.virtual_keyboard_shown || self.toolbar.menu_open)
+                    {
                         let (_, rect) =
                             ui.allocate_space(egui::vec2(available_width, MOBILE_TOOL_BAR_SIZE));
                         ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
@@ -726,21 +756,21 @@ impl Editor {
                             .y
                     });
 
-                    if !self.readonly {
+                    if !self.edit.readonly {
                         self.show_toolbar(root, ui);
                     }
                     self.show_find_centered(ui);
 
                     // these are computed during render
-                    self.renderer.galleys.galleys.clear();
-                    self.renderer.bounds.wrap_lines.clear();
-                    self.renderer.touch_consuming_rects.clear();
+                    self.edit.renderer.galleys.galleys.clear();
+                    self.edit.renderer.bounds.wrap_lines.clear();
+                    self.edit.renderer.touch_consuming_rects.clear();
 
                     // ...then show editor content
                     let scroll_area_output = self.show_scrollable_editor(ui, root);
                     self.next_resp.scroll_updated =
                         scroll_area_output.state.offset.y != scroll_area_offset;
-                    self.scroll_area_velocity = scroll_area_output.state.velocity();
+                    self.edit.scroll_area_velocity = scroll_area_output.state.velocity();
 
                     Some(scroll_area_id)
                 };
@@ -770,24 +800,34 @@ impl Editor {
                     let selection = (
                         start.clamp(
                             0.into(),
-                            self.renderer.buffer.current.segs.last_cursor_position(),
+                            self.edit
+                                .renderer
+                                .buffer
+                                .current
+                                .segs
+                                .last_cursor_position(),
                         ),
                         end.clamp(
                             0.into(),
-                            self.renderer.buffer.current.segs.last_cursor_position(),
+                            self.edit
+                                .renderer
+                                .buffer
+                                .current
+                                .segs
+                                .last_cursor_position(),
                         ),
                     );
-                    self.renderer.buffer.queue(vec![
+                    self.edit.renderer.buffer.queue(vec![
                         lb_rs::model::text::operation_types::Operation::Select(selection),
                     ]);
-                    self.renderer.buffer.update();
+                    self.edit.renderer.buffer.update();
                 }
 
                 scroll_area_id
             })
             .inner;
 
-        let text_areas = std::mem::take(&mut self.renderer.text_areas);
+        let text_areas = std::mem::take(&mut self.edit.renderer.text_areas);
         if !text_areas.is_empty() {
             ui.painter()
                 .add(egui_wgpu_renderer::egui_wgpu::Callback::new_paint_callback(
@@ -798,12 +838,12 @@ impl Editor {
         self.show_emoji_completions(ui);
         self.show_link_completions(ui);
 
-        self.renderer.syntax.garbage_collect();
+        self.edit.renderer.syntax.garbage_collect();
 
         let render_elapsed = start.elapsed();
 
-        if self.renderer.debug {
-            self.renderer.show_debug_fps(ui);
+        if self.edit.renderer.debug {
+            self.edit.renderer.show_debug_fps(ui);
         }
 
         if PRINT {
@@ -812,7 +852,7 @@ impl Editor {
                 "--------------------------------------------------------------------------------"
                     .bright_black()
             );
-            println!("document: {:?}", self.renderer.buffer.current.text);
+            println!("document: {:?}", self.edit.renderer.buffer.current.text);
             println!(
                 "{}",
                 "--------------------------------------------------------------------------------"
@@ -830,39 +870,42 @@ impl Editor {
         }
 
         // post-frame bookkeeping
-        let all_selected = self.renderer.buffer.current.selection
-            == (0.into(), self.renderer.last_cursor_position());
+        let all_selected = self.edit.renderer.buffer.current.selection
+            == (0.into(), self.edit.renderer.last_cursor_position());
         if embeds_updated || height_updated || width_updated {
             if embeds_updated {
                 self.unprocessed_scroll = Some(Instant::now());
             }
-            self.renderer.layout_cache.clear();
+            self.edit.renderer.layout_cache.clear();
             ui.ctx().request_repaint();
         } else if resp.selection_updated {
             let new_selection = self
+                .edit
                 .in_progress_selection
-                .unwrap_or(self.renderer.buffer.current.selection);
-            self.renderer
+                .unwrap_or(self.edit.renderer.buffer.current.selection);
+            self.edit
+                .renderer
                 .layout_cache
                 .invalidate_reveal_change(prior_selection, new_selection);
             ui.ctx().request_repaint();
         }
         if self.initialized && resp.selection_updated && !all_selected {
-            self.pending_scroll = Some(ScrollTarget::Cursor);
+            self.edit.pending_scroll = Some(ScrollTarget::Cursor);
             ui.ctx().request_repaint();
         }
-        if self.initialized && self.renderer.touch_mode && height_updated {
-            self.pending_scroll = Some(ScrollTarget::Cursor);
+        if self.initialized && self.edit.renderer.touch_mode && height_updated {
+            self.edit.pending_scroll = Some(ScrollTarget::Cursor);
             ui.ctx().request_repaint();
         }
         if self.next_resp.scroll_updated {
             self.unprocessed_scroll = Some(Instant::now());
             ui.ctx().request_repaint();
         }
-        self.event
+        self.edit
+            .event
             .internal_events
-            .append(&mut self.renderer.render_events);
-        if !self.event.internal_events.is_empty() {
+            .append(&mut self.edit.renderer.render_events);
+        if !self.edit.event.internal_events.is_empty() {
             ui.ctx().request_repaint();
         }
         // persistence: write
@@ -873,10 +916,10 @@ impl Editor {
                 .markdown
                 .file
                 .entry(self.file_id)
-                .and_modify(|f| f.selection = self.renderer.buffer.current.selection)
+                .and_modify(|f| f.selection = self.edit.renderer.buffer.current.selection)
                 .or_insert(MdFilePersistence {
                     scroll_offset: Default::default(),
-                    selection: self.renderer.buffer.current.selection,
+                    selection: self.edit.renderer.buffer.current.selection,
                     image_dims: Default::default(),
                 });
             persistence_updated = true;
@@ -889,7 +932,7 @@ impl Editor {
                     let state: Option<scroll_area::State> = ui.data(|d| d.get_temp(scroll_area_id));
                     let scroll_offset = if let Some(state) = state { state.offset.y } else { 0. };
 
-                    let image_dims = self.renderer.embeds.image_dims();
+                    let image_dims = self.edit.renderer.embeds.image_dims();
                     let mut persistence = self.persistence.data.write().unwrap();
                     persistence
                         .markdown
@@ -932,11 +975,12 @@ impl Editor {
     }
 
     pub fn will_consume_touch(&self, pos: Pos2) -> bool {
-        self.renderer
+        self.edit
+            .renderer
             .touch_consuming_rects
             .iter()
             .any(|rect| rect.contains(pos))
-            || self.scroll_area_velocity.abs().max_elem() > 0.
+            || self.edit.scroll_area_velocity.abs().max_elem() > 0.
             || self.toolbar.menu_open
     }
 
@@ -949,13 +993,13 @@ impl Editor {
             Margin::symmetric(0, 15)
         };
         ScrollArea::vertical()
-            .scroll_source(if self.renderer.touch_mode {
+            .scroll_source(if self.edit.renderer.touch_mode {
                 ScrollSource::ALL
             } else {
                 ScrollSource::SCROLL_BAR | ScrollSource::MOUSE_WHEEL
             })
             .id_salt(self.file_id)
-            .scroll_bar_visibility(if self.renderer.touch_mode {
+            .scroll_bar_visibility(if self.edit.renderer.touch_mode {
                 ScrollBarVisibility::AlwaysVisible
             } else {
                 ScrollBarVisibility::VisibleWhenNeeded
@@ -969,12 +1013,12 @@ impl Editor {
                             let scroll_view_height = ui.max_rect().height();
                             ui.allocate_space(Vec2 { x: ui.available_width(), y: 0. });
 
-                            let padding = (ui.available_width() - self.renderer.width) / 2.;
+                            let padding = (ui.available_width() - self.edit.renderer.width) / 2.;
 
-                            self.renderer.top_left = ui.max_rect().min
-                                + (padding + self.renderer.layout.margin) * Vec2::X;
+                            self.edit.renderer.top_left = ui.max_rect().min
+                                + (padding + self.edit.renderer.layout.margin) * Vec2::X;
                             let height = {
-                                let document_height = self.renderer.height(root, &[root]);
+                                let document_height = self.edit.renderer.height(root, &[root]);
                                 let unfilled_space = if document_height < scroll_view_height {
                                     scroll_view_height - document_height
                                 } else {
@@ -985,9 +1029,10 @@ impl Editor {
                                 document_height + unfilled_space.max(end_of_text_padding)
                             };
                             let rect = Rect::from_min_size(
-                                self.renderer.top_left,
+                                self.edit.renderer.top_left,
                                 Vec2::new(
-                                    self.renderer.width - 2. * self.renderer.layout.margin,
+                                    self.edit.renderer.width
+                                        - 2. * self.edit.renderer.layout.margin,
                                     height,
                                 ),
                             );
@@ -997,7 +1042,7 @@ impl Editor {
                             let response = ui.interact(
                                 rect,
                                 self.id(),
-                                if self.renderer.touch_mode {
+                                if self.edit.renderer.touch_mode {
                                     Sense::click()
                                 } else {
                                     Sense::click_and_drag()
@@ -1017,25 +1062,34 @@ impl Editor {
                             ui.advance_cursor_after_rect(rect);
 
                             ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
-                                self.renderer
-                                    .show_block(ui, root, self.renderer.top_left, &[root]);
+                                self.edit.renderer.show_block(
+                                    ui,
+                                    root,
+                                    self.edit.renderer.top_left,
+                                    &[root],
+                                );
                             });
                         });
                 });
-                self.renderer.galleys.galleys.sort_by_key(|g| g.range);
+                self.edit.renderer.galleys.galleys.sort_by_key(|g| g.range);
 
                 // show selection
                 if ui.ctx().os() != OperatingSystem::IOS {
                     let selection = self
+                        .edit
                         .in_progress_selection
-                        .unwrap_or(self.renderer.buffer.current.selection);
-                    let theme = self.renderer.ctx.get_lb_theme();
+                        .unwrap_or(self.edit.renderer.buffer.current.selection);
+                    let theme = self.edit.renderer.ctx.get_lb_theme();
                     let color = theme.bg().get_color(theme.prefs().primary);
-                    self.show_range(ui, selection, color.lerp_to_gamma(theme.neutral_bg(), 0.7));
-                    self.show_offset(ui, selection.1, color);
+                    self.edit.show_range(
+                        ui,
+                        selection,
+                        color.lerp_to_gamma(theme.neutral_bg(), 0.7),
+                    );
+                    self.edit.show_offset(ui, selection.1, color);
 
                     if self.focused(ui.ctx()) {
-                        if let Some([top, bot]) = self.cursor_line(selection.1) {
+                        if let Some([top, bot]) = self.edit.cursor_line(selection.1) {
                             let cursor_rect = egui::Rect::from_min_max(top, bot);
                             ui.output_mut(|o| {
                                 o.ime = Some(egui::output::IMEOutput {
@@ -1049,7 +1103,7 @@ impl Editor {
 
                 // show find match highlights
                 if !self.find.matches.is_empty() {
-                    let theme = self.renderer.ctx.get_lb_theme();
+                    let theme = self.edit.renderer.ctx.get_lb_theme();
                     let highlight_color = theme.neutral_bg_tertiary();
                     let current_color = theme.fg().yellow.lerp_to_gamma(theme.neutral_bg(), 0.5);
                     for (i, &match_range) in self.find.matches.iter().enumerate() {
@@ -1058,15 +1112,15 @@ impl Editor {
                         } else {
                             highlight_color
                         };
-                        self.show_range(ui, match_range, color);
+                        self.edit.show_range(ui, match_range, color);
                     }
                 }
 
                 if ui.ctx().os() == OperatingSystem::Android {
-                    self.show_selection_handles(ui);
+                    self.edit.show_selection_handles(ui);
                 }
-                match self.pending_scroll.take() {
-                    Some(ScrollTarget::Cursor) => self.scroll_to_cursor(ui),
+                match self.edit.pending_scroll.take() {
+                    Some(ScrollTarget::Cursor) => self.edit.scroll_to_cursor(ui),
                     Some(ScrollTarget::FindMatch) => self.scroll_to_find_match(ui),
                     None => {}
                 }
@@ -1075,10 +1129,10 @@ impl Editor {
 
     fn show_find_centered(&mut self, ui: &mut Ui) {
         let available = ui.available_width();
-        let content_width = if self.renderer.touch_mode {
-            self.renderer.width
+        let content_width = if self.edit.renderer.touch_mode {
+            self.edit.renderer.width
         } else {
-            self.toolbar_width().min(self.renderer.width)
+            self.toolbar_width().min(self.edit.renderer.width)
         };
         let content_left = ui.max_rect().left() + (available - content_width) / 2.;
         let top = ui.cursor().min.y;
@@ -1087,50 +1141,52 @@ impl Editor {
         let prev_match = self.find.current_match_range();
         let scope_resp = ui.scope_builder(egui::UiBuilder::new().max_rect(find_rect), |ui| {
             self.find
-                .show(&self.renderer.buffer, self.virtual_keyboard_shown, ui)
+                .show(&self.edit.renderer.buffer, self.virtual_keyboard_shown, ui)
         });
         let find_output = scope_resp.inner;
         let rendered_rect = scope_resp.response.rect;
         ui.advance_cursor_after_rect(rendered_rect);
         self.next_resp.find_widget_height = rendered_rect.height();
 
-        self.event.internal_events.extend(find_output.events);
+        self.edit.event.internal_events.extend(find_output.events);
         if find_output.scroll_to_match {
-            self.pending_scroll = Some(ScrollTarget::FindMatch);
+            self.edit.pending_scroll = Some(ScrollTarget::FindMatch);
         }
 
         // match-driven reveal-cache invalidation, mirroring the cursor-selection path
         let new_match = self.find.current_match_range();
         if prev_match != new_match {
             if let Some(old) = prev_match {
-                self.renderer
+                self.edit
+                    .renderer
                     .layout_cache
                     .invalidate_reveal_change(old, old);
             }
             if let Some(new) = new_match {
-                self.renderer
+                self.edit
+                    .renderer
                     .layout_cache
                     .invalidate_reveal_change(new, new);
             }
         }
         if find_output.closed {
-            self.renderer.layout_cache.clear();
+            self.edit.renderer.layout_cache.clear();
         }
 
         // bridge find state → renderer inputs for this frame's editor render.
         // Must happen after Find::show so galley_required_ranges and
         // reveal_ranges reflect the new current_match; otherwise the match
         // galley isn't built and scroll_to_find_match has nothing to scroll to.
-        self.renderer.find_current_match = new_match;
+        self.edit.renderer.find_current_match = new_match;
         if let Some(range) = new_match {
-            self.renderer.reveal_ranges.push(range);
+            self.edit.renderer.reveal_ranges.push(range);
         }
     }
 
     fn scroll_to_find_match(&self, ui: &mut Ui) {
         if let Some(idx) = self.find.current_match {
             if let Some(match_range) = self.find.matches.get(idx) {
-                let rects = self.range_rects(*match_range);
+                let rects = self.edit.range_rects(*match_range);
                 if let Some(rect) = rects.first() {
                     ui.scroll_to_rect(rect.expand(rect.height()), Some(egui::Align::Center));
                 }
@@ -1416,7 +1472,7 @@ mod test {
         /// Workspace.enterFrame() — runs a full headless egui frame through
         /// Editor::show(), processing all pending events.
         fn enter_frame(&mut self) {
-            let ctx = self.editor.renderer.ctx.clone();
+            let ctx = self.editor.edit.renderer.ctx.clone();
             let pending = std::mem::take(&mut self.pending);
             let _ = ctx.run(RawInput::default(), |ctx| {
                 ctx.set_lb_theme(Theme::default(Mode::Dark));
@@ -1431,11 +1487,11 @@ mod test {
         }
 
         fn get_text(&self) -> &str {
-            &self.editor.renderer.buffer.current.text
+            &self.editor.edit.renderer.buffer.current.text
         }
 
         fn get_selection(&self) -> (usize, usize) {
-            let sel = self.editor.renderer.buffer.current.selection;
+            let sel = self.editor.edit.renderer.buffer.current.selection;
             (sel.0.0, sel.1.0)
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/output/ui_text_input_tokenizer.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/output/ui_text_input_tokenizer.rs
@@ -1,4 +1,4 @@
-use crate::tab::markdown_editor::Editor;
+use crate::tab::markdown_editor::MdEdit;
 use crate::tab::markdown_editor::bounds::{BoundCase, BoundExt as _};
 use crate::tab::markdown_editor::input::Bound;
 use lb_rs::model::text::offset_types::{DocCharOffset, RangeExt as _};
@@ -27,7 +27,7 @@ pub trait UITextInputTokenizer {
     ) -> Option<(DocCharOffset, DocCharOffset)>;
 }
 
-impl UITextInputTokenizer for Editor {
+impl UITextInputTokenizer for MdEdit {
     fn is_position_at_boundary(
         &self, text_position: DocCharOffset, at_boundary: Bound, in_backward_direction: bool,
     ) -> bool {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
@@ -350,14 +350,14 @@ fn matching_shortcode<'a>(emoji: &'a emojis::Emoji, query: &str) -> &'a str {
 
 impl Editor {
     pub fn show_emoji_completions(&mut self, ui: &mut Ui) {
-        if self.readonly || !self.emoji_completions.active {
+        if self.edit.readonly || !self.emoji_completions.active {
             return;
         }
 
-        let Some((colon_offset, replace_end)) = detect_query(&self.renderer.buffer) else {
+        let Some((colon_offset, replace_end)) = detect_query(&self.edit.renderer.buffer) else {
             return;
         };
-        let Some(query) = query_from_range(&self.renderer.buffer, (colon_offset, replace_end))
+        let Some(query) = query_from_range(&self.edit.renderer.buffer, (colon_offset, replace_end))
         else {
             return;
         };
@@ -372,7 +372,7 @@ impl Editor {
         }
 
         // Anchor the popup at the opening colon so it doesn't shift right as the user types.
-        let Some([cursor_top, cursor_bot]) = self.cursor_line(colon_offset) else {
+        let Some([cursor_top, cursor_bot]) = self.edit.cursor_line(colon_offset) else {
             return;
         };
 
@@ -407,8 +407,8 @@ impl Editor {
                 let span_refs: Vec<(&str, bool)> =
                     s.iter().map(|(t, b)| (t.as_str(), *b)).collect();
                 let mut label = GlyphonLabel::new_rich(span_refs, text_color)
-                    .font_size(self.renderer.layout.completion_font_size)
-                    .line_height(self.renderer.layout.completion_line_height);
+                    .font_size(self.edit.renderer.layout.completion_font_size)
+                    .line_height(self.edit.renderer.layout.completion_line_height);
                 if let Some(hint) = hints.get(i) {
                     label = label.hint(hint, hint_color);
                 }
@@ -418,7 +418,7 @@ impl Editor {
 
         // -- Position popup --------------------------------------------------------
         let popup_width = max_width + POPUP_PADDING;
-        let popup_height = results.len() as f32 * self.renderer.layout.completion_row_height;
+        let popup_height = results.len() as f32 * self.edit.renderer.layout.completion_row_height;
         let screen_rect = ui.ctx().screen_rect();
         let popup_y = if cursor_top.y - popup_height >= screen_rect.min.y {
             cursor_top.y - popup_height
@@ -429,16 +429,17 @@ impl Editor {
             Pos2::new(cursor_top.x, popup_y),
             Vec2::new(popup_width, popup_height),
         );
-        self.renderer.touch_consuming_rects.push(popup_rect);
+        self.edit.renderer.touch_consuming_rects.push(popup_rect);
 
         let row_rects: Vec<Rect> = (0..results.len())
             .map(|i| {
                 Rect::from_min_size(
                     Pos2::new(
                         popup_rect.min.x,
-                        popup_rect.min.y + i as f32 * self.renderer.layout.completion_row_height,
+                        popup_rect.min.y
+                            + i as f32 * self.edit.renderer.layout.completion_row_height,
                     ),
-                    Vec2::new(popup_width, self.renderer.layout.completion_row_height),
+                    Vec2::new(popup_width, self.edit.renderer.layout.completion_row_height),
                 )
             })
             .collect();
@@ -454,7 +455,7 @@ impl Editor {
         }
 
         // -- Draw backgrounds ------------------------------------------------------
-        self.renderer.draw_completion_popup(
+        self.edit.renderer.draw_completion_popup(
             ui,
             popup_rect,
             &row_rects,
@@ -471,14 +472,14 @@ impl Editor {
             let text_top = rect.min.y + 4.0;
             let content_rect = Rect::from_min_size(
                 Pos2::new(rect.min.x + 8.0, text_top),
-                Vec2::new(popup_width - 16.0, self.renderer.layout.completion_line_height),
+                Vec2::new(popup_width - 16.0, self.edit.renderer.layout.completion_line_height),
             );
 
             let span_refs: Vec<(&str, bool)> =
                 spans.iter().map(|(t, b)| (t.as_str(), *b)).collect();
             let mut label = GlyphonLabel::new_rich(span_refs, text_color)
-                .font_size(self.renderer.layout.completion_font_size)
-                .line_height(self.renderer.layout.completion_line_height);
+                .font_size(self.edit.renderer.layout.completion_font_size)
+                .line_height(self.edit.renderer.layout.completion_line_height);
             if let Some(hint) = hints.get(idx) {
                 label = label.hint(hint, hint_color);
             }
@@ -496,7 +497,7 @@ impl Editor {
         // -- Apply clicked result --------------------------------------------------
         if let Some(idx) = clicked {
             self.emoji_completions.apply_completion(
-                &mut self.event.internal_events,
+                &mut self.edit.event.internal_events,
                 colon_offset,
                 replace_end,
                 shortcodes[idx],

--- a/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
@@ -658,28 +658,29 @@ fn abbreviate_segments(
 
 impl Editor {
     pub fn show_link_completions(&mut self, ui: &mut Ui) {
-        if self.readonly || !self.link_completions.active {
+        if self.edit.readonly || !self.link_completions.active {
             return;
         }
 
-        let Some(((bracket_start, replace_end), mode)) = detect_any(&self.renderer.buffer) else {
+        let Some(((bracket_start, replace_end), mode)) = detect_any(&self.edit.renderer.buffer)
+        else {
             return;
         };
-        let qr = query_range(&self.renderer.buffer, (bracket_start, replace_end), mode);
-        let query = self.renderer.buffer[qr].to_string();
+        let qr = query_range(&self.edit.renderer.buffer, (bracket_start, replace_end), mode);
+        let query = self.edit.renderer.buffer[qr].to_string();
 
         if self.link_completions.suppressed.as_deref() == Some(query.as_str()) {
             return;
         }
 
-        let cache = self.renderer.files.read().unwrap();
+        let cache = self.edit.renderer.files.read().unwrap();
         let mut results = search(&cache, self.file_id, &query, mode);
         drop(cache);
         if results.is_empty() {
             return;
         }
 
-        let Some([cursor_top, cursor_bot]) = self.cursor_line(bracket_start) else {
+        let Some([cursor_top, cursor_bot]) = self.edit.cursor_line(bracket_start) else {
             return;
         };
 
@@ -706,8 +707,8 @@ impl Editor {
             .enumerate()
             .map(|(i, r)| {
                 let mut label = GlyphonLabel::new(&r.name, text_color)
-                    .font_size(self.renderer.layout.completion_font_size)
-                    .line_height(self.renderer.layout.completion_line_height);
+                    .font_size(self.edit.renderer.layout.completion_font_size)
+                    .line_height(self.edit.renderer.layout.completion_line_height);
                 if let Some(shortcut) = shortcuts.get(i) {
                     label = label.hint(shortcut, hint_color);
                 }
@@ -717,8 +718,8 @@ impl Editor {
 
         let measure_path = |text: &str| -> f32 {
             GlyphonLabel::new(text, hint_color)
-                .font_size(self.renderer.layout.completion_font_size - 2.0)
-                .line_height(self.renderer.layout.completion_line_height)
+                .font_size(self.edit.renderer.layout.completion_font_size - 2.0)
+                .line_height(self.edit.renderer.layout.completion_line_height)
                 .measure(ui)
                 .x
         };
@@ -742,7 +743,7 @@ impl Editor {
             })
             .fold(0.0_f32, f32::max);
 
-        let popup_height = results.len() as f32 * self.renderer.layout.completion_row_height;
+        let popup_height = results.len() as f32 * self.edit.renderer.layout.completion_row_height;
         let screen_rect = ui.ctx().screen_rect();
         let popup_y = if cursor_top.y - popup_height >= screen_rect.min.y {
             cursor_top.y - popup_height
@@ -753,16 +754,17 @@ impl Editor {
             Pos2::new(cursor_top.x, popup_y),
             Vec2::new(popup_width, popup_height),
         );
-        self.renderer.touch_consuming_rects.push(popup_rect);
+        self.edit.renderer.touch_consuming_rects.push(popup_rect);
 
         let row_rects: Vec<Rect> = (0..results.len())
             .map(|i| {
                 Rect::from_min_size(
                     Pos2::new(
                         popup_rect.min.x,
-                        popup_rect.min.y + i as f32 * self.renderer.layout.completion_row_height,
+                        popup_rect.min.y
+                            + i as f32 * self.edit.renderer.layout.completion_row_height,
                     ),
-                    Vec2::new(popup_width, self.renderer.layout.completion_row_height),
+                    Vec2::new(popup_width, self.edit.renderer.layout.completion_row_height),
                 )
             })
             .collect();
@@ -778,7 +780,7 @@ impl Editor {
         }
 
         // -- Draw backgrounds ------------------------------------------------------
-        self.renderer.draw_completion_popup(
+        self.edit.renderer.draw_completion_popup(
             ui,
             popup_rect,
             &row_rects,
@@ -795,7 +797,7 @@ impl Editor {
             let text_top = rect.min.y + 4.0;
             let content_rect = Rect::from_min_size(
                 Pos2::new(rect.min.x + 8.0, text_top),
-                Vec2::new(popup_width - 16.0, self.renderer.layout.completion_line_height),
+                Vec2::new(popup_width - 16.0, self.edit.renderer.layout.completion_line_height),
             );
 
             // Name (bold on matched chars) + shortcut hint (e.g. ⌘1).
@@ -804,8 +806,8 @@ impl Editor {
             let span_refs: Vec<(&str, bool)> =
                 spans.iter().map(|(t, b)| (t.as_str(), *b)).collect();
             let mut label = GlyphonLabel::new_rich(span_refs, text_color)
-                .font_size(self.renderer.layout.completion_font_size)
-                .line_height(self.renderer.layout.completion_line_height);
+                .font_size(self.edit.renderer.layout.completion_font_size)
+                .line_height(self.edit.renderer.layout.completion_line_height);
             if let Some(shortcut) = shortcuts.get(idx) {
                 label = label.hint(shortcut, hint_color);
             }
@@ -823,12 +825,12 @@ impl Editor {
                 })
                 .collect();
             let shaped = GlyphonLabel::new_colored(colored_spans, hint_color)
-                .font_size(self.renderer.layout.completion_font_size - 2.0)
-                .line_height(self.renderer.layout.completion_line_height)
+                .font_size(self.edit.renderer.layout.completion_font_size - 2.0)
+                .line_height(self.edit.renderer.layout.completion_line_height)
                 .build(ui.ctx());
             let path_rect = Rect::from_min_size(
                 Pos2::new(content_rect.max.x - shortcut_width - 8.0 - shaped.size.x, text_top),
-                Vec2::new(shaped.size.x, self.renderer.layout.completion_line_height),
+                Vec2::new(shaped.size.x, self.edit.renderer.layout.completion_line_height),
             );
             text_areas.push(shaped.text_area(path_rect, ui.ctx(), clip_rect));
         }
@@ -844,7 +846,7 @@ impl Editor {
         if let Some(idx) = clicked {
             let r = &results[idx];
             self.link_completions.apply_completion(
-                &mut self.event.internal_events,
+                &mut self.edit.event.internal_events,
                 bracket_start,
                 replace_end,
                 &r.name,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
@@ -150,7 +150,7 @@ impl<'ast> Editor {
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.visuals_mut().widgets.active.bg_fill =
-                        self.renderer.ctx.get_lb_theme().fg().blue;
+                        self.edit.renderer.ctx.get_lb_theme().fg().blue;
 
                     let is_ios = cfg!(target_os = "ios");
                     let is_mobile = is_ios || cfg!(target_os = "android");
@@ -504,8 +504,8 @@ impl<'ast> Editor {
 
         for node in root.descendants() {
             if let NodeValue::Heading(NodeHeading { level, .. }) = &node.data.borrow().value {
-                if self.renderer.node_range(node).contains_range(
-                    &self.renderer.buffer.current.selection,
+                if self.edit.renderer.node_range(node).contains_range(
+                    &self.edit.renderer.buffer.current.selection,
                     true,
                     true,
                 ) {
@@ -541,9 +541,10 @@ impl<'ast> Editor {
         &self, icon: Icon, style: NodeValue, root: &'ast AstNode<'ast>, ui: &mut Ui,
     ) -> Option<Event> {
         let applied = if style.is_inline() {
-            self.inline_styled(root, self.renderer.buffer.current.selection, &style)
+            self.edit
+                .inline_styled(root, self.edit.renderer.buffer.current.selection, &style)
         } else {
-            self.unapply_block(root, &style)
+            self.edit.unapply_block(root, &style)
         };
 
         self.button(icon, style, applied, ui)
@@ -575,11 +576,11 @@ impl<'ast> Editor {
                     Frame::canvas(ui.style())
                         .inner_margin(margin)
                         .stroke(Stroke::NONE)
-                        .fill(self.renderer.ctx.get_lb_theme().neutral_bg())
+                        .fill(self.edit.renderer.ctx.get_lb_theme().neutral_bg())
                         .show(ui, |ui| {
                             // setup
                             ui.visuals_mut().widgets.active.bg_fill =
-                                self.renderer.ctx.get_lb_theme().fg().blue;
+                                self.edit.renderer.ctx.get_lb_theme().fg().blue;
 
                             let is_ios = cfg!(target_os = "ios");
 
@@ -587,24 +588,25 @@ impl<'ast> Editor {
 
                             let scroll_view_height = ui.max_rect().height();
                             ui.allocate_space(Vec2 { x: ui.available_width(), y: 0. });
-                            let padding = (ui.available_width() - self.renderer.width) / 2.;
+                            let padding = (ui.available_width() - self.edit.renderer.width) / 2.;
 
                             let mut top_left =
                                 ui.max_rect().min + (padding + MENU_MARGIN) * Vec2::X;
-                            let md_width = self.renderer.width - 2. * MENU_MARGIN;
+                            let md_width = self.edit.renderer.width - 2. * MENU_MARGIN;
 
                             // store values
-                            let source_lines = mem::take(&mut self.renderer.bounds.source_lines);
-                            let buffer = mem::take(&mut self.renderer.buffer);
+                            let source_lines =
+                                mem::take(&mut self.edit.renderer.bounds.source_lines);
+                            let buffer = mem::take(&mut self.edit.renderer.buffer);
                             let inline_paragraphs =
-                                mem::take(&mut self.renderer.bounds.inline_paragraphs);
+                                mem::take(&mut self.edit.renderer.bounds.inline_paragraphs);
 
-                            let galleys = mem::take(&mut self.renderer.galleys.galleys);
-                            let wrap_lines = mem::take(&mut self.renderer.bounds.wrap_lines);
+                            let galleys = mem::take(&mut self.edit.renderer.galleys.galleys);
+                            let wrap_lines = mem::take(&mut self.edit.renderer.bounds.wrap_lines);
                             let touch_consuming_rects =
-                                mem::take(&mut self.renderer.touch_consuming_rects);
+                                mem::take(&mut self.edit.renderer.touch_consuming_rects);
 
-                            self.renderer.layout_cache.clear();
+                            self.edit.renderer.layout_cache.clear();
 
                             // page title
                             ui.add_space(MENU_SPACE);
@@ -1014,20 +1016,20 @@ impl<'ast> Editor {
                             };
                             let rect = Rect::from_min_size(
                                 top_left,
-                                Vec2::new(self.renderer.width, height),
+                                Vec2::new(self.edit.renderer.width, height),
                             );
 
                             ui.advance_cursor_after_rect(rect);
 
                             // restore stored values
-                            self.renderer.buffer = buffer;
-                            self.renderer.bounds.source_lines = source_lines;
-                            self.renderer.bounds.inline_paragraphs = inline_paragraphs;
-                            self.renderer.calc_words();
+                            self.edit.renderer.buffer = buffer;
+                            self.edit.renderer.bounds.source_lines = source_lines;
+                            self.edit.renderer.bounds.inline_paragraphs = inline_paragraphs;
+                            self.edit.renderer.calc_words();
 
-                            self.renderer.galleys.galleys = galleys;
-                            self.renderer.bounds.wrap_lines = wrap_lines;
-                            self.renderer.touch_consuming_rects = touch_consuming_rects;
+                            self.edit.renderer.galleys.galleys = galleys;
+                            self.edit.renderer.bounds.wrap_lines = wrap_lines;
+                            self.edit.renderer.touch_consuming_rects = touch_consuming_rects;
                         });
                 });
             });
@@ -1062,75 +1064,77 @@ impl<'ast> Editor {
     }
 
     pub fn markdown_label_height(&mut self, md: &str) -> f32 {
-        self.renderer.buffer = md.into();
+        self.edit.renderer.buffer = md.into();
 
         // place cursor (affects capture)
-        self.renderer.buffer.queue(vec![Operation::Select(
-            self.renderer
+        self.edit.renderer.buffer.queue(vec![Operation::Select(
+            self.edit
+                .renderer
                 .buffer
                 .current
                 .segs
                 .last_cursor_position()
                 .into_range(),
         )]);
-        self.renderer.buffer.update();
+        self.edit.renderer.buffer.update();
 
         // parse
         let arena = Arena::new();
         let options = MdRender::comrak_options();
-        let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n";
+        let text_with_newline = self.edit.renderer.buffer.current.text.to_string() + "\n";
         let root = comrak::parse_document(&arena, &text_with_newline, &options);
 
         // pre-render work
-        self.renderer.calc_source_lines();
-        self.renderer.compute_bounds(root);
-        self.renderer.bounds.inline_paragraphs.sort();
-        self.renderer.calc_words();
+        self.edit.renderer.calc_source_lines();
+        self.edit.renderer.compute_bounds(root);
+        self.edit.renderer.bounds.inline_paragraphs.sort();
+        self.edit.renderer.calc_words();
 
-        let height = self.renderer.height(root, &[root]);
+        let height = self.edit.renderer.height(root, &[root]);
 
-        self.renderer.layout_cache.clear();
+        self.edit.renderer.layout_cache.clear();
 
         height
     }
 
     pub fn markdown_label(&mut self, ui: &mut Ui, top_left: Pos2, width: f32, md: &str) {
-        self.renderer.buffer = md.into();
+        self.edit.renderer.buffer = md.into();
 
         // place cursor (affects capture)
-        self.renderer.buffer.queue(vec![Operation::Select(
-            self.renderer
+        self.edit.renderer.buffer.queue(vec![Operation::Select(
+            self.edit
+                .renderer
                 .buffer
                 .current
                 .segs
                 .last_cursor_position()
                 .into_range(),
         )]);
-        self.renderer.buffer.update();
+        self.edit.renderer.buffer.update();
 
         // parse
         let arena = Arena::new();
         let options = MdRender::comrak_options();
-        let text_with_newline = self.renderer.buffer.current.text.to_string() + "\n";
+        let text_with_newline = self.edit.renderer.buffer.current.text.to_string() + "\n";
         let root = comrak::parse_document(&arena, &text_with_newline, &options);
 
         // pre-render work
-        self.renderer.calc_source_lines();
-        self.renderer.compute_bounds(root);
-        self.renderer.bounds.inline_paragraphs.sort();
-        self.renderer.calc_words();
+        self.edit.renderer.calc_source_lines();
+        self.edit.renderer.compute_bounds(root);
+        self.edit.renderer.bounds.inline_paragraphs.sort();
+        self.edit.renderer.calc_words();
 
-        let height = self.renderer.height(root, &[root]);
+        let height = self.edit.renderer.height(root, &[root]);
         let rect = Rect::from_min_size(top_left, Vec2::new(width, height));
 
-        self.renderer.show_block(
+        self.edit.renderer.show_block(
             &mut ui.new_child(UiBuilder::new().max_rect(rect).layout(*ui.layout())),
             root,
             top_left,
             &[root],
         );
 
-        self.renderer.layout_cache.clear();
+        self.edit.renderer.layout_cache.clear();
     }
 }
 

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -81,7 +81,7 @@ impl Tab {
 
     pub fn seq(&self) -> usize {
         match &self.content {
-            ContentState::Open(TabContent::Markdown(md)) => md.renderer.buffer.current.seq,
+            ContentState::Open(TabContent::Markdown(md)) => md.edit.renderer.buffer.current.seq,
             _ => 0,
         }
     }
@@ -267,7 +267,7 @@ impl TabContent {
 
     pub fn seq(&self) -> usize {
         match self {
-            TabContent::Markdown(md) => md.renderer.buffer.current.seq,
+            TabContent::Markdown(md) => md.edit.renderer.buffer.current.seq,
             _ => 0,
         }
     }
@@ -277,7 +277,7 @@ impl TabContent {
     pub fn clone_content(&self) -> Option<TabSaveContent> {
         match self {
             TabContent::Markdown(md) => {
-                Some(TabSaveContent::String(md.renderer.buffer.current.text.clone()))
+                Some(TabSaveContent::String(md.edit.renderer.buffer.current.text.clone()))
             }
             TabContent::Svg(svg) => Some(TabSaveContent::Svg(Box::new(svg.buffer.clone()))),
             _ => None,

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -513,7 +513,7 @@ impl Workspace {
     pub fn process_clip_events(&mut self) {
         let Some(file_id) = self.current_tab().and_then(|tab| {
             let md = tab.markdown()?;
-            if md.readonly { None } else { Some(md.file_id) }
+            if md.edit.readonly { None } else { Some(md.file_id) }
         }) else {
             return;
         };
@@ -695,7 +695,8 @@ impl Workspace {
                                     )));
                             } else {
                                 let md = tab.markdown_mut().unwrap();
-                                md.renderer
+                                md.edit
+                                    .renderer
                                     .buffer
                                     .reload(String::from_utf8_lossy(&bytes).into());
                                 md.hmac = maybe_hmac;
@@ -741,7 +742,7 @@ impl Workspace {
                                 if let Some(md) = tab.markdown_mut() {
                                     if let TabSaveContent::String(content) = content {
                                         md.hmac = Some(hmac);
-                                        md.renderer.buffer.saved(seq, content);
+                                        md.edit.renderer.buffer.saved(seq, content);
                                     }
                                 } else if let Some(svg) = tab.svg_mut() {
                                     if let TabSaveContent::Svg(content) = content {


### PR DESCRIPTION
* moves edit-supporting fields into a new MdEdit substruct of the editor
* places that now depend only on edit get `impl Editor` -> `impl MdEdit`
* places that still depend on editor get `self.field` -> `self.edit.field`
* toolbar, find, and completions notably remain on editor