### PR TITLE
egui: don't open welcome.md on account import

### DIFF
--- a/clients/egui/src/lib.rs
+++ b/clients/egui/src/lib.rs
@@ -98,9 +98,8 @@ impl Lockbook {
             // Account screen.
             Self::Onboard(screen) => {
                 if let Some(handoff) = screen.update(ctx) {
-                    let OnboardHandOff { settings, core, acct_data } = handoff;
+                    let OnboardHandOff { settings, core, acct_data, is_new_user } = handoff;
 
-                    let is_new_user = true;
                     let acct_scr = AccountScreen::new(settings, &core, acct_data, ctx, is_new_user);
                     *self = Self::Account(acct_scr);
 

--- a/clients/egui/src/onboard.rs
+++ b/clients/egui/src/onboard.rs
@@ -16,6 +16,7 @@ pub struct OnboardHandOff {
     pub settings: Arc<RwLock<Settings>>,
     pub core: Lb,
     pub acct_data: Vec<File>,
+    pub is_new_user: bool,
 }
 
 enum AccountUpdate {
@@ -95,6 +96,7 @@ impl OnboardScreen {
                             settings: self.settings.clone(),
                             core: self.core.clone(),
                             acct_data,
+                            is_new_user: true,
                         });
                     }
                     Err(msg) => {
@@ -115,6 +117,7 @@ impl OnboardScreen {
                             settings: self.settings.clone(),
                             core: self.core.clone(),
                             acct_data,
+                            is_new_user: false,
                         });
                     }
                     Err(err) => self.import_err = Some(err),


### PR DESCRIPTION
Only open the welcome.md document for newly created accounts, not for imported accounts. The `OnboardHandOff` now includes an `is_new_user` flag that distinguishes between account creation (`true`) and account import (`false`).

Closes #4272