### PR TITLE
workspace: embedded images don't count as user activity

### DIFF
--- a/libs/content/workspace/src/resolvers/image_embed.rs
+++ b/libs/content/workspace/src/resolvers/image_embed.rs
@@ -43,7 +43,7 @@ impl EmbedResolver for ImageEmbedResolver {
     }
 
     fn show(&self, ui: &mut Ui, url: &str, rect: Rect) {
-        let state = self.images.get_or_load(url, self.file_id);
+        let state = self.images.get_or_load(url, self.file_id, false);
         let image_state = state.lock().unwrap().deref().clone();
         match image_state {
             ImageState::Loading => {
@@ -84,7 +84,7 @@ impl EmbedResolver for ImageEmbedResolver {
     }
 
     fn warm(&self, url: &str) {
-        let state = self.images.get_or_load(url, self.file_id);
+        let state = self.images.get_or_load(url, self.file_id, false);
         let guard = state.lock().unwrap();
         if let ImageState::Loaded(texture_id) = *guard {
             let [w, h] = self

--- a/libs/content/workspace/src/tab/image_viewer.rs
+++ b/libs/content/workspace/src/tab/image_viewer.rs
@@ -25,7 +25,7 @@ impl ImageViewer {
         painter.rect_filled(painter.clip_rect(), 0., ui.visuals().extreme_bg_color);
 
         let url = format!("lb://{}", self.id);
-        let state = self.images.get_or_load(&url, self.id);
+        let state = self.images.get_or_load(&url, self.id, true);
         let image_state = state.lock().unwrap().deref().clone();
 
         match image_state {

--- a/libs/content/workspace/src/widgets/image_cache.rs
+++ b/libs/content/workspace/src/widgets/image_cache.rs
@@ -115,10 +115,13 @@ impl ImageCache {
 
     /// Look up or spawn a load for the given URL. `from_file_id` is used to
     /// resolve relative paths and `lb://` URIs against the lockbook file tree.
+    /// `user_activity` indicates whether this read should count toward suggested docs.
     ///
     /// Call between `begin_frame` and `end_frame`. URLs not looked up during
     /// a frame are evicted at `end_frame` time.
-    pub fn get_or_load(&self, url: &str, from_file_id: Uuid) -> Arc<Mutex<ImageState>> {
+    pub fn get_or_load(
+        &self, url: &str, from_file_id: Uuid, user_activity: bool,
+    ) -> Arc<Mutex<ImageState>> {
         let mut inner = self.inner.lock().unwrap();
         if let Some(state) = inner.current.get(url) {
             return state.clone();
@@ -129,13 +132,19 @@ impl ImageCache {
         }
 
         let state: Arc<Mutex<ImageState>> = Default::default();
-        self.spawn_load(url, from_file_id, state.clone(), self.last_modified.clone());
+        self.spawn_load(
+            url,
+            from_file_id,
+            user_activity,
+            state.clone(),
+            self.last_modified.clone(),
+        );
         inner.current.insert(url.to_string(), state.clone());
         state
     }
 
     fn spawn_load(
-        &self, url: &str, from_file_id: Uuid, state: Arc<Mutex<ImageState>>,
+        &self, url: &str, from_file_id: Uuid, user_activity: bool, state: Arc<Mutex<ImageState>>,
         last_modified: Arc<AtomicU64>,
     ) {
         let url = url.to_string();
@@ -163,7 +172,8 @@ impl ImageCache {
 
             let texture_closure = async_on_wasm!({
                 let image_bytes = if let Some(id) = maybe_lb_id {
-                    core.read_document(id, false).map_err(|e| e.to_string())?
+                    core.read_document(id, user_activity)
+                        .map_err(|e| e.to_string())?
                 } else {
                     if !url.starts_with("http://") && !url.starts_with("https://") {
                         return Err(format!("image not found: {url}"));


### PR DESCRIPTION
Images embedded in markdown documents (via relative paths or lb:// URLs) shouldn't appear in suggested docs just because the containing document was viewed.

**Changes:**
- Added `user_activity` parameter to `ImageCache::get_or_load`
- Embedded images pass `false` (don't count toward suggested docs)
- Image viewer passes `true` (directly viewing an image should count)

Closes #2646