### PR TITLE
egui: cmd+click file tree opens in new tab

### DIFF
--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -827,6 +827,9 @@ impl FileTree {
             if !shift_clicked && ui.input(|i| i.raw.modifiers.command) {
                 cmd_clicked = true;
 
+                if file.is_document() {
+                    resp.open_requests.insert(id, OpenRequest::new_tab());
+                }
                 self.selected.insert(id);
             }
 


### PR DESCRIPTION
When cmd+clicking (ctrl+click on Windows/Linux) a document in the file tree, it now opens in a new tab instead of just adding it to the selection.

Closes #4455