### PR TITLE
cli: human-readable subscription renewal date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,6 +4570,7 @@ dependencies = [
 name = "lockbook"
 version = "26.4.14"
 dependencies = [
+ "chrono",
  "cli-rs 0.2.0",
  "colored 3.0.0",
  "fs_extra",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -20,3 +20,4 @@ lb-fs = { version = "26", path = "../../libs/lb-fs/" }
 fs_extra = "1.3.0"
 tokio = { version = "1.35.1", features = ["full"] }
 colored = "3.0.0"
+chrono = "0.4"

--- a/clients/cli/src/account.rs
+++ b/clients/cli/src/account.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::str::FromStr;
 
+use chrono::{TimeZone, Utc};
 use cli_rs::cli_error::{CliError, CliResult};
 
 use is_terminal::IsTerminal;
@@ -149,7 +150,12 @@ pub async fn status() -> Result<(), CliError> {
                 println!("state: {account_state:?}");
             }
         }
-        println!("renews on: {}", info.period_end);
+        let renewal_date = Utc
+            .timestamp_millis_opt(info.period_end as i64)
+            .single()
+            .map(|dt| dt.format("%B %d, %Y").to_string())
+            .unwrap_or_else(|| info.period_end.to_string());
+        println!("renews on: {}", renewal_date);
     } else {
         println!("trial tier");
     }


### PR DESCRIPTION
Formats the subscription `period_end` timestamp as a human-readable date (e.g., "April 21, 2026") instead of displaying the raw Unix timestamp in milliseconds.

**Before:** `renews on: 1776796574000`
**After:** `renews on: April 21, 2026`

Closes #4376