### PR TITLE
lb-rs: reduce cpu usage for background syncs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
-# [profile.release]
-# debug = true
+[profile.release]
+debug = true
 # [profile.bench]
 # debug = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true
 # [profile.bench]
 # debug = true
 

--- a/libs/lb/lb-rs/src/io/mod.rs
+++ b/libs/lb/lb-rs/src/io/mod.rs
@@ -41,6 +41,11 @@ pub struct CoreV4 {
     pub doc_events: List<DocEvent>,
     pub id: Single<LbID>,
     pub pinned_files: List<Uuid>,
+
+    /// Sentinel for `send_debug_info` throttling: the millisecond timestamp of the
+    /// most recent panic file we've already uploaded. `None` means we have never
+    /// sent debug info; `Some(0)` means we've sent before but no panic file existed.
+    pub last_extracted_panic: Single<i64>,
 }
 
 pub struct LbRO<'a> {

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -97,37 +97,14 @@ impl LocalLb {
     #[cfg(not(target_family = "wasm"))]
     async fn collect_panics(&self, populate_content: bool) -> LbResult<Vec<PanicInfo>> {
         let mut panics = vec![];
-
-        let dir_path = &self.config.writeable_path;
-        let path = Path::new(dir_path);
-
-        let prefix = "panic---";
-        let suffix = ".log";
-        let timestamp_format = "%Y-%m-%d---%H-%M-%S";
-
-        let mut entries = fs::read_dir(path).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            let file_name = entry.file_name().into_string().unwrap_or_default();
-
-            // Check if the filename matches the expected format
-            if file_name.starts_with(prefix) && file_name.ends_with(suffix) {
-                // Extract the timestamp portion from the filename
-                let timestamp_str = &file_name[prefix.len()..file_name.len() - suffix.len()];
-
-                // Parse the timestamp
-                if let Ok(time) = NaiveDateTime::parse_from_str(timestamp_str, timestamp_format) {
-                    let file_path = path.join(file_name);
-                    let content = if populate_content {
-                        let contents = fs::read_to_string(&file_path).await?;
-                        let contents = format!("time: {time}: contents: {contents}");
-                        contents
-                    } else {
-                        Default::default()
-                    };
-
-                    panics.push(PanicInfo { time, file_path, content });
-                }
-            }
+        let mut iter = iter_panic_files(&self.config.writeable_path).await?;
+        while let Some(entry) = iter.next().await? {
+            let content = if populate_content {
+                entry.content().await?
+            } else {
+                String::new()
+            };
+            panics.push(PanicInfo { time: entry.time, file_path: entry.file_path, content });
         }
         panics.sort_by(|a, b| b.time.cmp(&a.time));
 
@@ -220,6 +197,56 @@ pub struct PanicInfo {
     pub time: NaiveDateTime,
     pub file_path: PathBuf,
     pub content: String,
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub struct PanicFiles {
+    entries: tokio::fs::ReadDir,
+    base_path: PathBuf,
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub struct PanicFile {
+    pub time: NaiveDateTime,
+    pub file_path: PathBuf,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl PanicFiles {
+    pub async fn next(&mut self) -> LbResult<Option<PanicFile>> {
+        const PREFIX: &str = "panic---";
+        const SUFFIX: &str = ".log";
+        const TIMESTAMP_FORMAT: &str = "%Y-%m-%d---%H-%M-%S";
+
+        while let Some(entry) = self.entries.next_entry().await? {
+            let file_name = entry.file_name().into_string().unwrap_or_default();
+            if !file_name.starts_with(PREFIX) || !file_name.ends_with(SUFFIX) {
+                continue;
+            }
+            let timestamp_str = &file_name[PREFIX.len()..file_name.len() - SUFFIX.len()];
+            let Ok(time) = NaiveDateTime::parse_from_str(timestamp_str, TIMESTAMP_FORMAT) else {
+                continue;
+            };
+            let file_path = self.base_path.join(file_name);
+            return Ok(Some(PanicFile { time, file_path }));
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl PanicFile {
+    pub async fn content(&self) -> LbResult<String> {
+        let contents = fs::read_to_string(&self.file_path).await?;
+        Ok(format!("time: {}: contents: {}", self.time, contents))
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub async fn iter_panic_files(path: &str) -> LbResult<PanicFiles> {
+    let base_path = Path::new(path).to_path_buf();
+    let entries = fs::read_dir(&base_path).await?;
+    Ok(PanicFiles { entries, base_path })
 }
 
 pub fn generate_panic_filename(path: &str) -> String {

--- a/libs/lb/lb-rs/src/service/debug.rs
+++ b/libs/lb/lb-rs/src/service/debug.rs
@@ -99,11 +99,7 @@ impl LocalLb {
         let mut panics = vec![];
         let mut iter = iter_panic_files(&self.config.writeable_path).await?;
         while let Some(entry) = iter.next().await? {
-            let content = if populate_content {
-                entry.content().await?
-            } else {
-                String::new()
-            };
+            let content = if populate_content { entry.content().await? } else { String::new() };
             panics.push(PanicInfo { time: entry.time, file_path: entry.file_path, content });
         }
         panics.sort_by(|a, b| b.time.cmp(&a.time));
@@ -243,10 +239,29 @@ impl PanicFile {
 }
 
 #[cfg(not(target_family = "wasm"))]
-pub async fn iter_panic_files(path: &str) -> LbResult<PanicFiles> {
+pub(crate) async fn iter_panic_files(path: &str) -> LbResult<PanicFiles> {
     let base_path = Path::new(path).to_path_buf();
     let entries = fs::read_dir(&base_path).await?;
     Ok(PanicFiles { entries, base_path })
+}
+
+/// Millisecond UTC timestamp of the most recent panic file on disk, if any.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) async fn latest_panic_time(path: &str) -> LbResult<Option<i64>> {
+    let mut iter = iter_panic_files(path).await?;
+    let mut max: Option<i64> = None;
+    while let Some(entry) = iter.next().await? {
+        let new_ts = entry.time.and_utc().timestamp_millis();
+        match &mut max {
+            Some(ts) => {
+                if new_ts > *ts {
+                    *ts = new_ts;
+                }
+            }
+            None => max = Some(new_ts),
+        }
+    }
+    Ok(max)
 }
 
 pub fn generate_panic_filename(path: &str) -> String {

--- a/libs/lb/lb-rs/src/subscribers/syncer.rs
+++ b/libs/lb/lb-rs/src/subscribers/syncer.rs
@@ -1170,25 +1170,58 @@ impl LocalLb {
 
     #[cfg(not(target_family = "wasm"))]
     async fn send_debug_info(&self, account: Account) {
+        use crate::service::debug;
+
+        let max_panic_time = debug::latest_panic_time(&self.config.writeable_path)
+            .await
+            .unwrap_or_else(|e| {
+                warn!("could not enumerate panic files: {e:?}");
+                None
+            });
+
+        let last_sent = {
+            let tx = self.ro_tx().await;
+            tx.db().last_extracted_panic.get().copied()
+        };
+
+        let should_send = match (last_sent, max_panic_time) {
+            (None, _) => true,
+            (Some(prev), Some(cur)) => cur > prev,
+            (Some(_), None) => false,
+        };
+
+        if !should_send {
+            return;
+        }
+
         let debug_info = self
             .debug_info("none provided - sync".to_string(), false)
             .await
             .unwrap();
 
-        if self.config.background_work {
-            let bg_self = self.clone();
-            tokio::spawn(async move {
-                bg_self
-                    .client
-                    .request(&account, UpsertDebugInfoRequest { debug_info })
-                    .await
-                    .log_and_ignore();
-            });
-        } else {
-            self.client
+        let new_marker = max_panic_time.unwrap_or(0);
+        let bg_self = self.clone();
+        let task = async move {
+            match bg_self
+                .client
                 .request(&account, UpsertDebugInfoRequest { debug_info })
                 .await
-                .log_and_ignore();
+            {
+                Ok(_) => {
+                    let mut tx = bg_self.begin_tx().await;
+                    if let Err(e) = tx.db().last_extracted_panic.insert(new_marker) {
+                        warn!("could not record last_extracted_panic: {e:?}");
+                    }
+                    tx.end();
+                }
+                Err(e) => warn!("send_debug_info failed: {e:?}"),
+            }
+        };
+
+        if self.config.background_work {
+            tokio::spawn(task);
+        } else {
+            task.await;
         }
     }
 

--- a/libs/lb/lb-rs/src/subscribers/syncer.rs
+++ b/libs/lb/lb-rs/src/subscribers/syncer.rs
@@ -296,7 +296,7 @@ impl LocalLb {
 
         let futures = docs_to_pull
             .into_iter()
-            .map(|(id, hmac)| async move { self.fetch_doc(id, hmac).await.map(|_| id) });
+            .map(|(id, hmac)| async move { self.ensure_doc_available(id, hmac).await.map(|_| id) });
 
         let mut stream = stream::iter(futures).buffer_unordered(
             thread::available_parallelism()
@@ -312,15 +312,15 @@ impl LocalLb {
         Ok(())
     }
 
-    pub(crate) async fn fetch_doc(
+    pub(crate) async fn ensure_doc_available(
         &self, id: Uuid, hmac: DocumentHmac,
-    ) -> LbResult<EncryptedDocument> {
+    ) -> LbResult<Option<EncryptedDocument>> {
         // todo: in a lot of cases there is a list of ids we're trying to get, it would be better
         // if the caller managed the event updates, the status would be more meaningful for longer
 
         // in this world, can we get stuck pushing a doc as well? Probably fine for now
-        if let Ok(Some(doc)) = self.docs.maybe_get(id, Some(hmac)).await {
-            return Ok(doc);
+        if self.docs.exists(id, Some(hmac)) {
+            return Ok(None);
         }
 
         self.events
@@ -335,7 +335,16 @@ impl LocalLb {
         self.events
             .sync_update(SyncIncrement::PullingDocument(id, false));
 
-        Ok(remote_document.content)
+        Ok(Some(remote_document.content))
+    }
+
+    pub(crate) async fn fetch_doc(
+        &self, id: Uuid, hmac: DocumentHmac,
+    ) -> LbResult<EncryptedDocument> {
+        match self.ensure_doc_available(id, hmac).await? {
+            Some(doc) => Ok(doc),
+            None => self.docs.get(id, Some(hmac)).await,
+        }
     }
 
     /// Pulls remote changes and constructs a changeset Merge such that Stage<Stage<Stage<Base, Remote>, Local>, Merge> is valid.
@@ -1383,6 +1392,10 @@ impl LocalLb {
                 continue;
             }
 
+            if self.docs.exists(id, hmac) {
+                continue;
+            }
+
             // skip non-first-party files
             let name = tree.name(&id, &self.keychain)?;
             if !name.ends_with(".md") && !name.ends_with(".svg") {
@@ -1399,7 +1412,7 @@ impl LocalLb {
         // can be
         for (id, hmac) in files_to_pull {
             if let Some(hmac) = hmac {
-                self.fetch_doc(id, hmac).await?;
+                self.ensure_doc_available(id, hmac).await?;
             }
         }
 


### PR DESCRIPTION
knocks down two high spots within lb-rs's background sync operations:
- for beta users, we used to send debug_info for every sync. But now we only do if there's something new to report, or if we haven't sent one in a long time (-8% cpu usage)
- sync wants to "ensure a file exists" but often doesn't care about it's contents unless it's doing a merge operation. We were using a wasteful `maybe_get` which reads a files when it doesn't need to just to ensure they're available locally.

beyond this there's two more optimizations that we could pursue:
- we could stop hashing uuid's, spend a surprising amount of CPU on this, can't stop on the server, but can prob stop here.
- can cache a different category of decryption in memory.

these are well suited for flamegraphs produced while running the exhaustive syncer which I plan to restore soon, so I'll defer these for now.