### PR TITLE
egui: fix file tree selection background color

### DIFF
--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -1045,10 +1045,10 @@ impl FileTree {
         let primary = theme.bg().get_color(theme.prefs().primary);
         let bg = theme.neutral_bg();
         if self.selected.contains(&file.id) {
-            default_fill = bg.lerp_to_gamma(primary, 0.1);
-            ui.visuals_mut().widgets.hovered.bg_fill = bg.lerp_to_gamma(primary, 0.2);
+            default_fill = primary.lerp_to_gamma(bg, 0.1);
+            ui.visuals_mut().widgets.hovered.bg_fill = primary.lerp_to_gamma(bg, 0.2);
         } else {
-            ui.visuals_mut().widgets.hovered.bg_fill = bg.lerp_to_gamma(primary, 0.1);
+            ui.visuals_mut().widgets.hovered.bg_fill = bg.lerp_to_gamma(primary, 0.5);
         }
 
         if self.cursor == Some(file.id) && focused {

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -1042,16 +1042,13 @@ impl FileTree {
             DocType::from_name(if is_renaming { &self.rename_buffer } else { &file.name });
 
         let mut default_fill = Color32::TRANSPARENT;
+        let primary = theme.bg().get_color(theme.prefs().primary);
+        let bg = theme.neutral_bg();
         if self.selected.contains(&file.id) {
-            ui.visuals_mut().widgets.hovered.bg_fill = theme
-                .bg()
-                .get_color(theme.prefs().primary)
-                .gamma_multiply(0.4);
+            default_fill = bg.lerp_to_gamma(primary, 0.1);
+            ui.visuals_mut().widgets.hovered.bg_fill = bg.lerp_to_gamma(primary, 0.2);
         } else {
-            ui.visuals_mut().widgets.hovered.bg_fill = theme
-                .bg()
-                .get_color(theme.prefs().primary)
-                .gamma_multiply(0.1);
+            ui.visuals_mut().widgets.hovered.bg_fill = bg.lerp_to_gamma(primary, 0.1);
         }
 
         if self.cursor == Some(file.id) && focused {
@@ -1328,7 +1325,7 @@ impl FileTree {
     }
 
     const BTN_ROUNDING: f32 = 5.0;
-    const BTN_MARGIN: Vec2 = egui::vec2(10.0, 0.0);
+    const BTN_MARGIN: Vec2 = egui::vec2(15.0, 0.0);
 }
 
 /// Model related things


### PR DESCRIPTION
Selected files in the file tree weren't showing a background color unless hovered. Now they display a subtle highlight (0.2 gamma multiplied primary color) to indicate selection.

Closes #4358