### PR TITLE
android: hide workspace open button when not needed

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/FilesListFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/FilesListFragment.kt
@@ -181,6 +181,7 @@ class FilesListFragment : Fragment(), FilesFragment {
                 }
             }
             currentTab = it
+            updateOpenWorkspacePaneButtonVisibility()
         }
 
         model.isSuggestedDocsVisible.observe(viewLifecycleOwner) {
@@ -250,6 +251,10 @@ class FilesListFragment : Fragment(), FilesFragment {
             binding.drawerLayout.open()
         }
 
+        binding.root.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            updateOpenWorkspacePaneButtonVisibility()
+        }
+
         binding.navigationView.getHeaderView(0).let { header ->
 
             header.findViewById<LinearLayout>(R.id.set_theme).setOnClickListener {
@@ -291,6 +296,18 @@ class FilesListFragment : Fragment(), FilesFragment {
         }
 
         toggleMenuBar()
+        updateOpenWorkspacePaneButtonVisibility()
+    }
+
+    private fun updateOpenWorkspacePaneButtonVisibility() {
+        val isWorkspacePaneSlideable = (activity as? MainScreenActivity)
+            ?.binding
+            ?.slidingPaneLayout
+            ?.isSlideable == true
+        val isWelcomeOpen = currentTab.type == WorkspaceTabType.Welcome
+
+        menu.menu.findItem(R.id.menu_files_list_open_ws)?.isVisible =
+            isWorkspacePaneSlideable && !isWelcomeOpen
     }
 
     private fun setUpFilesList() {


### PR DESCRIPTION
hides the workspace open button on tablet view and when workspace has no open documents thus removing the welcome screen on mobile. 