### PR TITLE
infra: force apple deploy actions to node 24

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -20,6 +20,7 @@ jobs:
       APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
       MAC_MINI_LOGIN_KEYCHAIN: ${{ secrets.MAC_MINI_LOGIN_KEYCHAIN }}
       GITHUB_TOKEN: ${{ secrets.FH_PAT }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
     - uses: actions/checkout@v4
     - name: Configure PATH


### PR DESCRIPTION
## Summary
- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on the `DeployApple` job so `actions/checkout@v4` and `actions/upload-artifact@v4` run on Node 24 instead of Node 20.
- Recent self-hosted mac mini runs have been stalling on the `Upload macOS app` step — the upload to `*.blob.core.windows.net` starts but transfers zero bytes for 5+ minutes, tripping `actions/upload-artifact@v4`'s internal stall detector ([24685974696](https://github.com/lockbook/lockbook/actions/runs/24685974696), [24688642242](https://github.com/lockbook/lockbook/actions/runs/24688642242)). App Store uploads from the same job succeed, so only the Azure blob endpoint is affected.
- Trying Node 24 to see if its http/socket stack handles this path differently. GitHub is forcing this default in June anyway, per the runner deprecation warning.

## Test plan
- [ ] Dispatch `Apple Deployment` workflow on this branch and confirm all three upload steps succeed.