### PR TITLE
cli: clipboard-aware account import/export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,6 +4570,7 @@ dependencies = [
 name = "lockbook"
 version = "26.4.14"
 dependencies = [
+ "arboard",
  "chrono",
  "cli-rs 0.2.0",
  "colored 3.0.0",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -20,4 +20,5 @@ lb-fs = { version = "26", path = "../../libs/lb-fs/" }
 fs_extra = "1.3.0"
 tokio = { version = "1.35.1", features = ["full"] }
 colored = "3.0.0"
+arboard = "3"
 chrono = "0.4"

--- a/clients/cli/src/account.rs
+++ b/clients/cli/src/account.rs
@@ -1,11 +1,13 @@
 use std::io;
 use std::str::FromStr;
 
+use arboard::Clipboard;
 use chrono::{TimeZone, Utc};
 use cli_rs::cli_error::{CliError, CliResult};
 
 use is_terminal::IsTerminal;
 use lb_rs::DEFAULT_API_LOCATION;
+use lb_rs::Lb;
 use lb_rs::model::api::{PaymentMethod, PaymentPlatform, StripeAccountTier};
 
 use crate::{core, ensure_account, input};
@@ -23,21 +25,38 @@ pub async fn new(username: String, api_url: ApiUrl) -> CliResult<()> {
 #[tokio::main]
 pub async fn import(api_url: ApiUrl) -> CliResult<()> {
     let lb = &core().await?;
-    if io::stdin().is_terminal() {
-        return Err(CliError::from("to import an existing lockbook account, pipe your account string into this command, e.g.:\npbpaste | lockbook account import".to_string()));
+
+    // if being piped, read from stdin
+    if !io::stdin().is_terminal() {
+        let mut account_string = String::new();
+        io::stdin()
+            .read_line(&mut account_string)
+            .map_err(|e| CliError::from(format!("failed to read from stdin: {e}")))?;
+        return import_key(lb, account_string.trim(), &api_url.0).await;
     }
 
-    let mut account_string = String::new();
-    io::stdin()
-        .read_line(&mut account_string)
-        .expect("failed to read from stdin");
-    account_string = account_string.trim().to_string();
+    // try clipboard first
+    if let Some(clip) = try_clipboard() {
+        println!("trying clipboard...");
+        if import_key(lb, &clip, &api_url.0).await.is_ok() {
+            return Ok(());
+        }
+        println!("clipboard did not contain a valid key.");
+    }
 
+    // fall back to prompting
+    let account_string: String = input::std_in("paste your private key: ")?;
+    import_key(lb, account_string.trim(), &api_url.0).await
+}
+
+fn try_clipboard() -> Option<String> {
+    Clipboard::new().ok()?.get_text().ok()
+}
+
+async fn import_key(lb: &Lb, key: &str, api_url: &str) -> CliResult<()> {
     println!("importing account...");
-    lb.import_account(&account_string, Some(&api_url.0)).await?;
-
+    lb.import_account(key, Some(api_url)).await?;
     println!("account imported! next, try to sync by running: lockbook sync");
-
     Ok(())
 }
 
@@ -46,24 +65,20 @@ pub async fn export(skip_check: bool) -> CliResult<()> {
     let lb = &core().await?;
     ensure_account(lb)?;
 
-    let should_ask = !skip_check;
-    let mut should_show = false;
+    // skip confirmation if piped or flag is set
+    let interactive = io::stdout().is_terminal();
+    let should_ask = interactive && !skip_check;
 
     if should_ask {
         let answer: String = input::std_in(
             "your private key is about to be visible. do you want to proceed? [y/n]: ",
         )?;
-        if answer == "y" || answer == "Y" {
-            should_show = true;
+        if answer != "y" && answer != "Y" {
+            return Ok(());
         }
-    } else {
-        should_show = true;
     }
 
-    if should_show {
-        print!("{}", lb.export_account_private_key()?);
-    }
-
+    print!("{}", lb.export_account_private_key()?);
     Ok(())
 }
 


### PR DESCRIPTION
**Import improvements:**
- When run interactively, tries clipboard contents first
- If clipboard doesn't contain a valid key, prompts user to paste
- When piped, reads from stdin as before

**Export improvements:**
- Skips confirmation prompt when output is piped (e.g., `lockbook account export | pbcopy`)
- Still prompts when run interactively unless `--skip-check` is passed

Closes #4418
Closes #2999
closes https://github.com/lockbook/lockbook/issues/3562