### PR TITLE
infra: skip artifact recompression for apple uploads

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -54,12 +54,14 @@ jobs:
       with:
         name: lockbook-macos
         path: clients/apple/build/lockbook-macos.app.zip
+        compression-level: 0
     - name: Upload macOS CLI
       if: ${{ !inputs.release }}
       uses: actions/upload-artifact@v4
       with:
         name: lockbook-cli-macos
         path: target/universal-cli/lockbook-cli-macos.tar.gz
+        compression-level: 0
     - name: Upload macOS egui
       if: ${{ !inputs.release }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add `compression-level: 0` to the `Upload macOS app` and `Upload macOS CLI` steps in `.github/workflows/apple.yml`. Both artifacts are already compressed (`.app.zip`, `.tar.gz`), so the action's default level-6 recompression burns CPU and slows the upload feed for no size benefit.
- Two consecutive `Master` runs failed at `Upload macOS app` with `write EPIPE` to `*.blob.core.windows.net` after stalling 8-9 minutes mid-stream ([24685974696](https://github.com/lockbook/lockbook/actions/runs/24685974696), [24638713226](https://github.com/lockbook/lockbook/actions/runs/24638713226)). Shrinking the upload duration reduces the window where those stalls can land.
- The `Upload macOS egui` step is left at the default since the raw binary benefits from compression.

## Test plan
- [ ] Dispatch `Apple Deployment` workflow off this branch with `release: false` and confirm all three upload steps succeed.