### PR TITLE
md: fix 120 fps / width too narrow

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/md_label.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/md_label.rs
@@ -56,7 +56,6 @@ impl MdLabel {
         let root = self.renderer.reparse(&arena);
 
         let height = self.renderer.height(root, &[root]);
-        self.renderer.top_left = top_left;
         let rect = Rect::from_min_size(top_left, Vec2::new(width, height));
 
         self.renderer.galleys.galleys.clear();

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -132,9 +132,8 @@ pub struct MdRender {
     pub syntax: SyntaxHighlightCache,
 
     // viewport
-    pub top_left: Pos2,
     pub width: f32,
-    pub height: f32,
+    pub viewport_height: f32,
 
     // debug
     pub debug: bool,
@@ -232,6 +231,11 @@ pub struct Editor {
     // misc
     pub virtual_keyboard_shown: bool,
     pub unprocessed_scroll: Option<Instant>,
+
+    /// Last frame's available render area, for change detection. Tracked
+    /// separately from `renderer.width` (the centered content-column width,
+    /// which on wide windows is strictly less than the available width).
+    prev_dimensions: Option<Vec2>,
 
     // outputs from drawing a frame need an additional frame to process before reporting
     next_resp: Response,
@@ -373,9 +377,8 @@ impl MdRender {
             files: Arc::new(RwLock::new(FileCache::empty())),
             layout_cache: Default::default(),
             syntax: Default::default(),
-            top_left: Default::default(),
             width: Default::default(),
-            height: Default::default(),
+            viewport_height: Default::default(),
             debug: false,
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
@@ -410,9 +413,8 @@ impl MdRender {
             files: Arc::new(RwLock::new(FileCache::empty())),
             layout_cache: Default::default(),
             syntax: Default::default(),
-            top_left: Default::default(),
             width: Default::default(),
-            height: Default::default(),
+            viewport_height: Default::default(),
             debug: false,
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
@@ -514,9 +516,8 @@ impl Editor {
             layout_cache: Default::default(),
             syntax: Default::default(),
 
-            top_left: Default::default(),
             width: Default::default(),
-            height: Default::default(),
+            viewport_height: Default::default(),
 
             debug: false,
             frame_times: [Instant::now(); 10],
@@ -552,6 +553,8 @@ impl Editor {
             // this is used to toggle the mobile toolbar
             virtual_keyboard_shown: cfg!(target_os = "android"),
             unprocessed_scroll: Default::default(),
+
+            prev_dimensions: None,
 
             next_resp: Default::default(),
         }
@@ -635,10 +638,12 @@ impl Editor {
             .width()
             .min(self.edit.renderer.layout.max_width)
             .round();
-        let height_updated = self.edit.renderer.height != height;
-        let width_updated = self.edit.renderer.width != width;
-        self.edit.renderer.height = height;
-        self.edit.renderer.width = width;
+        let dimensions = Vec2::new(width, height);
+        let (height_updated, width_updated) = match self.prev_dimensions {
+            Some(prev) => (prev.y != dimensions.y, prev.x != dimensions.x),
+            None => (true, true),
+        };
+        self.prev_dimensions = Some(dimensions);
 
         let dark_mode = ui.style().visuals.dark_mode;
         if dark_mode != self.edit.renderer.dark_mode {
@@ -1050,14 +1055,17 @@ impl Editor {
                             let scroll_view_height = ui.max_rect().height();
                             ui.allocate_space(Vec2 { x: ui.available_width(), y: 0. });
 
-                            let padding = (ui.available_width() - self.edit.renderer.width) / 2.;
-
-                            self.edit.renderer.top_left = ui.max_rect().min
+                            let column_width = ui
+                                .available_width()
+                                .min(self.edit.renderer.layout.max_width)
+                                .round();
+                            let content_width =
+                                column_width - 2. * self.edit.renderer.layout.margin;
+                            let padding = (ui.available_width() - column_width) / 2.;
+                            let top_left = ui.max_rect().min
                                 + (padding + self.edit.renderer.layout.margin) * Vec2::X;
-                            // Pre-subtract margin so height() and show see the same
-                            // renderer.width. Otherwise margin gets subtracted twice,
-                            // cell widths diverge, and cached heights go stale.
-                            self.edit.renderer.width -= 2. * self.edit.renderer.layout.margin;
+
+                            self.edit.renderer.width = content_width;
                             let height = {
                                 let document_height = self.edit.renderer.height(root, &[root]);
                                 let unfilled_space = if document_height < scroll_view_height {
@@ -1069,10 +1077,8 @@ impl Editor {
 
                                 document_height + unfilled_space.max(end_of_text_padding)
                             };
-                            let rect = Rect::from_min_size(
-                                self.edit.renderer.top_left,
-                                Vec2::new(self.edit.renderer.width, height),
-                            );
+                            let rect =
+                                Rect::from_min_size(top_left, Vec2::new(content_width, height));
 
                             // delegate to MdEdit::show for parse, event processing,
                             // render, cursor/selection drawing, touch handles,

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -139,7 +139,7 @@ impl MdEdit {
     pub fn show(&mut self, ui: &mut Ui, rect: Rect, id: Id) {
         self.renderer.dark_mode = ui.style().visuals.dark_mode;
         self.renderer.width = rect.width();
-        self.renderer.top_left = rect.min;
+        self.renderer.viewport_height = ui.clip_rect().height();
 
         ui.ctx().check_for_id_clash(id, rect, "");
         let prev_focused = ui.memory(|m| m.has_focus(id));

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -36,7 +36,7 @@ impl<'ast> MdRender {
         let value = &node.data.borrow().value;
         let sp = &node.data.borrow().sourcepos;
         match value {
-            NodeValue::FrontMatter(_) => self.width - 2. * self.layout.margin,
+            NodeValue::FrontMatter(_) => self.width,
             NodeValue::Raw(_) => unreachable!("can only be created programmatically"),
 
             // container_block
@@ -44,7 +44,7 @@ impl<'ast> MdRender {
             NodeValue::BlockQuote => indented_width(),
             NodeValue::DescriptionItem(_) => unimplemented!("extension disabled"),
             NodeValue::DescriptionList => unimplemented!("extension disabled"),
-            NodeValue::Document => self.width - 2. * self.layout.margin,
+            NodeValue::Document => self.width,
             NodeValue::FootnoteDefinition(_) => indented_width(),
             NodeValue::Item(_) => indented_width(),
             NodeValue::List(_) => indented_width(), // indentation handled by items

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -60,8 +60,9 @@ impl<'ast> MdRender {
         // satisfy the margin (initial frames before viewport is known,
         // zero-height containers), the image collapses to 0 rather than
         // letting negative dimensions corrupt the surrounding block layout.
-        let image_max_size =
-            (Vec2::new(self.width, self.height) - Vec2::splat(self.layout.margin)).max(Vec2::ZERO);
+        let image_max_size = (Vec2::new(self.width, self.viewport_height)
+            - Vec2::splat(self.layout.margin))
+        .max(Vec2::ZERO);
 
         // only shrink images, never stretch beyond their natural size
         let width = width.min(texture_size.x).min(image_max_size.x);


### PR DESCRIPTION
A poor abstraction caused the width to rapidly alternate within a frame, destroying cache performance and pinning to 120fps. The rendered width was wrong.