### PR TITLE
infra: fix ci

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Check Lock File
       run: nix-shell -p gtk3 pkg-config glib gobject-introspection gdk-pixbuf --command "cargo run -p lbdev -- ci assert-git-clean"
     - name: Install Nightly
-      run: rustup toolchain install nightly
+      run: rustup toolchain install nightly-2026-04-27
     - name: Install udeps
       run: nix-shell -p openssl pkg-config --command "cargo install cargo-udeps --locked --version 0.1.55"
     - name: Check Unused Dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install Nightly
       run: rustup toolchain install nightly
     - name: Install udeps
-      run: nix-shell -p openssl pkg-config --command "cargo install cargo-udeps --locked"
+      run: nix-shell -p openssl pkg-config --command "cargo install cargo-udeps --locked --version 0.1.55"
     - name: Check Unused Dependencies
       run: nix-shell -p openssl pkg-config glib gobject-introspection gdk-pixbuf gtk3 --command "cargo run -p lbdev -- ci assert-no-udeps"
     - name: Cleanup

--- a/utils/lbdev/src/ci/mod.rs
+++ b/utils/lbdev/src/ci/mod.rs
@@ -126,7 +126,7 @@ fn build_info_address(port: &str) -> String {
 
 pub fn assert_no_udeps() -> CliResult<()> {
     Command::new("cargo")
-        .args(["+nightly", "udeps"])
+        .args(["+nightly-2026-04-27", "udeps"])
         .current_dir(root())
         .assert_success()
 }


### PR DESCRIPTION
Latest cargo-udeps (0.1.61) pulls in cargo 0.96 / cargo-credential 0.4.10 / etc., which require rustc 1.91–1.93. CI's nix-shell currently provides rustc 1.89, so `cargo install cargo-udeps --locked` fails.

Pinning to 0.1.55 — an older release whose transitive deps still build on 1.89.

If this still fails, drop further (0.1.50, then 0.1.45). Longer-term fix is bumping the toolchain in the nix-shell.