### PR TITLE
md: cleanup readonly/plaintext/interactive wiring

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -867,7 +867,7 @@ pub unsafe extern "C" fn can_undo(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.edit.readonly && markdown.edit.renderer.buffer.can_undo()
+    !markdown.edit.renderer.readonly && markdown.edit.renderer.buffer.can_undo()
 }
 
 /// # Safety
@@ -880,7 +880,7 @@ pub unsafe extern "C" fn can_redo(obj: *mut c_void) -> bool {
         None => return false,
     };
 
-    !markdown.edit.readonly && markdown.edit.renderer.buffer.can_redo()
+    !markdown.edit.renderer.readonly && markdown.edit.renderer.buffer.can_redo()
 }
 
 /// # Safety

--- a/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/canonical.rs
@@ -66,7 +66,7 @@ impl<'ast> MdEdit {
                 })
             }
             egui::Event::Paste(text) => {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
 
@@ -118,7 +118,7 @@ impl<'ast> MdEdit {
                 }
             }
             egui::Event::Text(text) => {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::Replace {
@@ -130,7 +130,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key, pressed: true, modifiers, .. }
                 if matches!(key, Key::Backspace | Key::Delete) =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::Delete {
@@ -150,13 +150,13 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Enter, pressed: true, modifiers, .. }
                 if !cfg!(target_os = "ios") =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::Newline { shift: modifiers.shift })
             }
             egui::Event::Key { key: Key::Tab, pressed: true, modifiers, .. } if !modifiers.alt => {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 if !modifiers.shift && cfg!(target_os = "ios") {
@@ -174,7 +174,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::X, pressed: true, modifiers, .. }
                 if modifiers.command && !modifiers.shift && !cfg!(target_os = "ios") =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::Cut)
@@ -188,19 +188,19 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Z, pressed: true, modifiers, .. }
                 if modifiers.command && !cfg!(target_os = "ios") =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 if !modifiers.shift { Some(Event::Undo) } else { Some(Event::Redo) }
             }
             egui::Event::Key { key: Key::B, pressed: true, modifiers, .. } if modifiers.command => {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle { region: Region::Selection, style: NodeValue::Strong })
             }
             egui::Event::Key { key: Key::I, pressed: true, modifiers, .. } if modifiers.command => {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle { region: Region::Selection, style: NodeValue::Emph })
@@ -208,7 +208,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::C, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 if !modifiers.alt {
@@ -228,7 +228,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::X, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle {
@@ -239,13 +239,13 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::H, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle { region: Region::Selection, style: NodeValue::Highlight })
             }
             egui::Event::Key { key: Key::U, pressed: true, modifiers, .. } if modifiers.command => {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle { region: Region::Selection, style: NodeValue::Underline })
@@ -253,7 +253,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::P, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle {
@@ -264,7 +264,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::S, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle { region: Region::Selection, style: NodeValue::Subscript })
@@ -272,7 +272,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::E, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle {
@@ -281,7 +281,7 @@ impl<'ast> MdEdit {
                 })
             }
             egui::Event::Key { key: Key::K, pressed: true, modifiers, .. } if modifiers.command => {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleStyle {
@@ -292,7 +292,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num7, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -308,7 +308,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num8, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -324,7 +324,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num9, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -341,7 +341,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num1, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -354,7 +354,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num2, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -367,7 +367,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num3, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -380,7 +380,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num4, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -393,7 +393,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num5, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -406,7 +406,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Num6, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -419,7 +419,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::Q, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -432,7 +432,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::R, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.alt =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some({
@@ -445,7 +445,7 @@ impl<'ast> MdEdit {
             egui::Event::Key { key: Key::D, pressed: true, modifiers, .. }
                 if modifiers.command && modifiers.shift =>
             {
-                if self.readonly {
+                if self.renderer.readonly {
                     return None;
                 }
                 Some(Event::ToggleFold)

--- a/libs/content/workspace/src/tab/markdown_editor/input/events.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/events.rs
@@ -8,7 +8,7 @@ impl Editor {
     /// and Paste are left for the workspace's image-import pass;
     /// `PredictedTouch` / `MultiTouchGesture` are left for other tabs.
     pub(crate) fn drain_workspace_events(&self, ctx: &Context) -> Vec<Event> {
-        if self.edit.readonly {
+        if self.edit.renderer.readonly {
             return Vec::new();
         }
         ctx.pop_events_where(&mut |e| {

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -106,7 +106,16 @@ pub struct MdRender {
     // render input
     pub in_progress_selection: Option<(DocCharOffset, DocCharOffset)>,
     pub find_current_match: Option<(DocCharOffset, DocCharOffset)>,
+    /// Gates fold UI. Stays true in readonly — fold is the one mutation
+    /// allowed there (saves are gated separately).
     pub interactive: bool,
+    /// Gates click on interactive render elements that mutate the doc
+    /// (task checkbox). Fold clicks ignore it (changes aren't saved)
+    pub readonly: bool,
+    /// When true, render via the per-line source text — no markdown block
+    /// parsing, no fold UI, no completion popups. Set at construction from
+    /// the non-`md` ext check; callers may also flip it directly.
+    pub plaintext: bool,
     pub reveal_ranges: Vec<(DocCharOffset, DocCharOffset)>,
     pub text_highlight_range: Option<(DocCharOffset, DocCharOffset)>,
 
@@ -146,11 +155,6 @@ pub struct MdEdit {
 
     pub cursor: CursorState,
     pub event: EventState,
-
-    /// Capability flag — whether this editor may mutate the buffer. Preview
-    /// tabs set this to true; every mutation path in `input/canonical.rs`
-    /// early-returns when set.
-    pub readonly: bool,
 
     /// No physical keyboard (phone or iPad compact mode). Used by completion
     /// popups to hide Cmd/Ctrl+N shortcut hints.
@@ -335,6 +339,8 @@ impl MdRender {
             in_progress_selection: None,
             find_current_match: None,
             interactive: false,
+            readonly: true,
+            plaintext: false,
             embeds: Box::new(()),
             link_resolver: Box::new(()),
             client: Default::default(),
@@ -370,6 +376,8 @@ impl MdRender {
             in_progress_selection: None,
             find_current_match: None,
             interactive: false,
+            readonly: true,
+            plaintext: false,
             embeds: Box::new(()),
             link_resolver: Box::new(()),
             client: Default::default(),
@@ -383,10 +391,6 @@ impl MdRender {
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
         }
-    }
-
-    pub fn plaintext_mode(&self) -> bool {
-        self.ext.to_lowercase() != "md"
     }
 
     /// Re-parse the buffer into a fresh AST and rebuild all text-derived
@@ -444,6 +448,7 @@ impl Editor {
     ) -> Self {
         let MdResources { ctx, core, persistence, files, link_resolver, embeds } = res;
         let MdConfig { readonly, ext, tablet_or_desktop } = cfg;
+        let plaintext = ext.to_lowercase() != "md";
 
         let dark_mode = ctx.style().visuals.dark_mode;
         let touch_mode = matches!(ctx.os(), OperatingSystem::Android | OperatingSystem::IOS);
@@ -469,7 +474,9 @@ impl Editor {
 
             in_progress_selection: None,
             find_current_match: None,
-            interactive: false,
+            interactive: true,
+            readonly,
+            plaintext,
             reveal_ranges: Vec::new(),
             text_highlight_range: None,
 
@@ -493,7 +500,6 @@ impl Editor {
         Self {
             edit: MdEdit {
                 renderer,
-                readonly,
                 phone_mode,
                 cursor: Default::default(),
                 event: Default::default(),
@@ -591,7 +597,7 @@ impl Editor {
     }
 
     pub fn plaintext_mode(&self) -> bool {
-        self.edit.renderer.plaintext_mode()
+        self.edit.renderer.plaintext
     }
 
     pub fn show(&mut self, ui: &mut Ui) -> Response {
@@ -690,7 +696,7 @@ impl Editor {
 
                     // ...then show editor content (or toolbar settings)...
                     let available_width = ui.available_width();
-                    let toolbar_height = if !self.edit.readonly
+                    let toolbar_height = if !self.edit.renderer.readonly
                         && (self.virtual_keyboard_shown || self.toolbar.menu_open)
                     {
                         MOBILE_TOOL_BAR_SIZE
@@ -744,7 +750,7 @@ impl Editor {
                         .inner;
 
                     // ...then show toolbar at the bottom
-                    if !self.edit.readonly
+                    if !self.edit.renderer.readonly
                         && (self.virtual_keyboard_shown || self.toolbar.menu_open)
                     {
                         let (_, rect) =
@@ -764,7 +770,7 @@ impl Editor {
                             .y
                     });
 
-                    if !self.edit.readonly {
+                    if !self.edit.renderer.readonly {
                         self.show_toolbar(root, ui);
                     }
                     self.show_find_centered(ui);

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -61,7 +61,7 @@ impl MdEdit {
             &files,
             file_id,
         );
-        if !self.readonly {
+        if !self.renderer.readonly && !self.renderer.plaintext {
             self.emoji_completions.handle_input(
                 ctx,
                 &self.renderer.buffer,
@@ -114,7 +114,7 @@ impl MdEdit {
         // after this returns and before `show` — those append-only additions
         // survive into render. `show` itself doesn't touch reveal_ranges.
         self.renderer.reveal_ranges.clear();
-        if !self.readonly && ctx.memory(|m| m.has_focus(id)) {
+        if !self.renderer.readonly && ctx.memory(|m| m.has_focus(id)) {
             self.renderer
                 .reveal_ranges
                 .push(self.renderer.buffer.current.selection);
@@ -172,7 +172,7 @@ impl MdEdit {
         ui.ctx()
             .style_mut(|s| s.visuals.window_stroke = Stroke::NONE);
         if !cfg!(target_os = "ios") && !cfg!(target_os = "android") {
-            let readonly = self.readonly;
+            let readonly = self.renderer.readonly;
             let mut menu_events: Vec<Event> = Vec::new();
             response.context_menu(|ui| {
                 ui.horizontal(|ui| {
@@ -328,7 +328,7 @@ impl MdEdit {
         self.renderer.galleys.galleys.sort_by_key(|g| g.range);
 
         // cursor / selection — iOS draws natively
-        if ui.ctx().os() != OperatingSystem::IOS && !self.readonly {
+        if ui.ctx().os() != OperatingSystem::IOS && !self.renderer.readonly {
             let selection = self
                 .in_progress_selection
                 .unwrap_or(self.renderer.buffer.current.selection);
@@ -409,6 +409,9 @@ impl MdEdit {
     /// clip — so popup text lands on a later glyphon layer and can extend
     /// past the editor's viewport (e.g. over a toolbar above the cursor).
     pub fn show_completions(&mut self, ui: &mut Ui) {
+        if self.renderer.plaintext {
+            return;
+        }
         self.show_emoji_completions(ui);
         self.show_link_completions(ui);
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
@@ -30,7 +30,7 @@ impl<'ast> MdRender {
         let width = self.width(node);
 
         let any_children = node.children().next().is_some();
-        if any_children && !self.plaintext_mode() {
+        if any_children && !self.plaintext {
             self.block_children_height(node)
         } else {
             let highlighter_syntax =
@@ -77,7 +77,7 @@ impl<'ast> MdRender {
         let width = self.width(node);
 
         let any_children = node.children().next().is_some();
-        if any_children && !self.plaintext_mode() {
+        if any_children && !self.plaintext {
             self.show_block_children(ui, node, top_left);
         } else {
             let has_syntax = syntax_set()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -128,12 +128,13 @@ impl<'ast> MdRender {
 
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
-        let show_fold_button = self.touch_mode
-            || hovered
-            || fold_button_space.contains(pointer)
-            || annotation_space.contains(pointer)
-            || self.fold(node).is_some()
-            || self.selected_fold_item(node);
+        let show_fold_button = self.interactive
+            && (self.touch_mode
+                || hovered
+                || fold_button_space.contains(pointer)
+                || annotation_space.contains(pointer)
+                || self.fold(node).is_some()
+                || self.selected_fold_item(node));
         if !show_fold_button {
             return;
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -35,10 +35,11 @@ impl<'ast> MdRender {
         let extra_height = self.layout.row_spacing / 2.;
         let clickable_space = checkbox_space.expand(extra_width.min(extra_height));
 
+        let sense = if self.readonly { Sense::hover() } else { Sense::click() };
         let checkbox_response =
             // ui.id().with() instead of Id::new() so two views of the same document
             // get distinct checkbox IDs
-            ui.interact(clickable_space, ui.id().with(self.node_range(node)), Sense::click());
+            ui.interact(clickable_space, ui.id().with(self.node_range(node)), sense);
         if checkbox_response.clicked() {
             let check_offset = self.check_offset(node);
             let new_check = if checked { ' ' } else { 'x' };
@@ -48,7 +49,7 @@ impl<'ast> MdRender {
                 advance_cursor: false,
             });
         }
-        if checkbox_response.hovered() {
+        if checkbox_response.hovered() && !self.readonly {
             ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
         }
         self.touch_consuming_rects.push(clickable_space);
@@ -111,12 +112,13 @@ impl<'ast> MdRender {
 
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
-        let show_fold_button = self.touch_mode
-            || hovered
-            || fold_button_space.contains(pointer)
-            || annotation_space.contains(pointer)
-            || self.fold(node).is_some()
-            || self.selected_fold_item(node);
+        let show_fold_button = self.interactive
+            && (self.touch_mode
+                || hovered
+                || fold_button_space.contains(pointer)
+                || annotation_space.contains(pointer)
+                || self.fold(node).is_some()
+                || self.selected_fold_item(node));
         if !show_fold_button {
             return;
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -162,11 +162,12 @@ impl<'ast> MdRender {
 
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
-        let show_fold_button = self.touch_mode
-            || hovered
-            || fold_button_space.contains(pointer)
-            || self.fold(node).is_some()
-            || self.selected_block(node);
+        let show_fold_button = self.interactive
+            && (self.touch_mode
+                || hovered
+                || fold_button_space.contains(pointer)
+                || self.fold(node).is_some()
+                || self.selected_block(node));
         if !show_fold_button {
             return;
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
@@ -350,7 +350,7 @@ fn matching_shortcode<'a>(emoji: &'a emojis::Emoji, query: &str) -> &'a str {
 
 impl MdEdit {
     pub fn show_emoji_completions(&mut self, ui: &mut Ui) {
-        if self.readonly || !self.emoji_completions.active {
+        if self.renderer.readonly || !self.emoji_completions.active {
             return;
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
@@ -658,7 +658,7 @@ fn abbreviate_segments(
 
 impl MdEdit {
     pub fn show_link_completions(&mut self, ui: &mut Ui) {
-        if self.readonly || !self.link_completions.active {
+        if self.renderer.readonly || !self.link_completions.active {
             return;
         }
 

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -513,7 +513,7 @@ impl Workspace {
     pub fn process_clip_events(&mut self) {
         let Some(file_id) = self.current_tab().and_then(|tab| {
             let md = tab.markdown()?;
-            if md.edit.readonly { None } else { Some(md.edit.file_id) }
+            if md.edit.renderer.readonly { None } else { Some(md.edit.file_id) }
         }) else {
             return;
         };


### PR DESCRIPTION
fold buttons can be used on readonly documents but disabled for other md experiences