### PR TITLE
md: remove sorted siblings

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -421,10 +421,9 @@ impl<'ast> MdEdit {
                     if matches!(node.data().value, NodeValue::Heading(_))
                         && self.renderer.selected_block(node)
                     {
-                        let siblings = self.renderer.sorted_siblings(node);
                         self.renderer.apply_fold(
                             node,
-                            self.renderer.heading_contents(node, &siblings),
+                            self.renderer.heading_contents(node),
                             unapply,
                         );
                     }
@@ -432,12 +431,8 @@ impl<'ast> MdEdit {
                     if matches!(node.data().value, NodeValue::Item(_) | NodeValue::TaskItem(_))
                         && self.renderer.selected_fold_item(node)
                     {
-                        let siblings = self.renderer.sorted_siblings(node);
-                        self.renderer.apply_fold(
-                            node,
-                            self.renderer.item_contents(node, &siblings),
-                            unapply,
-                        );
+                        self.renderer
+                            .apply_fold(node, self.renderer.item_contents(node), unapply);
                     }
                 }
             }

--- a/libs/content/workspace/src/tab/markdown_editor/md_label.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/md_label.rs
@@ -30,7 +30,7 @@ impl MdLabel {
         self.prepare(md, width);
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
-        self.renderer.height(root, &[root])
+        self.renderer.height(root)
     }
 
     /// Render `md` into `ui` at the current cursor position, wrapping at
@@ -55,7 +55,7 @@ impl MdLabel {
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
 
-        let height = self.renderer.height(root, &[root]);
+        let height = self.renderer.height(root);
         let rect = Rect::from_min_size(top_left, Vec2::new(width, height));
 
         self.renderer.galleys.galleys.clear();
@@ -64,7 +64,7 @@ impl MdLabel {
 
         // Scoped ui for clipping; the scope's cursor side-effects stay local.
         ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
-            self.renderer.show_block(ui, root, top_left, &[root]);
+            self.renderer.show_block(ui, root, top_left);
         });
 
         (std::mem::take(&mut self.renderer.text_areas), rect)

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1078,7 +1078,7 @@ impl Editor {
 
                             self.edit.renderer.width = content_width;
                             let height = {
-                                let document_height = self.edit.renderer.height(root, &[root]);
+                                let document_height = self.edit.renderer.height(root);
                                 let unfilled_space = if document_height < scroll_view_height {
                                     scroll_view_height - document_height
                                 } else {

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -326,10 +326,10 @@ impl MdEdit {
         self.renderer.bounds.wrap_lines.clear();
         self.renderer.text_areas.clear();
 
-        let height = self.renderer.height(root, &[root]);
+        let height = self.renderer.height(root);
         let render_rect = Rect::from_min_size(rect.min, Vec2::new(rect.width(), height));
         ui.scope_builder(UiBuilder::new().max_rect(render_rect), |ui| {
-            self.renderer.show_block(ui, root, rect.min, &[root]);
+            self.renderer.show_block(ui, root, rect.min);
         });
         self.renderer.galleys.galleys.sort_by_key(|g| g.range);
 
@@ -412,7 +412,7 @@ impl MdEdit {
         self.renderer.width = width;
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
-        self.renderer.height(root, &[root])
+        self.renderer.height(root)
     }
 
     /// Render active completion popups. Caller invokes this after the main

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
@@ -54,9 +54,9 @@ impl<'ast> MdRender {
 
     pub fn show_alert(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
-        node_alert: &NodeAlert, siblings: &[&'ast AstNode<'ast>],
+        node_alert: &NodeAlert,
     ) {
-        let height = self.height(node, siblings);
+        let height = self.height(node);
         let annotation_size = Vec2 { x: self.layout.indent, y: height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
@@ -40,11 +40,8 @@ impl<'ast> MdRender {
         result
     }
 
-    pub fn show_block_quote(
-        &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
-        siblings: &[&'ast AstNode<'ast>],
-    ) {
-        let height = self.height(node, siblings);
+    pub fn show_block_quote(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2) {
+        let height = self.height(node);
         let annotation_size = Vec2 { x: self.layout.indent, y: height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -28,10 +28,7 @@ impl<'ast> MdRender {
         }
     }
 
-    pub fn show_item(
-        &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2,
-        siblings: &[&'ast AstNode<'ast>],
-    ) {
+    pub fn show_item(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2) {
         let first_line = self.node_first_line(node);
         let row_height = self.node_line_row_height(node, first_line);
 
@@ -54,7 +51,12 @@ impl<'ast> MdRender {
                 );
             }
             ListType::Ordered => {
-                let sibling_index = self.sibling_index(node, siblings);
+                let mut sibling_index = 0usize;
+                let mut prev = node.previous_sibling();
+                while let Some(p) = prev {
+                    sibling_index += 1;
+                    prev = p.previous_sibling();
+                }
                 let number = start + sibling_index;
 
                 let text = format!("{number}.");
@@ -143,8 +145,8 @@ impl<'ast> MdRender {
             ui,
             node,
             (fold_button_size, fold_button_icon_size, fold_button_space),
-            self.item_contents(node, siblings),
-            self.item_fold_reveal(node, siblings),
+            self.item_contents(node),
+            self.item_fold_reveal(node),
         );
     }
 
@@ -254,9 +256,7 @@ impl<'ast> MdRender {
         }
     }
 
-    pub fn item_contents(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> (Grapheme, Grapheme) {
+    pub fn item_contents(&self, node: &'ast AstNode<'ast>) -> (Grapheme, Grapheme) {
         // contents start at the end of the first child, which acts as a sort of section title
         // if no children, start at end of node first line
         let mut contents = if let Some(first_child) = node.children().next() {
@@ -265,9 +265,7 @@ impl<'ast> MdRender {
             self.node_first_line(node).end().into_range()
         };
 
-        let sibling_index = self.sibling_index(node, siblings);
-
-        if let Some(sibling) = siblings[sibling_index + 1..].first() {
+        if let Some(sibling) = node.next_sibling() {
             let sibling_first_line = self.node_first_line_idx(sibling);
             let last_line = sibling_first_line - 1;
             contents.1 = self.bounds.source_lines[last_line].end();
@@ -281,10 +279,8 @@ impl<'ast> MdRender {
     }
 
     /// Returns true if the item contents should be revealed whether the heading is folded or not
-    pub fn item_fold_reveal(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> bool {
-        self.range_contains_revealed(self.item_contents(node, siblings), false, true)
+    pub fn item_fold_reveal(&self, node: &'ast AstNode<'ast>) -> bool {
+        self.range_contains_revealed(self.item_contents(node), false, true)
     }
 
     /// Returns true if the item is selected for folding; specialized adaptation of self.selected_block()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -78,13 +78,11 @@ impl<'ast> MdRender {
 
     // the height of a block that contains blocks is the sum of the heights of the blocks it contains
     pub fn block_children_height(&self, node: &'ast AstNode<'ast>) -> f32 {
-        let children = self.sorted_children(node);
-
         let mut height_sum = 0.0;
-        for child in &children {
-            height_sum += self.block_pre_spacing_height(child, &children);
-            height_sum += self.height(child, &children);
-            height_sum += self.block_post_spacing_height(child, &children);
+        for child in node.children() {
+            height_sum += self.block_pre_spacing_height(child);
+            height_sum += self.height(child);
+            height_sum += self.block_post_spacing_height(child);
         }
         height_sum
     }
@@ -94,8 +92,6 @@ impl<'ast> MdRender {
     pub fn show_block_children(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
     ) {
-        let children = self.sorted_children(node);
-
         let required_ranges =
             self.galley_required_ranges(self.in_progress_selection, self.find_current_match);
         let viewport = ui.clip_rect();
@@ -107,24 +103,24 @@ impl<'ast> MdRender {
         let past_all_required =
             |offset: Grapheme| -> bool { required_ranges.iter().all(|rr| offset > rr.end()) };
 
-        for child in &children {
+        for child in node.children() {
             let child_range = self.node_range(child);
-            let pre_lines = self.pre_spacing_lines(child, &children);
-            let post_lines = self.post_spacing_lines(child, &children);
+            let pre_lines = self.pre_spacing_lines(child);
+            let post_lines = self.post_spacing_lines(child);
 
             // add pre-spacing
-            let pre_spacing = self.block_pre_spacing_height(child, &children);
+            let pre_spacing = self.block_pre_spacing_height(child);
             let pre_spacing_below_viewport = viewport.max.y < top_left.y;
             let pre_spacing_above_viewport = viewport.min.y > top_left.y + pre_spacing;
             let pre_spacing_visible = !pre_spacing_above_viewport && !pre_spacing_below_viewport;
             let pre_spacing_needed = intersects_any_required(&self.spacing_range(&pre_lines));
             if pre_spacing_visible || pre_spacing_needed {
-                self.show_block_pre_spacing(ui, child, top_left, &children);
+                self.show_block_pre_spacing(ui, child, top_left);
             }
             top_left.y += pre_spacing;
 
             // add block
-            let child_height = self.height(child, &children);
+            let child_height = self.height(child);
 
             if self.debug {
                 self.show_debug_block_highlight(
@@ -141,7 +137,7 @@ impl<'ast> MdRender {
             let block_visible = !block_above_viewport && !block_below_viewport;
             let block_needed = intersects_any_required(&child_range);
             if block_visible || block_needed {
-                self.show_block(ui, child, top_left, &children);
+                self.show_block(ui, child, top_left);
             } else {
                 let in_buffer = top_left.y + child_height > viewport.min.y - buffer
                     && top_left.y < viewport.max.y + buffer;
@@ -154,13 +150,13 @@ impl<'ast> MdRender {
             top_left.y += child_height;
 
             // add post-spacing
-            let post_spacing = self.block_post_spacing_height(child, &children);
+            let post_spacing = self.block_post_spacing_height(child);
             let post_spacing_below_viewport = viewport.max.y < top_left.y;
             let post_spacing_above_viewport = viewport.min.y > top_left.y + post_spacing;
             let post_spacing_visible = !post_spacing_above_viewport && !post_spacing_below_viewport;
             let post_spacing_needed = intersects_any_required(&self.spacing_range(&post_lines));
             if post_spacing_visible || post_spacing_needed {
-                self.show_block_post_spacing(ui, child, top_left, &children);
+                self.show_block_post_spacing(ui, child, top_left);
             }
             top_left.y += post_spacing;
 
@@ -584,17 +580,15 @@ impl<'ast> MdRender {
 
     // compute bounds for blocks stacked vertically
     pub fn compute_bounds_block_children(&mut self, node: &'ast AstNode<'ast>) {
-        let children = self.sorted_children(node);
-
-        for child in &children {
+        for child in node.children() {
             // add pre-spacing bounds
-            self.compute_bounds_block_pre_spacing(child, &children);
+            self.compute_bounds_block_pre_spacing(child);
 
             // add block bounds
             self.compute_bounds(child);
 
             // add post-spacing bounds
-            self.compute_bounds_block_post_spacing(child, &children);
+            self.compute_bounds_block_post_spacing(child);
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table_row.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table_row.rs
@@ -27,9 +27,8 @@ impl<'ast> MdRender {
         } else {
             // the height of the row is the height of the tallest cell
             let mut cell_height_max = 0.0f32;
-            let children = self.sorted_children(node);
-            for table_cell in &children {
-                cell_height_max = cell_height_max.max(self.height(table_cell, &children));
+            for table_cell in node.children() {
+                cell_height_max = cell_height_max.max(self.height(table_cell));
             }
 
             cell_height_max
@@ -89,13 +88,12 @@ impl<'ast> MdRender {
     fn reveal_table_row(&self, node: &'ast AstNode<'ast>) -> bool {
         let selection = self.buffer.current.selection;
         let row_range = self.node_range(node);
-        let children = self.sorted_children(node); // todo: these will always already be sorted
         let line = self.node_first_line(node);
         let node_line = self.node_line(node, line);
 
         // check for cursor between cells
         let mut range_start = row_range.start();
-        for cell in &children {
+        for cell in node.children() {
             let cell_range = if let Some((_, _, cell_children_range, _, _)) =
                 self.split_range(cell, node_line)
             {
@@ -114,7 +112,7 @@ impl<'ast> MdRender {
         }
 
         // check for cursor after last cell
-        if let Some(cell) = children.last() {
+        if let Some(cell) = node.children().last() {
             let cell_range = if let Some((_, _, cell_children_range, _, _)) =
                 self.split_range(cell, node_line)
             {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -13,7 +13,7 @@ impl<'ast> MdRender {
 
     pub fn show_task_item(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2,
-        node_task_item: &NodeTaskItem, siblings: &[&'ast AstNode<'ast>],
+        node_task_item: &NodeTaskItem,
     ) {
         let theme = self.ctx.get_lb_theme();
         let maybe_check = node_task_item.symbol;
@@ -128,8 +128,8 @@ impl<'ast> MdRender {
             ui,
             node,
             (fold_button_size, fold_button_icon_size, fold_button_space),
-            self.item_contents(node, siblings),
-            self.item_fold_reveal(node, siblings),
+            self.item_contents(node),
+            self.item_fold_reveal(node),
         );
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -137,7 +137,6 @@ impl<'ast> MdRender {
 
     pub fn show_heading(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2, level: u8, setext: bool,
-        siblings: &[&'ast AstNode<'ast>],
     ) {
         if setext {
             self.show_setext_heading(ui, node, top_left, level);
@@ -147,8 +146,7 @@ impl<'ast> MdRender {
 
         let pointer = ui.input(|i| i.pointer.latest_pos().unwrap_or_default());
         let hovered = {
-            let siblings_height = self.height(node, siblings)
-                + self.heading_contained_siblings_height(node, siblings);
+            let siblings_height = self.height(node) + self.heading_contained_siblings_height(node);
             let siblings_space =
                 Rect::from_min_size(top_left, Vec2::new(self.width(node), siblings_height));
 
@@ -176,8 +174,8 @@ impl<'ast> MdRender {
             ui,
             node,
             (fold_button_size, fold_button_icon_size, fold_button_space),
-            self.heading_contents(node, siblings),
-            self.heading_fold_reveal(node, siblings),
+            self.heading_contents(node),
+            self.heading_fold_reveal(node),
         );
     }
 
@@ -427,79 +425,47 @@ impl<'ast> MdRender {
         }
     }
 
-    fn heading_contained_siblings_height(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> f32 {
-        let contained_siblings = self.heading_contained_siblings(node, siblings);
+    fn heading_contained_siblings_height(&self, node: &'ast AstNode<'ast>) -> f32 {
+        let NodeValue::Heading(heading) = &node.data.borrow().value else {
+            panic!("heading_contained_siblings_height() invoked for non-heading")
+        };
+        let level = heading.level;
         let mut height_sum = 0.0;
-        for sibling in &contained_siblings {
-            height_sum += self.block_pre_spacing_height(sibling, siblings);
-            height_sum += self.height(sibling, siblings);
-            height_sum += self.block_post_spacing_height(sibling, siblings);
+        let mut sibling = node.next_sibling();
+        while let Some(s) = sibling {
+            if let NodeValue::Heading(sib_h) = &s.data.borrow().value {
+                if sib_h.level <= level {
+                    break;
+                }
+            }
+            height_sum += self.block_pre_spacing_height(s);
+            height_sum += self.height(s);
+            height_sum += self.block_post_spacing_height(s);
+            sibling = s.next_sibling();
         }
         height_sum
     }
 
-    fn heading_contained_siblings(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> Vec<&'ast AstNode<'ast>> {
+    pub fn heading_contents(&self, node: &'ast AstNode<'ast>) -> (Grapheme, Grapheme) {
         let NodeValue::Heading(heading) = &node.data.borrow().value else {
             panic!("heading_contents() invoked for non-heading")
         };
 
         let mut contents = self.node_range(node).end().into_range();
-        let sibling_index = self.sibling_index(node, siblings);
-
-        let mut result = Vec::new();
-
-        for sibling in siblings[sibling_index + 1..].iter() {
-            // an equal or more significant subsequent heading concludes this heading's contents
-            if let NodeValue::Heading(sibling_heading) = &sibling.data.borrow().value {
-                if sibling_heading.level <= heading.level {
-                    let sibling_first_line = self.node_first_line_idx(sibling);
+        let mut sibling = node.next_sibling();
+        while let Some(s) = sibling {
+            if let NodeValue::Heading(sib_h) = &s.data.borrow().value {
+                if sib_h.level <= heading.level {
+                    let sibling_first_line = self.node_first_line_idx(s);
                     let last_line = sibling_first_line - 1;
                     contents.1 = self.bounds.source_lines[last_line].end();
-
-                    break;
+                    return contents;
                 }
             }
-
-            result.push(*sibling);
+            sibling = s.next_sibling();
         }
-
-        result
-    }
-
-    pub fn heading_contents(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> (Grapheme, Grapheme) {
-        let NodeValue::Heading(heading) = &node.data.borrow().value else {
-            panic!("heading_contents() invoked for non-heading")
-        };
-
-        let mut contents = self.node_range(node).end().into_range();
-        let sibling_index = self.sibling_index(node, siblings);
-        let mut concluded_by_subsequent_heading = false;
-        for sibling in siblings[sibling_index + 1..].iter() {
-            // an equal or more significant subsequent heading concludes this heading's contents
-            if let NodeValue::Heading(sibling_heading) = &sibling.data.borrow().value {
-                if sibling_heading.level <= heading.level {
-                    let sibling_first_line = self.node_first_line_idx(sibling);
-                    let last_line = sibling_first_line - 1;
-                    contents.1 = self.bounds.source_lines[last_line].end();
-                    concluded_by_subsequent_heading = true;
-
-                    break;
-                }
-            }
-        }
-        if !concluded_by_subsequent_heading {
-            // absent an equal or more significant subsequent
-            // heading, we contain the remaining content of the
-            // parent
-            contents.1 = self.node_range(node.parent().unwrap()).end();
-        }
-
+        // No concluding heading: contain the rest of the parent.
+        contents.1 = self.node_range(node.parent().unwrap()).end();
         contents
     }
 
@@ -557,9 +523,7 @@ impl<'ast> MdRender {
     }
 
     /// Returns true if the heading contents should be revealed whether the heading is folded or not
-    pub fn heading_fold_reveal(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> bool {
-        self.range_contains_revealed(self.heading_contents(node, siblings), false, true)
+    pub fn heading_fold_reveal(&self, node: &'ast AstNode<'ast>) -> bool {
+        self.range_contains_revealed(self.heading_contents(node), false, true)
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -89,7 +89,7 @@ impl<'ast> MdRender {
         }
     }
 
-    pub fn height(&self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>]) -> f32 {
+    pub fn height(&self, node: &'ast AstNode<'ast>) -> f32 {
         if let Some(cached) = self.get_cached_node_height(node) {
             return cached;
         }
@@ -128,7 +128,7 @@ impl<'ast> MdRender {
         }
 
         // hide folded nodes only if they are not revealed
-        if self.hidden_by_fold(node, siblings) {
+        if self.hidden_by_fold(node) {
             return 0.;
         }
 
@@ -199,7 +199,6 @@ impl<'ast> MdRender {
 
     pub(crate) fn show_block(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
-        siblings: &[&'ast AstNode<'ast>],
     ) {
         let ui = &mut self.node_ui(ui, node);
 
@@ -230,7 +229,7 @@ impl<'ast> MdRender {
         }
 
         // hide folded nodes only if they are not revealed
-        if self.hidden_by_fold(node, siblings) {
+        if self.hidden_by_fold(node) {
             return;
         }
 
@@ -241,15 +240,13 @@ impl<'ast> MdRender {
             NodeValue::Raw(_) => unreachable!("can only be created programmatically"),
 
             // container_block
-            NodeValue::Alert(node_alert) => {
-                self.show_alert(ui, node, top_left, node_alert, siblings)
-            }
-            NodeValue::BlockQuote => self.show_block_quote(ui, node, top_left, siblings),
+            NodeValue::Alert(node_alert) => self.show_alert(ui, node, top_left, node_alert),
+            NodeValue::BlockQuote => self.show_block_quote(ui, node, top_left),
             NodeValue::DescriptionItem(_) => unimplemented!("extension disabled"),
             NodeValue::DescriptionList => unimplemented!("extension disabled"),
             NodeValue::Document => self.show_document(ui, node, top_left),
             NodeValue::FootnoteDefinition(_) => self.show_footnote_definition(ui, node, top_left),
-            NodeValue::Item(_) => self.show_item(ui, node, top_left, siblings),
+            NodeValue::Item(_) => self.show_item(ui, node, top_left),
             NodeValue::List(_) => self.show_block_children(ui, node, top_left),
             NodeValue::MultilineBlockQuote(_) => unimplemented!("extension disabled"),
             NodeValue::Table(_) => self.show_table(ui, node, top_left),
@@ -257,7 +254,7 @@ impl<'ast> MdRender {
                 self.show_table_row(ui, node, top_left, *is_header_row)
             }
             NodeValue::TaskItem(node_task_item) => {
-                self.show_task_item(ui, node, top_left, node_task_item, siblings)
+                self.show_task_item(ui, node, top_left, node_task_item)
             }
 
             // inline
@@ -294,7 +291,7 @@ impl<'ast> MdRender {
             NodeValue::DescriptionDetails => unimplemented!("extension disabled"),
             NodeValue::DescriptionTerm => unimplemented!("extension disabled"),
             NodeValue::Heading(NodeHeading { level, setext, .. }) => {
-                self.show_heading(ui, node, top_left, *level, *setext, siblings)
+                self.show_heading(ui, node, top_left, *level, *setext)
             }
             NodeValue::HtmlBlock(_) => self.show_html_block(ui, node, top_left),
             NodeValue::Paragraph => self.show_paragraph(ui, node, top_left),
@@ -315,28 +312,6 @@ impl<'ast> MdRender {
             && self.node_contains_selection(parent)
             && (node.is_container_block() && !self.node_contains_selection(node)
                 || node.is_leaf_block())
-    }
-
-    /// Returns the children of the given node. With footnotes disabled,
-    /// comrak reports children in sourcepos order so no sorting is needed.
-    pub fn sorted_children(&self, node: &'ast AstNode<'ast>) -> Vec<&'ast AstNode<'ast>> {
-        node.children().collect()
-    }
-
-    /// Returns the siblings of the given node in sourcepos order.
-    pub fn sorted_siblings(&self, node: &'ast AstNode<'ast>) -> Vec<&'ast AstNode<'ast>> {
-        if let Some(parent) = node.parent() { self.sorted_children(parent) } else { vec![node] }
-    }
-
-    pub fn sibling_index(
-        &self, node: &'ast AstNode<'ast>, sorted_siblings: &[&'ast AstNode<'ast>],
-    ) -> usize {
-        let this_sibling_index = sorted_siblings
-            .iter()
-            .position(|sibling| node.same_node(sibling))
-            .unwrap();
-
-        this_sibling_index
     }
 
     /// Returns the portion of the line that's within the node, excluding line
@@ -517,9 +492,7 @@ impl<'ast> MdRender {
         None
     }
 
-    pub fn hidden_by_fold(
-        &self, node: &'ast AstNode<'ast>, _siblings: &[&'ast AstNode<'ast>],
-    ) -> bool {
+    pub fn hidden_by_fold(&self, node: &'ast AstNode<'ast>) -> bool {
         self.get_cached_hidden_by_fold(node)
             .expect("hidden_by_fold queried for a node not in the current AST")
     }
@@ -575,15 +548,12 @@ impl<'ast> MdRender {
             // headings get pushed — they "block" prior less-significant
             // folded headings from contributing past us.
             if let Some(level) = heading_level {
-                let folded = self.fold(c).is_some()
-                    && !self.heading_fold_reveal(c, &self.sorted_siblings(c));
+                let folded = self.fold(c).is_some() && !self.heading_fold_reveal(c);
                 heading_stack.push((level, folded));
             }
 
             let child_item_fold_active = item_fold_active
-                || (is_item_or_task
-                    && self.fold(c).is_some()
-                    && !self.item_fold_reveal(c, &self.sorted_siblings(c)));
+                || (is_item_or_task && self.fold(c).is_some() && !self.item_fold_reveal(c));
             self.populate_hidden_by_fold_subtree(c, child_item_fold_active);
 
             child = c.next_sibling();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
@@ -23,26 +23,24 @@ impl<'ast> MdRender {
     /// the empty lines between the previous sibling (or parent start) and this
     /// node. Returns `None` when there is no pre-spacing (document root, table
     /// rows, folded nodes).
-    pub fn pre_spacing_lines(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> Option<Range<usize>> {
+    pub fn pre_spacing_lines(&self, node: &'ast AstNode<'ast>) -> Option<Range<usize>> {
         let parent = node.parent()?;
         if matches!(node.data.borrow().value, NodeValue::TableRow(_)) {
             return None;
         }
-        if self.hidden_by_fold(node, siblings) {
+        if self.hidden_by_fold(node) {
             return None;
         }
 
-        let sibling_index = self.sibling_index(node, siblings);
-        let first = if sibling_index == 0 {
-            let mut first = self.node_first_line_idx(parent);
-            if matches!(&parent.data.borrow().value, NodeValue::Alert(_)) {
-                first += 1;
+        let first = match node.previous_sibling() {
+            None => {
+                let mut first = self.node_first_line_idx(parent);
+                if matches!(&parent.data.borrow().value, NodeValue::Alert(_)) {
+                    first += 1;
+                }
+                first
             }
-            first
-        } else {
-            self.node_last_line_idx(siblings[sibling_index - 1]) + 1
+            Some(prev) => self.node_last_line_idx(prev) + 1,
         };
 
         Some(first..self.node_first_line_idx(node))
@@ -51,16 +49,13 @@ impl<'ast> MdRender {
     /// Returns the source line index range for the post-spacing of `node`, i.e.
     /// the empty lines between this node and the parent's end. Only the last
     /// sibling has post-spacing; returns `None` otherwise.
-    pub fn post_spacing_lines(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> Option<Range<usize>> {
+    pub fn post_spacing_lines(&self, node: &'ast AstNode<'ast>) -> Option<Range<usize>> {
         let parent = node.parent()?;
         if matches!(node.data.borrow().value, NodeValue::TableRow(_)) {
             return None;
         }
 
-        let sibling_index = self.sibling_index(node, siblings);
-        if sibling_index != siblings.len() - 1 {
+        if node.next_sibling().is_some() {
             return None;
         }
 
@@ -69,18 +64,15 @@ impl<'ast> MdRender {
         Some(first..(last + 1))
     }
 
-    pub fn block_pre_spacing_height(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> f32 {
-        let Some(line_range) = self.pre_spacing_lines(node, siblings) else {
+    pub fn block_pre_spacing_height(&self, node: &'ast AstNode<'ast>) -> f32 {
+        let Some(line_range) = self.pre_spacing_lines(node) else {
             return 0.;
         };
 
         let width = self.width(node);
         let mut result = 0.;
 
-        let sibling_index = self.sibling_index(node, siblings);
-        if sibling_index != 0 {
+        if node.previous_sibling().is_some() {
             result += self.layout.block_spacing;
         }
 
@@ -101,16 +93,14 @@ impl<'ast> MdRender {
 
     pub fn show_block_pre_spacing(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
-        siblings: &[&'ast AstNode<'ast>],
     ) {
-        let Some(line_range) = self.pre_spacing_lines(node, siblings) else {
+        let Some(line_range) = self.pre_spacing_lines(node) else {
             return;
         };
 
         let width = self.width(node);
 
-        let sibling_index = self.sibling_index(node, siblings);
-        if sibling_index != 0 {
+        if node.previous_sibling().is_some() {
             top_left.y += self.layout.block_spacing;
         }
 
@@ -126,10 +116,8 @@ impl<'ast> MdRender {
         }
     }
 
-    pub(crate) fn block_post_spacing_height(
-        &self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) -> f32 {
-        let Some(line_range) = self.post_spacing_lines(node, siblings) else {
+    pub(crate) fn block_post_spacing_height(&self, node: &'ast AstNode<'ast>) -> f32 {
+        let Some(line_range) = self.post_spacing_lines(node) else {
             return 0.;
         };
 
@@ -154,9 +142,8 @@ impl<'ast> MdRender {
 
     pub(crate) fn show_block_post_spacing(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
-        siblings: &[&'ast AstNode<'ast>],
     ) {
-        let Some(line_range) = self.post_spacing_lines(node, siblings) else {
+        let Some(line_range) = self.post_spacing_lines(node) else {
             return;
         };
 
@@ -175,10 +162,8 @@ impl<'ast> MdRender {
         }
     }
 
-    pub fn compute_bounds_block_pre_spacing(
-        &mut self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) {
-        let Some(line_range) = self.pre_spacing_lines(node, siblings) else {
+    pub fn compute_bounds_block_pre_spacing(&mut self, node: &'ast AstNode<'ast>) {
+        let Some(line_range) = self.pre_spacing_lines(node) else {
             return;
         };
 
@@ -189,10 +174,8 @@ impl<'ast> MdRender {
         }
     }
 
-    pub(crate) fn compute_bounds_block_post_spacing(
-        &mut self, node: &'ast AstNode<'ast>, siblings: &[&'ast AstNode<'ast>],
-    ) {
-        let Some(line_range) = self.post_spacing_lines(node, siblings) else {
+    pub(crate) fn compute_bounds_block_post_spacing(&mut self, node: &'ast AstNode<'ast>) {
+        let Some(line_range) = self.post_spacing_lines(node) else {
             return;
         };
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
@@ -93,8 +93,7 @@ impl<'ast> MdRender {
             }
 
             NodeValue::List(_) => {
-                let children = self.sorted_children(node);
-                let last_child = children.last().unwrap();
+                let last_child = node.children().last().unwrap();
                 range.1 = self.node_range(last_child).1;
             }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
@@ -1113,7 +1113,7 @@ impl<'ast> Editor {
         self.edit.renderer.bounds.inline_paragraphs.sort();
         self.edit.renderer.calc_words();
 
-        let height = self.edit.renderer.height(root, &[root]);
+        let height = self.edit.renderer.height(root);
 
         self.edit.renderer.layout_cache.clear();
 
@@ -1147,14 +1147,13 @@ impl<'ast> Editor {
         self.edit.renderer.bounds.inline_paragraphs.sort();
         self.edit.renderer.calc_words();
 
-        let height = self.edit.renderer.height(root, &[root]);
+        let height = self.edit.renderer.height(root);
         let rect = Rect::from_min_size(top_left, Vec2::new(width, height));
 
         self.edit.renderer.show_block(
             &mut ui.new_child(UiBuilder::new().max_rect(rect).layout(*ui.layout())),
             root,
             top_left,
-            &[root],
         );
 
         self.edit.renderer.layout_cache.clear();


### PR DESCRIPTION
It was originally introduced for footnote support, which we currently do not have. This eliminates many allocations per frame - to allocate a vec of node references so we can sort them.