### PR TITLE
lb-rs: pinned files

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Lb.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Lb.swift
@@ -47,6 +47,9 @@ public protocol LbAPI {
     func suggestedDocs() -> Result<[UUID], LbError>
     func clearSuggestedId(id: UUID) -> Result<Void, LbError>
     func clearSuggestedDocs() -> Result<Void, LbError>
+    func pinFile(id: UUID) -> Result<Void, LbError>
+    func unpinFile(id: UUID) -> Result<Void, LbError>
+    func listPinned() -> Result<[UUID], LbError>
     func getUsage() -> Result<UsageMetrics, LbError>
     func importFiles(sources: [String], dest: UUID) -> Result<Void, LbError>
     func exportFile(sourceId: UUID, dest: String, edit: Bool) -> Result<Void, LbError>
@@ -528,6 +531,39 @@ public class Lb: LbAPI {
         return .success(())
     }
 
+    public func pinFile(id: UUID) -> Result<Void, LbError> {
+        let err = lb_pin_file(lb, id.toLbUuid())
+
+        if let err {
+            defer { lb_free_err(err) }
+            return .failure(LbError(err.pointee))
+        }
+
+        return .success(())
+    }
+
+    public func unpinFile(id: UUID) -> Result<Void, LbError> {
+        let err = lb_unpin_file(lb, id.toLbUuid())
+
+        if let err {
+            defer { lb_free_err(err) }
+            return .failure(LbError(err.pointee))
+        }
+
+        return .success(())
+    }
+
+    public func listPinned() -> Result<[UUID], LbError> {
+        let res = lb_list_pinned(lb)
+        defer { lb_free_id_list_res(res) }
+
+        guard res.err == nil else {
+            return .failure(LbError(res.err.pointee))
+        }
+
+        return .success(Array(UnsafeBufferPointer(start: res.ids, count: Int(res.len))).toUUIDs())
+    }
+
     public func getUsage() -> Result<UsageMetrics, LbError> {
         let res = lb_get_usage(lb)
         defer { lb_free_usage_metrics(res) }
@@ -756,6 +792,9 @@ public class MockLb: LbAPI {
     public func suggestedDocs() -> Result<[UUID], LbError> { .success([file1.id, file2.id, file3.id]) }
     public func clearSuggestedId(id: UUID) -> Result<Void, LbError> { .success(()) }
     public func clearSuggestedDocs() -> Result<Void, LbError> { .success(()) }
+    public func pinFile(id: UUID) -> Result<Void, LbError> { .success(()) }
+    public func unpinFile(id: UUID) -> Result<Void, LbError> { .success(()) }
+    public func listPinned() -> Result<[UUID], LbError> { .success([file1.id]) }
     public func getUsage() -> Result<UsageMetrics, LbError> { .success(UsageMetrics(serverUsedExact: 100, serverUsedHuman: "100B", serverCapExact: 1000, serverCapHuman: "1000B")) }
     public func importFiles(sources: [String], dest: UUID) -> Result<Void, LbError> { .success(()) }
     public func exportFile(sourceId: UUID, dest: String, edit: Bool) -> Result<Void, LbError> { .success(()) }

--- a/libs/lb/lb-c/src/lib.rs
+++ b/libs/lb/lb-c/src/lib.rs
@@ -613,6 +613,39 @@ pub extern "C" fn lb_clear_suggested_id(lb: *mut Lb, id: LbUuid) -> *mut LbFfiEr
     }
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn lb_pin_file(lb: *mut Lb, id: LbUuid) -> *mut LbFfiErr {
+    let lb = rlb(lb);
+
+    match lb.pin_file(id.into()) {
+        Ok(()) => null_mut(),
+        Err(err) => lb_err(err),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn lb_unpin_file(lb: *mut Lb, id: LbUuid) -> *mut LbFfiErr {
+    let lb = rlb(lb);
+
+    match lb.unpin_file(id.into()) {
+        Ok(()) => null_mut(),
+        Err(err) => lb_err(err),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn lb_list_pinned(lb: *mut Lb) -> LbIdListRes {
+    let lb = rlb(lb);
+
+    match lb.list_pinned() {
+        Ok(ids) => {
+            let (ids, len) = carray(ids.into_iter().map(LbUuid::from).collect());
+            LbIdListRes { err: null_mut(), ids, len }
+        }
+        Err(err) => LbIdListRes { err: lb_err(err), ids: null_mut(), len: 0 },
+    }
+}
+
 #[repr(C)]
 pub struct LbUsageMetricsRes {
     err: *mut LbFfiErr,

--- a/libs/lb/lb-rs/src/blocking.rs
+++ b/libs/lb/lb-rs/src/blocking.rs
@@ -225,6 +225,18 @@ impl Lb {
         self.block_on(self.lb.clear_suggested_id(target_id))
     }
 
+    pub fn pin_file(&self, id: Uuid) -> LbResult<()> {
+        self.block_on(self.lb.pin_file(id))
+    }
+
+    pub fn unpin_file(&self, id: Uuid) -> LbResult<()> {
+        self.block_on(self.lb.unpin_file(id))
+    }
+
+    pub fn list_pinned(&self) -> LbResult<Vec<Uuid>> {
+        self.block_on(self.lb.list_pinned())
+    }
+
     // TODO: examine why the old get_usage does a bunch of things
     pub fn get_usage(&self) -> LbResult<UsageMetrics> {
         self.block_on(self.lb.get_usage())

--- a/libs/lb/lb-rs/src/io/mod.rs
+++ b/libs/lb/lb-rs/src/io/mod.rs
@@ -40,6 +40,7 @@ pub struct CoreV4 {
 
     pub doc_events: List<DocEvent>,
     pub id: Single<LbID>,
+    pub pinned_files: List<Uuid>,
 }
 
 pub struct LbRO<'a> {

--- a/libs/lb/lb-rs/src/service/mod.rs
+++ b/libs/lb/lb-rs/src/service/mod.rs
@@ -17,5 +17,6 @@ pub mod keychain;
 pub mod lb_id;
 pub mod logging;
 pub mod path;
+pub mod pin;
 pub mod share;
 pub mod usage;

--- a/libs/lb/lb-rs/src/service/pin.rs
+++ b/libs/lb/lb-rs/src/service/pin.rs
@@ -1,0 +1,77 @@
+use crate::Lb;
+use crate::model::errors::{LbErrKind, LbResult};
+use crate::model::file_like::FileLike;
+use crate::model::tree_like::TreeLike;
+use uuid::Uuid;
+
+impl Lb {
+    #[instrument(level = "debug", skip(self), err(Debug))]
+    pub async fn pin_file(&self, id: Uuid) -> LbResult<()> {
+        let mut tx = self.begin_tx().await;
+        let db = tx.db();
+
+        let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
+
+        let file = tree.maybe_find(&id).ok_or(LbErrKind::FileNonexistent)?;
+
+        if !file.is_document() {
+            return Err(LbErrKind::FileNotDocument.into());
+        }
+
+        if tree.calculate_deleted(&id)? {
+            return Err(LbErrKind::FileNonexistent.into());
+        }
+
+        if db.pinned_files.get().contains(&id) {
+            return Ok(());
+        }
+
+        db.pinned_files.push(id)?;
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self), err(Debug))]
+    pub async fn unpin_file(&self, id: Uuid) -> LbResult<()> {
+        let mut tx = self.begin_tx().await;
+        let db = tx.db();
+
+        let entries: Vec<Uuid> = db
+            .pinned_files
+            .get()
+            .iter()
+            .filter(|pinned| **pinned != id)
+            .copied()
+            .collect();
+
+        db.pinned_files.clear()?;
+        for entry in entries {
+            db.pinned_files.push(entry)?;
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self), err(Debug))]
+    pub async fn list_pinned(&self) -> LbResult<Vec<Uuid>> {
+        let db = self.ro_tx().await;
+        let db = db.db();
+
+        let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
+
+        let mut result = Vec::new();
+        for id in db.pinned_files.get().iter() {
+            if tree.maybe_find(id).is_none() {
+                continue;
+            }
+            if tree.calculate_deleted(id)? {
+                continue;
+            }
+            if tree.in_pending_share(id)? {
+                continue;
+            }
+            result.push(*id);
+        }
+
+        Ok(result)
+    }
+}

--- a/libs/lb/lb-rs/tests/pin_service_tests.rs
+++ b/libs/lb/lb-rs/tests/pin_service_tests.rs
@@ -1,0 +1,139 @@
+use lb_rs::Lb;
+use lb_rs::model::errors::LbErrKind;
+use lb_rs::model::file_metadata::FileType;
+use test_utils::*;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn list_pinned_empty() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let pinned = core.list_pinned().await.unwrap();
+    let expected: Vec<Uuid> = vec![];
+    assert_eq!(pinned, expected);
+}
+
+#[tokio::test]
+async fn pin_unpin_roundtrip() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let doc = core.create_at_path("hello.md").await.unwrap();
+    core.pin_file(doc.id).await.unwrap();
+
+    let pinned = core.list_pinned().await.unwrap();
+    assert_eq!(pinned, vec![doc.id]);
+
+    core.unpin_file(doc.id).await.unwrap();
+    let pinned = core.list_pinned().await.unwrap();
+    let expected: Vec<Uuid> = vec![];
+    assert_eq!(pinned, expected);
+}
+
+#[tokio::test]
+async fn pin_is_idempotent() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let doc = core.create_at_path("hello.md").await.unwrap();
+    core.pin_file(doc.id).await.unwrap();
+    core.pin_file(doc.id).await.unwrap();
+    core.pin_file(doc.id).await.unwrap();
+
+    let pinned = core.list_pinned().await.unwrap();
+    assert_eq!(pinned, vec![doc.id]);
+}
+
+#[tokio::test]
+async fn unpin_not_pinned_is_noop() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let doc = core.create_at_path("hello.md").await.unwrap();
+    core.unpin_file(doc.id).await.unwrap();
+
+    let pinned = core.list_pinned().await.unwrap();
+    let expected: Vec<Uuid> = vec![];
+    assert_eq!(pinned, expected);
+}
+
+#[tokio::test]
+async fn pin_preserves_order() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let a = core.create_at_path("a.md").await.unwrap();
+    let b = core.create_at_path("b.md").await.unwrap();
+    let c = core.create_at_path("c.md").await.unwrap();
+
+    core.pin_file(b.id).await.unwrap();
+    core.pin_file(a.id).await.unwrap();
+    core.pin_file(c.id).await.unwrap();
+
+    let pinned = core.list_pinned().await.unwrap();
+    assert_eq!(pinned, vec![b.id, a.id, c.id]);
+}
+
+#[tokio::test]
+async fn pin_rejects_folder() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let root = core.root().await.unwrap();
+    let folder = core
+        .create_file("subdir", &root.id, FileType::Folder)
+        .await
+        .unwrap();
+
+    let res = core.pin_file(folder.id).await;
+    match res {
+        Err(e) => assert!(matches!(e.kind, LbErrKind::FileNotDocument)),
+        Ok(()) => panic!("expected pin_file to reject a folder"),
+    }
+}
+
+#[tokio::test]
+async fn pin_rejects_nonexistent() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let res = core.pin_file(Uuid::new_v4()).await;
+    match res {
+        Err(e) => assert!(matches!(e.kind, LbErrKind::FileNonexistent)),
+        Ok(()) => panic!("expected pin_file to reject a missing id"),
+    }
+}
+
+#[tokio::test]
+async fn list_pinned_filters_deleted() {
+    let core: Lb = test_core().await;
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    let keep = core.create_at_path("keep.md").await.unwrap();
+    let gone = core.create_at_path("gone.md").await.unwrap();
+
+    core.pin_file(keep.id).await.unwrap();
+    core.pin_file(gone.id).await.unwrap();
+
+    core.delete(&gone.id).await.unwrap();
+
+    let pinned = core.list_pinned().await.unwrap();
+    assert_eq!(pinned, vec![keep.id]);
+}


### PR DESCRIPTION
core api for #3608

I messed around with a UI for this in macOS and it was a good time. I intend to merge the new search ui first tho #4312 and then I want the file tree to be where you structure your experience with intent. This means replacing suggested docs with pinned files. And then I want suggested docs to seed empty representations of search, and potentially appear on the new tab place. Where intent is most clearly expressed as wanting to start a new task, searching for a new file etc.

> [!CAUTION]
A note on db migration, this adds a new row, does not require a migration. Right now this is not exposed in any UIs so  you will have no corresponding db events. Once you start to use the feature however, older versions of lb-rs won't know how to handle the new events (pinned) and will fail to start. None of our distribution channels really support downgrading so this is a dev only problem. But also the actual UI feature won't come for a bit, and the longer I wait to implement the UI feature the less likely anyone will hit a snag while downgrading. So overall nothing to worry about.