### PR TITLE
md: fix android selection

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -77,7 +77,8 @@ impl MdEdit {
         let selection_start_line = self.cursor_line(selection.0);
         let selection_end_line = self.cursor_line(selection.1);
 
-        let radius = 10.0;
+        let radius = 12.0;
+        let hit_pad = 12.0;
 
         // draw selection handles
         // handles invisible but still draggable when selection is empty
@@ -138,7 +139,8 @@ impl MdEdit {
                     x: selection_start_line[1].x,
                     y: selection_start_line[1].y + 2. * radius,
                 },
-            };
+            }
+            .expand(hit_pad);
             let start_response = ui.allocate_rect(selection_start_handle_rect, Sense::drag());
 
             // adjust cursor based on selection handle drag
@@ -165,7 +167,8 @@ impl MdEdit {
                     x: selection_end_line[1].x + 2. * radius,
                     y: selection_end_line[1].y + 2. * radius,
                 },
-            };
+            }
+            .expand(hit_pad);
             let end_response = ui.allocate_rect(selection_end_handle_rect, Sense::drag());
 
             // adjust cursor based on selection handle drag

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -26,6 +26,24 @@ impl MdEdit {
         }
     }
 
+    pub fn selection_tap(&self, pos: Pos2) -> bool {
+        let selection = self.renderer.buffer.current.selection;
+        let pad_rect = |rect: Rect| {
+            let pad_x = ((48.0 - rect.width()) / 2.0).max(0.0);
+            let pad_y = ((48.0 - rect.height()) / 2.0).max(0.0);
+            rect.expand2(Vec2::new(pad_x, pad_y))
+        };
+        if selection.is_empty() {
+            self.cursor_line(selection.0)
+                .map(|[top, bot]| pad_rect(Rect::from_min_max(top, bot)).contains(pos))
+                .unwrap_or(false)
+        } else {
+            self.range_rects(selection)
+                .iter()
+                .any(|&r| pad_rect(r).contains(pos))
+        }
+    }
+
     pub fn range_rects(&self, range: (Grapheme, Grapheme)) -> Vec<Rect> {
         let mut result = Vec::new();
 
@@ -80,9 +98,6 @@ impl MdEdit {
         let radius = 12.0;
         let hit_pad = 12.0;
 
-        // draw selection handles
-        // handles invisible but still draggable when selection is empty
-        // we must allocate handles to check if they were dragged last frame
         if !self.renderer.buffer.current.selection.is_empty() {
             if let Some(selection_start_line) = selection_start_line {
                 let selection_start_center = Pos2 {

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -165,9 +165,11 @@ impl MdEdit {
                     ui.ctx().push_markdown_event(Event::Select { region });
                 }
             } else if start_response.dragged() {
+                let line_height = selection_start_line[1].y - selection_start_line[0].y;
+                let offset = Vec2::new(0.0, -line_height - radius);
                 let region = Region::BetweenLocations {
                     start: Location::Pos(
-                        ui.input(|i| i.pointer.interact_pos().unwrap_or_default() - 10. * Vec2::Y),
+                        ui.input(|i| i.pointer.interact_pos().unwrap_or_default()) + offset,
                     ),
                     end: Location::Grapheme(self.renderer.buffer.current.selection.1),
                 };
@@ -193,10 +195,12 @@ impl MdEdit {
                     ui.ctx().push_markdown_event(Event::Select { region });
                 }
             } else if end_response.dragged() {
+                let line_height = selection_end_line[1].y - selection_end_line[0].y;
+                let offset = Vec2::new(0.0, -line_height - radius);
                 let region = Region::BetweenLocations {
                     start: Location::Grapheme(self.renderer.buffer.current.selection.0),
                     end: Location::Pos(
-                        ui.input(|i| i.pointer.interact_pos().unwrap_or_default() - 10. * Vec2::Y),
+                        ui.input(|i| i.pointer.interact_pos().unwrap_or_default()) + offset,
                     ),
                 };
                 self.in_progress_selection = Some(self.region_to_range(region));

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -96,115 +96,85 @@ impl MdEdit {
         let selection_end_line = self.cursor_line(selection.1);
 
         let radius = 12.0;
-        let hit_pad = 12.0;
 
         if !self.renderer.buffer.current.selection.is_empty() {
-            if let Some(selection_start_line) = selection_start_line {
-                let selection_start_center = Pos2 {
-                    x: selection_start_line[1].x - radius,
-                    y: selection_start_line[1].y + radius,
-                };
-                ui.painter()
-                    .circle_filled(selection_start_center, radius, color);
-                ui.painter().rect_filled(
-                    Rect {
-                        min: Pos2 {
-                            x: selection_start_center.x,
-                            y: selection_start_center.y - radius,
-                        },
-                        max: Pos2 {
-                            x: selection_start_center.x + radius,
-                            y: selection_start_center.y,
-                        },
-                    },
-                    0.,
-                    color,
-                );
+            if let Some(line) = selection_start_line {
+                self.paint_handle(ui, line, radius, color, true);
             }
-
-            if let Some(selection_end_line) = selection_end_line {
-                let selection_end_center = Pos2 {
-                    x: selection_end_line[1].x + radius,
-                    y: selection_end_line[1].y + radius,
-                };
-                ui.painter()
-                    .circle_filled(selection_end_center, radius, color);
-                ui.painter().rect_filled(
-                    Rect {
-                        min: Pos2 {
-                            x: selection_end_center.x - radius,
-                            y: selection_end_center.y - radius,
-                        },
-                        max: Pos2 { x: selection_end_center.x, y: selection_end_center.y },
-                    },
-                    0.,
-                    color,
-                );
+            if let Some(line) = selection_end_line {
+                self.paint_handle(ui, line, radius, color, false);
             }
         }
 
-        if let Some(selection_start_line) = selection_start_line {
-            // allocate rects to capture selection handle drag
-            let selection_start_handle_rect = Rect {
-                min: Pos2 {
-                    x: selection_start_line[1].x - 2. * radius,
-                    y: selection_start_line[1].y,
-                },
-                max: Pos2 {
-                    x: selection_start_line[1].x,
-                    y: selection_start_line[1].y + 2. * radius,
-                },
-            }
-            .expand(hit_pad);
-            let start_response = ui.allocate_rect(selection_start_handle_rect, Sense::drag());
-
-            // adjust cursor based on selection handle drag
-            if start_response.drag_stopped() {
-                if let Some(in_progress_selection) = mem::take(&mut self.in_progress_selection) {
-                    let region = Region::from(in_progress_selection);
-                    ui.ctx().push_markdown_event(Event::Select { region });
-                }
-            } else if start_response.dragged() {
-                let line_height = selection_start_line[1].y - selection_start_line[0].y;
-                let offset = Vec2::new(0.0, -line_height - radius);
-                let region = Region::BetweenLocations {
-                    start: Location::Pos(
-                        ui.input(|i| i.pointer.interact_pos().unwrap_or_default()) + offset,
-                    ),
-                    end: Location::Grapheme(self.renderer.buffer.current.selection.1),
-                };
-                self.in_progress_selection = Some(self.region_to_range(region));
-            }
+        if let Some(line) = selection_start_line {
+            self.interact_handle(ui, line, radius, true);
         }
-        if let Some(selection_end_line) = selection_end_line {
-            // allocate rects to capture selection handle drag
-            let selection_end_handle_rect = Rect {
-                min: Pos2 { x: selection_end_line[1].x, y: selection_end_line[1].y },
-                max: Pos2 {
-                    x: selection_end_line[1].x + 2. * radius,
-                    y: selection_end_line[1].y + 2. * radius,
-                },
-            }
-            .expand(hit_pad);
-            let end_response = ui.allocate_rect(selection_end_handle_rect, Sense::drag());
+        if let Some(line) = selection_end_line {
+            self.interact_handle(ui, line, radius, false);
+        }
+    }
 
-            // adjust cursor based on selection handle drag
-            if end_response.drag_stopped() {
-                if let Some(in_progress_selection) = mem::take(&mut self.in_progress_selection) {
-                    let region = Region::from(in_progress_selection);
-                    ui.ctx().push_markdown_event(Event::Select { region });
-                }
-            } else if end_response.dragged() {
-                let line_height = selection_end_line[1].y - selection_end_line[0].y;
-                let offset = Vec2::new(0.0, -line_height - radius);
-                let region = Region::BetweenLocations {
-                    start: Location::Grapheme(self.renderer.buffer.current.selection.0),
-                    end: Location::Pos(
-                        ui.input(|i| i.pointer.interact_pos().unwrap_or_default()) + offset,
-                    ),
-                };
-                self.in_progress_selection = Some(self.region_to_range(region));
+    fn paint_handle(&self, ui: &Ui, line: [Pos2; 2], radius: f32, color: Color32, is_start: bool) {
+        let cursor_bot = line[1];
+        let center = Pos2 {
+            x: if is_start { cursor_bot.x - radius } else { cursor_bot.x + radius },
+            y: cursor_bot.y + radius,
+        };
+        ui.painter().circle_filled(center, radius, color);
+        let (rect_min_x, rect_max_x) =
+            if is_start { (center.x, center.x + radius) } else { (center.x - radius, center.x) };
+        ui.painter().rect_filled(
+            Rect::from_min_max(
+                Pos2::new(rect_min_x, center.y - radius),
+                Pos2::new(rect_max_x, center.y),
+            ),
+            0.,
+            color,
+        );
+    }
+
+    fn interact_handle(&mut self, ui: &mut Ui, line: [Pos2; 2], radius: f32, is_start: bool) {
+        let hit_pad = 12.0;
+        let cursor_bot = line[1];
+        let (min_x, max_x) = if is_start {
+            (cursor_bot.x - 2. * radius, cursor_bot.x)
+        } else {
+            (cursor_bot.x, cursor_bot.x + 2. * radius)
+        };
+        let hit_rect = Rect::from_min_max(
+            Pos2::new(min_x, cursor_bot.y),
+            Pos2::new(max_x, cursor_bot.y + 2. * radius),
+        )
+        .expand(hit_pad);
+        let response = ui.allocate_rect(hit_rect, Sense::drag());
+
+        if response.drag_stopped() {
+            if let Some(in_progress_selection) = mem::take(&mut self.in_progress_selection) {
+                let region = Region::from(in_progress_selection);
+                ui.ctx().push_markdown_event(Event::Select { region });
             }
+        } else if response.dragged() {
+            let line_height = line[1].y - line[0].y;
+            let offset = Vec2::new(0.0, -line_height - radius);
+            let mut new_pos = ui.input(|i| i.pointer.interact_pos().unwrap_or_default()) + offset;
+            // stay within the last galley's y-range so `pos_to_range`
+            // uses x-aware placement instead of jumping to doc end
+            if let Some(last) = self.renderer.galleys.galleys.last() {
+                new_pos.y = new_pos.y.min(last.rect.max.y - 1.0);
+            }
+            let selection = self.renderer.buffer.current.selection;
+            let region = if is_start {
+                Region::BetweenLocations {
+                    start: Location::Pos(new_pos),
+                    end: Location::Grapheme(selection.1),
+                }
+            } else {
+                Region::BetweenLocations {
+                    start: Location::Grapheme(selection.0),
+                    end: Location::Pos(new_pos),
+                }
+            };
+            self.in_progress_selection = Some(self.region_to_range(region));
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1116,31 +1116,42 @@ impl Editor {
 
                 let arena = Arena::new();
                 let root = self.edit.renderer.reparse(&arena);
-                let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
 
                 // affine render: widget body spans the full canvas
                 // (scrollbar at canvas right); content centers within
                 // that body via `content_x`.
-                self.edit.renderer.galleys.galleys.clear();
-                self.edit.renderer.bounds.wrap_lines.clear();
-                self.edit.renderer.text_areas.clear();
                 let touch_scroll = self.edit.renderer.touch_mode;
                 let content_x = canvas_rect.min.x
                     + ((canvas_rect.width() - self.edit.renderer.width) / 2.0).max(0.0);
-                ui.scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
-                    let trailing_precise = canvas_rect.height() / 2.0;
-                    let mut content = scroll_content::DocScrollContent::new(
-                        &mut self.edit.renderer,
-                        root,
-                        content_x,
-                        trailing_precise,
-                    )
-                    .with_default_leading();
-                    let mut scroll =
-                        crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id)
-                            .touch_scroll(touch_scroll);
-                    scroll.show(ui, &mut content);
-                });
+                let pre = ui
+                    .scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
+                        // begin → pre_render → finish: editor's click
+                        // sense must register after the affine body's
+                        // drag so taps win over drag in egui's hit-test.
+                        let scroll =
+                            crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id)
+                                .touch_scroll(touch_scroll);
+                        let begun = scroll.begin(ui);
+
+                        let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
+
+                        self.edit.renderer.galleys.galleys.clear();
+                        self.edit.renderer.bounds.wrap_lines.clear();
+                        self.edit.renderer.text_areas.clear();
+
+                        let trailing_precise = canvas_rect.height() / 2.0;
+                        let mut content = scroll_content::DocScrollContent::new(
+                            &mut self.edit.renderer,
+                            root,
+                            content_x,
+                            trailing_precise,
+                        )
+                        .with_default_leading();
+                        begun.finish(ui, &mut content);
+
+                        pre
+                    })
+                    .inner;
                 self.edit.renderer.galleys.galleys.sort_by_key(|g| g.range);
 
                 self.edit.post_render(ui, canvas_rect, scroll_id, pre);

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1125,9 +1125,6 @@ impl Editor {
                     + ((canvas_rect.width() - self.edit.renderer.width) / 2.0).max(0.0);
                 let pre = ui
                     .scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
-                        // begin → pre_render → finish: editor's click
-                        // sense must register after the affine body's
-                        // drag so taps win over drag in egui's hit-test.
                         let scroll =
                             crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id)
                                 .touch_scroll(touch_scroll);

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -274,24 +274,10 @@ impl MdEdit {
                 } else if response.clicked() && modifiers.shift {
                     Some(Region::ToLocation(location))
                 } else if response.clicked() {
-                    if cfg!(target_os = "android") {
-                        // android native context menu: tap-on-selection opens the menu
-                        let offset = self.pos_to_char_offset(pos);
-                        if self
-                            .renderer
-                            .buffer
-                            .current
-                            .selection
-                            .contains(offset, true, true)
-                        {
-                            ctx.set_context_menu(
-                                self.context_menu_pos(self.renderer.buffer.current.selection)
-                                    .unwrap_or(pos),
-                            );
-                            None
-                        } else {
-                            Some(Region::Location(location))
-                        }
+                    if cfg!(target_os = "android") && self.selection_tap(pos) {
+                        let selection = self.renderer.buffer.current.selection;
+                        ctx.set_context_menu(self.context_menu_pos(selection).unwrap_or(pos));
+                        None
                     } else {
                         Some(Region::Location(location))
                     }
@@ -413,7 +399,9 @@ impl MdEdit {
                 ));
         }
 
-        if ui.ctx().os() == OperatingSystem::Android {
+        let has_selection_handles = !self.renderer.buffer.current.selection.is_empty()
+            || self.in_progress_selection.is_some();
+        if ui.ctx().os() == OperatingSystem::Android && has_selection_handles {
             self.show_selection_handles(ui);
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -375,10 +375,6 @@ impl MdEdit {
             }
         }
 
-        if ui.ctx().os() == OperatingSystem::Android {
-            self.show_selection_handles(ui);
-        }
-
         // FindMatch is consumed by the caller (it owns find state).
         if matches!(self.pending_scroll, Some(ScrollTarget::Cursor)) {
             self.pending_scroll = None;
@@ -415,6 +411,10 @@ impl MdEdit {
                     ui.clip_rect(),
                     crate::GlyphonRendererCallback::new(text_areas),
                 ));
+        }
+
+        if ui.ctx().os() == OperatingSystem::Android {
+            self.show_selection_handles(ui);
         }
 
         // drain renderer's interactive-element events into the edit queue for next frame

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -121,31 +121,48 @@ impl AffineScrollArea {
         ctx.request_repaint();
     }
 
-    pub fn show<R: Rows>(&mut self, ui: &mut Ui, content: &mut R) -> Response {
-        // Take the parent's full max_rect — callers control the scroll
-        // area's size by setting the surrounding ui's max_rect (e.g.
-        // via `ui.scope_builder().max_rect(...)`).
+    /// Allocate the body's drag interaction. Caller may register its own
+    /// widgets between `begin` and [`AffineScrollAreaBegun::finish`];
+    /// those land at higher z than the body, so click senses on the
+    /// content win over the body's drag — see egui's `hit_test`.
+    pub fn begin(self, ui: &mut Ui) -> AffineScrollAreaBegun {
         let rect = ui.max_rect();
-
         let body_sense = if self.touch_scroll { Sense::drag() } else { Sense::hover() };
-        let response = ui.allocate_rect(rect, body_sense);
+        let body_response = ui.allocate_rect(rect, body_sense);
+        AffineScrollAreaBegun {
+            id_salt: self.id_salt,
+            touch_scroll: self.touch_scroll,
+            rect,
+            body_response,
+        }
+    }
 
-        // Scrollbar hit area registered AFTER the body so it shadows
-        // the body's hover in z-order. Same dimensions used by
-        // `draw_scrollbar` below.
+    pub fn show<R: Rows>(self, ui: &mut Ui, content: &mut R) -> Response {
+        self.begin(ui).finish(ui, content)
+    }
+}
+
+pub struct AffineScrollAreaBegun {
+    id_salt: egui::Id,
+    touch_scroll: bool,
+    rect: Rect,
+    body_response: Response,
+}
+
+impl AffineScrollAreaBegun {
+    pub fn finish<R: Rows>(self, ui: &mut Ui, content: &mut R) -> Response {
+        let Self { id_salt, touch_scroll, rect, body_response: response } = self;
+
         const BAR_WIDTH: f32 = 10.0;
         const BAR_INSET: f32 = 3.0;
         let bar_x = rect.max.x - BAR_WIDTH - BAR_INSET;
         let bar_track =
             Rect::from_min_size(Pos2::new(bar_x, rect.min.y), Vec2::new(BAR_WIDTH, rect.height()));
-        let bar_id = self.id_salt.with("scrollbar");
+        let bar_id = id_salt.with("scrollbar");
         let bar_response = ui.interact(bar_track, bar_id, Sense::click_and_drag());
 
         // Persisted scroll state.
-        let mut state: ScrollState = ui
-            .ctx()
-            .data(|d| d.get_temp(self.id_salt))
-            .unwrap_or_default();
+        let mut state: ScrollState = ui.ctx().data(|d| d.get_temp(id_salt)).unwrap_or_default();
 
         let viewport_height = rect.height();
 
@@ -187,7 +204,7 @@ impl AffineScrollArea {
 
         // Touch body drag → scroll + velocity tracking.
         let dt = ui.input(|i| i.stable_dt).max(0.0001);
-        if max_offset > 0.0 && self.touch_scroll && response.drag_started() {
+        if max_offset > 0.0 && touch_scroll && response.drag_started() {
             // Tap-during-momentum or drag-start: clear stale velocity
             // and the sliding-window history so the new gesture
             // doesn't inherit anything.
@@ -195,7 +212,7 @@ impl AffineScrollArea {
             state.drag_window = [(0.0, 0.0); DRAG_WINDOW_LEN];
             state.drag_window_idx = 0;
         }
-        if max_offset > 0.0 && self.touch_scroll && response.dragged() {
+        if max_offset > 0.0 && touch_scroll && response.dragged() {
             let drag_y = ui.input(|i| i.pointer.delta().y);
             // Drag UP (negative y) → scroll DOWN (offset grows). Same
             // sign convention as wheel.
@@ -233,7 +250,7 @@ impl AffineScrollArea {
         let pressed_in_rect = ui.input(|i| {
             i.pointer.any_pressed() && i.pointer.press_origin().is_some_and(|p| rect.contains(p))
         });
-        if self.touch_scroll && pressed_in_rect {
+        if touch_scroll && pressed_in_rect {
             state.velocity_precise = 0.0;
         }
 
@@ -270,7 +287,7 @@ impl AffineScrollArea {
         }
 
         // Persist state.
-        ui.ctx().data_mut(|d| d.insert_temp(self.id_salt, state));
+        ui.ctx().data_mut(|d| d.insert_temp(id_salt, state));
 
         response
     }

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -127,7 +127,7 @@ impl AffineScrollArea {
         // via `ui.scope_builder().max_rect(...)`).
         let rect = ui.max_rect();
 
-        let body_sense = if self.touch_scroll { Sense::click_and_drag() } else { Sense::hover() };
+        let body_sense = if self.touch_scroll { Sense::drag() } else { Sense::hover() };
         let response = ui.allocate_rect(rect, body_sense);
 
         // Scrollbar hit area registered AFTER the body so it shadows
@@ -230,8 +230,10 @@ impl AffineScrollArea {
         } else {
             state.velocity_precise = 0.0;
         }
-        // Tap (click without drag) cancels momentum.
-        if self.touch_scroll && response.clicked() {
+        let pressed_in_rect = ui.input(|i| {
+            i.pointer.any_pressed() && i.pointer.press_origin().is_some_and(|p| rect.contains(p))
+        });
+        if self.touch_scroll && pressed_in_rect {
             state.velocity_precise = 0.0;
         }
 


### PR DESCRIPTION
fixes:
* tapping for selection now works
* selection handles drawn above text not below
* selection handles no longer place selection directly where your finger is
* selection handles no longer snap to doc end when dragging below last line
* selection handles hit size increased
* context menu comes up at appropriate times (except perhaps long press)