### PR TITLE
lb & server: better, simpler networking for bigger files

### DIFF
--- a/libs/lb/lb-rs/src/model/pubkey.rs
+++ b/libs/lb/lb-rs/src/model/pubkey.rs
@@ -30,14 +30,13 @@ pub fn sign<T: Serialize>(
 
 pub fn verify<T: Serialize>(
     pk: &PublicKey, signed: &ECSigned<T>, max_delay_ms: u64, max_skew_ms: u64,
-    time_getter: TimeGetter,
+    current_time: i64,
 ) -> LbResult<()> {
     if &signed.public_key != pk {
         Err(LbErrKind::Sign(SignError::WrongPublicKey))?;
     }
 
     let auth_time = signed.timestamped_value.timestamp;
-    let current_time = time_getter().0;
     let max_skew_ms = max_skew_ms as i64;
     let max_delay_ms = max_delay_ms as i64;
 
@@ -90,14 +89,13 @@ mod unit_tests {
     use crate::model::pubkey::*;
 
     static EARLY_CLOCK: fn() -> Timestamp = || Timestamp(500);
-    static LATE_CLOCK: fn() -> Timestamp = || Timestamp(520);
 
     #[test]
     fn ec_test_sign_verify() {
         let sk = generate_key();
         let pk = PublicKey::from_secret_key(&sk);
         let value = sign(&sk, &pk, "Test", EARLY_CLOCK).unwrap();
-        verify(&pk, &value, 20, 20, LATE_CLOCK).unwrap();
+        verify(&pk, &value, 20, 20, 520).unwrap();
     }
 
     #[test]
@@ -105,7 +103,7 @@ mod unit_tests {
         let sk = generate_key();
         let pk = PublicKey::from_secret_key(&sk);
         let value = sign(&sk, &pk, "Test", EARLY_CLOCK).unwrap();
-        verify(&pk, &value, 10, 10, LATE_CLOCK).unwrap_err();
+        verify(&pk, &value, 10, 10, 520).unwrap_err();
     }
 
     #[test]

--- a/libs/lb/lb-rs/src/model/pubkey.rs
+++ b/libs/lb/lb-rs/src/model/pubkey.rs
@@ -29,8 +29,7 @@ pub fn sign<T: Serialize>(
 }
 
 pub fn verify<T: Serialize>(
-    pk: &PublicKey, signed: &ECSigned<T>, max_delay_ms: u64, max_skew_ms: u64,
-    current_time: i64,
+    pk: &PublicKey, signed: &ECSigned<T>, max_delay_ms: u64, max_skew_ms: u64, current_time: i64,
 ) -> LbResult<()> {
     if &signed.public_key != pk {
         Err(LbErrKind::Sign(SignError::WrongPublicKey))?;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -86,9 +86,7 @@ pub fn handle_version_header<Req: Request>(
 }
 
 pub fn verify_auth<TRequest>(
-    config: &config::Config,
-    request: &RequestWrapper<TRequest>,
-    request_time: clock::Timestamp,
+    config: &config::Config, request: &RequestWrapper<TRequest>, request_time: clock::Timestamp,
 ) -> LbResult<()>
 where
     TRequest: Request + Serialize,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -86,7 +86,9 @@ pub fn handle_version_header<Req: Request>(
 }
 
 pub fn verify_auth<TRequest>(
-    config: &config::Config, request: &RequestWrapper<TRequest>,
+    config: &config::Config,
+    request: &RequestWrapper<TRequest>,
+    request_time: clock::Timestamp,
 ) -> LbResult<()>
 where
     TRequest: Request + Serialize,
@@ -96,7 +98,7 @@ where
         &request.signed_request,
         config.server.max_auth_delay as u64,
         config.server.max_auth_delay as u64,
-        clock::get_time,
+        request_time.0,
     )
 }
 

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -83,19 +83,21 @@ macro_rules! core_req {
                             .with_label_values(&[<$Req>::ROUTE])
                             .start_timer();
 
-                        let request: RequestWrapper<$Req> =
-                            match deserialize_and_check(&state.config, request, version, request_time) {
-                                Ok(req) => req,
-                                Err(err) => {
-                                    warn!("request failed to parse: {:?}", err);
-                                    return warp::reply::with_status(
-                                        warp::reply::json::<Result<RequestWrapper<$Req>, _>>(&Err(
-                                            err,
-                                        )),
-                                        warp::http::StatusCode::BAD_REQUEST,
-                                    );
-                                }
-                            };
+                        let request: RequestWrapper<$Req> = match deserialize_and_check(
+                            &state.config,
+                            request,
+                            version,
+                            request_time,
+                        ) {
+                            Ok(req) => req,
+                            Err(err) => {
+                                warn!("request failed to parse: {:?}", err);
+                                return warp::reply::with_status(
+                                    warp::reply::json::<Result<RequestWrapper<$Req>, _>>(&Err(err)),
+                                    warp::http::StatusCode::BAD_REQUEST,
+                                );
+                            }
+                        };
 
                         let req_pk = request.signed_request.public_key;
                         let username = {
@@ -475,9 +477,7 @@ pub fn method(name: Method) -> impl Filter<Extract = (), Error = Rejection> + Cl
 }
 
 pub fn deserialize_and_check<Req>(
-    config: &Config,
-    request: Bytes,
-    version: Option<String>,
+    config: &Config, request: Bytes, version: Option<String>,
     request_time: lb_rs::model::clock::Timestamp,
 ) -> Result<RequestWrapper<Req>, ErrorWrapper<Req::Error>>
 where

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -51,11 +51,13 @@ macro_rules! core_req {
         method(<$Req>::METHOD)
             .and(warp::path(&<$Req>::ROUTE[1..]))
             .and(warp::any().map(move || cloned_state.clone()))
+            .and(warp::any().map(|| lb_rs::model::clock::get_time())) // Capture time before body
             .and(warp::body::bytes())
             .and(warp::header::optional::<String>("Accept-Version"))
             .and(warp::filters::addr::remote())
             .then(
                 |state: Arc<ServerState<S, A, G, D>>,
+                 request_time: lb_rs::model::clock::Timestamp,
                  request: Bytes,
                  version: Option<String>,
                  ip: Option<SocketAddr>| {
@@ -82,7 +84,7 @@ macro_rules! core_req {
                             .start_timer();
 
                         let request: RequestWrapper<$Req> =
-                            match deserialize_and_check(&state.config, request, version) {
+                            match deserialize_and_check(&state.config, request, version, request_time) {
                                 Ok(req) => req,
                                 Err(err) => {
                                     warn!("request failed to parse: {:?}", err);
@@ -473,7 +475,10 @@ pub fn method(name: Method) -> impl Filter<Extract = (), Error = Rejection> + Cl
 }
 
 pub fn deserialize_and_check<Req>(
-    config: &Config, request: Bytes, version: Option<String>,
+    config: &Config,
+    request: Bytes,
+    version: Option<String>,
+    request_time: lb_rs::model::clock::Timestamp,
 ) -> Result<RequestWrapper<Req>, ErrorWrapper<Req::Error>>
 where
     Req: Request + DeserializeOwned + Serialize,
@@ -485,7 +490,7 @@ where
         ErrorWrapper::<Req::Error>::BadRequest
     })?;
 
-    verify_auth(config, &request).map_err(|err| match err.kind {
+    verify_auth(config, &request, request_time).map_err(|err| match err.kind {
         LbErrKind::Sign(SignError::SignatureExpired(_))
         | LbErrKind::Sign(SignError::SignatureInTheFuture(_)) => {
             warn!("expired auth");


### PR DESCRIPTION
before tokio file uploads would timeout because of hardcoded timeouts inside reqwests. After tokio we got better defaults, but we would still only look at the request after the whole thing had made it into our server. So if you got a big file in but it took a long time, it would eventually fail because your auth expired. This captures the time before we start reading the body, and uses that at the time of auth checks. This also gets rid of the silly network retry we had in the mix. With a few of the other investments we've been making, practically speaking you should have no problems getting pretty large files into the server now. And they won't end up on your phone and other places you don't want them.

fixes #3276
fixes #1939

#3401 is naturally still open for the final state of these things, but this is a pretty low hanging improvement, which should dramatically improve the lives of multimedia heavy customers