### PR TITLE
iOS: migrate lb-rs to app group location

### DIFF
--- a/clients/apple/Shared/State/AppState.swift
+++ b/clients/apple/Shared/State/AppState.swift
@@ -8,9 +8,56 @@ class AppState: ObservableObject {
         #if os(macOS)
             NSHomeDirectory() + "/.lockbook"
         #else
-            FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last!.path
+            resolveIOSWritablePath()
         #endif
     }()
+
+    #if !os(macOS)
+    private static func resolveIOSWritablePath() -> String {
+        let fm = FileManager.default
+        let legacyURL = fm.urls(for: .documentDirectory, in: .userDomainMask).last!
+
+        guard let groupURL = fm.containerURL(forSecurityApplicationGroupIdentifier: "group.app.lockbook") else {
+            return legacyURL.path
+        }
+        let newURL = groupURL.appendingPathComponent("lockbook", isDirectory: true)
+
+        migrateLegacyDataIfNeeded(from: legacyURL, to: newURL)
+
+        return newURL.path
+    }
+
+    private static func migrateLegacyDataIfNeeded(from legacyURL: URL, to newURL: URL) {
+        let fm = FileManager.default
+
+        if (try? fm.createDirectory(at: newURL, withIntermediateDirectories: true)) == nil {
+            return
+        }
+
+        let legacyContents: [String]
+        do {
+            legacyContents = try fm.contentsOfDirectory(atPath: legacyURL.path)
+        } catch {
+            return
+        }
+
+        for name in legacyContents {
+            let src = legacyURL.appendingPathComponent(name)
+            let dst = newURL.appendingPathComponent(name)
+            if fm.fileExists(atPath: dst.path) { continue }
+            do {
+                try fm.moveItem(at: src, to: dst)
+            } catch {
+                do {
+                    try fm.copyItem(at: src, to: dst)
+                    try fm.removeItem(at: src)
+                } catch {
+                    continue
+                }
+            }
+        }
+    }
+    #endif
 
     static let LB_API_URL: String? = ProcessInfo.processInfo.environment["API_LOCATION"]
 

--- a/clients/apple/Shared/State/AppState.swift
+++ b/clients/apple/Shared/State/AppState.swift
@@ -22,40 +22,12 @@ class AppState: ObservableObject {
         }
         let newURL = groupURL.appendingPathComponent("lockbook", isDirectory: true)
 
-        migrateLegacyDataIfNeeded(from: legacyURL, to: newURL)
+        if !fm.fileExists(atPath: newURL.path) {
+            try? fm.moveItem(at: legacyURL, to: newURL)
+        }
+        try? fm.createDirectory(at: newURL, withIntermediateDirectories: true)
 
         return newURL.path
-    }
-
-    private static func migrateLegacyDataIfNeeded(from legacyURL: URL, to newURL: URL) {
-        let fm = FileManager.default
-
-        if (try? fm.createDirectory(at: newURL, withIntermediateDirectories: true)) == nil {
-            return
-        }
-
-        let legacyContents: [String]
-        do {
-            legacyContents = try fm.contentsOfDirectory(atPath: legacyURL.path)
-        } catch {
-            return
-        }
-
-        for name in legacyContents {
-            let src = legacyURL.appendingPathComponent(name)
-            let dst = newURL.appendingPathComponent(name)
-            if fm.fileExists(atPath: dst.path) { continue }
-            do {
-                try fm.moveItem(at: src, to: dst)
-            } catch {
-                do {
-                    try fm.copyItem(at: src, to: dst)
-                    try fm.removeItem(at: src)
-                } catch {
-                    continue
-                }
-            }
-        }
     }
     #endif
 


### PR DESCRIPTION
whatup @smailbarkouch this migrates lb-rs into the app group area which unlocks our ability to have widgets and other fun things I'd like to produce on the side, I tested that this is good in a variety of situations