### PR TITLE
md: affine scroll

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -186,14 +186,38 @@ impl MdEdit {
         }
     }
 
-    pub fn scroll_to_cursor(&self, ui: &mut Ui) {
-        let selection = self
+    pub fn scroll_to_cursor(&mut self, ui: &mut Ui, scroll_id: egui::Id, viewport_height: f32) {
+        let target = self
             .in_progress_selection
-            .unwrap_or(self.renderer.buffer.current.selection);
+            .unwrap_or(self.renderer.buffer.current.selection)
+            .1;
 
-        if let Some([top, bot]) = self.cursor_line(selection.1) {
-            let rect = Rect::from_min_max(top, bot);
-            ui.scroll_to_rect(rect.expand(rect.height()), None);
+        let arena = comrak::Arena::new();
+        let root = self.renderer.reparse(&arena);
+        let mut content = crate::tab::markdown_editor::scroll_content::DocScrollContent::new(
+            &mut self.renderer,
+            root,
+            0.0,
+            viewport_height / 2.0,
+        )
+        .with_default_leading();
+
+        let scroll = crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id);
+        let current_offset = scroll.offset(ui.ctx());
+
+        // Inclusive on `end` so an end-of-line cursor matches its row.
+        let offset = crate::widgets::affine_scroll::make_visible_offset(
+            &mut content,
+            viewport_height,
+            current_offset,
+            |c| {
+                c.text_range()
+                    .is_some_and(|(start, end)| target >= start && target <= end)
+            },
+        );
+
+        if let Some(o) = offset {
+            scroll.set_offset(ui.ctx(), o);
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -13,10 +13,9 @@ use comrak::nodes::AstNode;
 use comrak::{Arena, Options};
 use core::time::Duration;
 use egui::os::OperatingSystem;
-use egui::scroll_area::{ScrollAreaOutput, ScrollBarVisibility, ScrollSource};
 use egui::{
     Context, EventFilter, FontData, FontDefinitions, FontFamily, FontTweak, Frame, Id, Margin,
-    Pos2, Rect, ScrollArea, Stroke, Ui, UiBuilder, Vec2, scroll_area,
+    Pos2, Rect, Stroke, Ui, UiBuilder, Vec2,
 };
 use galleys::Galleys;
 use input::cursor::CursorState;
@@ -63,6 +62,7 @@ mod galleys;
 pub mod input;
 pub mod md_label;
 pub mod output;
+mod scroll_content;
 pub mod show;
 mod theme;
 mod widget;
@@ -263,7 +263,12 @@ impl MdPersistence {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct MdFilePersistence {
-    scroll_offset: f32,
+    /// `(anchor_block_idx, intra_offset_approx)` — the row index and
+    /// approx units within that row at which the scroll offset sits.
+    /// Width-independent (unlike a raw pixel offset) so reopening the
+    /// doc at a different width still lands on the right block.
+    #[serde(default)]
+    anchor: Option<(usize, f32)>,
     selection: (Grapheme, Grapheme),
     #[serde(default)]
     image_dims: HashMap<String, [f32; 2]>,
@@ -731,9 +736,13 @@ impl Editor {
         self.edit.renderer.apply_theme(ui);
         ui.spacing_mut().item_spacing.x = 0.;
 
-        let scroll_area_id = ui
+        let scroll_id = self.id();
+        let prev_offset =
+            crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id).offset(ui.ctx());
+
+        let editor_shown = ui
             .vertical(|ui| {
-                let scroll_area_id = if self.edit.renderer.touch_mode {
+                if self.edit.renderer.touch_mode {
                     self.show_find_centered(ui);
 
                     // ...then show editor content (or toolbar settings)...
@@ -745,47 +754,25 @@ impl Editor {
                     } else {
                         0.
                     };
-                    let scroll_area_id = ui
+                    let editor_shown = ui
                         .allocate_ui(
                             egui::vec2(
                                 ui.available_width(),
                                 ui.available_height() - toolbar_height,
                             ),
                             |ui| {
-                                ui.ctx().style_mut(|style| {
-                                    style.spacing.scroll = egui::style::ScrollStyle::solid();
-                                    style.spacing.scroll.bar_width = 10.;
-                                });
-
                                 if !self.toolbar.menu_open {
                                     // galleys / wrap_lines are cleared and
                                     // repopulated inside MdEdit::show — don't
                                     // clear here or input handling (which
                                     // reads last-frame galleys) sees nothing.
                                     self.edit.renderer.touch_consuming_rects.clear();
-
-                                    // show editor
-                                    let scroll_area_id =
-                                        ui.id().with(egui::Id::new(self.edit.file_id));
-                                    let scroll_area_offset = ui.data_mut(|d| {
-                                        d.get_persisted(scroll_area_id)
-                                            .map(|s: scroll_area::State| s.offset)
-                                            .unwrap_or_default()
-                                            .y
-                                    });
-
-                                    let scroll_area_output = self.show_scrollable_editor(ui, root);
-                                    self.next_resp.scroll_updated =
-                                        scroll_area_output.state.offset.y != scroll_area_offset;
-                                    self.edit.scroll_area_velocity =
-                                        scroll_area_output.state.velocity();
-
-                                    Some(scroll_area_id)
+                                    self.show_scrollable_editor(ui, root);
+                                    true
                                 } else {
                                     // show toolbar settings
                                     self.show_toolbar_menu(ui);
-
-                                    None
+                                    false
                                 }
                             },
                         )
@@ -802,16 +789,8 @@ impl Editor {
                         });
                     }
 
-                    scroll_area_id
+                    editor_shown
                 } else {
-                    let scroll_area_id = ui.id().with(egui::Id::new(self.edit.file_id));
-                    let scroll_area_offset = ui.data_mut(|d| {
-                        d.get_persisted(scroll_area_id)
-                            .map(|s: scroll_area::State| s.offset)
-                            .unwrap_or_default()
-                            .y
-                    });
-
                     if !self.edit.renderer.readonly {
                         self.show_toolbar(root, ui);
                     }
@@ -822,66 +801,77 @@ impl Editor {
                     // reads last-frame galleys) sees nothing.
                     self.edit.renderer.touch_consuming_rects.clear();
 
-                    // ...then show editor content
-                    let scroll_area_output = self.show_scrollable_editor(ui, root);
-                    self.next_resp.scroll_updated =
-                        scroll_area_output.state.offset.y != scroll_area_offset;
-                    self.edit.scroll_area_velocity = scroll_area_output.state.velocity();
-
-                    Some(scroll_area_id)
-                };
-
-                // persistence: read
-                if !self.initialized {
-                    let persisted = self
-                        .persistence
-                        .get_markdown()
-                        .file
-                        .get(&self.edit.file_id)
-                        .cloned()
-                        .unwrap_or_default();
-                    if let Some(scroll_area_id) = scroll_area_id {
-                        ui.data_mut(|d| {
-                            let state: Option<scroll_area::State> = d.get_persisted(scroll_area_id);
-                            if let Some(mut state) = state {
-                                state.offset.y = persisted.scroll_offset;
-                                d.insert_temp(scroll_area_id, state);
-                            }
-                        });
-                    }
-                    // set the selection using low-level API; using internal
-                    // events causes touch devices to scroll to cursor on 2nd
-                    // frame
-                    let (start, end) = persisted.selection;
-                    let selection = (
-                        start.clamp(
-                            0.into(),
-                            self.edit
-                                .renderer
-                                .buffer
-                                .current
-                                .segs
-                                .last_cursor_position(),
-                        ),
-                        end.clamp(
-                            0.into(),
-                            self.edit
-                                .renderer
-                                .buffer
-                                .current
-                                .segs
-                                .last_cursor_position(),
-                        ),
-                    );
-                    self.edit.renderer.buffer.queue(vec![
-                        lb_rs::model::text::operation_types::Operation::Select(selection),
-                    ]);
-                    self.edit.renderer.buffer.update();
+                    self.show_scrollable_editor(ui, root);
+                    true
                 }
-
-                scroll_area_id
             })
             .inner;
+
+        if editor_shown {
+            let scroll = crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id);
+            let new_offset = scroll.offset(ui.ctx());
+            self.next_resp.scroll_updated = new_offset != prev_offset;
+            self.edit.scroll_area_velocity = scroll.velocity(ui.ctx());
+
+            // persistence: read on first frame
+            if !self.initialized {
+                let persisted = self
+                    .persistence
+                    .get_markdown()
+                    .file
+                    .get(&self.edit.file_id)
+                    .cloned()
+                    .unwrap_or_default();
+                if let Some((anchor_idx, intra)) = persisted.anchor {
+                    let arena = Arena::new();
+                    let root = self.edit.renderer.reparse(&arena);
+                    let mut content = scroll_content::DocScrollContent::new(
+                        &mut self.edit.renderer,
+                        root,
+                        0.0,
+                        0.0,
+                    )
+                    .with_default_leading();
+                    let offset = crate::widgets::affine_scroll::anchor_to_offset(
+                        &mut content,
+                        anchor_idx,
+                        intra,
+                    );
+                    crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id)
+                        .set_offset(ui.ctx(), offset);
+                    let _ = content;
+                }
+                // set the selection using low-level API; using internal
+                // events causes touch devices to scroll to cursor on 2nd
+                // frame
+                let (start, end) = persisted.selection;
+                let selection = (
+                    start.clamp(
+                        0.into(),
+                        self.edit
+                            .renderer
+                            .buffer
+                            .current
+                            .segs
+                            .last_cursor_position(),
+                    ),
+                    end.clamp(
+                        0.into(),
+                        self.edit
+                            .renderer
+                            .buffer
+                            .current
+                            .segs
+                            .last_cursor_position(),
+                    ),
+                );
+                self.edit
+                    .renderer
+                    .buffer
+                    .queue(vec![lb_rs::model::text::operation_types::Operation::Select(selection)]);
+                self.edit.renderer.buffer.update();
+            }
+        }
 
         // Completion popups render last, outside the scroll area's clip, so
         // they composite over the toolbar / find widget when the cursor is
@@ -969,7 +959,7 @@ impl Editor {
                 .entry(self.edit.file_id)
                 .and_modify(|f| f.selection = self.edit.renderer.buffer.current.selection)
                 .or_insert(MdFilePersistence {
-                    scroll_offset: Default::default(),
+                    anchor: None,
                     selection: self.edit.renderer.buffer.current.selection,
                     image_dims: Default::default(),
                 });
@@ -978,10 +968,23 @@ impl Editor {
 
         let mut scroll_end_processed = false;
         if let Some(unprocessed_scroll) = self.unprocessed_scroll {
-            if unprocessed_scroll.elapsed() > Duration::from_millis(100) {
-                if let Some(scroll_area_id) = scroll_area_id {
-                    let state: Option<scroll_area::State> = ui.data(|d| d.get_temp(scroll_area_id));
-                    let scroll_offset = if let Some(state) = state { state.offset.y } else { 0. };
+            if unprocessed_scroll.elapsed() > Duration::from_millis(100) && editor_shown {
+                {
+                    let arena = Arena::new();
+                    let root = self.edit.renderer.reparse(&arena);
+                    let scroll_id = self.id();
+                    let scroll = crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id);
+                    let offset = scroll.offset(ui.ctx());
+                    let mut content = scroll_content::DocScrollContent::new(
+                        &mut self.edit.renderer,
+                        root,
+                        0.0,
+                        0.0,
+                    )
+                    .with_default_leading();
+                    let anchor =
+                        Some(crate::widgets::affine_scroll::offset_to_anchor(&mut content, offset));
+                    let _ = content;
 
                     let image_dims = self.edit.renderer.embeds.image_dims();
                     let mut persistence = self.persistence.data.write().unwrap();
@@ -990,11 +993,11 @@ impl Editor {
                         .file
                         .entry(self.edit.file_id)
                         .and_modify(|f| {
-                            f.scroll_offset = scroll_offset;
+                            f.anchor = anchor;
                             f.image_dims = image_dims.clone();
                         })
                         .or_insert(MdFilePersistence {
-                            scroll_offset,
+                            anchor,
                             selection: Default::default(),
                             image_dims,
                         });
@@ -1035,87 +1038,34 @@ impl Editor {
             || self.toolbar.menu_open
     }
 
-    fn show_scrollable_editor<'a>(
-        &mut self, ui: &mut Ui, root: &'a AstNode<'a>,
-    ) -> ScrollAreaOutput<()> {
-        let margin: Margin = if cfg!(target_os = "android") {
-            Margin::symmetric(0, 60)
-        } else {
-            Margin::symmetric(0, 15)
-        };
-        ScrollArea::vertical()
-            .scroll_source(if self.edit.renderer.touch_mode {
-                ScrollSource::ALL
-            } else {
-                ScrollSource::SCROLL_BAR | ScrollSource::MOUSE_WHEEL
-            })
-            .id_salt(self.edit.file_id)
-            .scroll_bar_visibility(if self.edit.renderer.touch_mode {
-                ScrollBarVisibility::AlwaysVisible
-            } else {
-                ScrollBarVisibility::VisibleWhenNeeded
-            })
+    fn show_scrollable_editor<'a>(&mut self, ui: &mut Ui, _root: &'a AstNode<'a>) {
+        let prev_seq = self.edit.renderer.buffer.current.seq;
+        let scroll_id = self.id();
+
+        Frame::canvas(ui.style())
+            .inner_margin(Margin::ZERO)
+            .stroke(Stroke::NONE)
             .show(ui, |ui| {
-                let prev_seq = self.edit.renderer.buffer.current.seq;
+                // Claim full available width with 0 vertical space so the
+                // Frame stretches horizontally regardless of how narrow the
+                // visible content turns out to be.
+                let avail_w = ui.available_width();
+                ui.allocate_space(Vec2::new(avail_w, 0.0));
 
-                ui.vertical_centered_justified(|ui| {
-                    Frame::canvas(ui.style())
-                        .inner_margin(margin)
-                        .stroke(Stroke::NONE)
-                        .show(ui, |ui| {
-                            let scroll_view_height = ui.max_rect().height();
-                            ui.allocate_space(Vec2 { x: ui.available_width(), y: 0. });
+                let canvas_rect = ui.max_rect();
+                let canvas_width = canvas_rect.width();
+                let layout_margin = self.edit.renderer.layout.margin;
 
-                            let column_width = ui
-                                .available_width()
-                                .min(self.edit.renderer.layout.max_width)
-                                .round();
-                            let content_width =
-                                column_width - 2. * self.edit.renderer.layout.margin;
-                            let padding = (ui.available_width() - column_width) / 2.;
-                            let top_left = ui.max_rect().min
-                                + (padding + self.edit.renderer.layout.margin) * Vec2::X;
+                // Content column width caps at `max_width`; the affine
+                // widget spans the full canvas so its scrollbar lands
+                // at the canvas right edge.
+                let max_width = self.edit.renderer.layout.max_width;
+                let col_width = (canvas_width - 2.0 * layout_margin).min(max_width).max(0.0);
+                self.edit.renderer.width = col_width;
 
-                            self.edit.renderer.width = content_width;
-                            let height = {
-                                let document_height = self.edit.renderer.height(root);
-                                let unfilled_space = if document_height < scroll_view_height {
-                                    scroll_view_height - document_height
-                                } else {
-                                    0.
-                                };
-                                let end_of_text_padding = scroll_view_height / 2.;
-
-                                document_height + unfilled_space.max(end_of_text_padding)
-                            };
-                            let rect =
-                                Rect::from_min_size(top_left, Vec2::new(content_width, height));
-
-                            // delegate to MdEdit::show for parse, event processing,
-                            // render, cursor/selection drawing, touch handles,
-                            // IME, and pending_scroll::Cursor consumption.
-                            self.edit.show(ui, rect, self.id());
-
-                            ui.advance_cursor_after_rect(rect);
-                        });
-                });
-
-                // if text changed during MdEdit::show, recompute find matches
-                // before painting match highlights (which index by offset).
-                if self.edit.renderer.buffer.current.seq != prev_seq {
-                    if let Some(term) = self.find.term.clone() {
-                        self.find.matches = self.find.find_all(&self.edit.renderer.buffer, &term);
-                        if self.find.matches.is_empty() {
-                            self.find.current_match = None;
-                        } else if let Some(idx) = self.find.current_match {
-                            if idx >= self.find.matches.len() {
-                                self.find.current_match = Some(self.find.matches.len() - 1);
-                            }
-                        }
-                    }
-                }
-
-                // paint find match highlights on top of the rendered content
+                // Paint find-match highlights first so the editor's text
+                // callback (submitted via post_render) lands on a layer
+                // above them.
                 if !self.find.matches.is_empty() {
                     let theme = self.edit.renderer.ctx.get_lb_theme();
                     let highlight_color = theme.neutral_bg_tertiary();
@@ -1130,13 +1080,60 @@ impl Editor {
                     }
                 }
 
-                // MdEdit::show consumed ScrollTarget::Cursor; FindMatch is
-                // editor-owned because Find lives on Editor.
-                if matches!(self.edit.pending_scroll, Some(ScrollTarget::FindMatch)) {
-                    self.edit.pending_scroll = None;
-                    self.scroll_to_find_match(ui);
+                let arena = Arena::new();
+                let root = self.edit.renderer.reparse(&arena);
+                let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
+
+                // affine render: widget body spans the full canvas
+                // (scrollbar at canvas right); content centers within
+                // that body via `content_x`.
+                self.edit.renderer.galleys.galleys.clear();
+                self.edit.renderer.bounds.wrap_lines.clear();
+                self.edit.renderer.text_areas.clear();
+                let touch_scroll = self.edit.renderer.touch_mode;
+                let content_x = canvas_rect.min.x
+                    + ((canvas_rect.width() - self.edit.renderer.width) / 2.0).max(0.0);
+                ui.scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
+                    let trailing_precise = canvas_rect.height() / 2.0;
+                    let mut content = scroll_content::DocScrollContent::new(
+                        &mut self.edit.renderer,
+                        root,
+                        content_x,
+                        trailing_precise,
+                    )
+                    .with_default_leading();
+                    let mut scroll =
+                        crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id)
+                            .touch_scroll(touch_scroll);
+                    scroll.show(ui, &mut content);
+                });
+                self.edit.renderer.galleys.galleys.sort_by_key(|g| g.range);
+
+                self.edit.post_render(ui, canvas_rect, scroll_id, pre);
+                ui.advance_cursor_after_rect(canvas_rect);
+            });
+
+        // if text changed during MdEdit::show, recompute find matches
+        // before painting match highlights (which index by offset).
+        if self.edit.renderer.buffer.current.seq != prev_seq {
+            if let Some(term) = self.find.term.clone() {
+                self.find.matches = self.find.find_all(&self.edit.renderer.buffer, &term);
+                if self.find.matches.is_empty() {
+                    self.find.current_match = None;
+                } else if let Some(idx) = self.find.current_match {
+                    if idx >= self.find.matches.len() {
+                        self.find.current_match = Some(self.find.matches.len() - 1);
+                    }
                 }
-            })
+            }
+        }
+
+        // MdEdit::show consumed ScrollTarget::Cursor; FindMatch is
+        // editor-owned because Find lives on Editor.
+        if matches!(self.edit.pending_scroll, Some(ScrollTarget::FindMatch)) {
+            self.edit.pending_scroll = None;
+            self.scroll_to_find_match(ui, scroll_id, ui.available_height());
+        }
     }
 
     fn show_find_centered(&mut self, ui: &mut Ui) {
@@ -1195,14 +1192,32 @@ impl Editor {
         }
     }
 
-    fn scroll_to_find_match(&self, ui: &mut Ui) {
-        if let Some(idx) = self.find.current_match {
-            if let Some(match_range) = self.find.matches.get(idx) {
-                let rects = self.edit.range_rects(*match_range);
-                if let Some(rect) = rects.first() {
-                    ui.scroll_to_rect(rect.expand(rect.height()), Some(egui::Align::Center));
-                }
-            }
+    fn scroll_to_find_match(&mut self, ui: &mut Ui, scroll_id: Id, viewport_height: f32) {
+        let Some(idx) = self.find.current_match else { return };
+        let Some(&(target, _)) = self.find.matches.get(idx) else { return };
+
+        let arena = Arena::new();
+        let root = self.edit.renderer.reparse(&arena);
+        let mut content = scroll_content::DocScrollContent::new(
+            &mut self.edit.renderer,
+            root,
+            0.0,
+            viewport_height / 2.0,
+        )
+        .with_default_leading();
+
+        let offset = crate::widgets::affine_scroll::align_offset(
+            &mut content,
+            viewport_height,
+            crate::widgets::affine_scroll::Align::Center,
+            |c| {
+                c.text_range()
+                    .is_some_and(|(start, end)| target >= start && target <= end)
+            },
+        );
+
+        if let Some(o) = offset {
+            crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id).set_offset(ui.ctx(), o);
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -137,9 +137,8 @@ pub struct MdRender {
     // viewport
     pub width: f32,
     pub viewport_height: f32,
-    /// Width the layout cache was last populated for. `reparse` clears
-    /// the cache when this differs from `width` so heights computed
-    /// for a different column don't bleed into the new layout.
+    /// Width the layout cache was last populated for; `reparse`
+    /// clears the cache when `width` diverges.
     last_layout_width: f32,
 
     // debug
@@ -442,9 +441,8 @@ impl MdRender {
     /// [`Arena`] — comrak's AST is arena-allocated. Callers who need heights
     /// also invoke [`MdRender::height`] on the returned root.
     pub fn reparse<'a>(&mut self, arena: &'a Arena<'a>) -> &'a AstNode<'a> {
-        // Width change invalidates every cached layout value (cache
-        // keys are node-range, not width-aware). Use bit-equality
-        // to handle the initial NaN sentinel cleanly.
+        // Layout-cache keys are node-range, not width-aware; clear on
+        // width change. Bit-equality covers the initial NaN.
         if self.width.to_bits() != self.last_layout_width.to_bits() {
             self.layout_cache.clear();
             self.last_layout_width = self.width;
@@ -690,11 +688,9 @@ impl Editor {
             changed
         };
 
-        // Invalidate caches BEFORE the render (not after). Heights
-        // depend on `viewport_height` (image clamping) and on resolved
-        // embed dimensions. Width invalidation is handled by `reparse`
-        // via `last_layout_width`, so width changes don't need to
-        // appear here.
+        // Heights depend on `viewport_height` (image clamping) and on
+        // resolved embed dimensions; clear so this frame paints the
+        // updated values. (Width invalidation lives in `reparse`.)
         if height_updated || embeds_updated {
             self.edit.renderer.layout_cache.clear();
         }
@@ -941,9 +937,8 @@ impl Editor {
             if embeds_updated {
                 self.unprocessed_scroll = Some(Instant::now());
             }
-            // Cache was cleared at top-of-frame so this render is
-            // already correct; just request the next repaint to settle
-            // anything frame-deferred (e.g. scroll persistence).
+            // Schedule a follow-up frame for the persistence write
+            // path keyed off `unprocessed_scroll`.
             ui.ctx().request_repaint();
         } else if resp.selection_updated {
             let new_selection = self

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1149,8 +1149,6 @@ impl Editor {
             }
         }
 
-        // MdEdit::show consumed ScrollTarget::Cursor; FindMatch is
-        // editor-owned because Find lives on Editor.
         if matches!(self.edit.pending_scroll, Some(ScrollTarget::FindMatch)) {
             self.edit.pending_scroll = None;
             self.scroll_to_find_match(ui, scroll_id, ui.available_height());

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -137,6 +137,10 @@ pub struct MdRender {
     // viewport
     pub width: f32,
     pub viewport_height: f32,
+    /// Width the layout cache was last populated for. `reparse` clears
+    /// the cache when this differs from `width` so heights computed
+    /// for a different column don't bleed into the new layout.
+    last_layout_width: f32,
 
     // debug
     pub debug: bool,
@@ -388,6 +392,7 @@ impl MdRender {
             syntax: Default::default(),
             width: Default::default(),
             viewport_height: Default::default(),
+            last_layout_width: f32::NAN,
             debug: false,
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
@@ -425,6 +430,7 @@ impl MdRender {
             syntax: Default::default(),
             width: Default::default(),
             viewport_height: Default::default(),
+            last_layout_width: f32::NAN,
             debug: false,
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
@@ -436,6 +442,14 @@ impl MdRender {
     /// [`Arena`] — comrak's AST is arena-allocated. Callers who need heights
     /// also invoke [`MdRender::height`] on the returned root.
     pub fn reparse<'a>(&mut self, arena: &'a Arena<'a>) -> &'a AstNode<'a> {
+        // Width change invalidates every cached layout value (cache
+        // keys are node-range, not width-aware). Use bit-equality
+        // to handle the initial NaN sentinel cleanly.
+        if self.width.to_bits() != self.last_layout_width.to_bits() {
+            self.layout_cache.clear();
+            self.last_layout_width = self.width;
+        }
+
         let options = Self::comrak_options();
         let text_with_newline = format!("{}\n", self.buffer.current.text);
         let root = comrak::parse_document(arena, &text_with_newline, &options);
@@ -534,6 +548,7 @@ impl Editor {
 
             width: Default::default(),
             viewport_height: Default::default(),
+            last_layout_width: f32::NAN,
 
             debug: false,
             frame_times: [Instant::now(); 10],
@@ -674,6 +689,15 @@ impl Editor {
             self.embeds_last_seen = current;
             changed
         };
+
+        // Invalidate caches BEFORE the render (not after). Heights
+        // depend on `viewport_height` (image clamping) and on resolved
+        // embed dimensions. Width invalidation is handled by `reparse`
+        // via `last_layout_width`, so width changes don't need to
+        // appear here.
+        if height_updated || embeds_updated {
+            self.edit.renderer.layout_cache.clear();
+        }
 
         // --- input phase ------------------------------------------------------
         // Route workspace-origin events (toolbar Markdown, Undo/Redo) through
@@ -917,7 +941,9 @@ impl Editor {
             if embeds_updated {
                 self.unprocessed_scroll = Some(Instant::now());
             }
-            self.edit.renderer.layout_cache.clear();
+            // Cache was cleared at top-of-frame so this render is
+            // already correct; just request the next repaint to settle
+            // anything frame-deferred (e.g. scroll persistence).
             ui.ctx().request_repaint();
         } else if resp.selection_updated {
             let new_selection = self

--- a/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
@@ -1,0 +1,183 @@
+//! [`ScrollContent`] adapter for the markdown editor.
+//!
+//! `DocScrollContent` walks the document's top-level blocks. Each
+//! block is one row, rendered atomically via `show_block`. Container
+//! chrome (block-quote bars, alert bars, list markers, code-block
+//! borders, etc.) is painted by the container's own `show_*` function,
+//! the same path `MdLabel` and tests use.
+//!
+//! Plus a virtual leading pad row at the start with `approx = precise
+//! = leading_precise` (real top padding — counted toward the
+//! scrollbar) and a virtual trailing pad at the end with `approx =
+//! 0`, `precise = trailing_precise` (overscroll room — not counted
+//! toward the scrollbar — so the last block can scroll into the
+//! middle of the viewport).
+
+use comrak::nodes::AstNode;
+use egui::{Pos2, Ui};
+use lb_rs::model::text::offset_types::Grapheme;
+
+use crate::tab::markdown_editor::MdRender;
+use crate::widgets::affine_scroll::Rows;
+
+pub struct DocScrollContent<'a, 'ast> {
+    pub renderer: &'a mut MdRender,
+    pub root: &'ast AstNode<'ast>,
+    /// Precise + approx height of the virtual leading pad row. Counts
+    /// toward the scrollbar — unlike `trailing_precise` which is
+    /// approx-zero — so the pad behaves like real top padding rather
+    /// than overscroll.
+    pub leading_precise: f32,
+    /// Precise height of the virtual trailing pad row (e.g. vh/2).
+    /// Approx height is 0 — overscroll, not content.
+    pub trailing_precise: f32,
+    /// X position to render content at. Lets the content sit centered
+    /// inside the canvas while the scroll widget's body (and scrollbar)
+    /// span the full canvas width.
+    pub content_x: f32,
+    cursor: Cursor<'ast>,
+}
+
+#[derive(Clone, Copy)]
+enum Cursor<'ast> {
+    Start,
+    Leading,
+    At { node: &'ast AstNode<'ast> },
+    Trailing,
+    End,
+}
+
+impl<'a, 'ast> DocScrollContent<'a, 'ast> {
+    pub fn new(
+        renderer: &'a mut MdRender, root: &'ast AstNode<'ast>, content_x: f32,
+        trailing_precise: f32,
+    ) -> Self {
+        Self {
+            renderer,
+            root,
+            leading_precise: 0.0,
+            trailing_precise,
+            content_x,
+            cursor: Cursor::Start,
+        }
+    }
+
+    /// Set `leading_precise` to the default top-padding for production
+    /// rendering. Larger on Android to clear the system status bar /
+    /// safe area. All production walks (render + persistence + scroll-
+    /// to) must agree on this value or anchor offsets drift by the
+    /// difference.
+    pub fn with_default_leading(mut self) -> Self {
+        self.leading_precise = if cfg!(target_os = "android") { 60.0 } else { 15.0 };
+        self
+    }
+
+    /// Source-text range covered by the row at the cursor's current
+    /// position, or `None` if the cursor is off a real row.
+    pub fn text_range(&self) -> Option<(Grapheme, Grapheme)> {
+        match self.cursor {
+            Cursor::At { node } => Some(self.renderer.node_range(node)),
+            Cursor::Leading | Cursor::Trailing | Cursor::Start | Cursor::End => None,
+        }
+    }
+}
+
+impl<'a, 'ast> Rows for DocScrollContent<'a, 'ast> {
+    fn reset(&mut self) {
+        self.cursor = Cursor::Start;
+    }
+
+    fn reset_back(&mut self) {
+        self.cursor = Cursor::End;
+    }
+
+    fn next(&mut self) -> bool {
+        match self.cursor {
+            Cursor::Start => self.cursor = Cursor::Leading,
+            Cursor::Leading => match self.root.children().next() {
+                Some(first) => self.cursor = Cursor::At { node: first },
+                // Childless doc — yield the root itself as a single
+                // row so `show_document`'s fallback (iterate source
+                // lines) runs and the cursor has a galley to land on.
+                None => self.cursor = Cursor::At { node: self.root },
+            },
+            Cursor::At { node } => match node.next_sibling() {
+                Some(next) => self.cursor = Cursor::At { node: next },
+                None => self.cursor = Cursor::Trailing,
+            },
+            Cursor::Trailing => {
+                self.cursor = Cursor::End;
+                return false;
+            }
+            Cursor::End => return false,
+        }
+        true
+    }
+
+    fn prev(&mut self) -> bool {
+        match self.cursor {
+            Cursor::End => self.cursor = Cursor::Trailing,
+            Cursor::Trailing => match self.root.children().last() {
+                Some(last) => self.cursor = Cursor::At { node: last },
+                None => self.cursor = Cursor::At { node: self.root },
+            },
+            Cursor::At { node } => match node.previous_sibling() {
+                Some(prev) => self.cursor = Cursor::At { node: prev },
+                None => self.cursor = Cursor::Leading,
+            },
+            Cursor::Leading => {
+                self.cursor = Cursor::Start;
+                return false;
+            }
+            Cursor::Start => return false,
+        }
+        true
+    }
+
+    fn approx(&self) -> f32 {
+        match self.cursor {
+            Cursor::At { node } => {
+                self.renderer.block_pre_spacing_height_approx(node)
+                    + self.renderer.height_approx(node)
+                    + self.renderer.block_post_spacing_height_approx(node)
+            }
+            Cursor::Leading => self.leading_precise,
+            Cursor::Trailing => 0.0,
+            Cursor::Start | Cursor::End => panic!("approx() with cursor off a row"),
+        }
+    }
+
+    fn precise(&mut self) -> f32 {
+        match self.cursor {
+            Cursor::At { node } => {
+                self.renderer.block_pre_spacing_height(node)
+                    + self.renderer.height(node)
+                    + self.renderer.block_post_spacing_height(node)
+            }
+            Cursor::Leading => self.leading_precise,
+            Cursor::Trailing => self.trailing_precise,
+            Cursor::Start | Cursor::End => panic!("precise() with cursor off a row"),
+        }
+    }
+
+    fn warm(&mut self) {
+        if let Cursor::At { node } = self.cursor {
+            self.renderer.warm_images(node);
+        }
+    }
+
+    fn render(&mut self, ui: &mut Ui, top_left: Pos2) {
+        match self.cursor {
+            Cursor::At { node } => {
+                let mut tl = Pos2::new(self.content_x, top_left.y);
+                self.renderer.show_block_pre_spacing(ui, node, tl);
+                tl.y += self.renderer.block_pre_spacing_height(node);
+                self.renderer.show_block(ui, node, tl);
+                tl.y += self.renderer.height(node);
+                self.renderer.show_block_post_spacing(ui, node, tl);
+            }
+            Cursor::Leading | Cursor::Trailing => {} // virtual padding — paints nothing
+            Cursor::Start | Cursor::End => panic!("render() with cursor off a row"),
+        }
+    }
+}

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -136,18 +136,15 @@ impl MdEdit {
         buf_resp
     }
 
-    /// Draw phase: pointer hit-test + context menu + pointer→selection,
-    /// then inline render of all blocks, then cursor / selection / IME
-    /// / scroll-to-cursor / text-callback. No scroll area — `MdEdit` is
-    /// a render primitive; callers that want scrolling (the editor)
-    /// invoke [`MdEdit::pre_render`] + their own render loop +
-    /// [`MdEdit::post_render`] instead.
+    /// Draw the document inline at `rect`: pointer + context menu via
+    /// [`MdEdit::pre_render`], paint every block, then cursor /
+    /// selection / IME / scroll-to-cursor / text callback via
+    /// [`MdEdit::post_render`].
     pub fn show(&mut self, ui: &mut Ui, rect: Rect, id: Id) {
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
         let pre = self.pre_render(ui, rect, id, root);
 
-        // inline render — caller-managed scroll lives one level up
         self.renderer.galleys.galleys.clear();
         self.renderer.bounds.wrap_lines.clear();
         self.renderer.text_areas.clear();
@@ -161,17 +158,13 @@ impl MdEdit {
         self.post_render(ui, rect, id, pre);
     }
 
-    /// Per-frame setup the editor and the chat composer share before
-    /// they each pick a render strategy: dark-mode + viewport snapshot,
-    /// pointer hit-test, context menu, pointer→selection translation.
-    /// Returns whether the widget held focus through the interact step
-    /// (the post-render path needs that).
+    /// Per-frame setup that runs before block rendering: dark-mode +
+    /// viewport snapshot, pointer hit-test, context menu, pointer →
+    /// selection. Returns the focus state for [`MdEdit::post_render`].
     pub fn pre_render<'a>(
         &mut self, ui: &mut Ui, rect: Rect, id: Id, root: &'a comrak::nodes::AstNode<'a>,
     ) -> PreRenderState {
         self.renderer.dark_mode = ui.style().visuals.dark_mode;
-        // `renderer.width` is set by the caller (the centered content
-        // column width) — don't overwrite, or we lose centering.
         self.renderer.viewport_height = ui.clip_rect().height();
 
         ui.ctx().check_for_id_clash(id, rect, "");
@@ -351,10 +344,10 @@ impl MdEdit {
         PreRenderState { focused }
     }
 
-    /// Per-frame teardown the editor and the chat composer share after
-    /// they've each rendered the document: cursor / selection / IME,
-    /// touch handles, scroll-to-cursor consumption, focus lock, glyphon
-    /// text-callback submission, and draining of internal events.
+    /// Per-frame teardown that runs after block rendering: cursor /
+    /// selection / IME, touch handles, scroll-to-cursor consumption,
+    /// focus lock, glyphon text-callback submission, draining of
+    /// internal events.
     pub fn post_render(&mut self, ui: &mut Ui, rect: Rect, id: Id, pre: PreRenderState) {
         let focused = pre.focused;
 
@@ -386,8 +379,7 @@ impl MdEdit {
             self.show_selection_handles(ui);
         }
 
-        // consume a pending scroll-to-cursor if queued. FindMatch is left to
-        // the caller (it owns find state). Composer never queues this.
+        // FindMatch is consumed by the caller (it owns find state).
         if matches!(self.pending_scroll, Some(ScrollTarget::Cursor)) {
             self.pending_scroll = None;
             self.scroll_to_cursor(ui, id, rect.height());

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -14,9 +14,7 @@
 
 use comrak::Arena;
 use egui::os::OperatingSystem;
-use egui::{
-    Context, EventFilter, Id, Pos2, Rect, Sense, Stroke, Ui, UiBuilder, Vec2, ViewportCommand,
-};
+use egui::{Context, EventFilter, Id, Pos2, Rect, Sense, Stroke, Ui, UiBuilder, ViewportCommand};
 use lb_rs::model::text::buffer::{self, Buffer};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _, RangeIterExt as _};
 
@@ -29,6 +27,11 @@ use crate::widgets::IconButton;
 
 use super::MdEdit;
 use super::input::{Bound, Event, Location, Region};
+
+/// Hand-off between [`MdEdit::pre_render`] and [`MdEdit::post_render`].
+pub struct PreRenderState {
+    focused: bool,
+}
 
 impl MdEdit {
     /// Input phase: consume keyboard events, drain the internal event queue,
@@ -133,12 +136,42 @@ impl MdEdit {
         buf_resp
     }
 
-    /// Draw phase: register the widget for pointer hit-test, process pointer
-    /// and context-menu events (piggybacking on the fresh `Response`), then
-    /// render.
+    /// Draw phase: pointer hit-test + context menu + pointer→selection,
+    /// then inline render of all blocks, then cursor / selection / IME
+    /// / scroll-to-cursor / text-callback. No scroll area — `MdEdit` is
+    /// a render primitive; callers that want scrolling (the editor)
+    /// invoke [`MdEdit::pre_render`] + their own render loop +
+    /// [`MdEdit::post_render`] instead.
     pub fn show(&mut self, ui: &mut Ui, rect: Rect, id: Id) {
+        let arena = Arena::new();
+        let root = self.renderer.reparse(&arena);
+        let pre = self.pre_render(ui, rect, id, root);
+
+        // inline render — caller-managed scroll lives one level up
+        self.renderer.galleys.galleys.clear();
+        self.renderer.bounds.wrap_lines.clear();
+        self.renderer.text_areas.clear();
+        let height = self.renderer.height(root);
+        let render_rect = Rect::from_min_size(rect.min, egui::Vec2::new(rect.width(), height));
+        ui.scope_builder(UiBuilder::new().max_rect(render_rect), |ui| {
+            self.renderer.show_block(ui, root, rect.min);
+        });
+        self.renderer.galleys.galleys.sort_by_key(|g| g.range);
+
+        self.post_render(ui, rect, id, pre);
+    }
+
+    /// Per-frame setup the editor and the chat composer share before
+    /// they each pick a render strategy: dark-mode + viewport snapshot,
+    /// pointer hit-test, context menu, pointer→selection translation.
+    /// Returns whether the widget held focus through the interact step
+    /// (the post-render path needs that).
+    pub fn pre_render<'a>(
+        &mut self, ui: &mut Ui, rect: Rect, id: Id, root: &'a comrak::nodes::AstNode<'a>,
+    ) -> PreRenderState {
         self.renderer.dark_mode = ui.style().visuals.dark_mode;
-        self.renderer.width = rect.width();
+        // `renderer.width` is set by the caller (the centered content
+        // column width) — don't overwrite, or we lose centering.
         self.renderer.viewport_height = ui.clip_rect().height();
 
         ui.ctx().check_for_id_clash(id, rect, "");
@@ -159,12 +192,6 @@ impl MdEdit {
         if response.hovered() || response_properly_clicked {
             ui.output_mut(|o| o.cursor_icon = egui::CursorIcon::Text);
         }
-
-        // Re-parse for rendering. handle_input already parsed and computed
-        // bounds; `clear()` or other inter-phase mutations by the caller
-        // could have left those stale, so recompute.
-        let arena = Arena::new();
-        let root = self.renderer.reparse(&arena);
 
         let mut ops = Vec::new();
 
@@ -321,17 +348,19 @@ impl MdEdit {
 
         self.renderer.in_progress_selection = self.in_progress_selection;
 
-        // --- render -----------------------------------------------------------
-        self.renderer.galleys.galleys.clear();
-        self.renderer.bounds.wrap_lines.clear();
-        self.renderer.text_areas.clear();
+        PreRenderState { focused }
+    }
 
-        let height = self.renderer.height(root);
-        let render_rect = Rect::from_min_size(rect.min, Vec2::new(rect.width(), height));
-        ui.scope_builder(UiBuilder::new().max_rect(render_rect), |ui| {
-            self.renderer.show_block(ui, root, rect.min);
-        });
-        self.renderer.galleys.galleys.sort_by_key(|g| g.range);
+    /// Per-frame teardown the editor and the chat composer share after
+    /// they've each rendered the document: cursor / selection / IME,
+    /// touch handles, scroll-to-cursor consumption, focus lock, glyphon
+    /// text-callback submission, and draining of internal events.
+    pub fn post_render(&mut self, ui: &mut Ui, rect: Rect, id: Id, pre: PreRenderState) {
+        let focused = pre.focused;
+
+        // Clip subsequent overlay paints (selection, cursor) to the
+        // editor rect so they don't bleed over toolbars or sidebars.
+        ui.set_clip_rect(rect.intersect(ui.clip_rect()));
 
         // cursor / selection — iOS draws natively
         if ui.ctx().os() != OperatingSystem::IOS && !self.renderer.readonly {
@@ -358,10 +387,10 @@ impl MdEdit {
         }
 
         // consume a pending scroll-to-cursor if queued. FindMatch is left to
-        // the caller (it owns find state).
+        // the caller (it owns find state). Composer never queues this.
         if matches!(self.pending_scroll, Some(ScrollTarget::Cursor)) {
             self.pending_scroll = None;
-            self.scroll_to_cursor(ui);
+            self.scroll_to_cursor(ui, id, rect.height());
         }
 
         // lock focus filter so arrow keys / tab / shift+enter keep reaching us

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -1,6 +1,12 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex, RwLock};
 use unicode_segmentation::UnicodeSegmentation as _;
+
+thread_local! {
+    /// Tunable factor for `height_approx`'s presumed character width
+    /// (multiplied by `row_height`). Production default is 0.5.
+    pub(crate) static APPROX_CHAR_WIDTH_FACTOR: Cell<f32> = const { Cell::new(0.5) };
+}
 
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
 
@@ -195,6 +201,104 @@ impl<'ast> MdRender {
         self.set_cached_node_height(node, height);
 
         height
+    }
+
+    /// Cheap height estimate. Walks the AST inline (no delegation to
+    /// per-block-type `height_*` functions), summing approximate
+    /// heights of leaf blocks via char-count × presumed-char-width
+    /// instead of cosmic-text shaping. Drift from precise layout is
+    /// expected — only safe for off-screen sizing (scrollbar). Visible
+    /// content must be measured via [`Self::height`].
+    pub fn height_approx(&self, node: &'ast AstNode<'ast>) -> f32 {
+        if let Some(cached) = self.get_cached_node_height_approx(node) {
+            return cached;
+        }
+        if self.hidden_by_fold(node) {
+            self.set_cached_node_height_approx(node, 0.);
+            return 0.;
+        }
+        if self.width(node) < self.layout.row_height {
+            self.set_cached_node_height_approx(node, 0.);
+            return 0.;
+        }
+        let value = &node.data.borrow().value;
+        let height = match value {
+            NodeValue::Document
+            | NodeValue::List(_)
+            | NodeValue::BlockQuote
+            | NodeValue::Item(_)
+            | NodeValue::TaskItem(_)
+            | NodeValue::Alert(_)
+            | NodeValue::Table(_)
+            | NodeValue::TableRow(_)
+            | NodeValue::FootnoteDefinition(_) => {
+                let mut total = 0.;
+                for child in node.children() {
+                    total += self.block_pre_spacing_height_approx(child);
+                    total += self.height_approx(child);
+                    total += self.block_post_spacing_height_approx(child);
+                }
+                total
+            }
+            NodeValue::Paragraph | NodeValue::Heading(_) | NodeValue::TableCell => {
+                let row_height = self.row_height(node);
+                let width = self.width(node).max(row_height);
+                let mut chars = 0usize;
+                for d in node.descendants() {
+                    match &d.data.borrow().value {
+                        NodeValue::Text(t) => chars += t.chars().count(),
+                        NodeValue::Code(c) => chars += c.literal.chars().count(),
+                        NodeValue::HtmlInline(s) => chars += s.chars().count(),
+                        NodeValue::Math(m) => chars += m.literal.chars().count(),
+                        NodeValue::SoftBreak | NodeValue::LineBreak => chars += 1,
+                        _ => {}
+                    }
+                }
+                let char_width = row_height * APPROX_CHAR_WIDTH_FACTOR.with(|c| c.get());
+                let chars_per_row = (width / char_width).floor().max(1.0) as usize;
+                let rows = ((chars as f32) / chars_per_row as f32).ceil().max(1.0);
+                rows * row_height + (rows - 1.0).max(0.0) * self.layout.row_spacing
+            }
+            NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_) => {
+                let row_height = self.row_height(node);
+                let n = (self.node_last_line_idx(node) - self.node_first_line_idx(node) + 1) as f32;
+                n * row_height + (n - 1.0).max(0.0) * self.layout.row_spacing
+            }
+            NodeValue::ThematicBreak => self.height_thematic_break(),
+            NodeValue::FrontMatter(_) => self.height_front_matter(node),
+            _ => 0.,
+        };
+        self.set_cached_node_height_approx(node, height);
+        height
+    }
+
+    /// Approx-y of the top of the last top-level block — i.e., the
+    /// scroll offset at which the last block's top sits at viewport
+    /// top. Function of doc + width only.
+    pub fn approx_y_top_last_block(&self, root: &'ast AstNode<'ast>) -> f32 {
+        let last = match root.last_child() {
+            Some(l) => l,
+            None => return 0.,
+        };
+        let mut y = 0.;
+        let mut child = root.first_child();
+        while let Some(c) = child {
+            if std::ptr::eq(c, last) {
+                break;
+            }
+            y += self.block_pre_spacing_height_approx(c);
+            y += self.height_approx(c);
+            y += self.block_post_spacing_height_approx(c);
+            child = c.next_sibling();
+        }
+        y += self.block_pre_spacing_height_approx(last);
+        y
+    }
+
+    /// Approx scroll extent — used to seed the affine widget's
+    /// `max_offset` when reading persisted state.
+    pub fn scroll_extent(&self, root: &'ast AstNode<'ast>, viewport_height: f32) -> f32 {
+        self.approx_y_top_last_block(root) + viewport_height
     }
 
     pub(crate) fn show_block(
@@ -624,6 +728,7 @@ type LinePrefixValue = (Graphemes, bool);
 #[derive(Default)]
 pub struct LayoutCache {
     pub height: RefCell<HashMap<(Grapheme, Grapheme), f32>>,
+    pub height_approx: RefCell<HashMap<(Grapheme, Grapheme), f32>>,
     pub line_prefix_len: RefCell<HashMap<LinePrefixKey, LinePrefixValue>>,
     pub node_range: RefCell<HashMap<u64, (Grapheme, Grapheme)>>,
     pub hidden_by_fold: RefCell<HashMap<(Grapheme, Grapheme), bool>>,
@@ -634,6 +739,7 @@ impl LayoutCache {
     /// Full clear for width/resize changes where everything must be recomputed.
     pub fn clear(&self) {
         self.height.borrow_mut().clear();
+        self.height_approx.borrow_mut().clear();
         self.line_prefix_len.borrow_mut().clear();
         self.node_range.borrow_mut().clear();
         self.hidden_by_fold.borrow_mut().clear();
@@ -648,6 +754,7 @@ impl LayoutCache {
     /// Glyphon buffers are content-addressed and survive.
     pub fn invalidate_text_change(&self) {
         self.height.borrow_mut().clear();
+        self.height_approx.borrow_mut().clear();
         self.hidden_by_fold.borrow_mut().clear();
         self.line_prefix_len.borrow_mut().clear();
         self.node_range.borrow_mut().clear();
@@ -850,6 +957,23 @@ impl<'ast> MdRender {
     pub fn set_cached_node_height(&self, node: &'ast AstNode<'ast>, height: f32) {
         let range = self.node_range(node);
         self.layout_cache.height.borrow_mut().insert(range, height);
+    }
+
+    pub fn get_cached_node_height_approx(&self, node: &'ast AstNode<'ast>) -> Option<f32> {
+        let range = self.node_range(node);
+        self.layout_cache
+            .height_approx
+            .borrow()
+            .get(&range)
+            .copied()
+    }
+
+    pub fn set_cached_node_height_approx(&self, node: &'ast AstNode<'ast>, height: f32) {
+        let range = self.node_range(node);
+        self.layout_cache
+            .height_approx
+            .borrow_mut()
+            .insert(range, height);
     }
 
     pub fn get_cached_line_prefix_len(

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -197,12 +197,10 @@ impl<'ast> MdRender {
         height
     }
 
-    /// Cheap height estimate. Walks the AST inline (no delegation to
-    /// per-block-type `height_*` functions), summing approximate
-    /// heights of leaf blocks via char-count × presumed-char-width
-    /// instead of cosmic-text shaping. Drift from precise layout is
-    /// expected — only safe for off-screen sizing (scrollbar). Visible
-    /// content must be measured via [`Self::height`].
+    /// Cheap height estimate keyed on char count × presumed char
+    /// width, no cosmic-text shaping. Drifts from precise layout —
+    /// safe for off-screen sizing (scrollbar) only; visible content
+    /// must use [`Self::height`].
     pub fn height_approx(&self, node: &'ast AstNode<'ast>) -> f32 {
         if let Some(cached) = self.get_cached_node_height_approx(node) {
             return cached;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -1,12 +1,6 @@
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::sync::{Arc, Mutex, RwLock};
 use unicode_segmentation::UnicodeSegmentation as _;
-
-thread_local! {
-    /// Tunable factor for `height_approx`'s presumed character width
-    /// (multiplied by `row_height`). Production default is 0.5.
-    pub(crate) static APPROX_CHAR_WIDTH_FACTOR: Cell<f32> = const { Cell::new(0.5) };
-}
 
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
 
@@ -254,7 +248,7 @@ impl<'ast> MdRender {
                         _ => {}
                     }
                 }
-                let char_width = row_height * APPROX_CHAR_WIDTH_FACTOR.with(|c| c.get());
+                let char_width = row_height * 0.5;
                 let chars_per_row = (width / char_width).floor().max(1.0) as usize;
                 let rows = ((chars as f32) / chars_per_row as f32).ceil().max(1.0);
                 rows * row_height + (rows - 1.0).max(0.0) * self.layout.row_spacing

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
@@ -64,6 +64,35 @@ impl<'ast> MdRender {
         Some(first..(last + 1))
     }
 
+    /// Cheap pre-spacing height estimate. Each blank line is one
+    /// `row_height`; plus inter-block `block_spacing`. Used by
+    /// `height_approx` for off-screen content.
+    pub fn block_pre_spacing_height_approx(&self, node: &'ast AstNode<'ast>) -> f32 {
+        if self.hidden_by_fold(node) {
+            return 0.;
+        }
+        let Some(line_range) = self.pre_spacing_lines(node) else {
+            return 0.;
+        };
+        let mut result = 0.;
+        if node.previous_sibling().is_some() {
+            result += self.layout.block_spacing;
+        }
+        let n = line_range.end.saturating_sub(line_range.start) as f32;
+        result += n * self.layout.row_height;
+        result += n * self.layout.block_spacing;
+        result
+    }
+
+    /// Cheap post-spacing height estimate.
+    pub fn block_post_spacing_height_approx(&self, node: &'ast AstNode<'ast>) -> f32 {
+        let Some(line_range) = self.post_spacing_lines(node) else {
+            return 0.;
+        };
+        let n = line_range.end.saturating_sub(line_range.start) as f32;
+        n * self.layout.row_height + n * self.layout.block_spacing
+    }
+
     pub fn block_pre_spacing_height(&self, node: &'ast AstNode<'ast>) -> f32 {
         let Some(line_range) = self.pre_spacing_lines(node) else {
             return 0.;

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1,0 +1,927 @@
+//! A vertical scroll area whose content has two notions of height per
+//! row: a cheap **approximate** height and an expensive **precise**
+//! height. The scrollbar operates in approx units (so the bar's range is
+//! a constant function of the doc), but visible content is laid out
+//! precisely. Scroll *events* are interpreted in precise units (= screen
+//! pixels of intended movement) and translated to approx via a piecewise
+//! affine map before they touch the scrollbar.
+//!
+//! # Why
+//!
+//! When rows are only cheap to estimate (rich text, shaped lines,
+//! etc.), measuring every row precisely to size the scrollbar is too
+//! slow. Approximating sizes is fast but breaks the "user scrolls N
+//! pixels, content moves N pixels" invariant.
+//!
+//! This widget bridges the two: scrollbar is approx (so always known
+//! and consistent), but the user's wheel/drag input is interpreted as a
+//! request to move content by N **precise** pixels. The widget walks
+//! the affine map at the current scroll position, converts to the
+//! corresponding approx delta, and updates the scrollbar.
+//!
+//! # Contract with `Rows`
+//!
+//! After [`Rows::reset`] the cursor sits before the first row; the
+//! first `next()` yields it. Once `next()` returns `None` the cursor
+//! is past the last row, and `prev()` from there yields the last.
+//! Symmetric for [`Rows::reset_back`] + `prev()`.
+
+use egui::{Pos2, Rect, Response, Sense, Stroke, Ui, Vec2};
+
+/// Sequence of variable-height rows the scroll area walks.
+///
+/// `approx` / `precise` / `render` operate on the row at the cursor's
+/// current position; calling them when the cursor is off a row (before
+/// start, past end, or after a `next`/`prev` returned `false`) panics.
+pub trait Rows {
+    fn reset(&mut self);
+    fn reset_back(&mut self);
+    fn next(&mut self) -> bool;
+    fn prev(&mut self) -> bool;
+
+    /// Called frequently while sizing the scrollbar and finding the anchor.
+    fn approx(&self) -> f32;
+
+    /// Called for rows the widget renders or walks in the precise-
+    /// from-end tail.
+    fn precise(&mut self) -> f32;
+
+    fn render(&mut self, ui: &mut Ui, top_left: Pos2);
+
+    /// Hint that the row is about to enter the viewport. Content can
+    /// kick off background work (e.g. start downloading images)
+    /// without painting. Called by the scroll area on rows within a
+    /// viewport-sized buffer above and below the visible window.
+    /// Default is a no-op.
+    fn warm(&mut self) {}
+}
+
+/// Per-frame state of the scroll area. Persisted in egui memory between
+/// frames keyed by [`AffineScrollArea::id_salt`].
+#[derive(Clone, Copy, Default)]
+struct ScrollState {
+    /// Position in approx units. `[0, max_offset]`.
+    offset_approx: f32,
+    /// Touch-scroll velocity in precise pixels per second. Positive
+    /// means content is moving up on screen (scroll offset growing).
+    velocity_precise: f32,
+    /// Sliding window of recent drag samples — `(delta_precise, dt)` —
+    /// averaged into `velocity_precise` to smooth out single-frame
+    /// noise.
+    drag_window: [(f32, f32); DRAG_WINDOW_LEN],
+    drag_window_idx: u8,
+}
+
+const DRAG_WINDOW_LEN: usize = 6;
+
+pub struct AffineScrollArea {
+    id_salt: egui::Id,
+    /// When true, drag on the body (not just the scrollbar) scrolls
+    /// the content with momentum. Intended for touch input.
+    touch_scroll: bool,
+}
+
+impl AffineScrollArea {
+    pub fn new(id_salt: impl std::hash::Hash) -> Self {
+        Self { id_salt: egui::Id::new(id_salt), touch_scroll: false }
+    }
+
+    pub fn touch_scroll(mut self, enabled: bool) -> Self {
+        self.touch_scroll = enabled;
+        self
+    }
+
+    /// Current touch-scroll velocity (precise px/sec). y is vertical;
+    /// x is always 0. Non-zero while momentum scroll is in flight.
+    /// Used to block other touch handling (e.g. cursor placement)
+    /// while content is coasting.
+    pub fn velocity(&self, ctx: &egui::Context) -> egui::Vec2 {
+        let state: ScrollState = ctx.data(|d| d.get_temp(self.id_salt)).unwrap_or_default();
+        egui::Vec2::new(0.0, state.velocity_precise)
+    }
+
+    /// Current scroll offset in approx units. For persistence.
+    pub fn offset(&self, ctx: &egui::Context) -> f32 {
+        ctx.data(|d| d.get_temp::<ScrollState>(self.id_salt))
+            .unwrap_or_default()
+            .offset_approx
+    }
+
+    /// Set scroll offset directly. Skips clamping — the scroll area
+    /// will clamp on next show against the current `max_offset`.
+    pub fn set_offset(&self, ctx: &egui::Context, offset_approx: f32) {
+        let mut state: ScrollState = ctx.data(|d| d.get_temp(self.id_salt)).unwrap_or_default();
+        state.offset_approx = offset_approx;
+        ctx.data_mut(|d| d.insert_temp(self.id_salt, state));
+        ctx.request_repaint();
+    }
+
+    pub fn show<R: Rows>(&mut self, ui: &mut Ui, content: &mut R) -> Response {
+        // Take the parent's full max_rect — callers control the scroll
+        // area's size by setting the surrounding ui's max_rect (e.g.
+        // via `ui.scope_builder().max_rect(...)`).
+        let rect = ui.max_rect();
+
+        let body_sense = if self.touch_scroll { Sense::click_and_drag() } else { Sense::hover() };
+        let response = ui.allocate_rect(rect, body_sense);
+
+        // Scrollbar hit area registered AFTER the body so it shadows
+        // the body's hover in z-order. Same dimensions used by
+        // `draw_scrollbar` below.
+        const BAR_WIDTH: f32 = 10.0;
+        const BAR_INSET: f32 = 3.0;
+        let bar_x = rect.max.x - BAR_WIDTH - BAR_INSET;
+        let bar_track =
+            Rect::from_min_size(Pos2::new(bar_x, rect.min.y), Vec2::new(BAR_WIDTH, rect.height()));
+        let bar_id = self.id_salt.with("scrollbar");
+        let bar_response = ui.interact(bar_track, bar_id, Sense::click_and_drag());
+
+        // Persisted scroll state.
+        let mut state: ScrollState = ui
+            .ctx()
+            .data(|d| d.get_temp(self.id_salt))
+            .unwrap_or_default();
+
+        let viewport_height = rect.height();
+
+        // approx_total: walk forward summing approx. Cheap.
+        let approx_total = sum_approx(content);
+
+        // max_offset: walk backward from the doc end summing precise
+        // until we cover one viewport. The crossing row becomes the
+        // anchor at max scroll; convert its intra-position back to
+        // approx. Bounded by the viewport's worth of rows.
+        let max_offset = compute_max_offset(content, viewport_height, approx_total);
+
+        // Scrollbar dimensions reason in approx space (cheap sizing),
+        // independent of `max_offset`'s precise-aware clamp.
+        let scrollbar_total = approx_total.max(viewport_height);
+
+        // Process scroll events: wheel, drag on scrollbar, programmatic.
+        // Wheel events are in screen pixels = precise. Translate to
+        // approx via the affine map at current offset.
+        //
+        // Use `raw_scroll_delta` (immediate, unsmoothed) rather than
+        // `smooth_scroll_delta` (kinetic). Tests need the full delta in
+        // one frame; production wheel input lands in raw too.
+        let raw_scroll_delta = ui.input(|i| i.raw_scroll_delta.y);
+        if raw_scroll_delta != 0.0 {
+            // egui's scroll convention: positive y means scroll up
+            // (content moves down). We want our offset to *increase*
+            // when user scrolls down (content moves up), so negate.
+            let precise_delta = -raw_scroll_delta;
+            let approx_delta = precise_to_approx_delta(content, state.offset_approx, precise_delta);
+            state.offset_approx = (state.offset_approx + approx_delta).clamp(0.0, max_offset);
+        }
+
+        // Touch body drag → scroll + velocity tracking.
+        let dt = ui.input(|i| i.stable_dt).max(0.0001);
+        if max_offset > 0.0 && self.touch_scroll && response.drag_started() {
+            // Tap-during-momentum or drag-start: clear stale velocity
+            // and the sliding-window history so the new gesture
+            // doesn't inherit anything.
+            state.velocity_precise = 0.0;
+            state.drag_window = [(0.0, 0.0); DRAG_WINDOW_LEN];
+            state.drag_window_idx = 0;
+        }
+        if max_offset > 0.0 && self.touch_scroll && response.dragged() {
+            let drag_y = ui.input(|i| i.pointer.delta().y);
+            // Drag UP (negative y) → scroll DOWN (offset grows). Same
+            // sign convention as wheel.
+            let precise_delta = -drag_y;
+            let approx_delta = precise_to_approx_delta(content, state.offset_approx, precise_delta);
+            state.offset_approx = (state.offset_approx + approx_delta).clamp(0.0, max_offset);
+            // Push this frame's sample into the sliding window.
+            // Velocity = sum(deltas) / sum(dts) over the window. Held
+            // frames (delta=0) drag the average toward 0, so a pause
+            // before release won't produce phantom momentum.
+            state.drag_window[state.drag_window_idx as usize] = (precise_delta, dt);
+            state.drag_window_idx = (state.drag_window_idx + 1) % (DRAG_WINDOW_LEN as u8);
+            let (sum_d, sum_dt) = state
+                .drag_window
+                .iter()
+                .fold((0.0, 0.0), |(sd, st), (d, t)| (sd + d, st + t));
+            state.velocity_precise = if sum_dt > 0.001 { sum_d / sum_dt } else { 0.0 };
+        } else if state.velocity_precise.abs() > 1.0 && !response.dragged() {
+            // Coast: apply velocity * dt, decay velocity.
+            const DECAY_PER_SEC: f32 = 4.0;
+            let precise_step = state.velocity_precise * dt;
+            let approx_step = precise_to_approx_delta(content, state.offset_approx, precise_step);
+            let new_offset = (state.offset_approx + approx_step).clamp(0.0, max_offset);
+            // If we hit a scroll boundary, kill momentum.
+            if (new_offset - state.offset_approx).abs() < 0.001 {
+                state.velocity_precise = 0.0;
+            } else {
+                state.offset_approx = new_offset;
+                state.velocity_precise *= (-DECAY_PER_SEC * dt).exp();
+            }
+            ui.ctx().request_repaint();
+        } else {
+            state.velocity_precise = 0.0;
+        }
+        // Tap (click without drag) cancels momentum.
+        if self.touch_scroll && response.clicked() {
+            state.velocity_precise = 0.0;
+        }
+
+        // Scrollbar drag/click. The thumb spans `visible_fraction *
+        // viewport_height`; the user can drag the thumb across the
+        // remaining `(1 - visible_fraction) * viewport_height` of
+        // track. That drag range maps onto `[0, max_offset]` in approx.
+        if max_offset > 0.0 && (bar_response.dragged() || bar_response.clicked()) {
+            let visible_fraction = (viewport_height / scrollbar_total).clamp(0.0, 1.0);
+            let track_drag_range = (rect.height() * (1.0 - visible_fraction)).max(1.0);
+            if bar_response.dragged() {
+                let drag_y = ui.input(|i| i.pointer.delta().y);
+                state.offset_approx = (state.offset_approx
+                    + drag_y * (max_offset / track_drag_range))
+                    .clamp(0.0, max_offset);
+            } else if let Some(pos) = bar_response.interact_pointer_pos() {
+                // Click jumps so the thumb's center lands at the cursor.
+                let thumb_h = visible_fraction * rect.height();
+                let target_thumb_top =
+                    (pos.y - rect.min.y - thumb_h / 2.0).clamp(0.0, track_drag_range);
+                state.offset_approx = target_thumb_top * (max_offset / track_drag_range);
+            }
+        }
+
+        // Find anchor and render visible rows.
+        ui.scope_builder(egui::UiBuilder::new().max_rect(rect), |ui| {
+            ui.set_clip_rect(rect);
+            render_visible(ui, content, rect, state.offset_approx);
+        });
+
+        // Draw scrollbar (simple vertical bar on the right).
+        if max_offset > 0.0 {
+            draw_scrollbar(ui, rect, state.offset_approx, scrollbar_total, viewport_height);
+        }
+
+        // Persist state.
+        ui.ctx().data_mut(|d| d.insert_temp(self.id_salt, state));
+
+        response
+    }
+}
+
+/// Where to position a target row within the viewport.
+#[derive(Clone, Copy, Debug)]
+pub enum Align {
+    /// Target's top at viewport top.
+    Top,
+    /// Target's center at viewport center.
+    Center,
+    /// Target's bottom at viewport bottom.
+    Bottom,
+}
+
+/// Compute the offset that places the first row matching `find` in the
+/// viewport per `align`. `find` is run on each row in forward order
+/// until it returns true. Returns `None` if no row matches.
+///
+/// Cost is bounded by the position of the target plus (for non-Top
+/// alignments) the precise content needed to fill the gap above the
+/// target — at most one viewport's worth.
+pub fn align_offset<R, F>(
+    content: &mut R, viewport_height: f32, align: Align, mut find: F,
+) -> Option<f32>
+where
+    R: Rows,
+    F: FnMut(&mut R) -> bool,
+{
+    content.reset();
+    let mut approx_top = 0.0f32;
+    let mut target_approx = 0.0f32;
+    let mut target_precise = 0.0f32;
+    let mut found = false;
+    while content.next() {
+        let h = content.approx();
+        if find(content) {
+            target_approx = h;
+            target_precise = content.precise();
+            found = true;
+            break;
+        }
+        approx_top += h;
+    }
+    if !found {
+        return None;
+    }
+
+    let target_gap = match align {
+        Align::Top => 0.0,
+        Align::Center => (viewport_height - target_precise) / 2.0,
+        Align::Bottom => viewport_height - target_precise,
+    };
+
+    if target_gap < 0.0 {
+        // Target is taller than the gap allows — anchor at target with
+        // its top above the viewport.
+        let intra_precise = -target_gap;
+        let slope = if target_approx > 0.0 { target_precise / target_approx } else { 1.0 };
+        let intra_approx = if slope > 0.0 { intra_precise / slope } else { 0.0 };
+        return Some((approx_top + intra_approx).max(0.0));
+    }
+
+    // Walk back from target, summing precise until we cover the gap.
+    // The crossing row becomes the anchor.
+    let mut precise_sum = 0.0f32;
+    let mut approx_sum = 0.0f32;
+    while content.prev() {
+        let p = content.precise();
+        let a = content.approx();
+        if precise_sum + p >= target_gap && a > 0.0 {
+            let intra_precise = p - (target_gap - precise_sum);
+            let slope = p / a;
+            let intra_approx = if slope > 0.0 { intra_precise / slope } else { 0.0 };
+            let anchor_approx_top = approx_top - approx_sum - a;
+            return Some((anchor_approx_top + intra_approx).max(0.0));
+        }
+        precise_sum += p;
+        approx_sum += a;
+    }
+
+    // Walked back to the doc start without filling the gap.
+    Some(0.0)
+}
+
+/// "Make visible" semantics: only return a new offset if `current_offset`
+/// has the target outside the viewport. When the target is already
+/// visible, returns `None` so the caller leaves scroll alone — avoids
+/// the constant-recenter feel of `Align::Center`. When out of view,
+/// returns the offset that brings the nearest edge of the target just
+/// into the viewport (Top alignment if scrolling up, Bottom if down).
+pub fn make_visible_offset<R, F>(
+    content: &mut R, viewport_height: f32, current_offset: f32, mut find: F,
+) -> Option<f32>
+where
+    R: Rows,
+    F: FnMut(&mut R) -> bool,
+{
+    let top = align_offset(content, viewport_height, Align::Top, &mut find)?;
+    let bottom = align_offset(content, viewport_height, Align::Bottom, &mut find)?;
+    let lo = top.min(bottom);
+    let hi = top.max(bottom);
+    if current_offset >= lo && current_offset <= hi {
+        None
+    } else if current_offset < lo {
+        Some(lo)
+    } else {
+        Some(hi)
+    }
+}
+
+/// Forward walk summing approx heights.
+fn sum_approx<R: Rows>(content: &mut R) -> f32 {
+    content.reset();
+    let mut total = 0.0f32;
+    while content.next() {
+        total += content.approx();
+    }
+    total
+}
+
+/// Convert a scroll offset (approx units) into the row the offset
+/// lands in plus an `intra_offset` (approx units within that row).
+/// Used for width-independent scroll persistence — the returned `idx`
+/// is the row's flat-order position from the start of the doc.
+pub fn offset_to_anchor<R: Rows>(content: &mut R, offset: f32) -> (usize, f32) {
+    content.reset();
+    let mut acc = 0.0f32;
+    let mut idx = 0usize;
+    let mut last_acc = 0.0f32;
+    let mut last_idx = 0usize;
+    while content.next() {
+        let h = content.approx();
+        if acc + h > offset {
+            return (idx, (offset - acc).max(0.0));
+        }
+        last_acc = acc;
+        last_idx = idx;
+        acc += h;
+        idx += 1;
+    }
+    if idx == 0 { (0, 0.0) } else { (last_idx, offset - last_acc) }
+}
+
+/// Inverse of [`offset_to_anchor`]. Out-of-range `anchor_idx` clamps to
+/// the last row; `intra` clamps to that row's approx height.
+pub fn anchor_to_offset<R: Rows>(content: &mut R, anchor_idx: usize, intra: f32) -> f32 {
+    content.reset();
+    let mut acc = 0.0f32;
+    let mut idx = 0usize;
+    let mut last_h = 0.0f32;
+    while content.next() {
+        let h = content.approx();
+        if idx == anchor_idx {
+            return acc + intra.clamp(0.0, h);
+        }
+        acc += h;
+        last_h = h;
+        idx += 1;
+    }
+    if idx == 0 { 0.0 } else { acc - last_h + intra.clamp(0.0, last_h) }
+}
+
+/// Walk precise heights from the end of the doc backwards until the
+/// cumulative reaches `viewport_height`. The row where it crosses is
+/// the anchor at max scroll; convert its intra-position back to approx
+/// units (via that row's slope) to get an `offset_approx` cap that,
+/// when rendered, places the doc's tail at the viewport bottom.
+///
+/// Cost is bounded by the tail rows visible at max scroll — not the
+/// whole doc — so this stays cheap even on long documents.
+///
+/// Edge cases:
+/// - viewport_height <= 0: returns 0.
+/// - Total precise content < viewport_height: returns 0 (doc fits).
+/// - Anchor would land in a 0-approx row: skip and continue
+///   backwards. The 0-approx row can't host an anchor because the
+///   slope is undefined.
+fn compute_max_offset<R: Rows>(content: &mut R, viewport_height: f32, approx_total: f32) -> f32 {
+    if viewport_height <= 0.0 {
+        return 0.0;
+    }
+    content.reset_back();
+    let mut cumulative_precise = 0.0f32;
+    let mut approx_tail_sum = 0.0f32;
+    while content.prev() {
+        let p = content.precise();
+        let a = content.approx();
+        cumulative_precise += p;
+        approx_tail_sum += a;
+        if cumulative_precise >= viewport_height && a > 0.0 {
+            let intra_precise = cumulative_precise - viewport_height;
+            let slope = p / a;
+            let intra_approx = if slope > 0.0 { intra_precise / slope } else { 0.0 };
+            return (approx_total - approx_tail_sum + intra_approx).max(0.0);
+        }
+    }
+    0.0
+}
+
+/// Walks rows until cumulative approx >= `offset_approx` to find the
+/// anchor row. Then paints anchor and downstream rows at consecutive
+/// precise positions. Anchor's intra-position is placed at the viewport
+/// top in screen space.
+fn render_visible<R: Rows>(ui: &mut Ui, content: &mut R, viewport: Rect, offset_approx: f32) {
+    content.reset();
+
+    let mut acc = 0.0f32;
+    let mut anchor_p = 0.0f32;
+    let mut intra_precise = 0.0f32;
+    let mut found = false;
+    while content.next() {
+        let h = content.approx();
+        if acc + h > offset_approx {
+            anchor_p = content.precise();
+            let anchor_a = h;
+            let intra_approx = offset_approx - acc;
+            let slope = if anchor_a > 0.0 { anchor_p / anchor_a } else { 1.0 };
+            intra_precise = intra_approx * slope;
+            content.render(ui, Pos2::new(viewport.min.x, viewport.min.y - intra_precise));
+            found = true;
+            break;
+        }
+        acc += h;
+    }
+    if !found {
+        return;
+    }
+
+    let mut y = -intra_precise + anchor_p;
+    while y < viewport.height() && content.next() {
+        let p = content.precise();
+        content.render(ui, Pos2::new(viewport.min.x, viewport.min.y + y));
+        y += p;
+    }
+
+    // Warm a viewport's worth past the bottom edge so images/etc.
+    // start loading before the user scrolls them in.
+    let warm_until = y + viewport.height();
+    while y < warm_until && content.next() {
+        y += content.precise();
+        content.warm();
+    }
+
+    // Warm a viewport's worth above the rendered region. Re-walk
+    // forward to the anchor (cheap; approx access is O(1) per row),
+    // then prev() warming until we've covered one viewport.
+    content.reset();
+    let mut acc = 0.0f32;
+    while content.next() {
+        let h = content.approx();
+        if acc + h > offset_approx {
+            break;
+        }
+        acc += h;
+    }
+    let mut warm_back = 0.0f32;
+    while warm_back < viewport.height() && content.prev() {
+        warm_back += content.precise();
+        content.warm();
+    }
+}
+
+/// Translate a precise delta (screen pixels of intended movement) into
+/// an approx delta to apply to the scrollbar offset. Walks rows
+/// starting at `offset_approx` consuming precise units; each row
+/// contributes at its approx/precise ratio.
+fn precise_to_approx_delta<R: Rows>(
+    content: &mut R, offset_approx: f32, precise_delta: f32,
+) -> f32 {
+    if precise_delta == 0.0 {
+        return 0.0;
+    }
+    content.reset();
+
+    let mut acc = 0.0f32;
+    let mut precise_remaining = precise_delta.abs();
+    let mut approx_consumed = 0.0f32;
+    let mut found = false;
+    while content.next() {
+        let approx_h = content.approx();
+        if acc + approx_h > offset_approx {
+            let intra_approx = offset_approx - acc;
+            let precise_h = content.precise();
+            let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
+            let approx_remaining_in_row = if precise_delta > 0.0 {
+                (approx_h - intra_approx).max(0.0)
+            } else {
+                intra_approx.max(0.0)
+            };
+            let precise_remaining_in_row = approx_remaining_in_row * slope;
+            if precise_remaining <= precise_remaining_in_row && slope > 0.0 {
+                let signed = precise_remaining / slope;
+                return if precise_delta > 0.0 { signed } else { -signed };
+            }
+            approx_consumed = approx_remaining_in_row;
+            precise_remaining -= precise_remaining_in_row;
+            found = true;
+            break;
+        }
+        acc += approx_h;
+    }
+    if !found {
+        return 0.0;
+    }
+
+    // Past the anchor every subsequent row is consumed across its
+    // full approx span.
+    loop {
+        let stepped = if precise_delta > 0.0 { content.next() } else { content.prev() };
+        if !stepped {
+            return if precise_delta > 0.0 { approx_consumed } else { -approx_consumed };
+        }
+        let approx_h = content.approx();
+        let precise_h = content.precise();
+        let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
+        let precise_in_row = approx_h * slope;
+        if precise_remaining <= precise_in_row && slope > 0.0 {
+            approx_consumed += precise_remaining / slope;
+            return if precise_delta > 0.0 { approx_consumed } else { -approx_consumed };
+        }
+        approx_consumed += approx_h;
+        precise_remaining -= precise_in_row;
+        if precise_remaining <= 0.0 {
+            return if precise_delta > 0.0 { approx_consumed } else { -approx_consumed };
+        }
+    }
+}
+
+fn draw_scrollbar(
+    ui: &Ui, viewport: Rect, offset_approx: f32, approx_total: f32, viewport_height: f32,
+) {
+    use crate::theme::palette_v2::ThemeExt as _;
+    // Must match the dimensions in `show()` — the scrollbar's hit area
+    // is allocated there, this only paints into it.
+    const BAR_WIDTH: f32 = 10.0;
+    const BAR_INSET: f32 = 3.0;
+
+    let theme = ui.ctx().get_lb_theme();
+    // Track: lerp neutral_bg toward neutral (a darker tone) — barely
+    // visible, just enough to anchor the thumb. Thumb: pure neutral
+    // (grey in either mode), prominent against the bg.
+    let track_color = theme.neutral_bg().lerp_to_gamma(theme.neutral(), 0.3);
+    let thumb_color = theme.neutral();
+
+    let bar_x = viewport.max.x - BAR_WIDTH - BAR_INSET;
+    let bar_track = Rect::from_min_size(
+        Pos2::new(bar_x, viewport.min.y),
+        Vec2::new(BAR_WIDTH, viewport.height()),
+    );
+    let visible_fraction = (viewport_height / approx_total).clamp(0.0, 1.0);
+    let offset_fraction = (offset_approx / approx_total).clamp(0.0, 1.0 - visible_fraction);
+    let thumb = Rect::from_min_size(
+        Pos2::new(bar_x, viewport.min.y + offset_fraction * viewport.height()),
+        Vec2::new(BAR_WIDTH, visible_fraction * viewport.height()),
+    );
+    ui.painter().rect_filled(bar_track, 3.0, track_color);
+    ui.painter()
+        .rect(thumb, 3.0, thumb_color, Stroke::NONE, egui::epaint::StrokeKind::Inside);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic content for testing the affine scroll math. Records
+    /// rendered rows so tests can assert positioning.
+    ///
+    /// `cursor` semantics: `None` = before first; `Some(i)` for `i <
+    /// len` = at row i; `Some(len)` = after last.
+    struct MockContent {
+        approx: Vec<f32>,
+        precise: Vec<f32>,
+        rendered: Vec<(usize, Pos2)>,
+        cursor: Option<usize>,
+    }
+
+    impl MockContent {
+        fn new(rows: Vec<(f32, f32)>) -> Self {
+            let approx = rows.iter().map(|(a, _)| *a).collect();
+            let precise = rows.iter().map(|(_, p)| *p).collect();
+            Self { approx, precise, rendered: Vec::new(), cursor: None }
+        }
+        fn at(&self) -> Option<usize> {
+            match self.cursor {
+                Some(i) if i < self.approx.len() => Some(i),
+                _ => None,
+            }
+        }
+    }
+
+    impl Rows for MockContent {
+        fn reset(&mut self) {
+            self.cursor = None;
+        }
+        fn reset_back(&mut self) {
+            self.cursor = Some(self.approx.len());
+        }
+        fn next(&mut self) -> bool {
+            let n = self.approx.len();
+            self.cursor = match self.cursor {
+                None => Some(0),
+                Some(i) if i < n => Some(i + 1),
+                Some(i) => Some(i),
+            };
+            self.at().is_some()
+        }
+        fn prev(&mut self) -> bool {
+            let n = self.approx.len();
+            self.cursor = match self.cursor {
+                Some(0) => None,
+                Some(i) if i <= n => Some(i - 1),
+                Some(_) => Some(n.saturating_sub(1)),
+                None => None,
+            };
+            self.at().is_some()
+        }
+        fn approx(&self) -> f32 {
+            self.approx[self.at().expect("approx() not at row")]
+        }
+        fn precise(&mut self) -> f32 {
+            self.precise[self.at().expect("precise() not at row")]
+        }
+        fn render(&mut self, _: &mut Ui, top_left: Pos2) {
+            let i = self.at().expect("render() not at row");
+            self.rendered.push((i, top_left));
+        }
+    }
+
+    #[test]
+    fn precise_to_approx_within_single_row() {
+        let mut c = MockContent::new(vec![(50.0, 100.0)]);
+        let approx_delta = precise_to_approx_delta(&mut c, 0.0, 30.0);
+        assert!((approx_delta - 15.0).abs() < 0.01, "got {}", approx_delta);
+    }
+
+    #[test]
+    fn precise_to_approx_crossing_row_boundary() {
+        let mut c = MockContent::new(vec![(50.0, 100.0), (50.0, 50.0)]);
+        let approx_delta = precise_to_approx_delta(&mut c, 0.0, 150.0);
+        assert!((approx_delta - 100.0).abs() < 0.01, "got {}", approx_delta);
+    }
+
+    #[test]
+    fn precise_to_approx_negative() {
+        let mut c = MockContent::new(vec![(50.0, 100.0)]);
+        let approx_delta = precise_to_approx_delta(&mut c, 30.0, -30.0);
+        assert!((approx_delta + 15.0).abs() < 0.01, "got {}", approx_delta);
+    }
+
+    /// 10 rows of 50px each, viewport=100px (2 rows visible). Target
+    /// is row 5 → Top alignment offset=250, Bottom alignment offset=200.
+    #[test]
+    fn make_visible_no_scroll_when_target_already_in_view() {
+        let mut c = MockContent::new(vec![(50.0, 50.0); 10]);
+        let result = make_visible_offset(&mut c, 100.0, 225.0, |c| c.at() == Some(5));
+        assert_eq!(result, None, "should not scroll when target is visible");
+    }
+
+    #[test]
+    fn make_visible_scrolls_down_when_target_below() {
+        let mut c = MockContent::new(vec![(50.0, 50.0); 10]);
+        let result = make_visible_offset(&mut c, 100.0, 0.0, |c| c.at() == Some(5));
+        let o = result.expect("should scroll");
+        assert!((o - 200.0).abs() < 0.5, "expected ~200, got {o}");
+    }
+
+    #[test]
+    fn make_visible_scrolls_up_when_target_above() {
+        let mut c = MockContent::new(vec![(50.0, 50.0); 10]);
+        let result = make_visible_offset(&mut c, 100.0, 400.0, |c| c.at() == Some(5));
+        let o = result.expect("should scroll");
+        assert!((o - 250.0).abs() < 0.5, "expected ~250, got {o}");
+    }
+
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    fn random_rows(rng: &mut StdRng, n: usize) -> Vec<(f32, f32)> {
+        (0..n)
+            .map(|_| {
+                let approx = rng.gen_range(10.0..200.0);
+                let ratio = rng.gen_range(0.3..3.0);
+                (approx, approx * ratio)
+            })
+            .collect()
+    }
+
+    /// Reference: visible (idx, screen_y) pairs at offset. Used by
+    /// property tests.
+    fn visible_row_positions<R: Rows>(
+        content: &mut R, viewport_height: f32, offset_approx: f32,
+    ) -> Vec<(usize, f32)> {
+        content.reset();
+        let mut acc = 0.0f32;
+        let mut idx = 0usize;
+        let mut anchor_p = 0.0f32;
+        let mut intra_precise = 0.0f32;
+        let mut out = Vec::new();
+        let mut found = false;
+        while content.next() {
+            let h = content.approx();
+            if acc + h > offset_approx {
+                anchor_p = content.precise();
+                let intra_approx = offset_approx - acc;
+                let slope = if h > 0.0 { anchor_p / h } else { 1.0 };
+                intra_precise = intra_approx * slope;
+                out.push((idx, -intra_precise));
+                found = true;
+                break;
+            }
+            acc += h;
+            idx += 1;
+        }
+        if !found {
+            return out;
+        }
+        let mut y = -intra_precise + anchor_p;
+        while y < viewport_height && content.next() {
+            idx += 1;
+            let p = content.precise();
+            out.push((idx, y));
+            y += p;
+        }
+        out
+    }
+
+    /// Property: after submitting a scroll event of `precise_delta`,
+    /// rows visible in both the before and after renders shift by
+    /// exactly `precise_delta` in screen space.
+    ///
+    /// This is the core invariant the affine scroll area exists to
+    /// satisfy. If broken, scrolling produces visible "jumps" at row
+    /// boundaries.
+    #[test]
+    fn property_scroll_delta_preserved_in_screen_space() {
+        const EPS: f32 = 0.01;
+        let viewport_height = 200.0;
+        let mut rng = StdRng::seed_from_u64(0);
+        for seed in 0..2048u64 {
+            let mut rng_inner = StdRng::seed_from_u64(seed);
+            let n_rows = rng_inner.gen_range(1..20);
+            let rows = random_rows(&mut rng_inner, n_rows);
+            let mut c = MockContent::new(rows.clone());
+
+            let approx_total: f32 = rows.iter().map(|(a, _)| *a).sum();
+            if approx_total <= viewport_height {
+                continue;
+            }
+            let max_offset = approx_total - viewport_height;
+            let offset_a: f32 = rng.gen_range(0.0..=max_offset);
+            let precise_delta: f32 = rng.gen_range(-150.0..=150.0);
+
+            let approx_delta = precise_to_approx_delta(&mut c, offset_a, precise_delta);
+            let offset_b = (offset_a + approx_delta).clamp(0.0, max_offset);
+
+            let effective_approx_delta = offset_b - offset_a;
+            let effective_precise_delta =
+                approx_to_precise_delta(&mut c, offset_a, effective_approx_delta);
+
+            let before = visible_row_positions(&mut c, viewport_height, offset_a);
+            let after = visible_row_positions(&mut c, viewport_height, offset_b);
+
+            for (idx_a, y_a) in &before {
+                if let Some(&(_, y_b)) = after.iter().find(|(i, _)| i == idx_a) {
+                    let diff = y_b - y_a;
+                    let expected = -effective_precise_delta;
+                    assert!(
+                        (diff - expected).abs() < EPS,
+                        "seed {seed}: row {idx_a} shifted by {diff}, expected {expected} \
+                         (offset {offset_a} → {offset_b}, precise {precise_delta}, \
+                         effective precise {effective_precise_delta})",
+                    );
+                }
+            }
+        }
+    }
+
+    /// Inverse of `precise_to_approx_delta`: given an approx delta,
+    /// returns the precise distance covered. Used in tests.
+    fn approx_to_precise_delta<R: Rows>(
+        content: &mut R, offset_approx: f32, approx_delta: f32,
+    ) -> f32 {
+        if approx_delta == 0.0 {
+            return 0.0;
+        }
+        content.reset();
+        let mut acc = 0.0f32;
+        let mut precise_consumed = 0.0f32;
+        let mut approx_remaining = approx_delta.abs();
+        let mut found = false;
+        while content.next() {
+            let approx_h = content.approx();
+            if acc + approx_h > offset_approx {
+                let intra_approx = offset_approx - acc;
+                let precise_h = content.precise();
+                let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
+                let approx_remaining_in_row = if approx_delta > 0.0 {
+                    (approx_h - intra_approx).max(0.0)
+                } else {
+                    intra_approx.max(0.0)
+                };
+                if approx_remaining <= approx_remaining_in_row {
+                    let signed = approx_remaining * slope;
+                    return if approx_delta > 0.0 { signed } else { -signed };
+                }
+                precise_consumed = approx_remaining_in_row * slope;
+                approx_remaining -= approx_remaining_in_row;
+                found = true;
+                break;
+            }
+            acc += approx_h;
+        }
+        if !found {
+            return 0.0;
+        }
+
+        loop {
+            let stepped = if approx_delta > 0.0 { content.next() } else { content.prev() };
+            if !stepped {
+                return if approx_delta > 0.0 { precise_consumed } else { -precise_consumed };
+            }
+            let approx_h = content.approx();
+            let precise_h = content.precise();
+            let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
+            if approx_remaining <= approx_h {
+                precise_consumed += approx_remaining * slope;
+                return if approx_delta > 0.0 { precise_consumed } else { -precise_consumed };
+            }
+            precise_consumed += approx_h * slope;
+            approx_remaining -= approx_h;
+            if approx_remaining <= 0.0 {
+                return if approx_delta > 0.0 { precise_consumed } else { -precise_consumed };
+            }
+        }
+    }
+
+    /// Property: precise→approx and approx→precise are inverses (for
+    /// deltas that don't run off the end of the doc).
+    #[test]
+    fn property_affine_map_invertible() {
+        const EPS: f32 = 0.01;
+        let mut rng = StdRng::seed_from_u64(42);
+        for seed in 0..2048u64 {
+            let mut rng_inner = StdRng::seed_from_u64(seed);
+            let n_rows = rng_inner.gen_range(1..20);
+            let rows = random_rows(&mut rng_inner, n_rows);
+            let mut c = MockContent::new(rows.clone());
+            let approx_total: f32 = rows.iter().map(|(a, _)| *a).sum();
+            let offset: f32 = rng.gen_range(0.0..=approx_total.max(1.0));
+            let approx_delta: f32 = rng.gen_range(-100.0..=100.0);
+
+            let new_offset = offset + approx_delta;
+            const EDGE: f32 = 5.0;
+            if new_offset < EDGE || new_offset > approx_total - EDGE {
+                continue;
+            }
+
+            let precise = approx_to_precise_delta(&mut c, offset, approx_delta);
+            let back = precise_to_approx_delta(&mut c, offset, precise);
+            assert!(
+                (back - approx_delta).abs() < EPS,
+                "seed {seed}: approx→precise→approx not identity ({approx_delta} → {precise} → {back})",
+            );
+        }
+    }
+}

--- a/libs/content/workspace/src/widgets/mod.rs
+++ b/libs/content/workspace/src/widgets/mod.rs
@@ -1,3 +1,4 @@
+pub mod affine_scroll;
 pub mod button;
 pub mod button_group;
 pub mod glyphon_cache;


### PR DESCRIPTION
Replace the editor's `egui::ScrollArea` with a custom `AffineScrollArea` that uses approximations to avoid fully measuring off screen content.

On init, we measure the approximate height of all blocks in the document to size the scroll bar. The scroll offset is stored in approximate coordinates. Dragging the scroll bar navigates the scroll offset smoothly.

The first content on the screen is determined using the approximate heights of the blocks above (which are already computed for the scrollbar). The content is sized precisely starting at this point until the screen is full.

When you submit a scroll event, it is interpreted in precise coordinates. We examine the blocks in the distance spanned by the offset from an anchor offset on the screen and multiply piecewise by the approx/precise ratio to convert to an approx scroll amount, then add that to the scroll offset.

The gains depend on our implementation of block heights being fast enough to layout the whole document quickly and accurate enough to not cause observable funkiness - an under approximation for a block makes you scroll by it more quickly when dragging the scrollbar. Our approximation pretends, basically, that the block's text is monospace and character-wrapped with char width = .5 * char height (an empirical choice).

The result: a 30x speedup of cold-starting the editor to any scroll offset, targeting the search preview use case.