### PR TITLE
lb & server: the usage api we deserve

### DIFF
--- a/libs/lb/lb-rs/src/model/file_like.rs
+++ b/libs/lb/lb-rs/src/model/file_like.rs
@@ -22,6 +22,7 @@ pub trait FileLike: PartialEq + Debug + Clone {
     fn document_hmac(&self) -> Option<&DocumentHmac>;
     fn user_access_keys(&self) -> &Vec<UserAccessInfo>;
     fn folder_access_key(&self) -> &EncryptedFolderAccessKey;
+    fn doc_size(&self) -> Option<usize>;
 
     fn display(&self) -> String {
         match self.file_type() {
@@ -116,6 +117,12 @@ impl FileLike for Meta {
             Meta::V1 { folder_access_key, .. } => folder_access_key,
         }
     }
+
+    fn doc_size(&self) -> Option<usize> {
+        match self {
+            Meta::V1 { doc_size, .. } => *doc_size,
+        }
+    }
 }
 
 impl<F> FileLike for F
@@ -165,6 +172,11 @@ where
     fn folder_access_key(&self) -> &EncryptedFolderAccessKey {
         let fm: &FileMetadata = self.as_ref();
         &fm.folder_access_key
+    }
+
+    fn doc_size(&self) -> Option<usize> {
+        // FileMetadata doesn't have doc_size field
+        None
     }
 }
 
@@ -222,6 +234,10 @@ impl FileLike for SignedMeta {
     fn folder_access_key(&self) -> &EncryptedFolderAccessKey {
         self.timestamped_value.value.folder_access_key()
     }
+
+    fn doc_size(&self) -> Option<usize> {
+        *self.timestamped_value.value.doc_size()
+    }
 }
 
 impl FileLike for ServerMeta {
@@ -259,5 +275,9 @@ impl FileLike for ServerMeta {
 
     fn folder_access_key(&self) -> &EncryptedFolderAccessKey {
         self.file.timestamped_value.value.folder_access_key()
+    }
+
+    fn doc_size(&self) -> Option<usize> {
+        *self.file.timestamped_value.value.doc_size()
     }
 }

--- a/libs/lb/lb-rs/src/model/lazy.rs
+++ b/libs/lb/lb-rs/src/model/lazy.rs
@@ -1,4 +1,5 @@
 use crate::model::access_info::UserAccessMode;
+use crate::model::api::METADATA_FEE;
 use crate::model::crypto::AESKey;
 use crate::model::errors::{LbErrKind, LbResult};
 use crate::model::file_like::FileLike;
@@ -126,6 +127,27 @@ impl<T: TreeLike> LazyTree<T> {
         }
 
         Ok(deleted)
+    }
+
+    /// Calculates the total usage in bytes for all non-deleted files owned by the owner.
+    /// This includes the document size plus METADATA_FEE for each file.
+    /// Files shared with this owner (but owned by others) are excluded.
+    pub fn calculate_usage(&mut self, owner: Owner) -> LbResult<u64> {
+        let mut total: u64 = 0;
+        for id in self.ids() {
+            // Check owner first
+            let file_owner = self.find(&id)?.owner();
+            if file_owner != owner {
+                continue;
+            }
+            // Skip deleted files
+            if self.calculate_deleted(&id)? {
+                continue;
+            }
+            let file_size = self.find(&id)?.doc_size().unwrap_or(0) as u64;
+            total += file_size + METADATA_FEE;
+        }
+        Ok(total)
     }
 
     pub fn decrypt_key(&mut self, id: &Uuid, keychain: &Keychain) -> LbResult<AESKey> {

--- a/libs/lb/lb-rs/src/model/server_ops.rs
+++ b/libs/lb/lb-rs/src/model/server_ops.rs
@@ -1,5 +1,4 @@
 use super::errors::{DiffError, LbErrKind, LbResult};
-use super::meta::Meta;
 use super::server_meta::{IntoServerMeta, ServerMeta};
 use super::signed_meta::SignedMeta;
 use crate::model::clock::get_time;
@@ -7,47 +6,11 @@ use crate::model::file_like::FileLike;
 use crate::model::file_metadata::FileDiff;
 use crate::model::lazy::{LazyStaged1, LazyTree};
 use crate::model::server_tree::ServerTree;
-use crate::model::signed_file::SignedFile;
 use crate::model::tree_like::TreeLike;
 
 type LazyServerStaged1<'a> = LazyStaged1<ServerTree<'a>, Vec<ServerMeta>>;
 
 impl<'a> LazyTree<ServerTree<'a>> {
-    /// Validates a diff prior to staging it. Performs individual validations, then validations that
-    /// require a tree
-    pub fn stage_diff(self, changes: Vec<FileDiff<SignedFile>>) -> LbResult<LazyServerStaged1<'a>> {
-        let mut changes_meta: Vec<FileDiff<SignedMeta>> = vec![];
-        for change in changes {
-            let mut new_meta: SignedMeta = change.new.into();
-            let mut old_meta = change.old.map(SignedMeta::from);
-            if let Some(old) = &mut old_meta {
-                let current_size = *self
-                    .maybe_find(old.id())
-                    .ok_or(LbErrKind::Diff(DiffError::OldFileNotFound))?
-                    .file
-                    .timestamped_value
-                    .value
-                    .doc_size();
-
-                match &mut old.timestamped_value.value {
-                    Meta::V1 { doc_size, .. } => {
-                        *doc_size = current_size;
-                    }
-                };
-
-                match &mut new_meta.timestamped_value.value {
-                    Meta::V1 { doc_size, .. } => {
-                        *doc_size = current_size;
-                    }
-                };
-            }
-
-            changes_meta.push(FileDiff { old: old_meta, new: new_meta });
-        }
-
-        self.stage_diff_v2(changes_meta)
-    }
-
     pub fn stage_diff_v2(
         self, mut changes: Vec<FileDiff<SignedMeta>>,
     ) -> LbResult<LazyServerStaged1<'a>> {

--- a/libs/lb/lb-rs/src/model/server_ops.rs
+++ b/libs/lb/lb-rs/src/model/server_ops.rs
@@ -12,7 +12,7 @@ type LazyServerStaged1<'a> = LazyStaged1<ServerTree<'a>, Vec<ServerMeta>>;
 
 impl<'a> LazyTree<ServerTree<'a>> {
     pub fn stage_diff_v2(
-        self, mut changes: Vec<FileDiff<SignedMeta>>,
+        self, changes: Vec<FileDiff<SignedMeta>>,
     ) -> LbResult<LazyServerStaged1<'a>> {
         // Check new.id == old.id
         for change in &changes {
@@ -51,7 +51,7 @@ impl<'a> LazyTree<ServerTree<'a>> {
         }
 
         // Check for race conditions and populate prior size
-        for change in &mut changes {
+        for change in &changes {
             match &change.old {
                 Some(old) => {
                     let current = &self
@@ -72,12 +72,18 @@ impl<'a> LazyTree<ServerTree<'a>> {
             }
         }
 
+        Ok(self.stage_unvalidated(changes))
+    }
+
+    pub fn stage_unvalidated(
+        self, changes: Vec<FileDiff<SignedMeta>>,
+    ) -> LazyServerStaged1<'a> {
         let now = get_time().0 as u64;
         let changes = changes
             .into_iter()
             .map(|change| change.new.add_time(now))
             .collect();
 
-        Ok(self.stage(changes))
+        self.stage(changes)
     }
 }

--- a/libs/lb/lb-rs/src/model/server_ops.rs
+++ b/libs/lb/lb-rs/src/model/server_ops.rs
@@ -75,9 +75,7 @@ impl<'a> LazyTree<ServerTree<'a>> {
         Ok(self.stage_unvalidated(changes))
     }
 
-    pub fn stage_unvalidated(
-        self, changes: Vec<FileDiff<SignedMeta>>,
-    ) -> LazyServerStaged1<'a> {
+    pub fn stage_unvalidated(self, changes: Vec<FileDiff<SignedMeta>>) -> LazyServerStaged1<'a> {
         let now = get_time().0 as u64;
         let changes = changes
             .into_iter()

--- a/libs/lb/lb-rs/tests/get_usage_tests.rs
+++ b/libs/lb/lb-rs/tests/get_usage_tests.rs
@@ -345,3 +345,47 @@ async fn sharee_cannot_exceed_sharer_data_cap() {
     let result = core_b.sync().await;
     assert_eq!(result.unwrap_err().kind, LbErrKind::UsageIsOverDataCap);
 }
+
+#[tokio::test]
+async fn sharee_cannot_exceed_sharer_data_cap_via_metadata() {
+    let core_a = test_core_with_account().await;
+    let core_b = test_core_with_account().await;
+    let account_b = core_b.get_account().unwrap();
+
+    // A shares a folder with B
+    let folder = core_a.create_at_path("shared_folder/").await.unwrap();
+    core_a
+        .share_file(folder.id, &account_b.username, ShareMode::Write)
+        .await
+        .unwrap();
+    core_a.sync().await.unwrap();
+
+    // B syncs and creates a link to the shared folder
+    core_b.sync().await.unwrap();
+    core_b.create_link_at_path("link", folder.id).await.unwrap();
+    core_b.sync().await.unwrap();
+
+    // B creates a large document that uses most of A's data cap
+    // Account for: root (1) + shared_folder (1) + large.md (1) = 3 files of metadata already
+    // Leave room for ~5 more files of metadata
+    let large_doc = core_b
+        .create_file("large.md", &folder.id, FileType::Document)
+        .await
+        .unwrap();
+    let content_size = FREE_TIER_USAGE_SIZE - (METADATA_FEE * 8);
+    let content: Vec<u8> = (0..content_size).map(|_| rand::random::<u8>()).collect();
+    core_b.write_document(large_doc.id, &content).await.unwrap();
+    core_b.sync().await.unwrap();
+
+    // Now B creates more empty files to exceed A's cap via metadata alone
+    for i in 0..10 {
+        core_b
+            .create_file(&format!("file{i}.md"), &folder.id, FileType::Document)
+            .await
+            .unwrap();
+    }
+
+    // B's sync should fail because the metadata would exceed A's data cap
+    let result = core_b.sync().await;
+    assert_eq!(result.unwrap_err().kind, LbErrKind::UsageIsOverDataCap);
+}

--- a/libs/lb/lb-rs/tests/get_usage_tests.rs
+++ b/libs/lb/lb-rs/tests/get_usage_tests.rs
@@ -309,3 +309,39 @@ async fn shared_docs_excluded() {
 
     assert_eq!(cores[1].get_usage().await.unwrap().usages.len(), 2);
 }
+
+#[tokio::test]
+async fn sharee_cannot_exceed_sharer_data_cap() {
+    let core_a = test_core_with_account().await;
+    let core_b = test_core_with_account().await;
+    let account_b = core_b.get_account().unwrap();
+
+    // A shares a folder with B
+    let folder = core_a.create_at_path("shared_folder/").await.unwrap();
+    core_a
+        .share_file(folder.id, &account_b.username, ShareMode::Write)
+        .await
+        .unwrap();
+    core_a.sync().await.unwrap();
+
+    // B syncs and creates a link to the shared folder
+    core_b.sync().await.unwrap();
+    core_b.create_link_at_path("link", folder.id).await.unwrap();
+    core_b.sync().await.unwrap();
+
+    // B creates 5 documents in the shared folder, each 1/4th of free tier usage
+    // The 5th file should exceed A's data cap
+    let file_size = FREE_TIER_USAGE_SIZE / 4;
+    for i in 0..5 {
+        let doc = core_b
+            .create_file(&format!("doc{i}.md"), &folder.id, FileType::Document)
+            .await
+            .unwrap();
+        let content: Vec<u8> = (0..file_size).map(|_| rand::random::<u8>()).collect();
+        core_b.write_document(doc.id, &content).await.unwrap();
+    }
+
+    // B's sync should fail because the content would exceed A's data cap
+    let result = core_b.sync().await;
+    assert_eq!(result.unwrap_err().kind, LbErrKind::UsageIsOverDataCap);
+}

--- a/server/src/account_service.rs
+++ b/server/src/account_service.rs
@@ -22,8 +22,7 @@ use lb_rs::model::api::{
 use lb_rs::model::clock::get_time;
 use lb_rs::model::file_like::FileLike;
 use lb_rs::model::file_metadata::Owner;
-use lb_rs::model::lazy::LazyTree;
-use lb_rs::model::server_meta::{IntoServerMeta, ServerMeta};
+use lb_rs::model::server_meta::IntoServerMeta;
 use lb_rs::model::server_tree::ServerTree;
 use lb_rs::model::tree_like::TreeLike;
 use lb_rs::model::usage::bytes_to_human;
@@ -156,65 +155,34 @@ where
         let db = lock.deref_mut();
 
         let cap = Self::get_cap(db, &context.public_key)?;
+        let owner = Owner(context.public_key);
 
         let mut tree = ServerTree::new(
-            Owner(context.public_key),
+            owner,
             &mut db.owned_files,
             &mut db.shared_files,
             &mut db.file_children,
             &mut db.metas,
         )?
         .to_lazy();
-        let usages = Self::get_usage_helper(&mut tree)?;
-        Ok(GetUsageResponse { usages, cap })
-    }
 
-    pub fn get_usage_helper<T>(
-        tree: &mut LazyTree<T>,
-    ) -> Result<Vec<FileUsage>, ServerError<GetUsageHelperError>>
-    where
-        T: TreeLike<F = ServerMeta>,
-    {
-        let ids = tree.ids();
-        let root_id = ids
-            .iter()
-            .find(|file_id| match tree.find(file_id) {
-                Ok(f) => f.is_root(),
-                Err(_) => false,
-            })
-            .ok_or(ClientError(GetUsageHelperError::UserDeleted))?;
-
-        let root_owner = tree
-            .maybe_find(root_id)
-            .ok_or(ClientError(GetUsageHelperError::UserDeleted))?
-            .owner();
-
-        let result = ids
-            .iter()
-            .filter_map(|&file_id| {
-                let file = match tree.find(&file_id) {
-                    Ok(file) => {
-                        if file.owner() != root_owner {
-                            return None;
-                        }
-                        file.clone()
-                    }
-                    _ => {
-                        return None;
-                    }
-                };
-
-                match tree.calculate_deleted(&file_id).unwrap_or(true) {
-                    true => None,
-                    false => {
-                        let file_size =
-                            file.file.timestamped_value.value.doc_size().unwrap_or(0) as u64;
-                        Some(FileUsage { file_id, size_bytes: file_size + METADATA_FEE })
-                    }
+        let usages = tree
+            .ids()
+            .into_iter()
+            .filter_map(|file_id| {
+                if tree.calculate_deleted(&file_id).unwrap_or(true) {
+                    return None;
                 }
+                let file = tree.find(&file_id).ok()?;
+                if file.owner() != owner {
+                    return None;
+                }
+                let file_size = file.doc_size().unwrap_or(0) as u64;
+                Some(FileUsage { file_id, size_bytes: file_size + METADATA_FEE })
             })
             .collect();
-        Ok(result)
+
+        Ok(GetUsageResponse { usages, cap })
     }
 
     pub fn get_cap(
@@ -403,13 +371,7 @@ where
         )?
         .to_lazy();
 
-        let usage: u64 = Self::get_usage_helper(&mut tree)
-            .map_err(|err| {
-                internal!("Cannot find user's usage, owner: {:?}, err: {:?}", owner, err)
-            })?
-            .iter()
-            .map(|a| a.size_bytes)
-            .sum();
+        let usage = tree.calculate_usage(owner)?;
 
         let usage_str = bytes_to_human(usage);
 
@@ -504,7 +466,6 @@ where
 #[derive(Debug)]
 pub enum GetUsageHelperError {
     UserNotFound,
-    UserDeleted,
 }
 
 #[derive(Debug)]

--- a/server/src/billing/billing_service.rs
+++ b/server/src/billing/billing_service.rs
@@ -286,10 +286,7 @@ where
             )?
             .to_lazy();
 
-            let usage: u64 = Self::get_usage_helper(&mut tree)?
-                .iter()
-                .map(|a| a.size_bytes)
-                .sum();
+            let usage = tree.calculate_usage(Owner(context.public_key))?;
 
             if usage > FREE_TIER_USAGE_SIZE {
                 debug!("Cannot downgrade user to free since they are over the data cap");

--- a/server/src/error_handler.rs
+++ b/server/src/error_handler.rs
@@ -349,7 +349,11 @@ impl From<LbErr> for ServerError<UpsertError> {
 
 impl From<LbErr> for ServerError<ChangeDocError> {
     fn from(err: LbErr) -> Self {
-        internal!("{:?}", err)
+        use lb_rs::model::api::ChangeDocError::*;
+        match err.kind {
+            LbErrKind::InsufficientPermission => ClientError(NotPermissioned),
+            _ => internal!("{:?}", err),
+        }
     }
 }
 

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -43,9 +43,42 @@ where
             let db = lock.deref_mut();
             let tx = db.begin_transaction()?;
 
-            let usage_cap =
-                Self::get_cap(db, &context.public_key).map_err(|err| internal!("{:?}", err))?;
+            // Collect unique owners from the updates
+            let mut affected_owners: HashSet<Owner> = HashSet::new();
+            for update in &request.updates {
+                affected_owners.insert(update.new.owner());
+            }
 
+            // Get usage caps and calculate old/new usage for each affected owner
+            // Each owner needs their own tree to see all their files
+            for &owner in &affected_owners {
+                let usage_cap =
+                    Self::get_cap(db, &owner.0).map_err(|err| internal!("{:?}", err))?;
+
+                let mut tree = ServerTree::new(
+                    owner,
+                    &mut db.owned_files,
+                    &mut db.shared_files,
+                    &mut db.file_children,
+                    &mut db.metas,
+                )?
+                .to_lazy();
+
+                let old_usage = tree.calculate_usage(owner)?;
+
+                let mut tree = tree.stage_diff_v2(request.updates.clone())?;
+                tree.assert_changes_authorized(req_owner)?;
+                let new_usage = tree.calculate_usage(owner)?;
+
+                debug!(?owner, ?old_usage, ?new_usage, ?usage_cap, "usage caps on upsert");
+
+                if new_usage > usage_cap && new_usage >= old_usage {
+                    warn!(?owner, "user over cap");
+                    return Err(ClientError(UpsertError::UsageIsOverDataCap));
+                }
+            }
+
+            // Now do the actual operation with requester's tree
             let mut tree = ServerTree::new(
                 req_owner,
                 &mut db.owned_files,
@@ -54,12 +87,6 @@ where
                 &mut db.metas,
             )?
             .to_lazy();
-
-            let old_usage = Self::get_usage_helper(&mut tree)
-                .map_err(|err| internal!("{:?}", err))?
-                .iter()
-                .map(|f| f.size_bytes)
-                .sum::<u64>();
 
             for id in tree.ids() {
                 if tree.calculate_deleted(&id)? {
@@ -75,19 +102,6 @@ where
             }
 
             tree.validate(req_owner)?;
-
-            let new_usage = Self::get_usage_helper(&mut tree)
-                .map_err(|err| internal!("{:?}", err))?
-                .iter()
-                .map(|f| f.size_bytes)
-                .sum::<u64>();
-
-            debug!(?old_usage, ?new_usage, ?usage_cap, "usage caps on upsert");
-
-            if new_usage > usage_cap && new_usage >= old_usage {
-                warn!("user over cap");
-                return Err(ClientError(UpsertError::UsageIsOverDataCap));
-            }
 
             let tree = tree.promote()?;
 

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -127,137 +127,88 @@ where
         &self, context: RequestContext<ChangeDocRequestV2>,
     ) -> Result<(), ServerError<ChangeDocError>> {
         use ChangeDocError::*;
-        let owner = Owner(context.public_key);
-        let request = context.request;
-        let id = *request.diff.id();
+        let ChangeDocRequestV2 { diff, new_content } = context.request;
 
         // Validate Diff
-        if request.diff.diff() != vec![Diff::Hmac] {
+        if diff.diff() != vec![Diff::Hmac] {
             return Err(ClientError(DiffMalformed));
         }
 
-        match request.diff.new.timestamped_value.value.doc_size() {
+        match diff.new.timestamped_value.value.doc_size() {
             Some(size) => {
-                if *size != request.new_content.value.len() {
+                if *size != new_content.value.len() {
                     return Err(ClientError(NewSizeIncorrect));
                 }
             }
             None => {
                 // do we even want to support this?
-                if !request.new_content.value.is_empty() {
+                if !new_content.value.is_empty() {
                     return Err(ClientError(NewSizeIncorrect));
                 }
             }
         }
 
-        let hmac = if let Some(hmac) = request.diff.new.document_hmac() {
-            base64::encode_config(hmac, base64::URL_SAFE)
-        } else {
-            return Err(ClientError(HmacMissing));
-        };
+        let hmac_bytes = *diff.new.document_hmac().ok_or(ClientError(HmacMissing))?;
+        let hmac = base64::encode_config(hmac_bytes, base64::URL_SAFE);
 
-        let req_pk = context.public_key;
+        let requester = Owner(context.public_key);
+        let id = *diff.id();
+        let new_meta = diff.new.clone().add_time(get_time().0 as u64);
 
-        {
-            let mut lock = self.index_db.lock().await;
-            let db = lock.deref_mut();
-            let usage_cap = Self::get_cap(db, &context.public_key)
-                .map_err(|err| internal!("{:?}", err))? as usize;
+        // phase 1: validate request before io
+        let mut lock = self.index_db.lock().await;
+        let db = lock.deref_mut();
+        let og_meta = db
+            .metas
+            .get()
+            .get(&id)
+            .ok_or(ClientError(DocumentNotFound))?
+            .clone();
+        let tree_owner = og_meta.owner();
 
-            let meta = db
-                .metas
-                .get()
-                .get(request.diff.new.id())
-                .ok_or(ClientError(DocumentNotFound))?
-                .clone();
+        let usage_cap = Self::get_cap(db, &tree_owner.0).map_err(|err| internal!("{:?}", err))?;
 
-            let mut tree = ServerTree::new(
-                owner,
-                &mut db.owned_files,
-                &mut db.shared_files,
-                &mut db.file_children,
-                &mut db.metas,
-            )?
-            .to_lazy();
+        let mut tree = ServerTree::new(
+            tree_owner,
+            &mut db.owned_files,
+            &mut db.shared_files,
+            &mut db.file_children,
+            &mut db.metas,
+        )?
+        .to_lazy();
 
-            let old_usage = Self::get_usage_helper(&mut tree)
-                .map_err(|err| internal!("{:?}", err))?
-                .iter()
-                .map(|f| f.size_bytes)
-                .sum::<u64>() as usize;
-            let old_size = *meta.file.timestamped_value.value.doc_size();
+        let old_usage = tree.calculate_usage(tree_owner)?;
+        let current_meta = &tree
+            .maybe_find(&id)
+            .ok_or(ClientError(DocumentNotFound))?
+            .file;
 
-            let new_size = request.new_content.value.len();
-
-            let new_usage = old_usage - old_size.unwrap_or_default() + new_size;
-
-            debug!(?old_usage, ?new_usage, ?usage_cap, "usage caps on change doc");
-
-            if new_usage > usage_cap {
-                warn!("user over cap");
-                return Err(ClientError(UsageIsOverDataCap));
+        if let Some(old) = &diff.old {
+            if current_meta != old {
+                return Err(ClientError(OldVersionIncorrect));
             }
-
-            let meta_owner = meta.owner();
-
-            let direct_access = meta_owner.0 == req_pk;
-
-            if tree.maybe_find(request.diff.new.id()).is_none() {
-                return Err(ClientError(NotPermissioned));
-            }
-
-            let mut share_access = false;
-            if !direct_access {
-                for ancestor in tree
-                    .ancestors(request.diff.id())?
-                    .iter()
-                    .chain(vec![request.diff.new.id()])
-                {
-                    let meta = tree.find(ancestor)?;
-
-                    if meta
-                        .user_access_keys()
-                        .iter()
-                        .any(|access| access.encrypted_for == req_pk)
-                    {
-                        share_access = true;
-                        break;
-                    }
-                }
-            }
-
-            if !direct_access && !share_access {
-                return Err(ClientError(NotPermissioned));
-            }
-
-            let meta = &tree
-                .maybe_find(request.diff.new.id())
-                .ok_or(ClientError(DocumentNotFound))?
-                .file;
-
-            if let Some(old) = &request.diff.old {
-                if meta != old {
-                    return Err(ClientError(OldVersionIncorrect));
-                }
-            }
-
-            if tree.calculate_deleted(request.diff.new.id())? {
-                return Err(ClientError(DocumentDeleted));
-            }
-
-            let id = request.diff.new.id();
-            let hmac = request.diff.new.document_hmac().unwrap();
-            db.scheduled_file_cleanups.remove(&(*id, *hmac))?;
         }
 
-        let new_version = get_time().0 as u64;
-        let new = request.diff.new.clone().add_time(new_version);
+        if tree.calculate_deleted(&id)? {
+            return Err(ClientError(DocumentDeleted));
+        }
+
+        let mut tree = tree.stage(vec![new_meta.clone()]);
+        tree.validate(requester)?;
+        let new_usage = tree.calculate_usage(tree_owner)?;
+
+        debug!(?old_usage, ?new_usage, ?usage_cap, "usage caps on change doc");
+
+        if new_usage > usage_cap && new_usage >= old_usage {
+            warn!("user over cap");
+            return Err(ClientError(UsageIsOverDataCap));
+        }
+
+        db.scheduled_file_cleanups.remove(&(id, hmac_bytes))?;
+        drop(lock);
+
         self.document_service
-            .insert(
-                request.diff.new.id(),
-                request.diff.new.document_hmac().unwrap(),
-                &request.new_content,
-            )
+            .insert(&id, &hmac_bytes, &new_content)
             .await?;
         debug!(?id, ?hmac, "Inserted document contents");
 
@@ -267,7 +218,7 @@ where
             let tx = db.begin_transaction()?;
 
             let mut tree = ServerTree::new(
-                owner,
+                requester,
                 &mut db.owned_files,
                 &mut db.shared_files,
                 &mut db.file_children,
@@ -275,29 +226,28 @@ where
             )?
             .to_lazy();
 
-            if tree.calculate_deleted(request.diff.new.id())? {
+            if tree.calculate_deleted(&id)? {
                 return Err(ClientError(DocumentDeleted));
             }
 
-            let meta = &tree
-                .maybe_find(request.diff.new.id())
+            let current_meta = &tree
+                .maybe_find(&id)
                 .ok_or(ClientError(DocumentNotFound))?
                 .file;
 
-            if let Some(old) = &request.diff.old {
-                if meta != old {
+            if let Some(old) = &diff.old {
+                if current_meta != old {
                     return Err(ClientError(OldVersionIncorrect));
                 }
             }
 
-            tree.stage(vec![new]).promote()?;
-            if let Some(old) = &request
-                .diff
-                .old
-                .and_then(|old| old.document_hmac().copied())
-            {
+            let mut tree = tree.stage(vec![new_meta]);
+            tree.validate(requester)?;
+            tree.promote()?;
+
+            if let Some(old_hmac) = diff.old.and_then(|old| old.document_hmac().copied()) {
                 db.scheduled_file_cleanups
-                    .insert((*request.diff.new.id(), *old), get_time().0)?;
+                    .insert((id, old_hmac), get_time().0)?;
             }
 
             tx.drop_safely()?;
@@ -309,9 +259,7 @@ where
 
         if result.is_err() {
             // Cleanup the NEW file created if, for some reason, the tx failed
-            self.document_service
-                .delete(request.diff.new.id(), request.diff.new.document_hmac().unwrap())
-                .await?;
+            self.document_service.delete(&id, &hmac_bytes).await?;
             debug!(?id, ?hmac, "Cleaned up new document contents after failed metadata update");
         }
 

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -35,52 +35,51 @@ where
         let request = context.request;
         let req_owner = Owner(context.public_key);
 
-        {
-            let mut prior_deleted = HashSet::new();
-            let mut current_deleted = HashSet::new();
+        let mut prior_deleted = HashSet::new();
+        let mut current_deleted = HashSet::new();
 
-            let mut lock = self.index_db.lock().await;
-            let db = lock.deref_mut();
-            let tx = db.begin_transaction()?;
+        let mut lock = self.index_db.lock().await;
+        let db = lock.deref_mut();
+        let tx = db.begin_transaction()?;
 
-            // Collect unique owners from the updates
-            let mut affected_owners: HashSet<Owner> = HashSet::new();
-            for update in &request.updates {
-                affected_owners.insert(update.new.owner());
+        // Quickly verify and fail fast and check things like access control
+        let mut tree = ServerTree::new(
+            req_owner,
+            &mut db.owned_files,
+            &mut db.shared_files,
+            &mut db.file_children,
+            &mut db.metas,
+        )?
+        .to_lazy();
+
+        for id in tree.ids() {
+            if tree.calculate_deleted(&id)? {
+                prior_deleted.insert(id);
             }
+        }
 
-            // Get usage caps and calculate old/new usage for each affected owner
-            // Each owner needs their own tree to see all their files
-            for &owner in &affected_owners {
-                let usage_cap =
-                    Self::get_cap(db, &owner.0).map_err(|err| internal!("{:?}", err))?;
-
-                let mut tree = ServerTree::new(
-                    owner,
-                    &mut db.owned_files,
-                    &mut db.shared_files,
-                    &mut db.file_children,
-                    &mut db.metas,
-                )?
-                .to_lazy();
-
-                let old_usage = tree.calculate_usage(owner)?;
-
-                let mut tree = tree.stage_diff_v2(request.updates.clone())?;
-                tree.assert_changes_authorized(req_owner)?;
-                let new_usage = tree.calculate_usage(owner)?;
-
-                debug!(?owner, ?old_usage, ?new_usage, ?usage_cap, "usage caps on upsert");
-
-                if new_usage > usage_cap && new_usage >= old_usage {
-                    warn!(?owner, "user over cap");
-                    return Err(ClientError(UpsertError::UsageIsOverDataCap));
-                }
+        let mut tree = tree.stage_diff_v2(request.updates.clone())?;
+        for id in tree.ids() {
+            if tree.calculate_deleted(&id)? {
+                current_deleted.insert(id);
             }
+        }
 
-            // Now do the actual operation with requester's tree
+        tree.validate(req_owner)?;
+
+        // Collect unique owners from the updates
+        let mut affected_owners: HashSet<Owner> = HashSet::new();
+        for update in &request.updates {
+            affected_owners.insert(update.new.owner());
+        }
+
+        // Get usage caps and calculate old/new usage for each affected owner
+        // Each owner needs their own tree to see all their files
+        for &owner in &affected_owners {
+            let usage_cap = Self::get_cap(db, &owner.0).map_err(|err| internal!("{:?}", err))?;
+
             let mut tree = ServerTree::new(
-                req_owner,
+                owner,
                 &mut db.owned_files,
                 &mut db.shared_files,
                 &mut db.file_children,
@@ -88,51 +87,59 @@ where
             )?
             .to_lazy();
 
-            for id in tree.ids() {
-                if tree.calculate_deleted(&id)? {
-                    prior_deleted.insert(id);
-                }
-            }
+            let old_usage = tree.calculate_usage(owner)?;
 
             let mut tree = tree.stage_diff_v2(request.updates.clone())?;
-            for id in tree.ids() {
-                if tree.calculate_deleted(&id)? {
-                    current_deleted.insert(id);
-                }
+            let new_usage = tree.calculate_usage(owner)?;
+
+            debug!(?owner, ?old_usage, ?new_usage, ?usage_cap, "usage caps on upsert");
+
+            if new_usage > usage_cap && new_usage >= old_usage {
+                warn!(?owner, "user over cap");
+                return Err(ClientError(UpsertError::UsageIsOverDataCap));
             }
-
-            tree.validate(req_owner)?;
-
-            let tree = tree.promote()?;
-
-            for id in tree.ids() {
-                if tree.find(&id)?.is_document()
-                    && current_deleted.contains(&id)
-                    && !prior_deleted.contains(&id)
-                {
-                    let meta = tree.find(&id)?;
-                    if let Some(hmac) = meta.file.timestamped_value.value.document_hmac().copied() {
-                        db.scheduled_file_cleanups
-                            .insert((*meta.id(), hmac), get_time().0)?;
-                    }
-                }
-            }
-
-            let all_files: Vec<ServerMeta> = tree.all_files()?.into_iter().cloned().collect();
-            for meta in all_files {
-                let id = meta.id();
-                if current_deleted.contains(id) && !prior_deleted.contains(id) {
-                    for user_access_info in meta.user_access_keys() {
-                        db.shared_files
-                            .remove(&Owner(user_access_info.encrypted_for), id)?;
-                    }
-                }
-            }
-
-            db.last_seen.insert(req_owner, get_time().0 as u64)?;
-
-            tx.drop_safely()?;
         }
+
+        // Now do the actual operation with requester's tree
+        let tree = ServerTree::new(
+            req_owner,
+            &mut db.owned_files,
+            &mut db.shared_files,
+            &mut db.file_children,
+            &mut db.metas,
+        )?
+        .to_lazy();
+
+        let tree = tree.stage_diff_v2(request.updates.clone())?;
+        let tree = tree.promote()?;
+
+        for id in tree.ids() {
+            if tree.find(&id)?.is_document()
+                && current_deleted.contains(&id)
+                && !prior_deleted.contains(&id)
+            {
+                let meta = tree.find(&id)?;
+                if let Some(hmac) = meta.file.timestamped_value.value.document_hmac().copied() {
+                    db.scheduled_file_cleanups
+                        .insert((*meta.id(), hmac), get_time().0)?;
+                }
+            }
+        }
+
+        let all_files: Vec<ServerMeta> = tree.all_files()?.into_iter().cloned().collect();
+        for meta in all_files {
+            let id = meta.id();
+            if current_deleted.contains(id) && !prior_deleted.contains(id) {
+                for user_access_info in meta.user_access_keys() {
+                    db.shared_files
+                        .remove(&Owner(user_access_info.encrypted_for), id)?;
+                }
+            }
+        }
+
+        db.last_seen.insert(req_owner, get_time().0 as u64)?;
+
+        tx.drop_safely()?;
 
         Ok(())
     }

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -32,8 +32,8 @@ where
     pub async fn upsert_file_metadata_v2(
         &self, context: RequestContext<UpsertRequestV2>,
     ) -> Result<(), ServerError<UpsertError>> {
-        let request = context.request;
         let req_owner = Owner(context.public_key);
+        let UpsertRequestV2 { updates } = context.request;
 
         let mut prior_deleted = HashSet::new();
         let mut current_deleted = HashSet::new();
@@ -42,7 +42,7 @@ where
         let db = lock.deref_mut();
         let tx = db.begin_transaction()?;
 
-        // Quickly verify and fail fast and check things like access control
+        // fail fast on things like access control
         let mut tree = ServerTree::new(
             req_owner,
             &mut db.owned_files,
@@ -58,18 +58,20 @@ where
             }
         }
 
-        let mut tree = tree.stage_diff_v2(request.updates.clone())?;
+        let mut tree = tree.stage_diff_v2(updates.clone())?;
+        tree.validate(req_owner)?;
+
         for id in tree.ids() {
             if tree.calculate_deleted(&id)? {
                 current_deleted.insert(id);
             }
         }
 
-        tree.validate(req_owner)?;
+        drop(tree);
 
         // Collect unique owners from the updates
         let mut affected_owners: HashSet<Owner> = HashSet::new();
-        for update in &request.updates {
+        for update in &updates {
             affected_owners.insert(update.new.owner());
         }
 
@@ -88,8 +90,7 @@ where
             .to_lazy();
 
             let old_usage = tree.calculate_usage(owner)?;
-
-            let mut tree = tree.stage_diff_v2(request.updates.clone())?;
+            let mut tree = tree.stage_unvalidated(updates.clone());
             let new_usage = tree.calculate_usage(owner)?;
 
             debug!(?owner, ?old_usage, ?new_usage, ?usage_cap, "usage caps on upsert");
@@ -100,7 +101,6 @@ where
             }
         }
 
-        // Now do the actual operation with requester's tree
         let tree = ServerTree::new(
             req_owner,
             &mut db.owned_files,
@@ -110,7 +110,7 @@ where
         )?
         .to_lazy();
 
-        let tree = tree.stage_diff_v2(request.updates.clone())?;
+        let tree = tree.stage_unvalidated(updates.clone());
         let tree = tree.promote()?;
 
         for id in tree.ids() {

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -317,11 +317,7 @@ where
         let time_one_hour_ago = get_time().0 as u64 - TWO_HOURS_IN_MILLIS as u64;
         let is_user_active_v2 = not_the_welcome_doc && last_seen > time_one_hour_ago;
 
-        let total_bytes: u64 = Self::get_usage_helper(&mut tree)
-            .unwrap_or_default()
-            .iter()
-            .map(|f| f.size_bytes)
-            .sum();
+        let total_bytes = tree.calculate_usage(owner).unwrap_or_default();
 
         let total_documents = if let Some(owned_files) = db.owned_files.get().get(&owner) {
             owned_files.len() as i64


### PR DESCRIPTION
we calculate storage too naively in many situations, locally we just ask the server and that itself is wrong #1879 in a subtle way.

this pr gives us the usage api we deserve, with the tricky calculations living in our tree logic (do you own the file? Is it delete? metadata fee? etc). The server will calculate a `usage_report` for the per-tree impact of any change to fix the bug in the server. And this API will allow us to compute rich usage statistics locally (https://github.com/lockbook/lockbook/issues/4410) and visualize the impact of unpushed changes: 
<img width="1080" height="272" alt="image" src="https://github.com/user-attachments/assets/98010c9e-bd78-4858-9587-d20ad0647dbb" />
