### PR TITLE
android: workspace back and forewords

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/model/WorkspaceViewModel.kt
+++ b/clients/android/app/src/main/java/app/lockbook/model/WorkspaceViewModel.kt
@@ -72,6 +72,24 @@ class WorkspaceViewModel : ViewModel() {
     val _isRendering = MutableLiveData<Boolean>()
     val isRendering: LiveData<Boolean>
         get() = _isRendering
+
+    /** request workspace view to navigate within tab history **/
+    private val _workspaceBackRequested = SingleMutableLiveData<Unit>()
+    val workspaceBackRequested: LiveData<Unit>
+        get() = _workspaceBackRequested
+
+    /** request workspace view to navigate forward within tab history **/
+    private val _workspaceForwardRequested = SingleMutableLiveData<Unit>()
+    val workspaceForwardRequested: LiveData<Unit>
+        get() = _workspaceForwardRequested
+
+    fun requestWorkspaceBack() {
+        _workspaceBackRequested.postValue(Unit)
+    }
+
+    fun requestWorkspaceForward() {
+        _workspaceForwardRequested.postValue(Unit)
+    }
 }
 
 data class WorkspaceTab(

--- a/clients/android/app/src/main/java/app/lockbook/screen/MainScreenActivity.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/MainScreenActivity.kt
@@ -225,7 +225,7 @@ class MainScreenActivity : AppCompatActivity() {
                     if (supportFragmentManager.findFragmentById(R.id.detail_container) !is WorkspaceFragment) {
                         model.updateMainScreenUI(UpdateMainScreenUI.PopBackstackToWorkspace)
                     } else if (slidingPaneLayout.isSlideable && slidingPaneLayout.isOpen) { // if you are on a small display where only files or an editor show once at a time, you want to handle behavior a bit differently
-                        model.updateMainScreenUI(UpdateMainScreenUI.CloseWorkspacePane)
+                        workspaceModel.requestWorkspaceBack()
                     } else if (maybeGetSearchFilesFragment() != null) {
                         updateMainScreenUI(UpdateMainScreenUI.ShowFiles)
                     } else if (maybeGetFilesFragment() == null || maybeGetFilesFragment()?.onBackPressed() == true) {

--- a/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
@@ -125,7 +125,7 @@ class WorkspaceFragment : Fragment() {
             println("ad-tra: set bottom inset ")
             workspaceWrapper.workspaceView.setBottomInset(it)
         }
-        
+
         model.keyboardVisible.observe(viewLifecycleOwner) { keyboardVisible ->
             if (keyboardVisible) {
                 binding.standardBottomSheet.visibility = View.GONE

--- a/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
@@ -93,33 +93,27 @@ class WorkspaceFragment : Fragment() {
         onCreateTabList(workspaceWrapper)
 
         model.openFile.observe(viewLifecycleOwner) { (id, newFile) ->
-            println("open file: $id, $newFile")
             workspaceWrapper.workspaceView.openDoc(id, newFile)
             activityModel.updateMainScreenUI(UpdateMainScreenUI.OpenWorkspacePane)
         }
 
         model.createDocAt.observe(viewLifecycleOwner) { it ->
-            println("ad-tra: create doc at")
             workspaceWrapper.workspaceView.createDocAt(it)
         }
 
         model.closeFile.observe(viewLifecycleOwner) { id ->
-            println("ad-tra: close file $id")
             workspaceWrapper.workspaceView.closeDoc(id)
         }
 
         model.currentTab.observe(viewLifecycleOwner) { tab ->
-            println("ad-tra: current tab: ${tab.id} ${tab.type}")
             updateCurrentTab(workspaceWrapper, tab)
         }
 
         model.refreshFilesRequested.observe(viewLifecycleOwner) {
-            println("ad-tra: workspace wants to refresh files")
             filesListModel.reloadFiles()
         }
 
         model.isRendering.observe(viewLifecycleOwner) { isRendering ->
-            println("ad-tra: set is rendering $isRendering ")
             if (isRendering) {
                 workspaceWrapper.workspaceView.startRendering()
             } else {
@@ -232,13 +226,10 @@ class WorkspaceFragment : Fragment() {
         model.keyboardVisible.observe(viewLifecycleOwner) { keyboardVisible ->
             if (keyboardVisible) {
                 binding.standardBottomSheet.visibility = View.GONE
-                activityModel.updateMainScreenUI(UpdateMainScreenUI.HideBottomViewNavigation)
             } else {
                 binding.standardBottomSheet.visibility = View.VISIBLE
             }
         }
-
-        return binding.root
     }
 
     override fun onDestroyView() {
@@ -246,7 +237,7 @@ class WorkspaceFragment : Fragment() {
         super.onDestroyView()
     }
 
-    private fun toggleBottomSheetExpansion(shouldExpand: Boolean) {
+    private fun toggleTabListExpansion(shouldExpand: Boolean) {
         val currOrientation = (binding.tabsList.layoutManager as LinearLayoutManager).orientation
         if ((currOrientation == LinearLayoutManager.VERTICAL && shouldExpand) ||
             (currOrientation == LinearLayoutManager.HORIZONTAL && !shouldExpand)
@@ -377,16 +368,13 @@ class WorkspaceFragment : Fragment() {
     private fun updateCurrentTab(workspaceWrapper: WorkspaceWrapperView, newTab: WorkspaceTab) {
 
         var tabTitle = filesListModel.fileModel.idsAndFiles[newTab.id]?.name
-        println("ad-tra: tab title a: $tabTitle")
 
         if (isMissingTab(tabTitle, newTab)) {
             filesListModel.fileModel.refreshFiles()
             tabTitle = filesListModel.fileModel.idsAndFiles[newTab.id]?.name
-            println("ad-tra: tab title b: $tabTitle")
         }
 
         if (isMissingTab(tabTitle, newTab)) {
-            println("ad-tra: tab title c: $tabTitle")
             // todo: differentiate between startup nulls and legitimate nulls
             return
         }
@@ -421,7 +409,6 @@ class WorkspaceFragment : Fragment() {
     }
 
     private fun updateToolbarOnTabChange(newTab: WorkspaceTabType, tabTitle: String?) {
-        println("ad-tra: new tab: $newTab")
         when (newTab) {
             WorkspaceTabType.Loading -> {}
             WorkspaceTabType.Welcome,
@@ -442,7 +429,6 @@ class WorkspaceFragment : Fragment() {
                 binding.workspaceToolbar.menu.findItem(R.id.menu_text_editor_share_externally).isVisible =
                     true
                 binding.workspaceToolbar.setTitle(tabTitle)
-                println("ad-tra: set tab to: $tabTitle")
             }
         }
     }

--- a/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
@@ -144,6 +144,17 @@ class WorkspaceFragment : Fragment() {
             }
         }
 
+        model.workspaceBackRequested.observe(viewLifecycleOwner) {
+            val navigatedBack = workspaceWrapper.workspaceView.back()
+            if (!navigatedBack) {
+                activityModel.updateMainScreenUI(UpdateMainScreenUI.CloseWorkspacePane)
+            }
+        }
+
+        model.workspaceForwardRequested.observe(viewLifecycleOwner) {
+            workspaceWrapper.workspaceView.forward()
+        }
+
         binding.workspaceToolbar.setNavigationIcon(R.drawable.ic_baseline_arrow_back_24)
 
         getCurrentFile()?.let {
@@ -220,6 +231,11 @@ class WorkspaceFragment : Fragment() {
         }
 
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 
     private fun toggleBottomSheetExpansion(shouldExpand: Boolean) {

--- a/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
@@ -121,6 +121,19 @@ class WorkspaceFragment : Fragment() {
             }
         }
 
+        model.bottomInset.observe(viewLifecycleOwner) {
+            println("ad-tra: set bottom inset ")
+            workspaceWrapper.workspaceView.setBottomInset(it)
+        }
+        
+        model.keyboardVisible.observe(viewLifecycleOwner) { keyboardVisible ->
+            if (keyboardVisible) {
+                binding.standardBottomSheet.visibility = View.GONE
+            } else {
+                binding.standardBottomSheet.visibility = View.VISIBLE
+            }
+        }
+
         model.workspaceBackRequested.observe(viewLifecycleOwner) {
             val navigatedBack = workspaceWrapper.workspaceView.back()
             if (!navigatedBack) {
@@ -131,19 +144,6 @@ class WorkspaceFragment : Fragment() {
         model.workspaceForwardRequested.observe(viewLifecycleOwner) {
             workspaceWrapper.workspaceView.forward()
         }
-
-        binding.workspaceToolbar.setNavigationIcon(R.drawable.ic_baseline_arrow_back_24)
-
-        getCurrentFile()?.let {
-            binding.workspaceToolbar.setTitle(it.name)
-        }
-
-        binding.workspaceToolbar.setNavigationOnClickListener {
-            (context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
-                .hideSoftInputFromWindow(view?.windowToken, 0)
-            activityModel.updateMainScreenUI(UpdateMainScreenUI.CloseWorkspacePane)
-        }
-        workspaceWrapper.workspaceView.showTabs(false)
 
         model.finishedAction.observe(viewLifecycleOwner) { action ->
             when (action) {
@@ -220,14 +220,6 @@ class WorkspaceFragment : Fragment() {
             } else if (distanceY <0 && !isKeyboardVisible) {
                 showBottomSheet()
                 showMaterialToolbar()
-            }
-        }
-
-        model.keyboardVisible.observe(viewLifecycleOwner) { keyboardVisible ->
-            if (keyboardVisible) {
-                binding.standardBottomSheet.visibility = View.GONE
-            } else {
-                binding.standardBottomSheet.visibility = View.VISIBLE
             }
         }
     }

--- a/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
@@ -107,6 +107,7 @@ class WorkspaceFragment : Fragment() {
 
         model.currentTab.observe(viewLifecycleOwner) { tab ->
             updateCurrentTab(workspaceWrapper, tab)
+            updateForwardButtonState(workspaceWrapper)
         }
 
         model.refreshFilesRequested.observe(viewLifecycleOwner) {
@@ -245,6 +246,11 @@ class WorkspaceFragment : Fragment() {
 
         animateBottomSheetHeight(newHeight) {
             binding.expandList.visibility = if (binding.expandList.isVisible) {
+                View.GONE
+            } else {
+                View.VISIBLE
+            }
+            binding.forwardWs.visibility = if (binding.forwardWs.isVisible) {
                 View.GONE
             } else {
                 View.VISIBLE
@@ -470,12 +476,20 @@ class WorkspaceFragment : Fragment() {
             model._tabListExpanded.value = !(model.tabListExpanded.value ?: false)
         }
 
+        binding.forwardWs.setOnClickListener {
+            workspaceWrapper.workspaceView.forward()
+        }
+
         binding.closeAllTabs.setOnClickListener {
             workspaceWrapper.workspaceView.closeAllTabs()
             workspaceWrapper.workspaceView.drawImmediately()
             model._tabListExpanded.postValue(false)
             activityModel.updateMainScreenUI(UpdateMainScreenUI.CloseWorkspacePane)
         }
+    }
+
+    private fun updateForwardButtonState(workspaceWrapper: WorkspaceWrapperView) {
+        binding.forwardWs.isEnabled = workspaceWrapper.workspaceView.canForward()
     }
     @SuppressLint("NotifyDataSetChanged")
     private fun setupTabList() {

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -571,13 +571,11 @@ class WorkspaceView(context: Context, val model: WorkspaceViewModel) : SurfaceVi
             if (response.tabsChanged) {
                 val newTab = Workspace.currentTab(WGPU_OBJ).toModelTab()
                 model._currentTab.value = newTab
-                println("ad-tra: tabs changed ${model.currentTab.value?.id}")
             }
 
             if (!response.selectedFile.isNullUUID()) {
                 val newTab = Workspace.currentTab(WGPU_OBJ).toModelTab()
                 model._currentTab.value = newTab
-                println("ad-tra: selected file changed ${model.currentTab.value?.id}")
             }
 
             if (model.currentTab.value?.type == WorkspaceTabType.Markdown) {

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -720,6 +720,32 @@ class WorkspaceView(context: Context, val model: WorkspaceViewModel) : SurfaceVi
         Workspace.showTabs(WGPU_OBJ, show)
     }
 
+    fun back(): Boolean {
+        if (WGPU_OBJ == Long.MAX_VALUE || surface == null) {
+            return false
+        }
+
+        val didNavigate = Workspace.back(WGPU_OBJ)
+        if (didNavigate) {
+            drawImmediately()
+        }
+
+        return didNavigate
+    }
+
+    fun forward(): Boolean {
+        if (WGPU_OBJ == Long.MAX_VALUE || surface == null) {
+            return false
+        }
+
+        val didNavigate = Workspace.forward(WGPU_OBJ)
+        if (didNavigate) {
+            drawImmediately()
+        }
+
+        return didNavigate
+    }
+
     fun isPenOnlyDraw(): Boolean {
         if (WGPU_OBJ == Long.MAX_VALUE || surface == null) {
             return false

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -767,6 +767,14 @@ class WorkspaceView(context: Context, val model: WorkspaceViewModel) : SurfaceVi
         return didNavigate
     }
 
+    fun canForward(): Boolean {
+        if (WGPU_OBJ == Long.MAX_VALUE || surface == null) {
+            return false
+        }
+
+        return Workspace.canForward(WGPU_OBJ)
+    }
+
     fun isPenOnlyDraw(): Boolean {
         if (WGPU_OBJ == Long.MAX_VALUE || surface == null) {
             return false

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -741,14 +741,6 @@ class WorkspaceView(context: Context, val model: WorkspaceViewModel) : SurfaceVi
         return WorkspaceTabType.fromInt(tab)
     }
 
-    fun showTabs(show: Boolean) {
-        if (WGPU_OBJ == Long.MAX_VALUE || surface == null) {
-            return
-        }
-
-        Workspace.showTabs(WGPU_OBJ, show)
-    }
-
     fun back(): Boolean {
         if (WGPU_OBJ == Long.MAX_VALUE || surface == null) {
             return false

--- a/clients/android/app/src/main/res/drawable/ic_baseline_arrow_forward_24.xml
+++ b/clients/android/app/src/main/res/drawable/ic_baseline_arrow_forward_24.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M647,520L160,520L160,440L647,440L423,216L480,160L800,480L480,800L423,744L647,520Z"/>
+</vector>

--- a/clients/android/app/src/main/res/layout/fragment_workspace.xml
+++ b/clients/android/app/src/main/res/layout/fragment_workspace.xml
@@ -49,7 +49,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/expand_list"
-            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+            style="@style/Widget.Material3.Button.IconButton.Filled"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="?android:listPreferredItemPaddingStart"
@@ -58,6 +58,21 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/close_all_tabs"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:shapeAppearanceOverlay="@style/MyShapeAppearance"
+            />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/forward_ws"
+            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/workspace_forward"
+            app:icon="@drawable/ic_baseline_arrow_forward_24"
+            app:layout_constraintStart_toEndOf="@+id/expand_list"
+            app:layout_constraintTop_toBottomOf="@+id/close_all_tabs"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:insetLeft="0dp"
+            app:shapeAppearanceOverlay="@style/MyQRShapeAppearance"
             />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -67,7 +82,8 @@
             android:orientation="horizontal"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:scrollbars="vertical"
-            app:layout_constraintStart_toEndOf="@+id/expand_list"
+            android:insetRight="0dp"
+            app:layout_constraintStart_toEndOf="@+id/forward_ws"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/close_all_tabs"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/clients/android/app/src/main/res/values/strings.xml
+++ b/clients/android/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="shared_navbar_item">Shared</string>
 
     <string name="expand_tabs_list">View more info about your tabs</string>
+    <string name="workspace_forward">Go forward in workspace</string>
     <string name="close_tab">Close a tab</string>
     <string name="close_all_tabs">Close all tabs</string>
     <string name="server_onboarding_text">Server:</string>

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -109,6 +109,8 @@ object Workspace {
     external fun closeDoc(rustObj: Long, id: String)
     external fun closeAllTabs(rustObj: Long)
     external fun showTabs(rustObj: Long, show: Boolean)
+    external fun back(rustObj: Long): Boolean
+    external fun forward(rustObj: Long): Boolean
 
     external fun getTabs(rustObj: Long) : Array<String>
 

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -108,7 +108,6 @@ object Workspace {
 
     external fun closeDoc(rustObj: Long, id: String)
     external fun closeAllTabs(rustObj: Long)
-    external fun showTabs(rustObj: Long, show: Boolean)
     external fun back(rustObj: Long): Boolean
     external fun forward(rustObj: Long): Boolean
 

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -110,6 +110,7 @@ object Workspace {
     external fun closeAllTabs(rustObj: Long)
     external fun back(rustObj: Long): Boolean
     external fun forward(rustObj: Long): Boolean
+    external fun canForward(rustObj: Long): Boolean
 
     external fun getTabs(rustObj: Long) : Array<String>
 

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -353,6 +353,14 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_forward(
 }
 
 #[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_canForward(
+    _env: JNIEnv, _: JClass, obj: jlong,
+) -> jboolean {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+    obj.workspace.can_forward().into()
+}
+
+#[no_mangle]
 pub extern "system" fn Java_app_lockbook_workspace_Workspace_getTabs(
     mut env: JNIEnv, _: JClass, obj: jlong,
 ) -> jobjectArray {

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -336,6 +336,36 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_showTabs(
 }
 
 #[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_back(
+    _env: JNIEnv, _: JClass, obj: jlong,
+) -> jboolean {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+
+    if obj.workspace.can_back() {
+        obj.workspace.back();
+        true
+    } else {
+        false
+    }
+    .into()
+}
+
+#[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_forward(
+    _env: JNIEnv, _: JClass, obj: jlong,
+) -> jboolean {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+
+    if obj.workspace.can_forward() {
+        obj.workspace.forward();
+        true
+    } else {
+        false
+    }
+    .into()
+}
+
+#[no_mangle]
 pub extern "system" fn Java_app_lockbook_workspace_Workspace_getTabs(
     mut env: JNIEnv, _: JClass, obj: jlong,
 ) -> jobjectArray {

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -323,15 +323,6 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_closeAllTabs(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_app_lockbook_workspace_Workspace_showTabs(
-    _env: JNIEnv, _: JClass, obj: jlong, show: jboolean,
-) {
-    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
-
-    obj.workspace.show_tabs = show == 1;
-}
-
-#[no_mangle]
 pub extern "system" fn Java_app_lockbook_workspace_Workspace_back(
     _env: JNIEnv, _: JClass, obj: jlong,
 ) -> jboolean {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -505,14 +505,16 @@ impl MdRender {
         &mut self, ui: &mut Ui, top_left: Pos2, wrap: &mut Wrap, range: (Grapheme, Grapheme),
         text_format: Format, override_text: Option<&str>, sense: Sense,
     ) -> Response {
-        let text = override_text.unwrap_or(&self.buffer[range]);
         let ppi = self.ctx.pixels_per_point();
         let padded = text_format.background != egui::Color32::TRANSPARENT;
         let sense = if text_format.spoiler { Sense::hover() } else { sense };
 
         #[cfg(debug_assertions)]
-        if text.contains('\n') {
-            panic!("show_text_line: text contains newline: {text:?}");
+        {
+            let text = override_text.unwrap_or(&self.buffer[range]);
+            if text.contains('\n') {
+                panic!("show_text_line: text contains newline: {text:?}");
+            }
         }
 
         let font_size = if text_format.superscript || text_format.subscript {

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -388,6 +388,15 @@ impl Workspace {
         self.current_tab_changed = true;
     }
 
+    pub fn can_back(&self) -> bool {
+        let Some(current_dest) = self.current_tab.as_ref() else { return false };
+        self.tab_strip
+            .iter()
+            .find(|s| &s.dest == current_dest)
+            .map(|slot| !slot.back.is_empty())
+            .unwrap_or(false)
+    }
+
     pub fn forward(&mut self) {
         let Some(current_dest) = self.current_tab.clone() else { return };
         let Some(slot_idx) = self.tab_strip.iter().position(|s| s.dest == current_dest) else {
@@ -402,6 +411,15 @@ impl Workspace {
         self.open_dest(&new_dest);
         self.current_tab = Some(new_dest);
         self.current_tab_changed = true;
+    }
+
+    pub fn can_forward(&self) -> bool {
+        let Some(current_dest) = self.current_tab.as_ref() else { return false };
+        self.tab_strip
+            .iter()
+            .find(|s| &s.dest == current_dest)
+            .map(|slot| !slot.forward.is_empty())
+            .unwrap_or(false)
     }
 
     pub fn close_tab(&mut self, i: usize) {


### PR DESCRIPTION
fixes:  #4405
this will map the back gesture to a workspace back if the undo stack is not empty else it will bring you back to the file tree view. 
this still opens every file in a new tab, which matches macos and ios but not egui. we should uniform behavior 

https://github.com/user-attachments/assets/3bfe8324-9d49-4c90-83f1-5ad208d496ab

