### PR TITLE
md: id-keyed affine scroll rewrite

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -193,8 +193,7 @@ impl MdEdit {
 
         let arena = comrak::Arena::new();
         let root = self.renderer.reparse(&arena);
-        let content = DocScrollContent::new(&self.renderer, root, canvas_rect.height() / 2.0)
-            .with_default_leading();
+        let content = DocScrollContent::for_frame(&self.renderer, root, canvas_rect.height());
 
         let Some(target_rect) = build_target_reveal(
             &self.renderer,
@@ -205,7 +204,8 @@ impl MdEdit {
         ) else {
             return;
         };
-        self.scroll_area.reveal(&content, target_rect, Align::Nearest);
+        self.scroll_area
+            .reveal(&content, target_rect, Align::Nearest);
     }
 
     pub fn cursor_line(&self, offset: Grapheme) -> Option<[Pos2; 2]> {

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -178,10 +178,10 @@ impl MdEdit {
         }
     }
 
-    pub fn scroll_to_cursor(&mut self, ui: &mut Ui, scroll_id: egui::Id, canvas_rect: Rect) {
+    pub fn scroll_to_cursor(&mut self, canvas_rect: Rect) {
         use crate::tab::markdown_editor::build_target_reveal;
-        use crate::tab::markdown_editor::scroll_content::{DocRowId, DocScrollContent};
-        use crate::widgets::affine_scroll::{AffineScrollArea, Align};
+        use crate::tab::markdown_editor::scroll_content::DocScrollContent;
+        use crate::widgets::affine_scroll::Align;
 
         // Make the moving end of the selection visible. Passed as a
         // zero-length range — `build_target_reveal` handles single-point
@@ -195,18 +195,17 @@ impl MdEdit {
         let root = self.renderer.reparse(&arena);
         let content = DocScrollContent::new(&self.renderer, root, canvas_rect.height() / 2.0)
             .with_default_leading();
-        let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
 
         let Some(target_rect) = build_target_reveal(
             &self.renderer,
             &content,
-            &scroll.state(ui.ctx()),
+            &self.scroll_area.state,
             (cursor, cursor),
             canvas_rect,
         ) else {
             return;
         };
-        scroll.reveal(ui.ctx(), &content, target_rect, Align::Nearest);
+        self.scroll_area.reveal(&content, target_rect, Align::Nearest);
     }
 
     pub fn cursor_line(&self, offset: Grapheme) -> Option<[Pos2; 2]> {

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -178,39 +178,35 @@ impl MdEdit {
         }
     }
 
-    pub fn scroll_to_cursor(&mut self, ui: &mut Ui, scroll_id: egui::Id, viewport_height: f32) {
-        let target = self
+    pub fn scroll_to_cursor(&mut self, ui: &mut Ui, scroll_id: egui::Id, canvas_rect: Rect) {
+        use crate::tab::markdown_editor::build_target_reveal;
+        use crate::tab::markdown_editor::scroll_content::{DocRowId, DocScrollContent};
+        use crate::widgets::affine_scroll::{AffineScrollArea, Align};
+
+        // Make the moving end of the selection visible. Passed as a
+        // zero-length range — `build_target_reveal` handles single-point
+        // and multi-line ranges identically.
+        let cursor = self
             .in_progress_selection
             .unwrap_or(self.renderer.buffer.current.selection)
             .1;
 
         let arena = comrak::Arena::new();
         let root = self.renderer.reparse(&arena);
-        let mut content = crate::tab::markdown_editor::scroll_content::DocScrollContent::new(
-            &mut self.renderer,
-            root,
-            0.0,
-            viewport_height / 2.0,
-        )
-        .with_default_leading();
+        let content = DocScrollContent::new(&self.renderer, root, canvas_rect.height() / 2.0)
+            .with_default_leading();
+        let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
 
-        let scroll = crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id);
-        let current_offset = scroll.offset(ui.ctx());
-
-        // Inclusive on `end` so an end-of-line cursor matches its row.
-        let offset = crate::widgets::affine_scroll::make_visible_offset(
-            &mut content,
-            viewport_height,
-            current_offset,
-            |c| {
-                c.text_range()
-                    .is_some_and(|(start, end)| target >= start && target <= end)
-            },
-        );
-
-        if let Some(o) = offset {
-            scroll.set_offset(ui.ctx(), o);
-        }
+        let Some(target_rect) = build_target_reveal(
+            &self.renderer,
+            &content,
+            &scroll.state(ui.ctx()),
+            (cursor, cursor),
+            canvas_rect,
+        ) else {
+            return;
+        };
+        scroll.reveal(ui.ctx(), &content, target_rect, Align::Nearest);
     }
 
     pub fn cursor_line(&self, offset: Grapheme) -> Option<[Pos2; 2]> {

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -192,6 +192,10 @@ pub struct MdEdit {
 
     /// File link / wikilink / image-link completion popup (`[[`, `[`, `![`).
     pub link_completions: LinkCompletions,
+
+    /// Owns the per-row scroll state (offset, momentum) and renders
+    /// the scrollbar. `id_salt` derived from `file_id` at construction.
+    pub scroll_area: AffineScrollArea<DocRowId>,
 }
 
 impl MdEdit {
@@ -203,6 +207,7 @@ impl MdEdit {
     pub fn empty(ctx: Context) -> Self {
         let mut renderer = MdRender::empty(ctx);
         renderer.readonly = false;
+        let file_id = Uuid::nil();
         Self {
             renderer,
             cursor: Default::default(),
@@ -211,9 +216,10 @@ impl MdEdit {
             in_progress_selection: None,
             pending_scroll: None,
             scroll_area_velocity: Default::default(),
-            file_id: Uuid::nil(),
+            file_id,
             emoji_completions: Default::default(),
             link_completions: Default::default(),
+            scroll_area: AffineScrollArea::new(file_id),
         }
     }
 }
@@ -578,6 +584,7 @@ impl Editor {
                 file_id,
                 emoji_completions: Default::default(),
                 link_completions: Default::default(),
+                scroll_area: AffineScrollArea::new(file_id),
             },
 
             core,
@@ -769,8 +776,7 @@ impl Editor {
         self.edit.renderer.apply_theme(ui);
         ui.spacing_mut().item_spacing.x = 0.;
 
-        let scroll_id = self.id();
-        let prev_offset = AffineScrollArea::<DocRowId>::new(scroll_id).stored_offset(ui.ctx());
+        let prev_offset = self.edit.scroll_area.stored_offset();
 
         let editor_shown = ui
             .vertical(|ui| {
@@ -842,10 +848,9 @@ impl Editor {
             .inner;
 
         if editor_shown {
-            let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
-            let new_offset = scroll.stored_offset(ui.ctx());
+            let new_offset = self.edit.scroll_area.stored_offset();
             self.next_resp.scroll_updated = new_offset != prev_offset;
-            self.edit.scroll_area_velocity = scroll.velocity(ui.ctx());
+            self.edit.scroll_area_velocity = self.edit.scroll_area.velocity();
 
             // persistence: read on first frame
             if !self.initialized {
@@ -868,7 +873,7 @@ impl Editor {
                         DocRowId::Block(anchor_idx)
                     };
                     let off = Offset::new(anchor, intra_precise);
-                    scroll.set_offset(ui.ctx(), &content, off);
+                    self.edit.scroll_area.set_offset(&content, off);
                 }
                 // set the selection using low-level API; using internal
                 // events causes touch devices to scroll to cursor on 2nd
@@ -1001,21 +1006,18 @@ impl Editor {
             if unprocessed_scroll.elapsed() > Duration::from_millis(100) && editor_shown {
                 let arena = Arena::new();
                 let root = self.edit.renderer.reparse(&arena);
-                let scroll_id = self.id();
-                let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
                 // Project the persisted offset onto current rows so a
                 // stale anchor (block deleted since save) is recovered
                 // rather than persisted as-is.
                 let content = scroll_content::DocScrollContent::new(&self.edit.renderer, root, 0.0)
                     .with_default_leading();
-                let anchor = scroll.offset(ui.ctx(), &content).and_then(|off| {
-                    match off.anchor {
+                let anchor =
+                    self.edit.scroll_area.offset(&content).and_then(|off| match off.anchor {
                         DocRowId::Block(i) | DocRowId::Line(i) => Some((i, off.intra_precise)),
                         // Cursor in leading/trailing pad isn't a block —
                         // persist None and let the next open default.
                         DocRowId::Leading | DocRowId::Trailing => None,
-                    }
-                });
+                    });
                 drop(content);
 
                 let image_dims = self.edit.renderer.embeds.image_dims();
@@ -1133,11 +1135,11 @@ impl Editor {
                 ui.scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
                     let trailing_precise = canvas_rect.height() / 2.0;
                     ui.set_clip_rect(canvas_rect);
-                    let scroll =
-                        AffineScrollArea::<DocRowId>::new(scroll_id).touch_scroll(touch_scroll);
+                    self.edit.scroll_area.touch_scroll = touch_scroll;
 
-                    // Phase 1: drive scroll math + scrollbar with an
-                    // immutable renderer borrow.
+                    // Phase 1: drive scroll math + scrollbar. The
+                    // immutable `DocScrollContent` borrow is released
+                    // before phase 2's mutable renderer paint.
                     let visible = {
                         let content = scroll_content::DocScrollContent::new(
                             &self.edit.renderer,
@@ -1145,7 +1147,7 @@ impl Editor {
                             trailing_precise,
                         )
                         .with_default_leading();
-                        scroll.show(ui, &content).visible
+                        self.edit.scroll_area.show(ui, &content).visible
                     };
 
                     // Phase 2: paint each visible row with a mutable
@@ -1190,7 +1192,7 @@ impl Editor {
         if matches!(self.edit.pending_scroll, Some(ScrollTarget::FindMatch)) {
             self.edit.pending_scroll = None;
             if let Some(canvas_rect) = captured_canvas_rect {
-                self.scroll_to_find_match(ui, scroll_id, canvas_rect);
+                self.scroll_to_find_match(canvas_rect);
             }
         }
     }
@@ -1251,7 +1253,7 @@ impl Editor {
         }
     }
 
-    fn scroll_to_find_match(&mut self, ui: &mut Ui, scroll_id: Id, canvas_rect: Rect) {
+    fn scroll_to_find_match(&mut self, canvas_rect: Rect) {
         let Some(idx) = self.find.current_match else { return };
         let Some(&match_range) = self.find.matches.get(idx) else { return };
 
@@ -1263,18 +1265,17 @@ impl Editor {
             canvas_rect.height() / 2.0,
         )
         .with_default_leading();
-        let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
 
         let Some(target_rect) = build_target_reveal(
             &self.edit.renderer,
             &content,
-            &scroll.state(ui.ctx()),
+            &self.edit.scroll_area.state,
             match_range,
             canvas_rect,
         ) else {
             return;
         };
-        scroll.reveal(ui.ctx(), &content, target_rect, Align::Center);
+        self.edit.scroll_area.reveal(&content, target_rect, Align::Center);
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -864,9 +864,11 @@ impl Editor {
                 if let Some((anchor_idx, intra_precise)) = persisted.anchor {
                     let arena = Arena::new();
                     let root = self.edit.renderer.reparse(&arena);
-                    let content =
-                        scroll_content::DocScrollContent::new(&self.edit.renderer, root, 0.0)
-                            .with_default_leading();
+                    let content = scroll_content::DocScrollContent::for_frame(
+                        &self.edit.renderer,
+                        root,
+                        self.edit.scroll_area.state.viewport_height,
+                    );
                     let anchor = if self.edit.renderer.plaintext {
                         DocRowId::Line(anchor_idx)
                     } else {
@@ -984,21 +986,23 @@ impl Editor {
         if !self.edit.event.internal_events.is_empty() {
             ui.ctx().request_repaint();
         }
-        // persistence: write
+        // persistence: write — sync the in-memory store each frame,
+        // flag the disk write only on actual change. Empty-selection
+        // cursor moves must persist too, so the trigger compares
+        // against stored state rather than a within-frame change.
         let mut persistence_updated = false;
-        if resp.selection_updated {
+        let current_selection = self.edit.renderer.buffer.current.selection;
+        {
             let mut persistence = self.persistence.data.write().unwrap();
-            persistence
+            let entry = persistence
                 .markdown
                 .file
                 .entry(self.edit.file_id)
-                .and_modify(|f| f.selection = self.edit.renderer.buffer.current.selection)
-                .or_insert(MdFilePersistence {
-                    anchor: None,
-                    selection: self.edit.renderer.buffer.current.selection,
-                    image_dims: Default::default(),
-                });
-            persistence_updated = true;
+                .or_default();
+            if entry.selection != current_selection {
+                entry.selection = current_selection;
+                persistence_updated = true;
+            }
         }
 
         let mut scroll_end_processed = false;
@@ -1009,15 +1013,21 @@ impl Editor {
                 // Project the persisted offset onto current rows so a
                 // stale anchor (block deleted since save) is recovered
                 // rather than persisted as-is.
-                let content = scroll_content::DocScrollContent::new(&self.edit.renderer, root, 0.0)
-                    .with_default_leading();
+                let content = scroll_content::DocScrollContent::for_frame(
+                    &self.edit.renderer,
+                    root,
+                    self.edit.scroll_area.state.viewport_height,
+                );
                 let anchor =
-                    self.edit.scroll_area.offset(&content).and_then(|off| match off.anchor {
-                        DocRowId::Block(i) | DocRowId::Line(i) => Some((i, off.intra_precise)),
-                        // Cursor in leading/trailing pad isn't a block —
-                        // persist None and let the next open default.
-                        DocRowId::Leading | DocRowId::Trailing => None,
-                    });
+                    self.edit
+                        .scroll_area
+                        .offset(&content)
+                        .and_then(|off| match off.anchor {
+                            DocRowId::Block(i) | DocRowId::Line(i) => Some((i, off.intra_precise)),
+                            // Cursor in leading/trailing pad isn't a block —
+                            // persist None and let the next open default.
+                            DocRowId::Leading | DocRowId::Trailing => None,
+                        });
                 drop(content);
 
                 let image_dims = self.edit.renderer.embeds.image_dims();
@@ -1133,7 +1143,6 @@ impl Editor {
                 let content_x = canvas_rect.min.x
                     + ((canvas_rect.width() - self.edit.renderer.width) / 2.0).max(0.0);
                 ui.scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
-                    let trailing_precise = canvas_rect.height() / 2.0;
                     ui.set_clip_rect(canvas_rect);
                     self.edit.scroll_area.touch_scroll = touch_scroll;
 
@@ -1141,17 +1150,19 @@ impl Editor {
                     // immutable `DocScrollContent` borrow is released
                     // before phase 2's mutable renderer paint.
                     let visible = {
-                        let content = scroll_content::DocScrollContent::new(
+                        let content = scroll_content::DocScrollContent::for_frame(
                             &self.edit.renderer,
                             root,
-                            trailing_precise,
-                        )
-                        .with_default_leading();
+                            canvas_rect.height(),
+                        );
                         let resp = self.edit.scroll_area.show(ui, &content);
                         // Register the scrollbar's track so iOS taps on
                         // it don't fall through to cursor-placement /
                         // keyboard-summon handlers.
-                        self.edit.renderer.touch_consuming_rects.push(resp.scrollbar_track);
+                        self.edit
+                            .renderer
+                            .touch_consuming_rects
+                            .push(resp.scrollbar_track);
                         resp.visible
                     };
 
@@ -1264,12 +1275,11 @@ impl Editor {
 
         let arena = Arena::new();
         let root = self.edit.renderer.reparse(&arena);
-        let content = scroll_content::DocScrollContent::new(
+        let content = scroll_content::DocScrollContent::for_frame(
             &self.edit.renderer,
             root,
-            canvas_rect.height() / 2.0,
-        )
-        .with_default_leading();
+            canvas_rect.height(),
+        );
 
         let Some(target_rect) = build_target_reveal(
             &self.edit.renderer,
@@ -1280,7 +1290,9 @@ impl Editor {
         ) else {
             return;
         };
-        self.edit.scroll_area.reveal(&content, target_rect, Align::Center);
+        self.edit
+            .scroll_area
+            .reveal(&content, target_rect, Align::Center);
     }
 }
 
@@ -1299,13 +1311,12 @@ impl Editor {
 /// without normalising.
 pub(crate) fn build_target_reveal(
     renderer: &MdRender, content: &scroll_content::DocScrollContent<'_, '_>,
-    state: &crate::widgets::affine_scroll::ScrollArea<DocRowId>,
-    range: (Grapheme, Grapheme), canvas_rect: Rect,
+    state: &crate::widgets::affine_scroll::ScrollArea<DocRowId>, range: (Grapheme, Grapheme),
+    canvas_rect: Rect,
 ) -> Option<Reveal<DocRowId>> {
     let (start, end) = if range.0 <= range.1 { range } else { (range.1, range.0) };
     let top = endpoint_offset(renderer, content, state, start, canvas_rect, EndpointSide::Top)?;
-    let bottom =
-        endpoint_offset(renderer, content, state, end, canvas_rect, EndpointSide::Bottom)?;
+    let bottom = endpoint_offset(renderer, content, state, end, canvas_rect, EndpointSide::Bottom)?;
     Some(Reveal { top, bottom })
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1131,59 +1131,71 @@ impl Editor {
 
                 let arena = Arena::new();
                 let root = self.edit.renderer.reparse(&arena);
-                let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
 
                 // affine render: widget body spans the full canvas
                 // (scrollbar at canvas right); content centers within
                 // that body via `content_x`.
-                self.edit.renderer.galleys.galleys.clear();
-                self.edit.renderer.bounds.wrap_lines.clear();
-                self.edit.renderer.text_areas.clear();
                 let touch_scroll = self.edit.renderer.touch_mode;
                 let content_x = canvas_rect.min.x
                     + ((canvas_rect.width() - self.edit.renderer.width) / 2.0).max(0.0);
-                ui.scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
-                    ui.set_clip_rect(canvas_rect);
-                    self.edit.scroll_area.touch_scroll = touch_scroll;
+                let pre = ui
+                    .scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
+                        ui.set_clip_rect(canvas_rect);
+                        self.edit.scroll_area.touch_scroll = touch_scroll;
 
-                    // Phase 1: drive scroll math + scrollbar. The
-                    // immutable `DocScrollContent` borrow is released
-                    // before phase 2's mutable renderer paint.
-                    let visible = {
-                        let content = scroll_content::DocScrollContent::for_frame(
-                            &self.edit.renderer,
-                            root,
-                            canvas_rect.height(),
-                        );
-                        let resp = self.edit.scroll_area.show(ui, &content);
-                        // Register the scrollbar's track so iOS taps on
-                        // it don't fall through to cursor-placement /
-                        // keyboard-summon handlers.
-                        self.edit
-                            .renderer
-                            .touch_consuming_rects
-                            .push(resp.scrollbar_track);
-                        resp.visible
-                    };
+                        // Body alloc → pre_render → scrollbar/content
+                        // ordering puts pre_render's click rect above
+                        // the body's drag (so taps reach it) but below
+                        // the scrollbar (so taps on the bar don't).
+                        let begun = self.edit.scroll_area.begin(ui);
 
-                    // Phase 2: paint each visible row with a mutable
-                    // renderer borrow. Block list re-collected because
-                    // the immutable borrow that held `DocScrollContent`'s
-                    // copy was just dropped.
-                    let blocks: Vec<_> = root.children().collect();
-                    for vrow in &visible {
-                        let top_left = Pos2::new(canvas_rect.min.x, canvas_rect.min.y + vrow.top);
-                        scroll_content::paint_row(
-                            ui,
-                            &mut self.edit.renderer,
-                            root,
-                            &blocks,
-                            &vrow.id,
-                            top_left,
-                            content_x,
-                        );
-                    }
-                });
+                        let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
+
+                        self.edit.renderer.galleys.galleys.clear();
+                        self.edit.renderer.bounds.wrap_lines.clear();
+                        self.edit.renderer.text_areas.clear();
+
+                        // Phase 1: drive scroll math + scrollbar. The
+                        // immutable `DocScrollContent` borrow is released
+                        // before phase 2's mutable renderer paint.
+                        let visible = {
+                            let content = scroll_content::DocScrollContent::for_frame(
+                                &self.edit.renderer,
+                                root,
+                                canvas_rect.height(),
+                            );
+                            let resp = self.edit.scroll_area.finish(ui, begun, &content);
+                            // Register the scrollbar's track so iOS taps
+                            // on it don't fall through to cursor-placement
+                            // / keyboard-summon handlers.
+                            self.edit
+                                .renderer
+                                .touch_consuming_rects
+                                .push(resp.scrollbar_track);
+                            resp.visible
+                        };
+
+                        // Phase 2: paint each visible row with a mutable
+                        // renderer borrow. Block list re-collected
+                        // because the immutable borrow that held
+                        // `DocScrollContent`'s copy was just dropped.
+                        let blocks: Vec<_> = root.children().collect();
+                        for vrow in &visible {
+                            let top_left =
+                                Pos2::new(canvas_rect.min.x, canvas_rect.min.y + vrow.top);
+                            scroll_content::paint_row(
+                                ui,
+                                &mut self.edit.renderer,
+                                root,
+                                &blocks,
+                                &vrow.id,
+                                top_left,
+                                content_x,
+                            );
+                        }
+                        pre
+                    })
+                    .inner;
                 self.edit.renderer.galleys.galleys.sort_by_key(|g| g.range);
 
                 self.edit.post_render(ui, canvas_rect, scroll_id, pre);

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1147,7 +1147,12 @@ impl Editor {
                             trailing_precise,
                         )
                         .with_default_leading();
-                        self.edit.scroll_area.show(ui, &content).visible
+                        let resp = self.edit.scroll_area.show(ui, &content);
+                        // Register the scrollbar's track so iOS taps on
+                        // it don't fall through to cursor-placement /
+                        // keyboard-summon handlers.
+                        self.edit.renderer.touch_consuming_rects.push(resp.scrollbar_track);
+                        resp.visible
                     };
 
                     // Phase 2: paint each visible row with a mutable

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -72,8 +72,10 @@ pub use input::Event;
 pub use md_label::MdLabel;
 
 use crate::TextBufferArea;
+use crate::tab::markdown_editor::scroll_content::DocRowId;
 use crate::tab::markdown_editor::widget::toolbar::ToolbarPersistence;
 use crate::theme::palette_v2::ThemeExt as _;
+use crate::widgets::affine_scroll::{AffineScrollArea, Align, Offset, Reveal};
 use crate::workspace::WsPersistentStore;
 
 #[derive(Debug, Default)]
@@ -267,8 +269,8 @@ impl MdPersistence {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct MdFilePersistence {
-    /// `(anchor_block_idx, intra_offset_approx)` — the row index and
-    /// approx units within that row at which the scroll offset sits.
+    /// `(anchor_block_idx, intra_precise)` — the row index and precise
+    /// pixels within that row at which the scroll offset sits.
     /// Width-independent (unlike a raw pixel offset) so reopening the
     /// doc at a different width still lands on the right block.
     #[serde(default)]
@@ -768,8 +770,7 @@ impl Editor {
         ui.spacing_mut().item_spacing.x = 0.;
 
         let scroll_id = self.id();
-        let prev_offset =
-            crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id).offset(ui.ctx());
+        let prev_offset = AffineScrollArea::<DocRowId>::new(scroll_id).stored_offset(ui.ctx());
 
         let editor_shown = ui
             .vertical(|ui| {
@@ -841,8 +842,8 @@ impl Editor {
             .inner;
 
         if editor_shown {
-            let scroll = crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id);
-            let new_offset = scroll.offset(ui.ctx());
+            let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
+            let new_offset = scroll.stored_offset(ui.ctx());
             self.next_resp.scroll_updated = new_offset != prev_offset;
             self.edit.scroll_area_velocity = scroll.velocity(ui.ctx());
 
@@ -855,24 +856,19 @@ impl Editor {
                     .get(&self.edit.file_id)
                     .cloned()
                     .unwrap_or_default();
-                if let Some((anchor_idx, intra)) = persisted.anchor {
+                if let Some((anchor_idx, intra_precise)) = persisted.anchor {
                     let arena = Arena::new();
                     let root = self.edit.renderer.reparse(&arena);
-                    let mut content = scroll_content::DocScrollContent::new(
-                        &mut self.edit.renderer,
-                        root,
-                        0.0,
-                        0.0,
-                    )
-                    .with_default_leading();
-                    let offset = crate::widgets::affine_scroll::anchor_to_offset(
-                        &mut content,
-                        anchor_idx,
-                        intra,
-                    );
-                    crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id)
-                        .set_offset(ui.ctx(), offset);
-                    let _ = content;
+                    let content =
+                        scroll_content::DocScrollContent::new(&self.edit.renderer, root, 0.0)
+                            .with_default_leading();
+                    let anchor = if self.edit.renderer.plaintext {
+                        DocRowId::Line(anchor_idx)
+                    } else {
+                        DocRowId::Block(anchor_idx)
+                    };
+                    let off = Offset::new(anchor, intra_precise);
+                    scroll.set_offset(ui.ctx(), &content, off);
                 }
                 // set the selection using low-level API; using internal
                 // events causes touch devices to scroll to cursor on 2nd
@@ -1003,42 +999,43 @@ impl Editor {
         let mut scroll_end_processed = false;
         if let Some(unprocessed_scroll) = self.unprocessed_scroll {
             if unprocessed_scroll.elapsed() > Duration::from_millis(100) && editor_shown {
-                {
-                    let arena = Arena::new();
-                    let root = self.edit.renderer.reparse(&arena);
-                    let scroll_id = self.id();
-                    let scroll = crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id);
-                    let offset = scroll.offset(ui.ctx());
-                    let mut content = scroll_content::DocScrollContent::new(
-                        &mut self.edit.renderer,
-                        root,
-                        0.0,
-                        0.0,
-                    )
+                let arena = Arena::new();
+                let root = self.edit.renderer.reparse(&arena);
+                let scroll_id = self.id();
+                let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
+                // Project the persisted offset onto current rows so a
+                // stale anchor (block deleted since save) is recovered
+                // rather than persisted as-is.
+                let content = scroll_content::DocScrollContent::new(&self.edit.renderer, root, 0.0)
                     .with_default_leading();
-                    let anchor =
-                        Some(crate::widgets::affine_scroll::offset_to_anchor(&mut content, offset));
-                    let _ = content;
+                let anchor = scroll.offset(ui.ctx(), &content).and_then(|off| {
+                    match off.anchor {
+                        DocRowId::Block(i) | DocRowId::Line(i) => Some((i, off.intra_precise)),
+                        // Cursor in leading/trailing pad isn't a block —
+                        // persist None and let the next open default.
+                        DocRowId::Leading | DocRowId::Trailing => None,
+                    }
+                });
+                drop(content);
 
-                    let image_dims = self.edit.renderer.embeds.image_dims();
-                    let mut persistence = self.persistence.data.write().unwrap();
-                    persistence
-                        .markdown
-                        .file
-                        .entry(self.edit.file_id)
-                        .and_modify(|f| {
-                            f.anchor = anchor;
-                            f.image_dims = image_dims.clone();
-                        })
-                        .or_insert(MdFilePersistence {
-                            anchor,
-                            selection: Default::default(),
-                            image_dims,
-                        });
-                    persistence_updated = true;
+                let image_dims = self.edit.renderer.embeds.image_dims();
+                let mut persistence = self.persistence.data.write().unwrap();
+                persistence
+                    .markdown
+                    .file
+                    .entry(self.edit.file_id)
+                    .and_modify(|f| {
+                        f.anchor = anchor;
+                        f.image_dims = image_dims.clone();
+                    })
+                    .or_insert(MdFilePersistence {
+                        anchor,
+                        selection: Default::default(),
+                        image_dims,
+                    });
+                persistence_updated = true;
 
-                    scroll_end_processed = true;
-                }
+                scroll_end_processed = true;
             }
         };
 
@@ -1076,6 +1073,11 @@ impl Editor {
         let prev_seq = self.edit.renderer.buffer.current.seq;
         let scroll_id = self.id();
 
+        // Captured by the Frame::canvas closure so post-render code
+        // (find-match scroll) can position galleys against the canvas
+        // origin without re-deriving it.
+        let mut captured_canvas_rect: Option<Rect> = None;
+
         Frame::canvas(ui.style())
             .inner_margin(Margin::ZERO)
             .stroke(Stroke::NONE)
@@ -1087,6 +1089,7 @@ impl Editor {
                 ui.allocate_space(Vec2::new(avail_w, 0.0));
 
                 let canvas_rect = ui.max_rect();
+                captured_canvas_rect = Some(canvas_rect);
                 let canvas_width = canvas_rect.width();
                 let layout_margin = self.edit.renderer.layout.margin;
 
@@ -1116,39 +1119,53 @@ impl Editor {
 
                 let arena = Arena::new();
                 let root = self.edit.renderer.reparse(&arena);
+                let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
 
                 // affine render: widget body spans the full canvas
                 // (scrollbar at canvas right); content centers within
                 // that body via `content_x`.
+                self.edit.renderer.galleys.galleys.clear();
+                self.edit.renderer.bounds.wrap_lines.clear();
+                self.edit.renderer.text_areas.clear();
                 let touch_scroll = self.edit.renderer.touch_mode;
                 let content_x = canvas_rect.min.x
                     + ((canvas_rect.width() - self.edit.renderer.width) / 2.0).max(0.0);
-                let pre = ui
-                    .scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
-                        let scroll =
-                            crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id)
-                                .touch_scroll(touch_scroll);
-                        let begun = scroll.begin(ui);
+                ui.scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
+                    let trailing_precise = canvas_rect.height() / 2.0;
+                    ui.set_clip_rect(canvas_rect);
+                    let scroll =
+                        AffineScrollArea::<DocRowId>::new(scroll_id).touch_scroll(touch_scroll);
 
-                        let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
-
-                        self.edit.renderer.galleys.galleys.clear();
-                        self.edit.renderer.bounds.wrap_lines.clear();
-                        self.edit.renderer.text_areas.clear();
-
-                        let trailing_precise = canvas_rect.height() / 2.0;
-                        let mut content = scroll_content::DocScrollContent::new(
-                            &mut self.edit.renderer,
+                    // Phase 1: drive scroll math + scrollbar with an
+                    // immutable renderer borrow.
+                    let visible = {
+                        let content = scroll_content::DocScrollContent::new(
+                            &self.edit.renderer,
                             root,
-                            content_x,
                             trailing_precise,
                         )
                         .with_default_leading();
-                        begun.finish(ui, &mut content);
+                        scroll.show(ui, &content).visible
+                    };
 
-                        pre
-                    })
-                    .inner;
+                    // Phase 2: paint each visible row with a mutable
+                    // renderer borrow. Block list re-collected because
+                    // the immutable borrow that held `DocScrollContent`'s
+                    // copy was just dropped.
+                    let blocks: Vec<_> = root.children().collect();
+                    for vrow in &visible {
+                        let top_left = Pos2::new(canvas_rect.min.x, canvas_rect.min.y + vrow.top);
+                        scroll_content::paint_row(
+                            ui,
+                            &mut self.edit.renderer,
+                            root,
+                            &blocks,
+                            &vrow.id,
+                            top_left,
+                            content_x,
+                        );
+                    }
+                });
                 self.edit.renderer.galleys.galleys.sort_by_key(|g| g.range);
 
                 self.edit.post_render(ui, canvas_rect, scroll_id, pre);
@@ -1172,7 +1189,9 @@ impl Editor {
 
         if matches!(self.edit.pending_scroll, Some(ScrollTarget::FindMatch)) {
             self.edit.pending_scroll = None;
-            self.scroll_to_find_match(ui, scroll_id, ui.available_height());
+            if let Some(canvas_rect) = captured_canvas_rect {
+                self.scroll_to_find_match(ui, scroll_id, canvas_rect);
+            }
         }
     }
 
@@ -1232,34 +1251,87 @@ impl Editor {
         }
     }
 
-    fn scroll_to_find_match(&mut self, ui: &mut Ui, scroll_id: Id, viewport_height: f32) {
+    fn scroll_to_find_match(&mut self, ui: &mut Ui, scroll_id: Id, canvas_rect: Rect) {
         let Some(idx) = self.find.current_match else { return };
-        let Some(&(target, _)) = self.find.matches.get(idx) else { return };
+        let Some(&match_range) = self.find.matches.get(idx) else { return };
 
         let arena = Arena::new();
         let root = self.edit.renderer.reparse(&arena);
-        let mut content = scroll_content::DocScrollContent::new(
-            &mut self.edit.renderer,
+        let content = scroll_content::DocScrollContent::new(
+            &self.edit.renderer,
             root,
-            0.0,
-            viewport_height / 2.0,
+            canvas_rect.height() / 2.0,
         )
         .with_default_leading();
+        let scroll = AffineScrollArea::<DocRowId>::new(scroll_id);
 
-        let offset = crate::widgets::affine_scroll::align_offset(
-            &mut content,
-            viewport_height,
-            crate::widgets::affine_scroll::Align::Center,
-            |c| {
-                c.text_range()
-                    .is_some_and(|(start, end)| target >= start && target <= end)
-            },
-        );
-
-        if let Some(o) = offset {
-            crate::widgets::affine_scroll::AffineScrollArea::new(scroll_id).set_offset(ui.ctx(), o);
-        }
+        let Some(target_rect) = build_target_reveal(
+            &self.edit.renderer,
+            &content,
+            &scroll.state(ui.ctx()),
+            match_range,
+            canvas_rect,
+        ) else {
+            return;
+        };
+        scroll.reveal(ui.ctx(), &content, target_rect, Align::Center);
     }
+}
+
+/// Build a [`Reveal`] spanning a Grapheme range — works for any of:
+/// single cursor (`(g, g)`), multi-line selection, or wrapped find
+/// match (where the match crosses a wrap boundary so it occupies more
+/// than one screen line).
+///
+/// Each endpoint independently prefers a galley-derived intra-row
+/// position so `Align::Center` lands the actual span at viewport
+/// center and `Align::Nearest` knows precisely which screen lines need
+/// to be in view. Falls back per endpoint to a row-anchor when no
+/// galley exists (e.g. an off-viewport top-level block before the next
+/// render shapes it). The range is reordered to `(min, max)` so
+/// callers can pass the buffer's raw `(anchor, cursor)` selection
+/// without normalising.
+pub(crate) fn build_target_reveal(
+    renderer: &MdRender, content: &scroll_content::DocScrollContent<'_, '_>,
+    state: &crate::widgets::affine_scroll::ScrollArea<DocRowId>,
+    range: (Grapheme, Grapheme), canvas_rect: Rect,
+) -> Option<Reveal<DocRowId>> {
+    let (start, end) = if range.0 <= range.1 { range } else { (range.1, range.0) };
+    let top = endpoint_offset(renderer, content, state, start, canvas_rect, EndpointSide::Top)?;
+    let bottom =
+        endpoint_offset(renderer, content, state, end, canvas_rect, EndpointSide::Bottom)?;
+    Some(Reveal { top, bottom })
+}
+
+#[derive(Clone, Copy)]
+enum EndpointSide {
+    Top,
+    Bottom,
+}
+
+fn endpoint_offset(
+    renderer: &MdRender, content: &scroll_content::DocScrollContent<'_, '_>,
+    state: &crate::widgets::affine_scroll::ScrollArea<DocRowId>, target: Grapheme,
+    canvas_rect: Rect, side: EndpointSide,
+) -> Option<Offset<DocRowId>> {
+    use crate::widgets::affine_scroll::Rows as _;
+    if let Some(galley_idx) = renderer.galleys.galley_at_offset(target) {
+        let galley = &renderer.galleys[galley_idx];
+        let y_range = galley
+            .rect
+            .y_range()
+            .expand(renderer.layout.row_spacing / 2.0);
+        let y = match side {
+            EndpointSide::Top => y_range.min,
+            EndpointSide::Bottom => y_range.max,
+        };
+        return state.offset_at_viewport_y(content, y - canvas_rect.min.y);
+    }
+    let row = content.find_text_row(target)?;
+    Some(match side {
+        EndpointSide::Top => Offset::at_top_of(row),
+        EndpointSide::Bottom => Offset { anchor: row, intra_precise: content.precise(&row) },
+    })
 }
 
 pub fn print_ast<'a>(root: &'a AstNode<'a>) {

--- a/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
@@ -82,6 +82,15 @@ impl<'a, 'ast> DocScrollContent<'a, 'ast> {
         self
     }
 
+    /// Per-frame rows with `trailing_precise = vh/2` and the default
+    /// leading pad. Render, persistence, and scroll-target lookups
+    /// must use this so they walk the same row sequence.
+    pub fn for_frame(
+        renderer: &'a MdRender, root: &'ast AstNode<'ast>, viewport_height: f32,
+    ) -> Self {
+        Self::new(renderer, root, viewport_height / 2.0).with_default_leading()
+    }
+
     /// First row whose source range contains `target` (inclusive on both
     /// ends so an end-of-line cursor matches its row).
     pub fn find_text_row(&self, target: Grapheme) -> Option<DocRowId> {
@@ -228,26 +237,15 @@ impl<'a, 'ast> Rows for DocScrollContent<'a, 'ast> {
         }
     }
 
-    /// `Block(i)` / `Line(i)` only goes stale by walking off the end
-    /// (insertions/deletions above shift the index but leave it valid).
-    /// Recover to the new last index — keeps the user near where they
-    /// were rather than snapping to the doc's top.
+    /// A stale `Block(i)` / `Line(i)` means the anchor walked off the
+    /// end (insertions/deletions above shift the index but leave it
+    /// valid), so the user was at-or-past the new doc's end. Recover
+    /// to `Trailing`: `at_top_of(Trailing)` lands `pad` from
+    /// `last_bottom`, so `clamp_to_max` snaps to `max_offset` —
+    /// "scrolled to bottom" with the pad visible.
     fn recover_anchor(&self, stale: &DocRowId) -> Option<DocRowId> {
         match stale {
-            DocRowId::Block(_) => {
-                if self.blocks.is_empty() {
-                    Some(DocRowId::Trailing)
-                } else {
-                    Some(DocRowId::Block(self.blocks.len() - 1))
-                }
-            }
-            DocRowId::Line(_) => {
-                if self.line_count == 0 {
-                    Some(DocRowId::Trailing)
-                } else {
-                    Some(DocRowId::Line(self.line_count - 1))
-                }
-            }
+            DocRowId::Block(_) | DocRowId::Line(_) => Some(DocRowId::Trailing),
             // Leading / Trailing are always-present sentinels; if a
             // caller asks to recover one of them something is wrong
             // upstream. Default to first().

--- a/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
@@ -8,11 +8,11 @@
 //! the same path `MdLabel` and tests use.
 //!
 //! Plus a virtual `Leading` row at the start with `approx = precise =
-//! leading_precise` (real top padding — counted toward the scrollbar)
-//! and a virtual `Trailing` row at the end with `approx = 0`, `precise
-//! = trailing_precise` (overscroll room — not counted toward the
-//! scrollbar) so the last block can scroll into the middle of the
-//! viewport.
+//! leading_precise` (real top padding) and a virtual `Trailing` row at
+//! the end with `approx = precise = trailing_precise` (overscroll room
+//! so the last block can scroll into the middle of the viewport).
+//! Both pads have known sizes, so `approx = precise` keeps the affine
+//! slope = 1 within them — no estimation error on rows we know exactly.
 //!
 //! In plaintext mode (`renderer.plaintext == true`) the rows are source
 //! lines indexed by `DocRowId::Line(idx)` instead of blocks.
@@ -48,13 +48,11 @@ pub struct DocScrollContent<'a, 'ast> {
     /// mode for `Line(idx)` bounds.
     line_count: usize,
     plaintext: bool,
-    /// Precise + approx height of the virtual leading pad row. Counts
-    /// toward the scrollbar — unlike `trailing_precise`, which is
-    /// approx-zero — so the pad behaves like real top padding rather
-    /// than overscroll.
+    /// Height of the virtual leading pad row (real top padding).
+    /// `approx = precise = leading_precise`.
     pub leading_precise: f32,
-    /// Precise height of the virtual trailing pad row (e.g. vh/2).
-    /// Approx height is 0 — overscroll, not content.
+    /// Height of the virtual trailing pad row (e.g. vh/2 of overscroll).
+    /// `approx = precise = trailing_precise`.
     pub trailing_precise: f32,
 }
 
@@ -203,7 +201,7 @@ impl<'a, 'ast> Rows for DocScrollContent<'a, 'ast> {
                 self.renderer.height_approx_source_line(*i, width)
                     + self.renderer.layout.row_spacing
             }
-            DocRowId::Trailing => 0.0,
+            DocRowId::Trailing => self.trailing_precise,
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
@@ -229,6 +229,33 @@ impl<'a, 'ast> Rows for DocScrollContent<'a, 'ast> {
             self.renderer.warm_images(self.blocks[*i]);
         }
     }
+
+    /// `Block(i)` / `Line(i)` only goes stale by walking off the end
+    /// (insertions/deletions above shift the index but leave it valid).
+    /// Recover to the new last index — keeps the user near where they
+    /// were rather than snapping to the doc's top.
+    fn recover_anchor(&self, stale: &DocRowId) -> Option<DocRowId> {
+        match stale {
+            DocRowId::Block(_) => {
+                if self.blocks.is_empty() {
+                    Some(DocRowId::Trailing)
+                } else {
+                    Some(DocRowId::Block(self.blocks.len() - 1))
+                }
+            }
+            DocRowId::Line(_) => {
+                if self.line_count == 0 {
+                    Some(DocRowId::Trailing)
+                } else {
+                    Some(DocRowId::Line(self.line_count - 1))
+                }
+            }
+            // Leading / Trailing are always-present sentinels; if a
+            // caller asks to recover one of them something is wrong
+            // upstream. Default to first().
+            DocRowId::Leading | DocRowId::Trailing => self.first(),
+        }
+    }
 }
 
 /// Paint a single row at `top_left` (screen coords). Companion to the

--- a/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
@@ -1,17 +1,21 @@
-//! [`ScrollContent`] adapter for the markdown editor.
+//! [`DocScrollContent`] — id-keyed [`Rows`] adapter for the markdown
+//! editor.
 //!
-//! `DocScrollContent` walks the document's top-level blocks. Each
+//! `DocRowId::Block(idx)` walks the document's top-level blocks. Each
 //! block is one row, rendered atomically via `show_block`. Container
 //! chrome (block-quote bars, alert bars, list markers, code-block
-//! borders, etc.) is painted by the container's own `show_*` function,
+//! borders, …) is painted by the container's own `show_*` function,
 //! the same path `MdLabel` and tests use.
 //!
-//! Plus a virtual leading pad row at the start with `approx = precise
-//! = leading_precise` (real top padding — counted toward the
-//! scrollbar) and a virtual trailing pad at the end with `approx =
-//! 0`, `precise = trailing_precise` (overscroll room — not counted
-//! toward the scrollbar — so the last block can scroll into the
-//! middle of the viewport).
+//! Plus a virtual `Leading` row at the start with `approx = precise =
+//! leading_precise` (real top padding — counted toward the scrollbar)
+//! and a virtual `Trailing` row at the end with `approx = 0`, `precise
+//! = trailing_precise` (overscroll room — not counted toward the
+//! scrollbar) so the last block can scroll into the middle of the
+//! viewport.
+//!
+//! In plaintext mode (`renderer.plaintext == true`) the rows are source
+//! lines indexed by `DocRowId::Line(idx)` instead of blocks.
 
 use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
@@ -20,52 +24,53 @@ use lb_rs::model::text::offset_types::Grapheme;
 use crate::tab::markdown_editor::MdRender;
 use crate::widgets::affine_scroll::Rows;
 
+/// Stable identity of a row in the document. `Leading` and `Trailing`
+/// are the always-present virtual padding rows; `Block(i)` is a top-
+/// level block index, `Line(i)` a source-line index in plaintext mode.
+///
+/// `Send + Sync + 'static` so [`crate::widgets::affine_scroll::ScrollArea<DocRowId>`]
+/// can be persisted in egui memory.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum DocRowId {
+    Leading,
+    Block(usize),
+    Line(usize),
+    Trailing,
+}
+
 pub struct DocScrollContent<'a, 'ast> {
-    pub renderer: &'a mut MdRender,
+    pub renderer: &'a MdRender,
     pub root: &'ast AstNode<'ast>,
+    /// Cached top-level child blocks for this frame. Empty in plaintext
+    /// mode (the [`Rows`] impl uses `Line(idx)` instead).
+    blocks: Vec<&'ast AstNode<'ast>>,
+    /// Source-line count, sampled at construction. Used in plaintext
+    /// mode for `Line(idx)` bounds.
+    line_count: usize,
+    plaintext: bool,
     /// Precise + approx height of the virtual leading pad row. Counts
-    /// toward the scrollbar — unlike `trailing_precise` which is
+    /// toward the scrollbar — unlike `trailing_precise`, which is
     /// approx-zero — so the pad behaves like real top padding rather
     /// than overscroll.
     pub leading_precise: f32,
     /// Precise height of the virtual trailing pad row (e.g. vh/2).
     /// Approx height is 0 — overscroll, not content.
     pub trailing_precise: f32,
-    /// X position to render content at. Lets the content sit centered
-    /// inside the canvas while the scroll widget's body (and scrollbar)
-    /// span the full canvas width.
-    pub content_x: f32,
-    cursor: Cursor<'ast>,
-}
-
-#[derive(Clone, Copy)]
-enum Cursor<'ast> {
-    Start,
-    Leading,
-    /// Markdown-mode row: one top-level AST block.
-    At {
-        node: &'ast AstNode<'ast>,
-    },
-    /// Plaintext-mode row: one source line.
-    AtLine {
-        line_idx: usize,
-    },
-    Trailing,
-    End,
 }
 
 impl<'a, 'ast> DocScrollContent<'a, 'ast> {
-    pub fn new(
-        renderer: &'a mut MdRender, root: &'ast AstNode<'ast>, content_x: f32,
-        trailing_precise: f32,
-    ) -> Self {
+    pub fn new(renderer: &'a MdRender, root: &'ast AstNode<'ast>, trailing_precise: f32) -> Self {
+        let plaintext = renderer.plaintext;
+        let blocks: Vec<_> = if plaintext { Vec::new() } else { root.children().collect() };
+        let line_count = renderer.bounds.source_lines.len();
         Self {
             renderer,
             root,
+            blocks,
+            line_count,
+            plaintext,
             leading_precise: 0.0,
             trailing_precise,
-            content_x,
-            cursor: Cursor::Start,
         }
     }
 
@@ -79,147 +84,179 @@ impl<'a, 'ast> DocScrollContent<'a, 'ast> {
         self
     }
 
-    /// Source-text range covered by the row at the cursor's current
-    /// position, or `None` if the cursor is off a real row.
-    pub fn text_range(&self) -> Option<(Grapheme, Grapheme)> {
-        match self.cursor {
-            Cursor::At { node } => Some(self.renderer.node_range(node)),
-            Cursor::AtLine { line_idx } => Some(self.renderer.bounds.source_lines[line_idx]),
-            Cursor::Leading | Cursor::Trailing | Cursor::Start | Cursor::End => None,
+    /// First row whose source range contains `target` (inclusive on both
+    /// ends so an end-of-line cursor matches its row).
+    pub fn find_text_row(&self, target: Grapheme) -> Option<DocRowId> {
+        if self.plaintext {
+            for i in 0..self.line_count {
+                let (s, e) = self.renderer.bounds.source_lines[i];
+                if target >= s && target <= e {
+                    return Some(DocRowId::Line(i));
+                }
+            }
+        } else {
+            for (i, node) in self.blocks.iter().enumerate() {
+                let (s, e) = self.renderer.node_range(node);
+                if target >= s && target <= e {
+                    return Some(DocRowId::Block(i));
+                }
+            }
         }
+        None
     }
 }
 
 impl<'a, 'ast> Rows for DocScrollContent<'a, 'ast> {
-    fn reset(&mut self) {
-        self.cursor = Cursor::Start;
+    type RowId = DocRowId;
+
+    fn first(&self) -> Option<DocRowId> {
+        Some(DocRowId::Leading)
     }
 
-    fn reset_back(&mut self) {
-        self.cursor = Cursor::End;
+    fn last(&self) -> Option<DocRowId> {
+        Some(DocRowId::Trailing)
     }
 
-    fn next(&mut self) -> bool {
-        let plaintext = self.renderer.plaintext;
-        let line_count = self.renderer.bounds.source_lines.len();
-        match self.cursor {
-            Cursor::Start => self.cursor = Cursor::Leading,
-            Cursor::Leading if plaintext && line_count > 0 => {
-                self.cursor = Cursor::AtLine { line_idx: 0 }
+    fn next(&self, id: &DocRowId) -> Option<DocRowId> {
+        match id {
+            DocRowId::Leading => {
+                if self.plaintext {
+                    if self.line_count > 0 {
+                        Some(DocRowId::Line(0))
+                    } else {
+                        Some(DocRowId::Trailing)
+                    }
+                } else if self.blocks.is_empty() {
+                    Some(DocRowId::Trailing)
+                } else {
+                    Some(DocRowId::Block(0))
+                }
             }
-            Cursor::Leading => match self.root.children().next() {
-                Some(first) => self.cursor = Cursor::At { node: first },
-                // Childless doc — yield the root itself as a single
-                // row so `show_document`'s fallback (iterate source
-                // lines) runs and the cursor has a galley to land on.
-                None => self.cursor = Cursor::At { node: self.root },
-            },
-            Cursor::At { node } => match node.next_sibling() {
-                Some(next) => self.cursor = Cursor::At { node: next },
-                None => self.cursor = Cursor::Trailing,
-            },
-            Cursor::AtLine { line_idx } if line_idx + 1 < line_count => {
-                self.cursor = Cursor::AtLine { line_idx: line_idx + 1 }
+            DocRowId::Block(i) => {
+                if self.plaintext || *i >= self.blocks.len() {
+                    return None;
+                }
+                if i + 1 < self.blocks.len() {
+                    Some(DocRowId::Block(i + 1))
+                } else {
+                    Some(DocRowId::Trailing)
+                }
             }
-            Cursor::AtLine { .. } => self.cursor = Cursor::Trailing,
-            Cursor::Trailing => {
-                self.cursor = Cursor::End;
-                return false;
+            DocRowId::Line(i) => {
+                if !self.plaintext || *i >= self.line_count {
+                    return None;
+                }
+                if i + 1 < self.line_count {
+                    Some(DocRowId::Line(i + 1))
+                } else {
+                    Some(DocRowId::Trailing)
+                }
             }
-            Cursor::End => return false,
+            DocRowId::Trailing => None,
         }
-        true
     }
 
-    fn prev(&mut self) -> bool {
-        let plaintext = self.renderer.plaintext;
-        let line_count = self.renderer.bounds.source_lines.len();
-        match self.cursor {
-            Cursor::End => self.cursor = Cursor::Trailing,
-            Cursor::Trailing if plaintext && line_count > 0 => {
-                self.cursor = Cursor::AtLine { line_idx: line_count - 1 }
+    fn prev(&self, id: &DocRowId) -> Option<DocRowId> {
+        match id {
+            DocRowId::Leading => None,
+            DocRowId::Block(i) => {
+                if self.plaintext || *i >= self.blocks.len() {
+                    return None;
+                }
+                if *i == 0 { Some(DocRowId::Leading) } else { Some(DocRowId::Block(i - 1)) }
             }
-            Cursor::Trailing => match self.root.children().last() {
-                Some(last) => self.cursor = Cursor::At { node: last },
-                None => self.cursor = Cursor::At { node: self.root },
-            },
-            Cursor::At { node } => match node.previous_sibling() {
-                Some(prev) => self.cursor = Cursor::At { node: prev },
-                None => self.cursor = Cursor::Leading,
-            },
-            Cursor::AtLine { line_idx } if line_idx > 0 => {
-                self.cursor = Cursor::AtLine { line_idx: line_idx - 1 }
+            DocRowId::Line(i) => {
+                if !self.plaintext || *i >= self.line_count {
+                    return None;
+                }
+                if *i == 0 { Some(DocRowId::Leading) } else { Some(DocRowId::Line(i - 1)) }
             }
-            Cursor::AtLine { .. } => self.cursor = Cursor::Leading,
-            Cursor::Leading => {
-                self.cursor = Cursor::Start;
-                return false;
+            DocRowId::Trailing => {
+                if self.plaintext {
+                    if self.line_count > 0 {
+                        Some(DocRowId::Line(self.line_count - 1))
+                    } else {
+                        Some(DocRowId::Leading)
+                    }
+                } else if !self.blocks.is_empty() {
+                    Some(DocRowId::Block(self.blocks.len() - 1))
+                } else {
+                    Some(DocRowId::Leading)
+                }
             }
-            Cursor::Start => return false,
         }
-        true
     }
 
-    fn approx(&self) -> f32 {
-        match self.cursor {
-            Cursor::At { node } => {
-                self.renderer.block_pre_spacing_height_approx(node)
-                    + self.renderer.height_approx(node)
-                    + self.renderer.block_post_spacing_height_approx(node)
+    fn approx(&self, id: &DocRowId) -> f32 {
+        match id {
+            DocRowId::Leading => self.leading_precise,
+            DocRowId::Block(i) => {
+                let n = self.blocks[*i];
+                self.renderer.block_pre_spacing_height_approx(n)
+                    + self.renderer.height_approx(n)
+                    + self.renderer.block_post_spacing_height_approx(n)
             }
             // Per-line plaintext rows: monospace char-count estimate
             // (no shaping); precise reflects actual cosmic-text wrap.
-            Cursor::AtLine { line_idx } => {
+            DocRowId::Line(i) => {
                 let width = self.renderer.width(self.root);
-                self.renderer.height_approx_source_line(line_idx, width)
+                self.renderer.height_approx_source_line(*i, width)
                     + self.renderer.layout.row_spacing
             }
-            Cursor::Leading => self.leading_precise,
-            Cursor::Trailing => 0.0,
-            Cursor::Start | Cursor::End => panic!("approx() with cursor off a row"),
+            DocRowId::Trailing => 0.0,
         }
     }
 
-    fn precise(&mut self) -> f32 {
-        match self.cursor {
-            Cursor::At { node } => {
-                self.renderer.block_pre_spacing_height(node)
-                    + self.renderer.height(node)
-                    + self.renderer.block_post_spacing_height(node)
+    fn precise(&self, id: &DocRowId) -> f32 {
+        match id {
+            DocRowId::Leading => self.leading_precise,
+            DocRowId::Block(i) => {
+                let n = self.blocks[*i];
+                self.renderer.block_pre_spacing_height(n)
+                    + self.renderer.height(n)
+                    + self.renderer.block_post_spacing_height(n)
             }
-            Cursor::AtLine { line_idx } => {
+            DocRowId::Line(i) => {
                 let width = self.renderer.width(self.root);
-                self.renderer.height_source_line(line_idx, width) + self.renderer.layout.row_spacing
+                self.renderer.height_source_line(*i, width) + self.renderer.layout.row_spacing
             }
-            Cursor::Leading => self.leading_precise,
-            Cursor::Trailing => self.trailing_precise,
-            Cursor::Start | Cursor::End => panic!("precise() with cursor off a row"),
+            DocRowId::Trailing => self.trailing_precise,
         }
     }
 
-    fn warm(&mut self) {
-        if let Cursor::At { node } = self.cursor {
-            self.renderer.warm_images(node);
+    fn warm(&self, id: &DocRowId) {
+        if let DocRowId::Block(i) = id {
+            self.renderer.warm_images(self.blocks[*i]);
         }
     }
+}
 
-    fn render(&mut self, ui: &mut Ui, top_left: Pos2) {
-        match self.cursor {
-            Cursor::At { node } => {
-                let mut tl = Pos2::new(self.content_x, top_left.y);
-                self.renderer.show_block_pre_spacing(ui, node, tl);
-                tl.y += self.renderer.block_pre_spacing_height(node);
-                self.renderer.show_block(ui, node, tl);
-                tl.y += self.renderer.height(node);
-                self.renderer.show_block_post_spacing(ui, node, tl);
-            }
-            Cursor::AtLine { line_idx } => {
-                let tl = Pos2::new(self.content_x, top_left.y);
-                let width = self.renderer.width(self.root);
-                self.renderer.show_source_line(ui, tl, line_idx, width);
-            }
-            Cursor::Leading | Cursor::Trailing => {} // virtual padding — paints nothing
-            Cursor::Start | Cursor::End => panic!("render() with cursor off a row"),
+/// Paint a single row at `top_left` (screen coords). Companion to the
+/// pull-style [`crate::widgets::affine_scroll::AffineScrollArea::show`]
+/// loop: the caller iterates `visible` and invokes this per row.
+///
+/// Takes `&mut MdRender` because `show_*` functions push galleys and
+/// text areas; takes `blocks` separately so the caller can drop the
+/// `&MdRender` borrow held by [`DocScrollContent`] before painting.
+pub fn paint_row<'ast>(
+    ui: &mut Ui, renderer: &mut MdRender, root: &'ast AstNode<'ast>,
+    blocks: &[&'ast AstNode<'ast>], id: &DocRowId, top_left: Pos2, content_x: f32,
+) {
+    match id {
+        DocRowId::Leading | DocRowId::Trailing => {} // virtual padding
+        DocRowId::Block(i) => {
+            let node = blocks[*i];
+            let mut tl = Pos2::new(content_x, top_left.y);
+            renderer.show_block_pre_spacing(ui, node, tl);
+            tl.y += renderer.block_pre_spacing_height(node);
+            renderer.show_block(ui, node, tl);
+            tl.y += renderer.height(node);
+            renderer.show_block_post_spacing(ui, node, tl);
+        }
+        DocRowId::Line(line_idx) => {
+            let tl = Pos2::new(content_x, top_left.y);
+            let width = renderer.width(root);
+            renderer.show_source_line(ui, tl, *line_idx, width);
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -364,7 +364,7 @@ impl MdEdit {
         // FindMatch is consumed by the caller (it owns find state).
         if matches!(self.pending_scroll, Some(ScrollTarget::Cursor)) {
             self.pending_scroll = None;
-            self.scroll_to_cursor(ui, id, rect.height());
+            self.scroll_to_cursor(ui, id, rect);
         }
 
         // lock focus filter so arrow keys / tab / shift+enter keep reaching us

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -364,7 +364,7 @@ impl MdEdit {
         // FindMatch is consumed by the caller (it owns find state).
         if matches!(self.pending_scroll, Some(ScrollTarget::Cursor)) {
             self.pending_scroll = None;
-            self.scroll_to_cursor(ui, id, rect);
+            self.scroll_to_cursor(rect);
         }
 
         // lock focus filter so arrow keys / tab / shift+enter keep reaching us

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -237,6 +237,7 @@ impl<'ast> MdRender {
                 let row_height = self.row_height(node);
                 let width = self.width(node).max(row_height);
                 let mut chars = 0usize;
+                let mut image_height = 0.0f32;
                 for d in node.descendants() {
                     match &d.data.borrow().value {
                         NodeValue::Text(t) => chars += t.chars().count(),
@@ -244,13 +245,25 @@ impl<'ast> MdRender {
                         NodeValue::HtmlInline(s) => chars += s.chars().count(),
                         NodeValue::Math(m) => chars += m.literal.chars().count(),
                         NodeValue::SoftBreak | NodeValue::LineBreak => chars += 1,
+                        // `embeds.size` is a HashMap lookup — returns
+                        // a placeholder before the image loads, the
+                        // actual dimensions after. The layout cache
+                        // invalidates on `embeds_updated`, so this
+                        // value picks up loaded dimensions on the
+                        // next read.
+                        NodeValue::Image(link) => {
+                            let dims = self.embeds.size(&link.url);
+                            image_height += self.image_size(dims, width).y;
+                        }
                         _ => {}
                     }
                 }
                 let char_width = row_height * 0.5;
                 let chars_per_row = (width / char_width).floor().max(1.0) as usize;
                 let rows = ((chars as f32) / chars_per_row as f32).ceil().max(1.0);
-                rows * row_height + (rows - 1.0).max(0.0) * self.layout.row_spacing
+                rows * row_height
+                    + (rows - 1.0).max(0.0) * self.layout.row_spacing
+                    + image_height
             }
             NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_) => {
                 let row_height = self.row_height(node);

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -261,9 +261,7 @@ impl<'ast> MdRender {
                 let char_width = row_height * 0.5;
                 let chars_per_row = (width / char_width).floor().max(1.0) as usize;
                 let rows = ((chars as f32) / chars_per_row as f32).ceil().max(1.0);
-                rows * row_height
-                    + (rows - 1.0).max(0.0) * self.layout.row_spacing
-                    + image_height
+                rows * row_height + (rows - 1.0).max(0.0) * self.layout.row_spacing + image_height
             }
             NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_) => {
                 let row_height = self.row_height(node);

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1,89 +1,847 @@
-//! A vertical scroll area whose content has two notions of height per
-//! row: a cheap **approximate** height and an expensive **precise**
-//! height. The scrollbar operates in approx units (so the bar's range is
-//! a constant function of the doc), but visible content is laid out
-//! precisely. Scroll *events* are interpreted in precise units (= screen
-//! pixels of intended movement) and translated to approx via a piecewise
-//! affine map before they touch the scrollbar.
+//! Vertical scroll area driven by a piecewise-affine map between cheap
+//! per-row `approx` heights (used by the scrollbar) and expensive
+//! per-row `precise` heights (used by layout).
 //!
-//! # Why
+//! Pixel-precise scroll input is exact: scrolling by N pixels moves
+//! content by exactly N pixels. The scrollbar coordinate is in approx
+//! units; the slope `precise/approx` only enters scrollbar math, so
+//! scrollbar accuracy degrades gracefully as the approximation worsens
+//! while the scroll-input feel stays correct.
 //!
-//! When rows are only cheap to estimate (rich text, shaped lines,
-//! etc.), measuring every row precisely to size the scrollbar is too
-//! slow. Approximating sizes is fast but breaks the "user scrolls N
-//! pixels, content moves N pixels" invariant.
+//! # Layout
 //!
-//! This widget bridges the two: scrollbar is approx (so always known
-//! and consistent), but the user's wheel/drag input is interpreted as a
-//! request to move content by N **precise** pixels. The widget walks
-//! the affine map at the current scroll position, converts to the
-//! corresponding approx delta, and updates the scrollbar.
-//!
-//! # Contract with `Rows`
-//!
-//! After [`Rows::reset`] the cursor sits before the first row; the
-//! first `next()` yields it. Once `next()` returns `None` the cursor
-//! is past the last row, and `prev()` from there yields the last.
-//! Symmetric for [`Rows::reset_back`] + `prev()`.
+//! - [`Rows`] + [`Offset`] are the public content surface. Id-keyed and
+//!   `&self`: the trait is a content provider, not a state machine.
+//! - [`ScrollArea<Id>`] holds offset + viewport + touch-momentum state and
+//!   exposes the affine math via id-typed methods that take a [`Rows`]
+//!   impl by reference. Pure data — no egui dependency.
+//! - [`AffineScrollArea<Id>`] is the egui adapter: persists the
+//!   [`ScrollArea`] in egui memory keyed by id_salt and layers
+//!   wheel/touch-drag/scrollbar-drag input + momentum on top.
+//! - [`Reveal`] + [`Align`] is the make-visible API.
 
 use egui::{Pos2, Rect, Response, Sense, Stroke, Ui, Vec2};
+use std::hash::Hash;
+use std::marker::PhantomData;
 
-/// Sequence of variable-height rows the scroll area walks.
+// ============================================================================
+// Trait + offset
+// ============================================================================
+
+/// Source of vertical content for a [`ScrollArea`].
 ///
-/// `approx` / `precise` / `render` operate on the row at the cursor's
-/// current position; calling them when the cursor is off a row (before
-/// start, past end, or after a `next`/`prev` returned `false`) panics.
+/// Cursor-free: every method takes a [`RowId`](Rows::RowId), so the trait
+/// is stateless about position. Caches and laid-out content live behind
+/// the impl's interior mutability if needed.
+///
+/// **Contract.** Implementations should honour:
+///
+/// - `approx(id) == 0.0  ⟺  precise(id) == 0.0` — zero-set agreement.
+///   A row that contributes nothing in approx must contribute nothing in
+///   precise, and vice versa, or the scrollbar/scroll-input mapping
+///   becomes ambiguous (div-by-zero, infinite slope).
+/// - `approx(id)` is constant per row — must not depend on layout work
+///   (text shaping, image loading) that hasn't happened yet. Drift
+///   between approx and precise across edits is fine; behaviour
+///   degrades smoothly as the approximation worsens.
+/// - `next(prev(id)) == Some(id)` and `prev(next(id)) == Some(id)`
+///   when both sides are `Some` — the row sequence is a doubly-linked
+///   walk.
+/// - **`next(id)` and `prev(id)` return `None` if `id` is not currently
+///   in the row sequence** — whether because `id` is at the boundary,
+///   *or* because `id` was once in the sequence but has since been
+///   removed. Callers (and [`ScrollArea`]) lean on this to detect a
+///   stale anchor after external mutation.
+///
+/// Behaviour when contracts are violated is bounded by [`Config::slope_band`]:
+/// the scrollbar may drift, but `ScrollArea` will not panic.
 pub trait Rows {
-    fn reset(&mut self);
-    fn reset_back(&mut self);
-    fn next(&mut self) -> bool;
-    fn prev(&mut self) -> bool;
+    /// Stable identity of a row. `Clone` rather than `Copy` so non-`Copy`
+    /// ids — `String` hashes, `Arc<Path>` keys, etc. — can be used
+    /// directly without a sidecar mapping.
+    type RowId: Clone + Eq + std::fmt::Debug;
 
-    /// Called frequently while sizing the scrollbar and finding the anchor.
-    fn approx(&self) -> f32;
+    fn first(&self) -> Option<Self::RowId>;
+    fn last(&self) -> Option<Self::RowId>;
+    fn next(&self, id: &Self::RowId) -> Option<Self::RowId>;
+    fn prev(&self, id: &Self::RowId) -> Option<Self::RowId>;
 
-    /// Called for rows the widget renders or walks in the precise-
-    /// from-end tail.
-    fn precise(&mut self) -> f32;
+    /// Cheap height. Constant per row — must not depend on layout work.
+    fn approx(&self, id: &Self::RowId) -> f32;
 
-    fn render(&mut self, ui: &mut Ui, top_left: Pos2);
+    /// Expensive height. Computed only for rows the widget paints.
+    fn precise(&self, id: &Self::RowId) -> f32;
 
-    /// Hint that the row is about to enter the viewport. Content can
-    /// kick off background work (e.g. start downloading images)
-    /// without painting. Called by the scroll area on rows within a
-    /// viewport-sized buffer above and below the visible window.
-    /// Default is a no-op.
-    fn warm(&mut self) {}
+    /// Hint that the row is about to enter the viewport. Default no-op.
+    fn warm(&self, _id: &Self::RowId) {}
 }
 
-/// Per-frame state of the scroll area. Persisted in egui memory between
-/// frames keyed by [`AffineScrollArea::id_salt`].
-#[derive(Clone, Copy, Default)]
-struct ScrollState {
-    /// Position in approx units. `[0, max_offset]`.
-    offset_approx: f32,
-    /// Touch-scroll velocity in precise pixels per second. Positive
-    /// means content is moving up on screen (scroll offset growing).
+/// Anchored scroll position. The top of the viewport sits at
+/// `intra_precise` precise pixels below the top of the row identified
+/// by `anchor`.
+///
+/// Anchor identity survives content edits that don't remove the anchor
+/// row. If the anchor is deleted, `Rows::next(anchor)` and
+/// `Rows::prev(anchor)` return `None`; widget callers detect this and
+/// fall back to a sentinel offset.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Offset<Id> {
+    pub anchor: Id,
+    pub intra_precise: f32,
+}
+
+impl<Id> Offset<Id> {
+    pub fn new(anchor: Id, intra_precise: f32) -> Self {
+        Self { anchor, intra_precise }
+    }
+
+    pub fn at_top_of(anchor: Id) -> Self {
+        Self { anchor, intra_precise: 0.0 }
+    }
+}
+
+// ============================================================================
+// Affine math (pure functions over Rows)
+// ============================================================================
+
+mod affine {
+    use super::{Offset, Rows};
+
+    /// Apply a precise-pixel scroll delta to an offset. Pure precise math
+    /// — slope never enters here. Clamps at document edges.
+    pub fn scroll_by<R: Rows>(rows: &R, mut off: Offset<R::RowId>, delta: f32) -> Offset<R::RowId> {
+        if delta > 0.0 {
+            let mut remaining = delta;
+            loop {
+                let row_precise = rows.precise(&off.anchor);
+                let in_row_left = (row_precise - off.intra_precise).max(0.0);
+                if remaining < in_row_left {
+                    off.intra_precise += remaining;
+                    return off;
+                }
+                match rows.next(&off.anchor) {
+                    Some(next_id) => {
+                        remaining -= in_row_left;
+                        off.anchor = next_id;
+                        off.intra_precise = 0.0;
+                    }
+                    None => {
+                        off.intra_precise = row_precise;
+                        return off;
+                    }
+                }
+            }
+        } else if delta < 0.0 {
+            let mut remaining = -delta;
+            loop {
+                if remaining <= off.intra_precise {
+                    off.intra_precise -= remaining;
+                    return off;
+                }
+                match rows.prev(&off.anchor) {
+                    Some(prev_id) => {
+                        remaining -= off.intra_precise;
+                        let prev_precise = rows.precise(&prev_id);
+                        off.anchor = prev_id;
+                        off.intra_precise = prev_precise;
+                    }
+                    None => {
+                        off.intra_precise = 0.0;
+                        return off;
+                    }
+                }
+            }
+        } else {
+            off
+        }
+    }
+
+    /// Signed precise-pixel distance from `a` to `b`. Positive if `b` is
+    /// below `a`. Returns `NaN` if `b`'s anchor isn't reachable.
+    pub fn signed_distance<R: Rows>(rows: &R, a: &Offset<R::RowId>, b: &Offset<R::RowId>) -> f32 {
+        if a.anchor == b.anchor {
+            return b.intra_precise - a.intra_precise;
+        }
+        let mut id = a.anchor.clone();
+        let mut dist = -a.intra_precise;
+        loop {
+            dist += rows.precise(&id);
+            match rows.next(&id) {
+                Some(next_id) => {
+                    if next_id == b.anchor {
+                        return dist + b.intra_precise;
+                    }
+                    id = next_id;
+                }
+                None => break,
+            }
+        }
+        let mut id = a.anchor.clone();
+        let mut dist = -a.intra_precise;
+        while let Some(prev_id) = rows.prev(&id) {
+            dist -= rows.precise(&prev_id);
+            if prev_id == b.anchor {
+                return dist + b.intra_precise;
+            }
+            id = prev_id;
+        }
+        f32::NAN
+    }
+
+    /// Like `signed_distance` but stops walking once cumulative distance
+    /// exceeds `bound` precise pixels. Used by `Reveal::Nearest` so
+    /// document size doesn't enter the cost.
+    pub fn signed_distance_bounded<R: Rows>(
+        rows: &R, a: &Offset<R::RowId>, b: &Offset<R::RowId>, bound: f32,
+    ) -> Option<f32> {
+        if a.anchor == b.anchor {
+            return Some(b.intra_precise - a.intra_precise);
+        }
+        let mut id = a.anchor.clone();
+        let mut dist = -a.intra_precise;
+        loop {
+            dist += rows.precise(&id);
+            if dist > bound {
+                break;
+            }
+            match rows.next(&id) {
+                Some(next_id) => {
+                    if next_id == b.anchor {
+                        return Some(dist + b.intra_precise);
+                    }
+                    id = next_id;
+                }
+                None => break,
+            }
+        }
+        let mut id = a.anchor.clone();
+        let mut dist = -a.intra_precise;
+        loop {
+            match rows.prev(&id) {
+                Some(prev_id) => {
+                    dist -= rows.precise(&prev_id);
+                    if dist < -bound {
+                        return None;
+                    }
+                    if prev_id == b.anchor {
+                        return Some(dist + b.intra_precise);
+                    }
+                    id = prev_id;
+                }
+                None => return None,
+            }
+        }
+    }
+
+    pub fn midpoint<R: Rows>(
+        rows: &R, top: Offset<R::RowId>, bottom: Offset<R::RowId>,
+    ) -> Offset<R::RowId> {
+        let dist = signed_distance(rows, &top, &bottom);
+        scroll_by(rows, top, dist / 2.0)
+    }
+
+    /// Position of the scroll thumb in approx coordinate. Walks rows
+    /// above the anchor for cumulative approx; uses local slope inside
+    /// the anchor row.
+    pub fn thumb_approx<R: Rows>(rows: &R, off: &Offset<R::RowId>, band: (f32, f32)) -> f32 {
+        let mut acc = 0.0;
+        let mut id = off.anchor.clone();
+        while let Some(prev_id) = rows.prev(&id) {
+            acc += rows.approx(&prev_id);
+            id = prev_id;
+        }
+        let row_precise = rows.precise(&off.anchor);
+        let row_approx = rows.approx(&off.anchor);
+        let intra_approx = if row_precise > 0.0 {
+            let slope = (row_approx / row_precise).clamp(band.0, band.1);
+            off.intra_precise * slope
+        } else {
+            0.0
+        };
+        acc + intra_approx
+    }
+
+    /// Inverse of `thumb_approx`.
+    pub fn from_thumb<R: Rows>(
+        rows: &R, approx_pos: f32, band: (f32, f32),
+    ) -> Option<Offset<R::RowId>> {
+        let first = rows.first()?;
+        if approx_pos <= 0.0 {
+            return Some(Offset::at_top_of(first));
+        }
+        let mut id = first;
+        let mut acc = 0.0;
+        loop {
+            let row_approx = rows.approx(&id);
+            if acc + row_approx >= approx_pos {
+                let intra_approx = approx_pos - acc;
+                let row_precise = rows.precise(&id);
+                let intra_precise = if row_approx > 0.0 {
+                    let inv_slope = (row_precise / row_approx).clamp(1.0 / band.1, 1.0 / band.0);
+                    intra_approx * inv_slope
+                } else {
+                    0.0
+                };
+                return Some(Offset { anchor: id, intra_precise });
+            }
+            match rows.next(&id) {
+                Some(next_id) => {
+                    acc += row_approx;
+                    id = next_id;
+                }
+                None => {
+                    let last_precise = rows.precise(&id);
+                    return Some(Offset { anchor: id, intra_precise: last_precise });
+                }
+            }
+        }
+    }
+
+    /// Total approx — walks the full row sequence. Cheap per-row but
+    /// O(N). Override-friendly slot for impls that maintain their own
+    /// counter; for now the walk is good enough.
+    pub fn total_approx<R: Rows>(rows: &R) -> f32 {
+        let mut acc = 0.0;
+        let mut id = match rows.first() {
+            Some(id) => id,
+            None => return 0.0,
+        };
+        loop {
+            acc += rows.approx(&id);
+            match rows.next(&id) {
+                Some(next_id) => id = next_id,
+                None => return acc,
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Public types: Action, VisibleRow, HitRow, Reveal, Align, Scrollbar, Config
+// ============================================================================
+
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    /// Allowed range for `approx / precise` per row. Rows whose true
+    /// ratio is outside the band substitute the clamped slope in
+    /// scrollbar math. Scroll input fidelity is unaffected.
+    pub slope_band: (f32, f32),
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { slope_band: (1e-3, 1e3) }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Action {
+    /// Scroll content by `delta` precise pixels. Positive = down.
+    ScrollByPixels(f32),
+    /// Drag the scrollbar thumb by `delta` approx units. Positive =
+    /// thumb moves down.
+    ScrollByThumb(f32),
+    ScrollToTop,
+    ScrollToBottom,
+    Resize(f32),
+}
+
+/// One row in the visible window emitted by [`ScrollArea::visible`].
+///
+/// `top` is in viewport-local coordinates (`0.0` is the viewport's top
+/// edge). The first row's `top` is `<= 0.0` when offset sits mid-row;
+/// the last row's `top + height` may exceed `viewport_height`. Caller
+/// clips at the viewport rect.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VisibleRow<Id> {
+    pub id: Id,
+    pub top: f32,
+    pub height: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HitRow<Id> {
+    pub id: Id,
+    pub intra_y: f32,
+}
+
+/// A rect to reveal via [`ScrollArea::reveal`]. `top == bottom` is a
+/// valid "point" reveal (cursor-style).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reveal<Id> {
+    pub top: Offset<Id>,
+    pub bottom: Offset<Id>,
+}
+
+impl<Id: Clone> Reveal<Id> {
+    pub fn point_at(off: Offset<Id>) -> Self {
+        Self { top: off.clone(), bottom: off }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Align {
+    Top,
+    Bottom,
+    Center,
+    /// No-op when the rect is fully visible. Otherwise minimum motion;
+    /// rect taller than viewport falls through to [`Top`](Align::Top).
+    Nearest,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Scrollbar {
+    pub track: Rect,
+    pub thumb: Rect,
+    pub total_approx: f32,
+    pub thumb_approx: f32,
+    pub scrollable_approx: f32,
+}
+
+impl Scrollbar {
+    pub fn hit(&self, y: f32) -> ScrollbarHit {
+        if y < self.track.min.y || y >= self.track.max.y {
+            return ScrollbarHit::None;
+        }
+        if y >= self.thumb.min.y && y <= self.thumb.max.y {
+            ScrollbarHit::Thumb
+        } else if y < self.thumb.min.y {
+            ScrollbarHit::TrackAbove
+        } else {
+            ScrollbarHit::TrackBelow
+        }
+    }
+
+    /// Convert a pixel delta on the track into an approx delta to feed
+    /// [`Action::ScrollByThumb`]. Returns `0.0` when the track is
+    /// degenerate or the document doesn't scroll.
+    pub fn pixel_to_approx(&self, pixel_delta: f32) -> f32 {
+        let movable = self.track.height() - self.thumb.height();
+        if movable <= 0.0 || self.scrollable_approx <= 0.0 {
+            return 0.0;
+        }
+        pixel_delta * self.scrollable_approx / movable
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollbarHit {
+    Thumb,
+    TrackAbove,
+    TrackBelow,
+    None,
+}
+
+const MIN_THUMB_PX: f32 = 12.0;
+
+// ============================================================================
+// ScrollArea — the math-only widget core
+// ============================================================================
+
+/// Vertical scroll area state. Pure data — no egui dependency. Persists
+/// the offset + viewport + touch-momentum state; takes [`Rows`] by
+/// reference at each query so the rows can borrow other state without
+/// fighting our lifetimes.
+///
+/// **Empty / mutated rows.** [`ScrollArea`] tolerates `Rows` becoming
+/// empty or having its current anchor removed out from under it. The
+/// stored offset can become stale; reads project it onto current rows
+/// via [`offset`](ScrollArea::offset). Mutation methods start from the
+/// projected offset and write back.
+#[derive(Debug, Clone)]
+pub struct ScrollArea<Id: Clone + Eq + std::fmt::Debug> {
+    /// User-intent offset. Read it through [`offset`](ScrollArea::offset),
+    /// which projects onto current rows.
+    stored_offset: Option<Offset<Id>>,
+    pub viewport_height: f32,
+    pub config: Config,
+    /// Touch-scroll velocity (precise px/sec). Positive = content moving
+    /// up on screen.
     velocity_precise: f32,
-    /// Sliding window of recent drag samples — `(delta_precise, dt)` —
-    /// averaged into `velocity_precise` to smooth out single-frame
-    /// noise.
+    /// Sliding window of recent drag samples (delta_precise, dt) for
+    /// smoothing single-frame noise into a stable release velocity.
     drag_window: [(f32, f32); DRAG_WINDOW_LEN],
     drag_window_idx: u8,
 }
 
 const DRAG_WINDOW_LEN: usize = 6;
 
-pub struct AffineScrollArea {
-    id_salt: egui::Id,
-    /// When true, drag on the body (not just the scrollbar) scrolls
-    /// the content with momentum. Intended for touch input.
-    touch_scroll: bool,
+impl<Id: Clone + Eq + std::fmt::Debug> Default for ScrollArea<Id> {
+    fn default() -> Self {
+        Self {
+            stored_offset: None,
+            viewport_height: 0.0,
+            config: Config::default(),
+            velocity_precise: 0.0,
+            drag_window: [(0.0, 0.0); DRAG_WINDOW_LEN],
+            drag_window_idx: 0,
+        }
+    }
 }
 
-impl AffineScrollArea {
-    pub fn new(id_salt: impl std::hash::Hash) -> Self {
-        Self { id_salt: egui::Id::new(id_salt), touch_scroll: false }
+impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
+    pub fn new(viewport_height: f32) -> Self {
+        Self { viewport_height: viewport_height.max(0.0), ..Default::default() }
+    }
+
+    pub fn velocity(&self) -> Vec2 {
+        Vec2::new(0.0, self.velocity_precise)
+    }
+
+    /// Raw persisted offset, *not* projected onto any rows. Use for
+    /// change-detection across frames where projecting would require
+    /// constructing rows just to read state.
+    pub fn stored_offset(&self) -> Option<Offset<Id>> {
+        self.stored_offset.clone()
+    }
+
+    /// The current scroll offset, projected onto the current rows.
+    /// Returns `None` iff rows is empty.
+    ///
+    /// Two cases the projection absorbs:
+    /// - **Anchor removed** → top of the first surviving row.
+    /// - **Anchor row shrank** (external mutation reduced
+    ///   `precise(anchor)` below stored `intra_precise`) → walk forward
+    ///   by the excess. Patch-through, not clamp.
+    pub fn offset<R: Rows<RowId = Id>>(&self, rows: &R) -> Option<Offset<Id>> {
+        let stored = match &self.stored_offset {
+            Some(off) if Self::anchor_valid(rows, &off.anchor) => off.clone(),
+            _ => return rows.first().map(Offset::at_top_of),
+        };
+        Some(Self::normalize(rows, stored))
+    }
+
+    fn normalize<R: Rows<RowId = Id>>(rows: &R, mut off: Offset<Id>) -> Offset<Id> {
+        if off.intra_precise < 0.0 {
+            off.intra_precise = 0.0;
+            return off;
+        }
+        loop {
+            let row_precise = rows.precise(&off.anchor);
+            if off.intra_precise <= row_precise {
+                return off;
+            }
+            match rows.next(&off.anchor) {
+                Some(next_id) => {
+                    off.intra_precise -= row_precise;
+                    off.anchor = next_id;
+                }
+                None => {
+                    off.intra_precise = row_precise;
+                    return off;
+                }
+            }
+        }
+    }
+
+    fn anchor_valid<R: Rows<RowId = Id>>(rows: &R, anchor: &Id) -> bool {
+        if rows.first().is_none() {
+            return false;
+        }
+        if rows.next(anchor).is_some() {
+            return true;
+        }
+        if rows.prev(anchor).is_some() {
+            return true;
+        }
+        rows.first().as_ref() == Some(anchor)
+    }
+
+    /// The largest offset where the document still fills the viewport.
+    /// `None` when rows is empty.
+    pub fn max_offset<R: Rows<RowId = Id>>(&self, rows: &R) -> Option<Offset<Id>> {
+        let last = rows.last()?;
+        let intra_precise = rows.precise(&last);
+        let last_bottom = Offset { anchor: last, intra_precise };
+        Some(affine::scroll_by(rows, last_bottom, -self.viewport_height))
+    }
+
+    fn clamp_to_max<R: Rows<RowId = Id>>(&self, rows: &R, off: Offset<Id>) -> Offset<Id> {
+        let Some(max) = self.max_offset(rows) else {
+            return off;
+        };
+        let Some(last) = rows.last() else {
+            return off;
+        };
+        let intra_precise = rows.precise(&last);
+        let last_bottom = Offset { anchor: last, intra_precise };
+        let dist_to_end = affine::signed_distance(rows, &off, &last_bottom);
+        if dist_to_end < self.viewport_height { max } else { off }
+    }
+
+    pub fn total_approx<R: Rows<RowId = Id>>(&self, rows: &R) -> f32 {
+        affine::total_approx(rows)
+    }
+
+    pub fn thumb_approx<R: Rows<RowId = Id>>(&self, rows: &R) -> f32 {
+        match self.offset(rows) {
+            Some(off) => affine::thumb_approx(rows, &off, self.config.slope_band),
+            None => 0.0,
+        }
+    }
+
+    pub fn signed_distance<R: Rows<RowId = Id>>(
+        &self, rows: &R, a: &Offset<Id>, b: &Offset<Id>,
+    ) -> f32 {
+        affine::signed_distance(rows, a, b)
+    }
+
+    /// The [`Offset`] corresponding to the given viewport-local y. Walks
+    /// from the current offset by `viewport_y` precise pixels — useful
+    /// for converting screen-space hit positions (e.g. cursor / find-
+    /// match galley positions) into doc anchors for [`Reveal`].
+    /// Returns `None` if rows is empty.
+    pub fn offset_at_viewport_y<R: Rows<RowId = Id>>(
+        &self, rows: &R, viewport_y: f32,
+    ) -> Option<Offset<Id>> {
+        let current = self.offset(rows)?;
+        Some(affine::scroll_by(rows, current, viewport_y))
+    }
+
+    /// Rows currently within the viewport, top-down. Bounded by viewport
+    /// rows, not document size.
+    pub fn visible<R: Rows<RowId = Id>>(&self, rows: &R) -> Vec<VisibleRow<Id>> {
+        let Some(off) = self.offset(rows) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut id = off.anchor;
+        let mut y = -off.intra_precise;
+        while y < self.viewport_height {
+            let height = rows.precise(&id);
+            let next = rows.next(&id);
+            out.push(VisibleRow { id: id.clone(), top: y, height });
+            y += height;
+            match next {
+                Some(n) => id = n,
+                None => break,
+            }
+        }
+        out
+    }
+
+    /// Translate a viewport-local y into the row at that position.
+    pub fn hit_row<R: Rows<RowId = Id>>(&self, rows: &R, y: f32) -> Option<HitRow<Id>> {
+        let off = self.offset(rows)?;
+        if y < 0.0 || y >= self.viewport_height {
+            return None;
+        }
+        let mut id = off.anchor;
+        let mut row_top = -off.intra_precise;
+        loop {
+            let height = rows.precise(&id);
+            if y >= row_top && y < row_top + height {
+                return Some(HitRow { id, intra_y: y - row_top });
+            }
+            row_top += height;
+            if row_top > self.viewport_height {
+                return None;
+            }
+            match rows.next(&id) {
+                Some(n) => id = n,
+                None => return None,
+            }
+        }
+    }
+
+    /// Place the offset at a specific anchor + intra-row precise. The
+    /// anchor must currently be in rows; otherwise no-op. Result clamps
+    /// so the document still fills the viewport.
+    ///
+    /// Cancels touch-scroll momentum so a programmatic jump isn't fought
+    /// by a coasting flick.
+    pub fn set_offset<R: Rows<RowId = Id>>(&mut self, rows: &R, off: Offset<Id>) {
+        if Self::anchor_valid(rows, &off.anchor) {
+            self.stored_offset = Some(self.clamp_to_max(rows, off));
+            self.kill_momentum();
+        }
+    }
+
+    /// Process an [`Action`]. Stale anchors recover via `offset()` first.
+    pub fn handle<R: Rows<RowId = Id>>(&mut self, rows: &R, action: Action) {
+        match action {
+            Action::ScrollByPixels(delta) => {
+                if let Some(off) = self.offset(rows) {
+                    let new = affine::scroll_by(rows, off, delta);
+                    self.stored_offset = Some(self.clamp_to_max(rows, new));
+                }
+            }
+            Action::ScrollByThumb(delta) => {
+                if self.offset(rows).is_some() {
+                    let target = self.thumb_approx(rows) + delta;
+                    if let Some(new_off) = affine::from_thumb(rows, target, self.config.slope_band)
+                    {
+                        self.stored_offset = Some(self.clamp_to_max(rows, new_off));
+                    }
+                }
+            }
+            Action::ScrollToTop => {
+                self.stored_offset = rows.first().map(Offset::at_top_of);
+            }
+            Action::ScrollToBottom => {
+                self.stored_offset = self.max_offset(rows);
+            }
+            Action::Resize(h) => {
+                self.viewport_height = h.max(0.0);
+                if let Some(off) = self.offset(rows) {
+                    self.stored_offset = Some(self.clamp_to_max(rows, off));
+                }
+            }
+        }
+    }
+
+    /// Scroll so `rect` is positioned per `align` within the viewport.
+    /// `Align::Nearest` does bounded visibility classification —
+    /// document size doesn't enter the cost.
+    pub fn reveal<R: Rows<RowId = Id>>(&mut self, rows: &R, rect: Reveal<Id>, align: Align) {
+        if !Self::anchor_valid(rows, &rect.top.anchor)
+            || !Self::anchor_valid(rows, &rect.bottom.anchor)
+        {
+            return;
+        }
+        let target = match align {
+            Align::Top => rect.top,
+            Align::Bottom => affine::scroll_by(rows, rect.bottom, -self.viewport_height),
+            Align::Center => {
+                let mid = affine::midpoint(rows, rect.top, rect.bottom);
+                affine::scroll_by(rows, mid, -self.viewport_height / 2.0)
+            }
+            Align::Nearest => {
+                let Some(target) = self.nearest_target(rows, rect) else {
+                    return;
+                };
+                target
+            }
+        };
+        self.set_offset(rows, target);
+    }
+
+    fn nearest_target<R: Rows<RowId = Id>>(
+        &self, rows: &R, rect: Reveal<Id>,
+    ) -> Option<Offset<Id>> {
+        let current = self.offset(rows)?;
+        let bound = self.viewport_height;
+
+        let y_top = affine::signed_distance_bounded(rows, &current, &rect.top, bound);
+        let y_bot = affine::signed_distance_bounded(rows, &current, &rect.bottom, bound);
+
+        let rect_height =
+            affine::signed_distance_bounded(rows, &rect.top, &rect.bottom, bound + 1.0);
+        let rect_taller_than_viewport = rect_height.map(|h| h > bound).unwrap_or(true);
+
+        if rect_taller_than_viewport {
+            return Some(rect.top);
+        }
+
+        match (y_top, y_bot) {
+            (Some(t), Some(b)) => {
+                if t >= 0.0 && b <= bound {
+                    None
+                } else if t < 0.0 {
+                    Some(rect.top)
+                } else {
+                    Some(affine::scroll_by(rows, rect.bottom, -bound))
+                }
+            }
+            (Some(t), None) => {
+                if t < 0.0 {
+                    Some(rect.top)
+                } else {
+                    Some(affine::scroll_by(rows, rect.bottom, -bound))
+                }
+            }
+            (None, Some(b)) => {
+                if b > bound {
+                    Some(affine::scroll_by(rows, rect.bottom, -bound))
+                } else {
+                    Some(rect.top)
+                }
+            }
+            (None, None) => {
+                let signed = affine::signed_distance(rows, &current, &rect.top);
+                if signed.is_nan() || signed < 0.0 {
+                    Some(rect.top)
+                } else {
+                    Some(affine::scroll_by(rows, rect.bottom, -bound))
+                }
+            }
+        }
+    }
+
+    /// Scrollbar geometry within `track`. Thumb's vertical extent is
+    /// proportional to the visible fraction in approx coordinates,
+    /// floored at `MIN_THUMB_PX` for grabability.
+    ///
+    /// `track.x` and `track.width()` pass through unchanged; the
+    /// embedder controls scrollbar width and horizontal placement.
+    pub fn scrollbar<R: Rows<RowId = Id>>(&self, rows: &R, track: Rect) -> Scrollbar {
+        let total = self.total_approx(rows);
+        let thumb_pos = self.thumb_approx(rows);
+        let scrollable_approx = self
+            .max_offset(rows)
+            .map(|off| affine::thumb_approx(rows, &off, self.config.slope_band))
+            .unwrap_or(0.0);
+        let visible_fraction =
+            if total > 0.0 { ((total - scrollable_approx) / total).clamp(0.0, 1.0) } else { 1.0 };
+        let thumb_h = (track.height() * visible_fraction)
+            .max(MIN_THUMB_PX)
+            .min(track.height());
+        let thumb_top_fraction = if scrollable_approx > 0.0 {
+            (thumb_pos / scrollable_approx).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let thumb_y = track.min.y + (track.height() - thumb_h) * thumb_top_fraction;
+        Scrollbar {
+            track,
+            thumb: Rect::from_min_size(
+                Pos2::new(track.min.x, thumb_y),
+                Vec2::new(track.width(), thumb_h),
+            ),
+            total_approx: total,
+            thumb_approx: thumb_pos,
+            scrollable_approx,
+        }
+    }
+
+    fn kill_momentum(&mut self) {
+        self.velocity_precise = 0.0;
+        self.drag_window = [(0.0, 0.0); DRAG_WINDOW_LEN];
+        self.drag_window_idx = 0;
+    }
+
+    fn record_drag_sample(&mut self, precise_delta: f32, dt: f32) {
+        self.drag_window[self.drag_window_idx as usize] = (precise_delta, dt);
+        self.drag_window_idx = (self.drag_window_idx + 1) % (DRAG_WINDOW_LEN as u8);
+        let (sum_d, sum_dt) = self
+            .drag_window
+            .iter()
+            .fold((0.0, 0.0), |(sd, st), (d, t)| (sd + d, st + t));
+        self.velocity_precise = if sum_dt > 0.001 { sum_d / sum_dt } else { 0.0 };
+    }
+}
+
+// ============================================================================
+// Egui adapter
+// ============================================================================
+
+/// Egui adapter: persists a [`ScrollArea<Id>`] in egui memory keyed by
+/// `id_salt` and layers wheel / touch-drag / scrollbar-drag input plus
+/// momentum on top.
+pub struct AffineScrollArea<Id> {
+    id_salt: egui::Id,
+    /// When true, drag on the body (not just the scrollbar) scrolls the
+    /// content with momentum. Intended for touch input.
+    touch_scroll: bool,
+    _phantom: PhantomData<Id>,
+}
+
+impl<Id> AffineScrollArea<Id>
+where
+    Id: Clone + Eq + std::fmt::Debug + Send + Sync + 'static,
+{
+    pub fn new(id_salt: impl Hash) -> Self {
+        Self { id_salt: egui::Id::new(id_salt), touch_scroll: false, _phantom: PhantomData }
     }
 
     pub fn touch_scroll(mut self, enabled: bool) -> Self {
@@ -91,867 +849,214 @@ impl AffineScrollArea {
         self
     }
 
-    /// Current touch-scroll velocity (precise px/sec). y is vertical;
-    /// x is always 0. Non-zero while momentum scroll is in flight.
-    /// Used to block other touch handling (e.g. cursor placement)
-    /// while content is coasting.
-    pub fn velocity(&self, ctx: &egui::Context) -> egui::Vec2 {
-        let state: ScrollState = ctx.data(|d| d.get_temp(self.id_salt)).unwrap_or_default();
-        egui::Vec2::new(0.0, state.velocity_precise)
-    }
-
-    /// Current scroll offset in approx units. For persistence.
-    pub fn offset(&self, ctx: &egui::Context) -> f32 {
-        ctx.data(|d| d.get_temp::<ScrollState>(self.id_salt))
+    /// Snapshot the persisted state. Cheap clone of POD + the optional
+    /// offset.
+    pub fn state(&self, ctx: &egui::Context) -> ScrollArea<Id> {
+        ctx.data(|d| d.get_temp::<ScrollArea<Id>>(self.id_salt))
             .unwrap_or_default()
-            .offset_approx
     }
 
-    /// Set scroll offset directly. Skips clamping — the scroll area
-    /// will clamp on next show against the current `max_offset`. Cancels
-    /// touch-scroll momentum so the programmatic jump isn't fought by a
-    /// coasting flick.
-    pub fn set_offset(&self, ctx: &egui::Context, offset_approx: f32) {
-        let mut state: ScrollState = ctx.data(|d| d.get_temp(self.id_salt)).unwrap_or_default();
-        state.offset_approx = offset_approx;
-        state.velocity_precise = 0.0;
-        state.drag_window = [(0.0, 0.0); DRAG_WINDOW_LEN];
-        state.drag_window_idx = 0;
+    fn write_state(&self, ctx: &egui::Context, state: ScrollArea<Id>) {
         ctx.data_mut(|d| d.insert_temp(self.id_salt, state));
+    }
+
+    /// Touch-scroll velocity (precise px/sec). y is vertical; x is
+    /// always 0. Non-zero while momentum is in flight.
+    pub fn velocity(&self, ctx: &egui::Context) -> Vec2 {
+        self.state(ctx).velocity()
+    }
+
+    /// Raw persisted offset for change-detection (no row projection).
+    /// Cheap egui-memory read.
+    pub fn stored_offset(&self, ctx: &egui::Context) -> Option<Offset<Id>> {
+        self.state(ctx).stored_offset()
+    }
+
+    /// Current offset projected onto the given rows, or `None` if rows
+    /// is empty.
+    pub fn offset<R: Rows<RowId = Id>>(&self, ctx: &egui::Context, rows: &R) -> Option<Offset<Id>> {
+        self.state(ctx).offset(rows)
+    }
+
+    /// Set offset directly. Cancels touch-scroll momentum.
+    pub fn set_offset<R: Rows<RowId = Id>>(&self, ctx: &egui::Context, rows: &R, off: Offset<Id>) {
+        let mut state = self.state(ctx);
+        state.set_offset(rows, off);
+        self.write_state(ctx, state);
         ctx.request_repaint();
     }
 
-    /// Allocate the body's drag interaction. Caller may register its own
-    /// widgets between `begin` and [`AffineScrollAreaBegun::finish`];
-    /// those land at higher z than the body, so click senses on the
-    /// content win over the body's drag — see egui's `hit_test`.
-    pub fn begin(self, ui: &mut Ui) -> AffineScrollAreaBegun {
+    /// Reveal a rect with the given alignment.
+    pub fn reveal<R: Rows<RowId = Id>>(
+        &self, ctx: &egui::Context, rows: &R, rect: Reveal<Id>, align: Align,
+    ) {
+        let mut state = self.state(ctx);
+        state.reveal(rows, rect, align);
+        self.write_state(ctx, state);
+        ctx.request_repaint();
+    }
+
+    /// Per-frame: allocate body + scrollbar hit areas, process input,
+    /// draw scrollbar, return body Response + visible rows. Caller paints
+    /// rows into `body` using the returned `top` offsets.
+    ///
+    /// Walks rows in a viewport-sized window above and below the visible
+    /// region, calling [`Rows::warm`] on each so impls can kick off
+    /// background work for rows about to enter view.
+    pub fn show<R: Rows<RowId = Id>>(&self, ui: &mut Ui, rows: &R) -> ShowResponse<Id> {
         let rect = ui.max_rect();
-        let body_sense = if self.touch_scroll { Sense::drag() } else { Sense::hover() };
-        let body_response = ui.allocate_rect(rect, body_sense);
-        AffineScrollAreaBegun {
-            id_salt: self.id_salt,
-            touch_scroll: self.touch_scroll,
-            rect,
-            body_response,
-        }
-    }
+        let body_sense = if self.touch_scroll { Sense::click_and_drag() } else { Sense::hover() };
+        let response = ui.allocate_rect(rect, body_sense);
 
-    pub fn show<R: Rows>(self, ui: &mut Ui, content: &mut R) -> Response {
-        self.begin(ui).finish(ui, content)
-    }
-}
-
-pub struct AffineScrollAreaBegun {
-    id_salt: egui::Id,
-    touch_scroll: bool,
-    rect: Rect,
-    body_response: Response,
-}
-
-impl AffineScrollAreaBegun {
-    pub fn finish<R: Rows>(self, ui: &mut Ui, content: &mut R) -> Response {
-        let Self { id_salt, touch_scroll, rect, body_response: response } = self;
-
+        // Scrollbar hit area registered AFTER the body so it shadows
+        // body hover in z-order.
         const BAR_WIDTH: f32 = 10.0;
         const BAR_INSET: f32 = 3.0;
         let bar_x = rect.max.x - BAR_WIDTH - BAR_INSET;
         let bar_track =
             Rect::from_min_size(Pos2::new(bar_x, rect.min.y), Vec2::new(BAR_WIDTH, rect.height()));
-        let bar_id = id_salt.with("scrollbar");
+        let bar_id = self.id_salt.with("scrollbar");
         let bar_response = ui.interact(bar_track, bar_id, Sense::click_and_drag());
 
-        // Persisted scroll state.
-        let mut state: ScrollState = ui.ctx().data(|d| d.get_temp(id_salt)).unwrap_or_default();
+        let mut state = self.state(ui.ctx());
+        state.handle(rows, Action::Resize(rect.height()));
 
-        let viewport_height = rect.height();
+        // Geometry-only snapshot before input — `scrollable_approx` is
+        // a function of (rows, viewport_height, slope_band), independent
+        // of the current offset, so this stays valid through input
+        // processing. Used both to size scrollbar-drag math and to gate
+        // touch-body-drag.
+        let bar_geom = state.scrollbar(rows, bar_track);
+        let scrollable = bar_geom.scrollable_approx > 0.0;
 
-        // approx_total: walk forward summing approx. Cheap.
-        let approx_total = sum_approx(content);
-
-        // max_offset: walk backward from the doc end summing precise
-        // until we cover one viewport. The crossing row becomes the
-        // anchor at max scroll; convert its intra-position back to
-        // approx. Bounded by the viewport's worth of rows.
-        let max_offset = compute_max_offset(content, viewport_height, approx_total);
-
-        // Per-input clamps below only fire when their branch runs; a
-        // passive doc shrink (no input this frame) would leave the
-        // persisted offset out of range.
-        state.offset_approx = state.offset_approx.clamp(0.0, max_offset);
-
-        // Scrollbar dimensions reason in approx space (cheap sizing),
-        // independent of `max_offset`'s precise-aware clamp.
-        let scrollbar_total = approx_total.max(viewport_height);
-
-        // Process scroll events: wheel, drag on scrollbar, programmatic.
-        // Wheel events are in screen pixels = precise. Translate to
-        // approx via the affine map at current offset.
-        //
-        // Use `raw_scroll_delta` (immediate, unsmoothed) rather than
-        // `smooth_scroll_delta` (kinetic). Tests need the full delta in
-        // one frame; production wheel input lands in raw too.
+        // Wheel: precise pixels. egui convention: positive y = scroll up
+        // (content moves down). We want offset to grow when user scrolls
+        // down (content moves up), so negate.
         let raw_scroll_delta =
             if ui.rect_contains_pointer(rect) { ui.input(|i| i.raw_scroll_delta.y) } else { 0.0 };
         if raw_scroll_delta != 0.0 {
-            // egui's scroll convention: positive y means scroll up
-            // (content moves down). We want our offset to *increase*
-            // when user scrolls down (content moves up), so negate.
-            let precise_delta = -raw_scroll_delta;
-            let approx_delta = precise_to_approx_delta(content, state.offset_approx, precise_delta);
-            state.offset_approx = (state.offset_approx + approx_delta).clamp(0.0, max_offset);
+            state.handle(rows, Action::ScrollByPixels(-raw_scroll_delta));
         }
 
         // Touch body drag → scroll + velocity tracking.
         let dt = ui.input(|i| i.stable_dt).max(0.0001);
-        if max_offset > 0.0 && touch_scroll && response.drag_started() {
-            // Tap-during-momentum or drag-start: clear stale velocity
-            // and the sliding-window history so the new gesture
-            // doesn't inherit anything.
-            state.velocity_precise = 0.0;
-            state.drag_window = [(0.0, 0.0); DRAG_WINDOW_LEN];
-            state.drag_window_idx = 0;
+        if scrollable && self.touch_scroll && response.drag_started() {
+            state.kill_momentum();
         }
-        if max_offset > 0.0 && touch_scroll && response.dragged() {
+        if scrollable && self.touch_scroll && response.dragged() {
             let drag_y = ui.input(|i| i.pointer.delta().y);
-            // Drag UP (negative y) → scroll DOWN (offset grows). Same
-            // sign convention as wheel.
             let precise_delta = -drag_y;
-            let approx_delta = precise_to_approx_delta(content, state.offset_approx, precise_delta);
-            state.offset_approx = (state.offset_approx + approx_delta).clamp(0.0, max_offset);
-            // Push this frame's sample into the sliding window.
-            // Velocity = sum(deltas) / sum(dts) over the window. Held
-            // frames (delta=0) drag the average toward 0, so a pause
-            // before release won't produce phantom momentum.
-            state.drag_window[state.drag_window_idx as usize] = (precise_delta, dt);
-            state.drag_window_idx = (state.drag_window_idx + 1) % (DRAG_WINDOW_LEN as u8);
-            let (sum_d, sum_dt) = state
-                .drag_window
-                .iter()
-                .fold((0.0, 0.0), |(sd, st), (d, t)| (sd + d, st + t));
-            state.velocity_precise = if sum_dt > 0.001 { sum_d / sum_dt } else { 0.0 };
+            state.handle(rows, Action::ScrollByPixels(precise_delta));
+            state.record_drag_sample(precise_delta, dt);
         } else if state.velocity_precise.abs() > 1.0 && !response.dragged() {
-            // Coast: apply velocity * dt, decay velocity.
             const DECAY_PER_SEC: f32 = 4.0;
             let precise_step = state.velocity_precise * dt;
-            let approx_step = precise_to_approx_delta(content, state.offset_approx, precise_step);
-            let new_offset = (state.offset_approx + approx_step).clamp(0.0, max_offset);
-            // If we hit a scroll boundary, kill momentum.
-            if (new_offset - state.offset_approx).abs() < 0.001 {
+            let before = state.offset(rows);
+            state.handle(rows, Action::ScrollByPixels(precise_step));
+            let after = state.offset(rows);
+            if before == after {
                 state.velocity_precise = 0.0;
             } else {
-                state.offset_approx = new_offset;
                 state.velocity_precise *= (-DECAY_PER_SEC * dt).exp();
             }
             ui.ctx().request_repaint();
         } else {
             state.velocity_precise = 0.0;
         }
-        let pressed_in_rect = ui.input(|i| {
-            i.pointer.any_pressed() && i.pointer.press_origin().is_some_and(|p| rect.contains(p))
-        });
-        if touch_scroll && pressed_in_rect {
+        if self.touch_scroll && response.clicked() {
             state.velocity_precise = 0.0;
         }
 
-        // Scrollbar drag/click. The thumb spans `visible_fraction *
-        // viewport_height`; the user can drag the thumb across the
-        // remaining `(1 - visible_fraction) * viewport_height` of
-        // track. That drag range maps onto `[0, max_offset]` in approx.
-        if max_offset > 0.0 && (bar_response.dragged() || bar_response.clicked()) {
-            let visible_fraction = (viewport_height / scrollbar_total).clamp(0.0, 1.0);
-            let track_drag_range = (rect.height() * (1.0 - visible_fraction)).max(1.0);
+        // Scrollbar drag/click. Drag deltas use the pre-input geometry
+        // — the user's drag is a pixel-velocity gesture, not a position
+        // command, so reading the live thumb position would double-apply
+        // any scroll that already happened this frame.
+        if scrollable && (bar_response.dragged() || bar_response.clicked()) {
             if bar_response.dragged() {
                 let drag_y = ui.input(|i| i.pointer.delta().y);
-                state.offset_approx = (state.offset_approx
-                    + drag_y * (max_offset / track_drag_range))
-                    .clamp(0.0, max_offset);
+                let approx_delta = bar_geom.pixel_to_approx(drag_y);
+                state.handle(rows, Action::ScrollByThumb(approx_delta));
             } else if let Some(pos) = bar_response.interact_pointer_pos() {
-                // Click jumps so the thumb's center lands at the cursor.
-                let thumb_h = visible_fraction * rect.height();
+                let movable = bar_geom.track.height() - bar_geom.thumb.height();
                 let target_thumb_top =
-                    (pos.y - rect.min.y - thumb_h / 2.0).clamp(0.0, track_drag_range);
-                state.offset_approx = target_thumb_top * (max_offset / track_drag_range);
+                    (pos.y - bar_geom.track.min.y - bar_geom.thumb.height() / 2.0)
+                        .clamp(0.0, movable.max(1.0));
+                let target_approx = if movable > 0.0 {
+                    target_thumb_top * (bar_geom.scrollable_approx / movable)
+                } else {
+                    0.0
+                };
+                let delta = target_approx - bar_geom.thumb_approx;
+                state.handle(rows, Action::ScrollByThumb(delta));
             }
         }
 
-        // Find anchor and render visible rows.
-        ui.scope_builder(egui::UiBuilder::new().max_rect(rect), |ui| {
-            ui.set_clip_rect(rect);
-            render_visible(ui, content, rect, state.offset_approx);
-        });
+        let visible = state.visible(rows);
+        warm_around_visible(rows, &visible, rect.height());
 
-        // Draw scrollbar (simple vertical bar on the right).
-        if max_offset > 0.0 {
-            draw_scrollbar(ui, rect, state.offset_approx, scrollbar_total, viewport_height);
+        if scrollable {
+            let bar_after = state.scrollbar(rows, bar_track);
+            draw_scrollbar(ui, bar_after);
         }
 
-        // Persist state.
-        ui.ctx().data_mut(|d| d.insert_temp(id_salt, state));
+        self.write_state(ui.ctx(), state);
 
-        response
+        ShowResponse { response, visible }
     }
 }
 
-/// Where to position a target row within the viewport.
-#[derive(Clone, Copy, Debug)]
-pub enum Align {
-    /// Target's top at viewport top.
-    Top,
-    /// Target's center at viewport center.
-    Center,
-    /// Target's bottom at viewport bottom.
-    Bottom,
+/// Returned by [`AffineScrollArea::show`].
+#[derive(Debug, Clone)]
+pub struct ShowResponse<Id> {
+    /// Body rect Response (hover, or click+drag for touch_scroll). Use
+    /// for context-menu attachment etc.
+    pub response: Response,
+    /// Visible rows top-down. `top` is viewport-local; add `viewport.min.y`
+    /// for screen coordinates.
+    pub visible: Vec<VisibleRow<Id>>,
 }
 
-/// Compute the offset that places the first row matching `find` in the
-/// viewport per `align`. `find` is run on each row in forward order
-/// until it returns true. Returns `None` if no row matches.
-///
-/// Cost is bounded by the position of the target plus (for non-Top
-/// alignments) the precise content needed to fill the gap above the
-/// target — at most one viewport's worth.
-pub fn align_offset<R, F>(
-    content: &mut R, viewport_height: f32, align: Align, mut find: F,
-) -> Option<f32>
-where
-    R: Rows,
-    F: FnMut(&mut R) -> bool,
-{
-    content.reset();
-    let mut approx_top = 0.0f32;
-    let mut target_approx = 0.0f32;
-    let mut target_precise = 0.0f32;
-    let mut found = false;
-    while content.next() {
-        let h = content.approx();
-        if find(content) {
-            target_approx = h;
-            target_precise = content.precise();
-            found = true;
-            break;
-        }
-        approx_top += h;
-    }
-    if !found {
-        return None;
-    }
-
-    let target_gap = match align {
-        Align::Top => 0.0,
-        Align::Center => (viewport_height - target_precise) / 2.0,
-        Align::Bottom => viewport_height - target_precise,
-    };
-
-    if target_gap < 0.0 {
-        // Target is taller than the gap allows — anchor at target with
-        // its top above the viewport.
-        let intra_precise = -target_gap;
-        let slope = if target_approx > 0.0 { target_precise / target_approx } else { 1.0 };
-        let intra_approx = if slope > 0.0 { intra_precise / slope } else { 0.0 };
-        return Some((approx_top + intra_approx).max(0.0));
-    }
-
-    // Walk back from target, summing precise until we cover the gap.
-    // The crossing row becomes the anchor.
-    let mut precise_sum = 0.0f32;
-    let mut approx_sum = 0.0f32;
-    while content.prev() {
-        let p = content.precise();
-        let a = content.approx();
-        if precise_sum + p >= target_gap && a > 0.0 {
-            let intra_precise = p - (target_gap - precise_sum);
-            let slope = p / a;
-            let intra_approx = if slope > 0.0 { intra_precise / slope } else { 0.0 };
-            let anchor_approx_top = approx_top - approx_sum - a;
-            return Some((anchor_approx_top + intra_approx).max(0.0));
-        }
-        precise_sum += p;
-        approx_sum += a;
-    }
-
-    // Walked back to the doc start without filling the gap.
-    Some(0.0)
-}
-
-/// "Make visible" semantics: only return a new offset if `current_offset`
-/// has the target outside the viewport. When the target is already
-/// visible, returns `None` so the caller leaves scroll alone — avoids
-/// the constant-recenter feel of `Align::Center`. When out of view,
-/// returns the offset that brings the nearest edge of the target just
-/// into the viewport (Top alignment if scrolling up, Bottom if down).
-pub fn make_visible_offset<R, F>(
-    content: &mut R, viewport_height: f32, current_offset: f32, mut find: F,
-) -> Option<f32>
-where
-    R: Rows,
-    F: FnMut(&mut R) -> bool,
-{
-    let top = align_offset(content, viewport_height, Align::Top, &mut find)?;
-    let bottom = align_offset(content, viewport_height, Align::Bottom, &mut find)?;
-    let lo = top.min(bottom);
-    let hi = top.max(bottom);
-    if current_offset >= lo && current_offset <= hi {
-        None
-    } else if current_offset < lo {
-        Some(lo)
-    } else {
-        Some(hi)
-    }
-}
-
-/// Forward walk summing approx heights.
-fn sum_approx<R: Rows>(content: &mut R) -> f32 {
-    content.reset();
-    let mut total = 0.0f32;
-    while content.next() {
-        total += content.approx();
-    }
-    total
-}
-
-/// Convert a scroll offset (approx units) into the row the offset
-/// lands in plus an `intra_offset` (approx units within that row).
-/// Used for width-independent scroll persistence — the returned `idx`
-/// is the row's flat-order position from the start of the doc.
-pub fn offset_to_anchor<R: Rows>(content: &mut R, offset: f32) -> (usize, f32) {
-    content.reset();
-    let mut acc = 0.0f32;
-    let mut idx = 0usize;
-    let mut last_acc = 0.0f32;
-    let mut last_idx = 0usize;
-    while content.next() {
-        let h = content.approx();
-        if acc + h > offset {
-            return (idx, (offset - acc).max(0.0));
-        }
-        last_acc = acc;
-        last_idx = idx;
-        acc += h;
-        idx += 1;
-    }
-    if idx == 0 { (0, 0.0) } else { (last_idx, offset - last_acc) }
-}
-
-/// Inverse of [`offset_to_anchor`]. Out-of-range `anchor_idx` clamps to
-/// the last row; `intra` clamps to that row's approx height.
-pub fn anchor_to_offset<R: Rows>(content: &mut R, anchor_idx: usize, intra: f32) -> f32 {
-    content.reset();
-    let mut acc = 0.0f32;
-    let mut idx = 0usize;
-    let mut last_h = 0.0f32;
-    while content.next() {
-        let h = content.approx();
-        if idx == anchor_idx {
-            return acc + intra.clamp(0.0, h);
-        }
-        acc += h;
-        last_h = h;
-        idx += 1;
-    }
-    if idx == 0 { 0.0 } else { acc - last_h + intra.clamp(0.0, last_h) }
-}
-
-/// Walk precise heights from the end of the doc backwards until the
-/// cumulative reaches `viewport_height`. The row where it crosses is
-/// the anchor at max scroll; convert its intra-position back to approx
-/// units (via that row's slope) to get an `offset_approx` cap that,
-/// when rendered, places the doc's tail at the viewport bottom.
-///
-/// Cost is bounded by the tail rows visible at max scroll — not the
-/// whole doc — so this stays cheap even on long documents.
-///
-/// Edge cases:
-/// - viewport_height <= 0: returns 0.
-/// - Total precise content < viewport_height: returns 0 (doc fits).
-/// - Anchor would land in a 0-approx row: skip and continue
-///   backwards. The 0-approx row can't host an anchor because the
-///   slope is undefined.
-fn compute_max_offset<R: Rows>(content: &mut R, viewport_height: f32, approx_total: f32) -> f32 {
-    if viewport_height <= 0.0 {
-        return 0.0;
-    }
-    content.reset_back();
-    let mut cumulative_precise = 0.0f32;
-    let mut approx_tail_sum = 0.0f32;
-    while content.prev() {
-        let p = content.precise();
-        let a = content.approx();
-        cumulative_precise += p;
-        approx_tail_sum += a;
-        if cumulative_precise >= viewport_height && a > 0.0 {
-            let intra_precise = cumulative_precise - viewport_height;
-            let slope = p / a;
-            let intra_approx = if slope > 0.0 { intra_precise / slope } else { 0.0 };
-            return (approx_total - approx_tail_sum + intra_approx).max(0.0);
-        }
-    }
-    0.0
-}
-
-/// Walks rows until cumulative approx >= `offset_approx` to find the
-/// anchor row. Then paints anchor and downstream rows at consecutive
-/// precise positions. Anchor's intra-position is placed at the viewport
-/// top in screen space.
-fn render_visible<R: Rows>(ui: &mut Ui, content: &mut R, viewport: Rect, offset_approx: f32) {
-    content.reset();
-
-    let mut acc = 0.0f32;
-    let mut anchor_p = 0.0f32;
-    let mut intra_precise = 0.0f32;
-    let mut found = false;
-    while content.next() {
-        let h = content.approx();
-        if acc + h > offset_approx {
-            anchor_p = content.precise();
-            let anchor_a = h;
-            let intra_approx = offset_approx - acc;
-            let slope = if anchor_a > 0.0 { anchor_p / anchor_a } else { 1.0 };
-            intra_precise = intra_approx * slope;
-            content.render(ui, Pos2::new(viewport.min.x, viewport.min.y - intra_precise));
-            found = true;
-            break;
-        }
-        acc += h;
-    }
-    if !found {
+fn warm_around_visible<R: Rows>(rows: &R, visible: &[VisibleRow<R::RowId>], viewport_height: f32) {
+    let Some(first) = visible.first() else {
         return;
-    }
+    };
+    let last = visible.last().unwrap();
 
-    let mut y = -intra_precise + anchor_p;
-    while y < viewport.height() && content.next() {
-        let p = content.precise();
-        content.render(ui, Pos2::new(viewport.min.x, viewport.min.y + y));
-        y += p;
-    }
-
-    // Warm a viewport's worth past the bottom edge so images/etc.
-    // start loading before the user scrolls them in.
-    let warm_until = y + viewport.height();
-    while y < warm_until && content.next() {
-        y += content.precise();
-        content.warm();
-    }
-
-    // Warm a viewport's worth above the rendered region. Re-walk
-    // forward to the anchor (cheap; approx access is O(1) per row),
-    // then prev() warming until we've covered one viewport.
-    content.reset();
-    let mut acc = 0.0f32;
-    while content.next() {
-        let h = content.approx();
-        if acc + h > offset_approx {
-            break;
-        }
-        acc += h;
-    }
-    let mut warm_back = 0.0f32;
-    while warm_back < viewport.height() && content.prev() {
-        warm_back += content.precise();
-        content.warm();
-    }
-}
-
-/// Translate a precise delta (screen pixels of intended movement) into
-/// an approx delta to apply to the scrollbar offset. Walks rows
-/// starting at `offset_approx` consuming precise units; each row
-/// contributes at its approx/precise ratio.
-fn precise_to_approx_delta<R: Rows>(
-    content: &mut R, offset_approx: f32, precise_delta: f32,
-) -> f32 {
-    if precise_delta == 0.0 {
-        return 0.0;
-    }
-    content.reset();
-
-    let mut acc = 0.0f32;
-    let mut precise_remaining = precise_delta.abs();
-    let mut approx_consumed = 0.0f32;
-    let mut found = false;
-    while content.next() {
-        let approx_h = content.approx();
-        if acc + approx_h > offset_approx {
-            let intra_approx = offset_approx - acc;
-            let precise_h = content.precise();
-            let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
-            let approx_remaining_in_row = if precise_delta > 0.0 {
-                (approx_h - intra_approx).max(0.0)
-            } else {
-                intra_approx.max(0.0)
-            };
-            let precise_remaining_in_row = approx_remaining_in_row * slope;
-            if precise_remaining <= precise_remaining_in_row && slope > 0.0 {
-                let signed = precise_remaining / slope;
-                return if precise_delta > 0.0 { signed } else { -signed };
+    // Below the visible window.
+    let mut id = last.id.clone();
+    let mut y = 0.0f32;
+    while y < viewport_height {
+        match rows.next(&id) {
+            Some(next_id) => {
+                rows.warm(&next_id);
+                y += rows.precise(&next_id);
+                id = next_id;
             }
-            approx_consumed = approx_remaining_in_row;
-            precise_remaining -= precise_remaining_in_row;
-            found = true;
-            break;
+            None => break,
         }
-        acc += approx_h;
-    }
-    if !found {
-        return 0.0;
     }
 
-    // Past the anchor every subsequent row is consumed across its
-    // full approx span.
-    loop {
-        let stepped = if precise_delta > 0.0 { content.next() } else { content.prev() };
-        if !stepped {
-            return if precise_delta > 0.0 { approx_consumed } else { -approx_consumed };
-        }
-        let approx_h = content.approx();
-        let precise_h = content.precise();
-        let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
-        let precise_in_row = approx_h * slope;
-        if precise_remaining <= precise_in_row && slope > 0.0 {
-            approx_consumed += precise_remaining / slope;
-            return if precise_delta > 0.0 { approx_consumed } else { -approx_consumed };
-        }
-        approx_consumed += approx_h;
-        precise_remaining -= precise_in_row;
-        if precise_remaining <= 0.0 {
-            return if precise_delta > 0.0 { approx_consumed } else { -approx_consumed };
+    // Above the visible window.
+    let mut id = first.id.clone();
+    let mut y = 0.0f32;
+    while y < viewport_height {
+        match rows.prev(&id) {
+            Some(prev_id) => {
+                rows.warm(&prev_id);
+                y += rows.precise(&prev_id);
+                id = prev_id;
+            }
+            None => break,
         }
     }
 }
 
-fn draw_scrollbar(
-    ui: &Ui, viewport: Rect, offset_approx: f32, approx_total: f32, viewport_height: f32,
-) {
+fn draw_scrollbar(ui: &Ui, bar: Scrollbar) {
     use crate::theme::palette_v2::ThemeExt as _;
-    // Must match the dimensions in `show()` — the scrollbar's hit area
-    // is allocated there, this only paints into it.
-    const BAR_WIDTH: f32 = 10.0;
-    const BAR_INSET: f32 = 3.0;
-
     let theme = ui.ctx().get_lb_theme();
-    // Track: lerp neutral_bg toward neutral (a darker tone) — barely
-    // visible, just enough to anchor the thumb. Thumb: pure neutral
-    // (grey in either mode), prominent against the bg.
     let track_color = theme.neutral_bg().lerp_to_gamma(theme.neutral(), 0.3);
     let thumb_color = theme.neutral();
-
-    let bar_x = viewport.max.x - BAR_WIDTH - BAR_INSET;
-    let bar_track = Rect::from_min_size(
-        Pos2::new(bar_x, viewport.min.y),
-        Vec2::new(BAR_WIDTH, viewport.height()),
-    );
-    let visible_fraction = (viewport_height / approx_total).clamp(0.0, 1.0);
-    let offset_fraction = (offset_approx / approx_total).clamp(0.0, 1.0 - visible_fraction);
-    let thumb = Rect::from_min_size(
-        Pos2::new(bar_x, viewport.min.y + offset_fraction * viewport.height()),
-        Vec2::new(BAR_WIDTH, visible_fraction * viewport.height()),
-    );
-    ui.painter().rect_filled(bar_track, 3.0, track_color);
+    ui.painter().rect_filled(bar.track, 3.0, track_color);
     ui.painter()
-        .rect(thumb, 3.0, thumb_color, Stroke::NONE, egui::epaint::StrokeKind::Inside);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Synthetic content for testing the affine scroll math. Records
-    /// rendered rows so tests can assert positioning.
-    ///
-    /// `cursor` semantics: `None` = before first; `Some(i)` for `i <
-    /// len` = at row i; `Some(len)` = after last.
-    struct MockContent {
-        approx: Vec<f32>,
-        precise: Vec<f32>,
-        rendered: Vec<(usize, Pos2)>,
-        cursor: Option<usize>,
-    }
-
-    impl MockContent {
-        fn new(rows: Vec<(f32, f32)>) -> Self {
-            let approx = rows.iter().map(|(a, _)| *a).collect();
-            let precise = rows.iter().map(|(_, p)| *p).collect();
-            Self { approx, precise, rendered: Vec::new(), cursor: None }
-        }
-        fn at(&self) -> Option<usize> {
-            match self.cursor {
-                Some(i) if i < self.approx.len() => Some(i),
-                _ => None,
-            }
-        }
-    }
-
-    impl Rows for MockContent {
-        fn reset(&mut self) {
-            self.cursor = None;
-        }
-        fn reset_back(&mut self) {
-            self.cursor = Some(self.approx.len());
-        }
-        fn next(&mut self) -> bool {
-            let n = self.approx.len();
-            self.cursor = match self.cursor {
-                None => Some(0),
-                Some(i) if i < n => Some(i + 1),
-                Some(i) => Some(i),
-            };
-            self.at().is_some()
-        }
-        fn prev(&mut self) -> bool {
-            let n = self.approx.len();
-            self.cursor = match self.cursor {
-                Some(0) => None,
-                Some(i) if i <= n => Some(i - 1),
-                Some(_) => Some(n.saturating_sub(1)),
-                None => None,
-            };
-            self.at().is_some()
-        }
-        fn approx(&self) -> f32 {
-            self.approx[self.at().expect("approx() not at row")]
-        }
-        fn precise(&mut self) -> f32 {
-            self.precise[self.at().expect("precise() not at row")]
-        }
-        fn render(&mut self, _: &mut Ui, top_left: Pos2) {
-            let i = self.at().expect("render() not at row");
-            self.rendered.push((i, top_left));
-        }
-    }
-
-    #[test]
-    fn precise_to_approx_within_single_row() {
-        let mut c = MockContent::new(vec![(50.0, 100.0)]);
-        let approx_delta = precise_to_approx_delta(&mut c, 0.0, 30.0);
-        assert!((approx_delta - 15.0).abs() < 0.01, "got {}", approx_delta);
-    }
-
-    #[test]
-    fn precise_to_approx_crossing_row_boundary() {
-        let mut c = MockContent::new(vec![(50.0, 100.0), (50.0, 50.0)]);
-        let approx_delta = precise_to_approx_delta(&mut c, 0.0, 150.0);
-        assert!((approx_delta - 100.0).abs() < 0.01, "got {}", approx_delta);
-    }
-
-    #[test]
-    fn precise_to_approx_negative() {
-        let mut c = MockContent::new(vec![(50.0, 100.0)]);
-        let approx_delta = precise_to_approx_delta(&mut c, 30.0, -30.0);
-        assert!((approx_delta + 15.0).abs() < 0.01, "got {}", approx_delta);
-    }
-
-    /// 10 rows of 50px each, viewport=100px (2 rows visible). Target
-    /// is row 5 → Top alignment offset=250, Bottom alignment offset=200.
-    #[test]
-    fn make_visible_no_scroll_when_target_already_in_view() {
-        let mut c = MockContent::new(vec![(50.0, 50.0); 10]);
-        let result = make_visible_offset(&mut c, 100.0, 225.0, |c| c.at() == Some(5));
-        assert_eq!(result, None, "should not scroll when target is visible");
-    }
-
-    #[test]
-    fn make_visible_scrolls_down_when_target_below() {
-        let mut c = MockContent::new(vec![(50.0, 50.0); 10]);
-        let result = make_visible_offset(&mut c, 100.0, 0.0, |c| c.at() == Some(5));
-        let o = result.expect("should scroll");
-        assert!((o - 200.0).abs() < 0.5, "expected ~200, got {o}");
-    }
-
-    #[test]
-    fn make_visible_scrolls_up_when_target_above() {
-        let mut c = MockContent::new(vec![(50.0, 50.0); 10]);
-        let result = make_visible_offset(&mut c, 100.0, 400.0, |c| c.at() == Some(5));
-        let o = result.expect("should scroll");
-        assert!((o - 250.0).abs() < 0.5, "expected ~250, got {o}");
-    }
-
-    use rand::{Rng, SeedableRng, rngs::StdRng};
-
-    fn random_rows(rng: &mut StdRng, n: usize) -> Vec<(f32, f32)> {
-        (0..n)
-            .map(|_| {
-                let approx = rng.gen_range(10.0..200.0);
-                let ratio = rng.gen_range(0.3..3.0);
-                (approx, approx * ratio)
-            })
-            .collect()
-    }
-
-    /// Reference: visible (idx, screen_y) pairs at offset. Used by
-    /// property tests.
-    fn visible_row_positions<R: Rows>(
-        content: &mut R, viewport_height: f32, offset_approx: f32,
-    ) -> Vec<(usize, f32)> {
-        content.reset();
-        let mut acc = 0.0f32;
-        let mut idx = 0usize;
-        let mut anchor_p = 0.0f32;
-        let mut intra_precise = 0.0f32;
-        let mut out = Vec::new();
-        let mut found = false;
-        while content.next() {
-            let h = content.approx();
-            if acc + h > offset_approx {
-                anchor_p = content.precise();
-                let intra_approx = offset_approx - acc;
-                let slope = if h > 0.0 { anchor_p / h } else { 1.0 };
-                intra_precise = intra_approx * slope;
-                out.push((idx, -intra_precise));
-                found = true;
-                break;
-            }
-            acc += h;
-            idx += 1;
-        }
-        if !found {
-            return out;
-        }
-        let mut y = -intra_precise + anchor_p;
-        while y < viewport_height && content.next() {
-            idx += 1;
-            let p = content.precise();
-            out.push((idx, y));
-            y += p;
-        }
-        out
-    }
-
-    /// Property: after submitting a scroll event of `precise_delta`,
-    /// rows visible in both the before and after renders shift by
-    /// exactly `precise_delta` in screen space.
-    ///
-    /// This is the core invariant the affine scroll area exists to
-    /// satisfy. If broken, scrolling produces visible "jumps" at row
-    /// boundaries.
-    #[test]
-    fn property_scroll_delta_preserved_in_screen_space() {
-        const EPS: f32 = 0.01;
-        let viewport_height = 200.0;
-        let mut rng = StdRng::seed_from_u64(0);
-        for seed in 0..2048u64 {
-            let mut rng_inner = StdRng::seed_from_u64(seed);
-            let n_rows = rng_inner.gen_range(1..20);
-            let rows = random_rows(&mut rng_inner, n_rows);
-            let mut c = MockContent::new(rows.clone());
-
-            let approx_total: f32 = rows.iter().map(|(a, _)| *a).sum();
-            if approx_total <= viewport_height {
-                continue;
-            }
-            let max_offset = approx_total - viewport_height;
-            let offset_a: f32 = rng.gen_range(0.0..=max_offset);
-            let precise_delta: f32 = rng.gen_range(-150.0..=150.0);
-
-            let approx_delta = precise_to_approx_delta(&mut c, offset_a, precise_delta);
-            let offset_b = (offset_a + approx_delta).clamp(0.0, max_offset);
-
-            let effective_approx_delta = offset_b - offset_a;
-            let effective_precise_delta =
-                approx_to_precise_delta(&mut c, offset_a, effective_approx_delta);
-
-            let before = visible_row_positions(&mut c, viewport_height, offset_a);
-            let after = visible_row_positions(&mut c, viewport_height, offset_b);
-
-            for (idx_a, y_a) in &before {
-                if let Some(&(_, y_b)) = after.iter().find(|(i, _)| i == idx_a) {
-                    let diff = y_b - y_a;
-                    let expected = -effective_precise_delta;
-                    assert!(
-                        (diff - expected).abs() < EPS,
-                        "seed {seed}: row {idx_a} shifted by {diff}, expected {expected} \
-                         (offset {offset_a} → {offset_b}, precise {precise_delta}, \
-                         effective precise {effective_precise_delta})",
-                    );
-                }
-            }
-        }
-    }
-
-    /// Inverse of `precise_to_approx_delta`: given an approx delta,
-    /// returns the precise distance covered. Used in tests.
-    fn approx_to_precise_delta<R: Rows>(
-        content: &mut R, offset_approx: f32, approx_delta: f32,
-    ) -> f32 {
-        if approx_delta == 0.0 {
-            return 0.0;
-        }
-        content.reset();
-        let mut acc = 0.0f32;
-        let mut precise_consumed = 0.0f32;
-        let mut approx_remaining = approx_delta.abs();
-        let mut found = false;
-        while content.next() {
-            let approx_h = content.approx();
-            if acc + approx_h > offset_approx {
-                let intra_approx = offset_approx - acc;
-                let precise_h = content.precise();
-                let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
-                let approx_remaining_in_row = if approx_delta > 0.0 {
-                    (approx_h - intra_approx).max(0.0)
-                } else {
-                    intra_approx.max(0.0)
-                };
-                if approx_remaining <= approx_remaining_in_row {
-                    let signed = approx_remaining * slope;
-                    return if approx_delta > 0.0 { signed } else { -signed };
-                }
-                precise_consumed = approx_remaining_in_row * slope;
-                approx_remaining -= approx_remaining_in_row;
-                found = true;
-                break;
-            }
-            acc += approx_h;
-        }
-        if !found {
-            return 0.0;
-        }
-
-        loop {
-            let stepped = if approx_delta > 0.0 { content.next() } else { content.prev() };
-            if !stepped {
-                return if approx_delta > 0.0 { precise_consumed } else { -precise_consumed };
-            }
-            let approx_h = content.approx();
-            let precise_h = content.precise();
-            let slope = if approx_h > 0.0 { precise_h / approx_h } else { 1.0 };
-            if approx_remaining <= approx_h {
-                precise_consumed += approx_remaining * slope;
-                return if approx_delta > 0.0 { precise_consumed } else { -precise_consumed };
-            }
-            precise_consumed += approx_h * slope;
-            approx_remaining -= approx_h;
-            if approx_remaining <= 0.0 {
-                return if approx_delta > 0.0 { precise_consumed } else { -precise_consumed };
-            }
-        }
-    }
-
-    /// Property: precise→approx and approx→precise are inverses (for
-    /// deltas that don't run off the end of the doc).
-    #[test]
-    fn property_affine_map_invertible() {
-        const EPS: f32 = 0.01;
-        let mut rng = StdRng::seed_from_u64(42);
-        for seed in 0..2048u64 {
-            let mut rng_inner = StdRng::seed_from_u64(seed);
-            let n_rows = rng_inner.gen_range(1..20);
-            let rows = random_rows(&mut rng_inner, n_rows);
-            let mut c = MockContent::new(rows.clone());
-            let approx_total: f32 = rows.iter().map(|(a, _)| *a).sum();
-            let offset: f32 = rng.gen_range(0.0..=approx_total.max(1.0));
-            let approx_delta: f32 = rng.gen_range(-100.0..=100.0);
-
-            let new_offset = offset + approx_delta;
-            const EDGE: f32 = 5.0;
-            if new_offset < EDGE || new_offset > approx_total - EDGE {
-                continue;
-            }
-
-            let precise = approx_to_precise_delta(&mut c, offset, approx_delta);
-            let back = precise_to_approx_delta(&mut c, offset, precise);
-            assert!(
-                (back - approx_delta).abs() < EPS,
-                "seed {seed}: approx→precise→approx not identity ({approx_delta} → {precise} → {back})",
-            );
-        }
-    }
+        .rect(bar.thumb, 3.0, thumb_color, Stroke::NONE, egui::epaint::StrokeKind::Inside);
 }

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -15,14 +15,105 @@
 //! - [`ScrollArea<Id>`] holds offset + viewport + touch-momentum state and
 //!   exposes the affine math via id-typed methods that take a [`Rows`]
 //!   impl by reference. Pure data — no egui dependency.
-//! - [`AffineScrollArea<Id>`] is the egui adapter: persists the
-//!   [`ScrollArea`] in egui memory keyed by id_salt and layers
-//!   wheel/touch-drag/scrollbar-drag input + momentum on top.
+//! - [`AffineScrollArea<Id>`] is the egui adapter: owns a
+//!   [`ScrollArea<Id>`] as a field, layers wheel / touch-drag /
+//!   scrollbar-drag input + momentum on top. Embed in the type that
+//!   owns the scrollable view.
 //! - [`Reveal`] + [`Align`] is the make-visible API.
+//!
+//! # Behaviors
+//!
+//! ## Scroll input
+//!
+//! - Wheel / trackpad scroll: 1 px of input moves content by 1 px,
+//!   regardless of `approx`/`precise` drift.
+//! - Touch body drag (when `touch_scroll = true`): content tracks
+//!   finger motion 1:1.
+//! - Touch fling momentum: after release, content coasts with
+//!   exponential decay; cancelled by tap, drag-start on body or
+//!   scrollbar, programmatic scroll, or hitting a scroll boundary.
+//! - A tap that cancels momentum is consumed by the scroll area; it
+//!   doesn't also place the cursor or toggle interactive elements
+//!   (fold buttons, task-list checkboxes). Embedders gate other touch
+//!   handlers on [`AffineScrollArea::velocity`].
+//! - Scrollbar thumb drag: 1 px of mouse-pointer motion ≈ 1 px of
+//!   thumb motion. The drag rate is in approx units, so it drifts
+//!   gracefully when per-row `approx`/`precise` is off.
+//! - Scrollbar track click: thumb snaps so its center lands at the
+//!   click; offset moves accordingly.
+//!
+//! ## Programmatic positioning
+//!
+//! - [`AffineScrollArea::set_offset`] / [`Action::ScrollToTop`] /
+//!   [`Action::ScrollToBottom`]: jump and clamp.
+//! - [`AffineScrollArea::reveal`] with [`Align::Top`] / [`Align::Bottom`]:
+//!   align the rect's edge with the corresponding viewport edge.
+//! - [`Align::Center`]: rect's vertical midpoint at viewport center.
+//! - [`Align::Nearest`]: no-op if the rect is fully visible; otherwise
+//!   minimum motion to bring it in.
+//! - For rects taller than the viewport (no in-viewport position
+//!   shows the whole rect), all alignments prefer the rect's top.
+//! - Typical use: cursor scroll uses `Nearest`; find-match scroll
+//!   uses `Center`.
+//!
+//! ## Rendering
+//!
+//! - Pull-style: [`AffineScrollArea::show`] returns rows in viewport
+//!   order with per-row top + height in viewport-local coordinates.
+//!   Embedders paint themselves; the widget never invokes a paint
+//!   callback.
+//! - Warm window: [`Rows::warm`] is called for rows in a
+//!   viewport-sized window above and below the visible region — gives
+//!   image caches and similar resources a head start.
+//!
+//! ## Scrollbar
+//!
+//! - Thumb size proportional to the visible fraction; floored at
+//!   [`MIN_THUMB_PX`] for grabability; fills the track when the doc
+//!   fits the viewport.
+//! - Thumb position proportional to scroll progress in approx
+//!   coordinate.
+//! - Track + thumb expressed in window-local pixels; embedder chooses
+//!   track placement and width.
+//!
+//! ## Persistence
+//!
+//! - [`AffineScrollArea::stored_offset`] returns the raw persisted
+//!   anchor without row projection — for change detection and
+//!   serialization.
+//! - On read ([`AffineScrollArea::offset`]), the stored anchor is
+//!   projected onto current rows: live anchor with valid intra-row
+//!   position → as-is; intra-row position larger than the row's
+//!   current `precise` (row shrunk under us) → walk forward by the
+//!   excess, advancing the anchor; anchor's row deleted entirely →
+//!   consult [`Rows::recover_anchor`].
+//!
+//! ## Doc-edit resilience
+//!
+//! - The scroll area holds no layout cache. Every read of `offset`,
+//!   `visible`, or `scrollbar` walks `Rows::approx` / `Rows::precise`
+//!   fresh, so changes to row heights (image load, syntax reveal,
+//!   width change, edits) are picked up without an invalidation step.
+//! - Rows added or removed mid-doc: the projection above keeps the
+//!   user near where they were if the anchor is still valid; if the
+//!   anchor's row is gone, [`Rows::recover_anchor`] supplies the new
+//!   home.
+//! - Empty rows: `offset` returns `None`, `visible` is empty, actions
+//!   are safe no-ops.
+//! - Resize: persisted offset re-clamps against the new viewport on
+//!   the next read.
+//!
+//! ## Performance budget
+//!
+//! - Per frame: O(`precise()` × viewport-rows + `approx()` × doc-rows).
+//!   Document size enters only through the cheap `approx()` walk
+//!   (constant per row, no layout work).
+//! - Every function calling `rows.precise(id)` takes a budget that
+//!   bounds its walk — a `bound: f32` argument, the `delta` of
+//!   `scroll_by`, or the row-shrink excess in `normalize`.
 
 use egui::{Pos2, Rect, Response, Sense, Stroke, Ui, Vec2};
 use std::hash::Hash;
-use std::marker::PhantomData;
 
 // ============================================================================
 // Trait + offset
@@ -34,7 +125,7 @@ use std::marker::PhantomData;
 /// is stateless about position. Caches and laid-out content live behind
 /// the impl's interior mutability if needed.
 ///
-/// **Contract.** Implementations should honour:
+/// # Contract
 ///
 /// - `approx(id) == 0.0  ⟺  precise(id) == 0.0` — zero-set agreement.
 ///   A row that contributes nothing in approx must contribute nothing in
@@ -53,8 +144,35 @@ use std::marker::PhantomData;
 ///   removed. Callers (and [`ScrollArea`]) lean on this to detect a
 ///   stale anchor after external mutation.
 ///
-/// Behaviour when contracts are violated is bounded by [`Config::slope_band`]:
-/// the scrollbar may drift, but `ScrollArea` will not panic.
+/// Behaviour when contracts are violated is bounded by the slope-band
+/// clamp on `approx / precise` per row: the scrollbar may drift, but
+/// `ScrollArea` will not panic.
+///
+/// # Choosing a `RowId`
+///
+/// The trait works with two natural design styles. They differ only
+/// in what kind of stability the id has across edits.
+///
+/// **Index-based** (`usize` into a `Vec`). Cheap to compute, cheap to
+/// compare, and the scroll position drifts gracefully under
+/// edits-above-the-anchor: insertions and deletions shift surrounding
+/// indices, so the anchor's id changes meaning to refer to whatever
+/// row took over its position — visually, the user stays put. Goes
+/// stale only when the index runs off the end (e.g., the doc shrunk
+/// past the saved anchor). Override [`recover_anchor`](Rows::recover_anchor)
+/// to clamp to the new last index rather than the default `first()`.
+///
+/// **Stable identity** (hash, generational handle, AST node pointer).
+/// The id refers to *the same content* regardless of edits to other
+/// rows; the row only goes stale when its content is deleted. The
+/// scroll position drifts under edits-above-the-anchor (the row's
+/// physical y changes as siblings are added/removed), but if the
+/// anchor row itself moves, the user follows it. The default
+/// [`recover_anchor`](Rows::recover_anchor) (returning `first()`) is
+/// usually right.
+///
+/// Pick based on which property your UI wants to express: stable
+/// *position* (index) or stable *content reference* (identity).
 pub trait Rows {
     /// Stable identity of a row. `Clone` rather than `Copy` so non-`Copy`
     /// ids — `String` hashes, `Arc<Path>` keys, etc. — can be used
@@ -74,6 +192,21 @@ pub trait Rows {
 
     /// Hint that the row is about to enter the viewport. Default no-op.
     fn warm(&self, _id: &Self::RowId) {}
+
+    /// Called by the scroll area when a stored anchor is no longer in
+    /// the row sequence — i.e. the anchor's row has been removed and
+    /// neither `next` nor `prev` can locate it. The returned `RowId`
+    /// is placed at viewport top, then clamped against `max_offset`.
+    /// `None` means "drop the offset entirely" (treats rows as empty).
+    ///
+    /// Default returns `first()`, suitable for stable-id row impls
+    /// where a deleted anchor is genuinely gone and the user is best
+    /// returned to the top. Index-based impls (whose id "drifts" with
+    /// surrounding edits and only goes stale at the tail end) typically
+    /// override to return the new `last()`.
+    fn recover_anchor(&self, _stale: &Self::RowId) -> Option<Self::RowId> {
+        self.first()
+    }
 }
 
 /// Anchored scroll position. The top of the viewport sits at
@@ -103,6 +236,12 @@ impl<Id> Offset<Id> {
 // ============================================================================
 // Affine math (pure functions over Rows)
 // ============================================================================
+//
+// Cost-class invariant: every function in this module that calls
+// `rows.precise(id)` takes either a `bound: f32` (precise pixels) or
+// the equivalent budget as one of its inputs (`scroll_by`'s `delta`,
+// `normalize`'s row-shrink excess). No public function performs an
+// unbounded `precise()` walk.
 
 mod affine {
     use super::{Offset, Rows};
@@ -156,94 +295,116 @@ mod affine {
         }
     }
 
-    /// Signed precise-pixel distance from `a` to `b`. Positive if `b` is
-    /// below `a`. Returns `NaN` if `b`'s anchor isn't reachable.
-    pub fn signed_distance<R: Rows>(rows: &R, a: &Offset<R::RowId>, b: &Offset<R::RowId>) -> f32 {
-        if a.anchor == b.anchor {
-            return b.intra_precise - a.intra_precise;
-        }
-        let mut id = a.anchor.clone();
-        let mut dist = -a.intra_precise;
-        loop {
-            dist += rows.precise(&id);
-            match rows.next(&id) {
-                Some(next_id) => {
-                    if next_id == b.anchor {
-                        return dist + b.intra_precise;
-                    }
-                    id = next_id;
-                }
-                None => break,
-            }
-        }
-        let mut id = a.anchor.clone();
-        let mut dist = -a.intra_precise;
-        while let Some(prev_id) = rows.prev(&id) {
-            dist -= rows.precise(&prev_id);
-            if prev_id == b.anchor {
-                return dist + b.intra_precise;
-            }
-            id = prev_id;
-        }
-        f32::NAN
+    pub enum Direction {
+        Forward,
+        Backward,
     }
 
-    /// Like `signed_distance` but stops walking once cumulative distance
-    /// exceeds `bound` precise pixels. Used by `Reveal::Nearest` so
-    /// document size doesn't enter the cost.
-    pub fn signed_distance_bounded<R: Rows>(
-        rows: &R, a: &Offset<R::RowId>, b: &Offset<R::RowId>, bound: f32,
-    ) -> Option<f32> {
-        if a.anchor == b.anchor {
-            return Some(b.intra_precise - a.intra_precise);
+    /// Cheap structural probe — does not call `precise()`. Walks
+    /// forward and backward simultaneously from `a_anchor` until one
+    /// side hits `b_anchor`. Returns `None` if `b_anchor` isn't in the
+    /// row sequence.
+    pub fn probe_direction<R: Rows>(
+        rows: &R, a_anchor: &R::RowId, b_anchor: &R::RowId,
+    ) -> Option<Direction> {
+        if a_anchor == b_anchor {
+            return None;
         }
-        let mut id = a.anchor.clone();
-        let mut dist = -a.intra_precise;
+        let mut fwd = a_anchor.clone();
+        let mut bwd = a_anchor.clone();
+        let mut fwd_alive = true;
+        let mut bwd_alive = true;
+        while fwd_alive || bwd_alive {
+            if fwd_alive {
+                match rows.next(&fwd) {
+                    Some(next) if &next == b_anchor => return Some(Direction::Forward),
+                    Some(next) => fwd = next,
+                    None => fwd_alive = false,
+                }
+            }
+            if bwd_alive {
+                match rows.prev(&bwd) {
+                    Some(prev) if &prev == b_anchor => return Some(Direction::Backward),
+                    Some(prev) => bwd = prev,
+                    None => bwd_alive = false,
+                }
+            }
+        }
+        None
+    }
+
+    /// Precise-pixel distance forward from `from` to `to`, walking
+    /// `precise()` per row up to `bound` precise pixels. Returns
+    /// `None` if `to` isn't reached forward within `bound`.
+    pub fn precise_distance_forward<R: Rows>(
+        rows: &R, from: &Offset<R::RowId>, to: &Offset<R::RowId>, bound: f32,
+    ) -> Option<f32> {
+        if from.anchor == to.anchor {
+            let d = to.intra_precise - from.intra_precise;
+            return (d >= 0.0).then_some(d);
+        }
+        let mut id = from.anchor.clone();
+        let mut dist = -from.intra_precise;
         loop {
             dist += rows.precise(&id);
             if dist > bound {
-                break;
+                return None;
             }
             match rows.next(&id) {
                 Some(next_id) => {
-                    if next_id == b.anchor {
-                        return Some(dist + b.intra_precise);
+                    if next_id == to.anchor {
+                        return Some(dist + to.intra_precise);
                     }
                     id = next_id;
-                }
-                None => break,
-            }
-        }
-        let mut id = a.anchor.clone();
-        let mut dist = -a.intra_precise;
-        loop {
-            match rows.prev(&id) {
-                Some(prev_id) => {
-                    dist -= rows.precise(&prev_id);
-                    if dist < -bound {
-                        return None;
-                    }
-                    if prev_id == b.anchor {
-                        return Some(dist + b.intra_precise);
-                    }
-                    id = prev_id;
                 }
                 None => return None,
             }
         }
     }
 
-    pub fn midpoint<R: Rows>(
-        rows: &R, top: Offset<R::RowId>, bottom: Offset<R::RowId>,
-    ) -> Offset<R::RowId> {
-        let dist = signed_distance(rows, &top, &bottom);
-        scroll_by(rows, top, dist / 2.0)
+    /// Signed precise-pixel distance from `a` to `b`, bounded by
+    /// `bound`. Positive if `b` is below `a`. Returns `None` if `b`
+    /// isn't within `bound` of `a` in either direction, or if `b`'s
+    /// anchor isn't in the row sequence.
+    ///
+    /// Implementation: a cheap [`probe_direction`] (no `precise()`
+    /// calls) decides which side to walk, then exactly one
+    /// [`precise_distance_forward`] runs in that direction.
+    pub fn precise_distance<R: Rows>(
+        rows: &R, a: &Offset<R::RowId>, b: &Offset<R::RowId>, bound: f32,
+    ) -> Option<f32> {
+        if a.anchor == b.anchor {
+            let d = b.intra_precise - a.intra_precise;
+            return (d.abs() <= bound).then_some(d);
+        }
+        match probe_direction(rows, &a.anchor, &b.anchor)? {
+            Direction::Forward => precise_distance_forward(rows, a, b, bound),
+            Direction::Backward => precise_distance_forward(rows, b, a, bound).map(|d| -d),
+        }
     }
+
+    /// Offset whose distance from `top` equals its distance from
+    /// `bottom`. `None` if the rect is taller than `bound` precise
+    /// pixels — caller should fall back (e.g. align Top) since no
+    /// midpoint exists within the budget.
+    pub fn midpoint<R: Rows>(
+        rows: &R, top: Offset<R::RowId>, bottom: Offset<R::RowId>, bound: f32,
+    ) -> Option<Offset<R::RowId>> {
+        let dist = precise_distance(rows, &top, &bottom, bound)?;
+        Some(scroll_by(rows, top, dist / 2.0))
+    }
+
+    /// Allowed range for `approx / precise` per row in scrollbar math.
+    /// Out-of-band rows (zero-set agreement violated, or cheap
+    /// estimate is way off true layout) substitute the clamped slope
+    /// — scrollbar geometry drifts proportionally, scroll-input
+    /// fidelity is unaffected.
+    const SLOPE_BAND: (f32, f32) = (1e-3, 1e3);
 
     /// Position of the scroll thumb in approx coordinate. Walks rows
     /// above the anchor for cumulative approx; uses local slope inside
     /// the anchor row.
-    pub fn thumb_approx<R: Rows>(rows: &R, off: &Offset<R::RowId>, band: (f32, f32)) -> f32 {
+    pub fn thumb_approx<R: Rows>(rows: &R, off: &Offset<R::RowId>) -> f32 {
         let mut acc = 0.0;
         let mut id = off.anchor.clone();
         while let Some(prev_id) = rows.prev(&id) {
@@ -253,7 +414,7 @@ mod affine {
         let row_precise = rows.precise(&off.anchor);
         let row_approx = rows.approx(&off.anchor);
         let intra_approx = if row_precise > 0.0 {
-            let slope = (row_approx / row_precise).clamp(band.0, band.1);
+            let slope = (row_approx / row_precise).clamp(SLOPE_BAND.0, SLOPE_BAND.1);
             off.intra_precise * slope
         } else {
             0.0
@@ -262,9 +423,7 @@ mod affine {
     }
 
     /// Inverse of `thumb_approx`.
-    pub fn from_thumb<R: Rows>(
-        rows: &R, approx_pos: f32, band: (f32, f32),
-    ) -> Option<Offset<R::RowId>> {
+    pub fn from_thumb<R: Rows>(rows: &R, approx_pos: f32) -> Option<Offset<R::RowId>> {
         let first = rows.first()?;
         if approx_pos <= 0.0 {
             return Some(Offset::at_top_of(first));
@@ -277,7 +436,8 @@ mod affine {
                 let intra_approx = approx_pos - acc;
                 let row_precise = rows.precise(&id);
                 let intra_precise = if row_approx > 0.0 {
-                    let inv_slope = (row_precise / row_approx).clamp(1.0 / band.1, 1.0 / band.0);
+                    let inv_slope =
+                        (row_precise / row_approx).clamp(1.0 / SLOPE_BAND.1, 1.0 / SLOPE_BAND.0);
                     intra_approx * inv_slope
                 } else {
                     0.0
@@ -317,22 +477,8 @@ mod affine {
 }
 
 // ============================================================================
-// Public types: Action, VisibleRow, HitRow, Reveal, Align, Scrollbar, Config
+// Public types: Action, VisibleRow, HitRow, Reveal, Align, Scrollbar
 // ============================================================================
-
-#[derive(Debug, Clone, Copy)]
-pub struct Config {
-    /// Allowed range for `approx / precise` per row. Rows whose true
-    /// ratio is outside the band substitute the clamped slope in
-    /// scrollbar math. Scroll input fidelity is unaffected.
-    pub slope_band: (f32, f32),
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self { slope_band: (1e-3, 1e3) }
-    }
-}
 
 #[derive(Debug, Clone)]
 pub enum Action {
@@ -454,7 +600,6 @@ pub struct ScrollArea<Id: Clone + Eq + std::fmt::Debug> {
     /// which projects onto current rows.
     stored_offset: Option<Offset<Id>>,
     pub viewport_height: f32,
-    pub config: Config,
     /// Touch-scroll velocity (precise px/sec). Positive = content moving
     /// up on screen.
     velocity_precise: f32,
@@ -471,7 +616,6 @@ impl<Id: Clone + Eq + std::fmt::Debug> Default for ScrollArea<Id> {
         Self {
             stored_offset: None,
             viewport_height: 0.0,
-            config: Config::default(),
             velocity_precise: 0.0,
             drag_window: [(0.0, 0.0); DRAG_WINDOW_LEN],
             drag_window_idx: 0,
@@ -504,11 +648,13 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
     ///   `precise(anchor)` below stored `intra_precise`) → walk forward
     ///   by the excess. Patch-through, not clamp.
     pub fn offset<R: Rows<RowId = Id>>(&self, rows: &R) -> Option<Offset<Id>> {
-        let stored = match &self.stored_offset {
-            Some(off) if Self::anchor_valid(rows, &off.anchor) => off.clone(),
-            _ => return rows.first().map(Offset::at_top_of),
-        };
-        Some(Self::normalize(rows, stored))
+        match &self.stored_offset {
+            Some(off) if Self::anchor_valid(rows, &off.anchor) => {
+                Some(Self::normalize(rows, off.clone()))
+            }
+            Some(off) => rows.recover_anchor(&off.anchor).map(Offset::at_top_of),
+            None => rows.first().map(Offset::at_top_of),
+        }
     }
 
     fn normalize<R: Rows<RowId = Id>>(rows: &R, mut off: Offset<Id>) -> Offset<Id> {
@@ -565,8 +711,14 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
         };
         let intra_precise = rows.precise(&last);
         let last_bottom = Offset { anchor: last, intra_precise };
-        let dist_to_end = affine::signed_distance(rows, &off, &last_bottom);
-        if dist_to_end < self.viewport_height { max } else { off }
+        // Directed walk: `last_bottom` is forward of any valid offset
+        // by construction. Bounded by viewport_height — past that we
+        // know there's enough content below to fill the viewport, so
+        // no clamp is needed.
+        match affine::precise_distance_forward(rows, &off, &last_bottom, self.viewport_height) {
+            Some(dist) if dist < self.viewport_height => max,
+            _ => off,
+        }
     }
 
     pub fn total_approx<R: Rows<RowId = Id>>(&self, rows: &R) -> f32 {
@@ -575,15 +727,18 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
 
     pub fn thumb_approx<R: Rows<RowId = Id>>(&self, rows: &R) -> f32 {
         match self.offset(rows) {
-            Some(off) => affine::thumb_approx(rows, &off, self.config.slope_band),
+            Some(off) => affine::thumb_approx(rows, &off),
             None => 0.0,
         }
     }
 
-    pub fn signed_distance<R: Rows<RowId = Id>>(
-        &self, rows: &R, a: &Offset<Id>, b: &Offset<Id>,
-    ) -> f32 {
-        affine::signed_distance(rows, a, b)
+    /// Signed precise-pixel distance from `a` to `b`, bounded by
+    /// `bound`. Positive if `b` is below `a`. Returns `None` if `b`
+    /// isn't within `bound` in either direction.
+    pub fn precise_distance<R: Rows<RowId = Id>>(
+        &self, rows: &R, a: &Offset<Id>, b: &Offset<Id>, bound: f32,
+    ) -> Option<f32> {
+        affine::precise_distance(rows, a, b, bound)
     }
 
     /// The [`Offset`] corresponding to the given viewport-local y. Walks
@@ -644,17 +799,28 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
         }
     }
 
-    /// Place the offset at a specific anchor + intra-row precise. The
-    /// anchor must currently be in rows; otherwise no-op. Result clamps
-    /// so the document still fills the viewport.
+    /// Place the offset at a specific anchor + intra-row precise.
+    /// Result clamps so the document still fills the viewport.
     ///
-    /// Cancels touch-scroll momentum so a programmatic jump isn't fought
-    /// by a coasting flick.
+    /// If the caller's anchor isn't in the row sequence (e.g., a
+    /// persisted index referring to a row that's since been deleted),
+    /// runs [`Rows::recover_anchor`] to obtain a replacement anchor
+    /// and places at its top. Returns silently if rows is empty or
+    /// recovery returns `None`.
+    ///
+    /// Cancels touch-scroll momentum so a programmatic jump isn't
+    /// fought by a coasting flick.
     pub fn set_offset<R: Rows<RowId = Id>>(&mut self, rows: &R, off: Offset<Id>) {
-        if Self::anchor_valid(rows, &off.anchor) {
-            self.stored_offset = Some(self.clamp_to_max(rows, off));
-            self.kill_momentum();
-        }
+        let off = if Self::anchor_valid(rows, &off.anchor) {
+            off
+        } else {
+            match rows.recover_anchor(&off.anchor) {
+                Some(recovered) => Offset::at_top_of(recovered),
+                None => return,
+            }
+        };
+        self.stored_offset = Some(self.clamp_to_max(rows, off));
+        self.kill_momentum();
     }
 
     /// Process an [`Action`]. Stale anchors recover via `offset()` first.
@@ -669,8 +835,7 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
             Action::ScrollByThumb(delta) => {
                 if self.offset(rows).is_some() {
                     let target = self.thumb_approx(rows) + delta;
-                    if let Some(new_off) = affine::from_thumb(rows, target, self.config.slope_band)
-                    {
+                    if let Some(new_off) = affine::from_thumb(rows, target) {
                         self.stored_offset = Some(self.clamp_to_max(rows, new_off));
                     }
                 }
@@ -703,8 +868,12 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
             Align::Top => rect.top,
             Align::Bottom => affine::scroll_by(rows, rect.bottom, -self.viewport_height),
             Align::Center => {
-                let mid = affine::midpoint(rows, rect.top, rect.bottom);
-                affine::scroll_by(rows, mid, -self.viewport_height / 2.0)
+                // Rect taller than viewport has no meaningful center
+                // anchor inside the viewport; degrade to Top.
+                match affine::midpoint(rows, rect.top.clone(), rect.bottom, self.viewport_height) {
+                    Some(mid) => affine::scroll_by(rows, mid, -self.viewport_height / 2.0),
+                    None => rect.top,
+                }
             }
             Align::Nearest => {
                 let Some(target) = self.nearest_target(rows, rect) else {
@@ -722,11 +891,10 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
         let current = self.offset(rows)?;
         let bound = self.viewport_height;
 
-        let y_top = affine::signed_distance_bounded(rows, &current, &rect.top, bound);
-        let y_bot = affine::signed_distance_bounded(rows, &current, &rect.bottom, bound);
+        let y_top = affine::precise_distance(rows, &current, &rect.top, bound);
+        let y_bot = affine::precise_distance(rows, &current, &rect.bottom, bound);
 
-        let rect_height =
-            affine::signed_distance_bounded(rows, &rect.top, &rect.bottom, bound + 1.0);
+        let rect_height = affine::precise_distance(rows, &rect.top, &rect.bottom, bound + 1.0);
         let rect_taller_than_viewport = rect_height.map(|h| h > bound).unwrap_or(true);
 
         if rect_taller_than_viewport {
@@ -758,11 +926,13 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
                 }
             }
             (None, None) => {
-                let signed = affine::signed_distance(rows, &current, &rect.top);
-                if signed.is_nan() || signed < 0.0 {
-                    Some(rect.top)
-                } else {
-                    Some(affine::scroll_by(rows, rect.bottom, -bound))
+                // Both endpoints are far away; only direction matters.
+                // No `precise()` needed.
+                match affine::probe_direction(rows, &current.anchor, &rect.top.anchor) {
+                    Some(affine::Direction::Forward) => {
+                        Some(affine::scroll_by(rows, rect.bottom, -bound))
+                    }
+                    _ => Some(rect.top),
                 }
             }
         }
@@ -779,7 +949,7 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
         let thumb_pos = self.thumb_approx(rows);
         let scrollable_approx = self
             .max_offset(rows)
-            .map(|off| affine::thumb_approx(rows, &off, self.config.slope_band))
+            .map(|off| affine::thumb_approx(rows, &off))
             .unwrap_or(0.0);
         let visible_fraction =
             if total > 0.0 { ((total - scrollable_approx) / total).clamp(0.0, 1.0) } else { 1.0 };
@@ -825,85 +995,64 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
 // Egui adapter
 // ============================================================================
 
-/// Egui adapter: persists a [`ScrollArea<Id>`] in egui memory keyed by
-/// `id_salt` and layers wheel / touch-drag / scrollbar-drag input plus
-/// momentum on top.
-pub struct AffineScrollArea<Id> {
+/// Egui adapter that owns a [`ScrollArea<Id>`] and layers wheel /
+/// touch-drag / scrollbar-drag input plus momentum on top. Embed this
+/// directly in the type that owns the scrollable view; it persists
+/// state across frames as a plain field.
+pub struct AffineScrollArea<Id: Clone + Eq + std::fmt::Debug> {
+    pub state: ScrollArea<Id>,
+    /// When true, drag on the body (not just the scrollbar) scrolls
+    /// the content with momentum. Intended for touch input.
+    pub touch_scroll: bool,
+    /// Salt for the scrollbar's interact rect — must be stable across
+    /// frames and unique among visible scroll areas.
     id_salt: egui::Id,
-    /// When true, drag on the body (not just the scrollbar) scrolls the
-    /// content with momentum. Intended for touch input.
-    touch_scroll: bool,
-    _phantom: PhantomData<Id>,
 }
 
-impl<Id> AffineScrollArea<Id>
-where
-    Id: Clone + Eq + std::fmt::Debug + Send + Sync + 'static,
-{
+impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
     pub fn new(id_salt: impl Hash) -> Self {
-        Self { id_salt: egui::Id::new(id_salt), touch_scroll: false, _phantom: PhantomData }
-    }
-
-    pub fn touch_scroll(mut self, enabled: bool) -> Self {
-        self.touch_scroll = enabled;
-        self
-    }
-
-    /// Snapshot the persisted state. Cheap clone of POD + the optional
-    /// offset.
-    pub fn state(&self, ctx: &egui::Context) -> ScrollArea<Id> {
-        ctx.data(|d| d.get_temp::<ScrollArea<Id>>(self.id_salt))
-            .unwrap_or_default()
-    }
-
-    fn write_state(&self, ctx: &egui::Context, state: ScrollArea<Id>) {
-        ctx.data_mut(|d| d.insert_temp(self.id_salt, state));
+        Self {
+            state: ScrollArea::default(),
+            touch_scroll: false,
+            id_salt: egui::Id::new(id_salt),
+        }
     }
 
     /// Touch-scroll velocity (precise px/sec). y is vertical; x is
     /// always 0. Non-zero while momentum is in flight.
-    pub fn velocity(&self, ctx: &egui::Context) -> Vec2 {
-        self.state(ctx).velocity()
+    pub fn velocity(&self) -> Vec2 {
+        self.state.velocity()
     }
 
     /// Raw persisted offset for change-detection (no row projection).
-    /// Cheap egui-memory read.
-    pub fn stored_offset(&self, ctx: &egui::Context) -> Option<Offset<Id>> {
-        self.state(ctx).stored_offset()
+    pub fn stored_offset(&self) -> Option<Offset<Id>> {
+        self.state.stored_offset()
     }
 
     /// Current offset projected onto the given rows, or `None` if rows
     /// is empty.
-    pub fn offset<R: Rows<RowId = Id>>(&self, ctx: &egui::Context, rows: &R) -> Option<Offset<Id>> {
-        self.state(ctx).offset(rows)
+    pub fn offset<R: Rows<RowId = Id>>(&self, rows: &R) -> Option<Offset<Id>> {
+        self.state.offset(rows)
     }
 
     /// Set offset directly. Cancels touch-scroll momentum.
-    pub fn set_offset<R: Rows<RowId = Id>>(&self, ctx: &egui::Context, rows: &R, off: Offset<Id>) {
-        let mut state = self.state(ctx);
-        state.set_offset(rows, off);
-        self.write_state(ctx, state);
-        ctx.request_repaint();
+    pub fn set_offset<R: Rows<RowId = Id>>(&mut self, rows: &R, off: Offset<Id>) {
+        self.state.set_offset(rows, off);
     }
 
     /// Reveal a rect with the given alignment.
-    pub fn reveal<R: Rows<RowId = Id>>(
-        &self, ctx: &egui::Context, rows: &R, rect: Reveal<Id>, align: Align,
-    ) {
-        let mut state = self.state(ctx);
-        state.reveal(rows, rect, align);
-        self.write_state(ctx, state);
-        ctx.request_repaint();
+    pub fn reveal<R: Rows<RowId = Id>>(&mut self, rows: &R, rect: Reveal<Id>, align: Align) {
+        self.state.reveal(rows, rect, align);
     }
 
     /// Per-frame: allocate body + scrollbar hit areas, process input,
-    /// draw scrollbar, return body Response + visible rows. Caller paints
-    /// rows into `body` using the returned `top` offsets.
+    /// draw scrollbar, return body Response + visible rows. Caller
+    /// paints rows into the body using the returned `top` offsets.
     ///
-    /// Walks rows in a viewport-sized window above and below the visible
-    /// region, calling [`Rows::warm`] on each so impls can kick off
-    /// background work for rows about to enter view.
-    pub fn show<R: Rows<RowId = Id>>(&self, ui: &mut Ui, rows: &R) -> ShowResponse<Id> {
+    /// Walks rows in a viewport-sized window above and below the
+    /// visible region, calling [`Rows::warm`] on each so impls can
+    /// kick off background work for rows about to enter view.
+    pub fn show<R: Rows<RowId = Id>>(&mut self, ui: &mut Ui, rows: &R) -> ShowResponse<Id> {
         let rect = ui.max_rect();
         let body_sense = if self.touch_scroll { Sense::click_and_drag() } else { Sense::hover() };
         let response = ui.allocate_rect(rect, body_sense);
@@ -918,15 +1067,13 @@ where
         let bar_id = self.id_salt.with("scrollbar");
         let bar_response = ui.interact(bar_track, bar_id, Sense::click_and_drag());
 
-        let mut state = self.state(ui.ctx());
-        state.handle(rows, Action::Resize(rect.height()));
+        self.state.handle(rows, Action::Resize(rect.height()));
 
-        // Geometry-only snapshot before input — `scrollable_approx` is
-        // a function of (rows, viewport_height, slope_band), independent
-        // of the current offset, so this stays valid through input
-        // processing. Used both to size scrollbar-drag math and to gate
-        // touch-body-drag.
-        let bar_geom = state.scrollbar(rows, bar_track);
+        // `scrollable_approx` is a function of (rows, viewport_height,
+        // slope_band), independent of the current offset, so this
+        // snapshot stays valid through input processing. Used both to
+        // size scrollbar-drag math and to gate touch-body-drag.
+        let bar_geom = self.state.scrollbar(rows, bar_track);
         let scrollable = bar_geom.scrollable_approx > 0.0;
 
         // Wheel: precise pixels. egui convention: positive y = scroll up
@@ -935,36 +1082,36 @@ where
         let raw_scroll_delta =
             if ui.rect_contains_pointer(rect) { ui.input(|i| i.raw_scroll_delta.y) } else { 0.0 };
         if raw_scroll_delta != 0.0 {
-            state.handle(rows, Action::ScrollByPixels(-raw_scroll_delta));
+            self.state.handle(rows, Action::ScrollByPixels(-raw_scroll_delta));
         }
 
         // Touch body drag → scroll + velocity tracking.
         let dt = ui.input(|i| i.stable_dt).max(0.0001);
         if scrollable && self.touch_scroll && response.drag_started() {
-            state.kill_momentum();
+            self.state.kill_momentum();
         }
         if scrollable && self.touch_scroll && response.dragged() {
             let drag_y = ui.input(|i| i.pointer.delta().y);
             let precise_delta = -drag_y;
-            state.handle(rows, Action::ScrollByPixels(precise_delta));
-            state.record_drag_sample(precise_delta, dt);
-        } else if state.velocity_precise.abs() > 1.0 && !response.dragged() {
+            self.state.handle(rows, Action::ScrollByPixels(precise_delta));
+            self.state.record_drag_sample(precise_delta, dt);
+        } else if self.state.velocity_precise.abs() > 1.0 && !response.dragged() {
             const DECAY_PER_SEC: f32 = 4.0;
-            let precise_step = state.velocity_precise * dt;
-            let before = state.offset(rows);
-            state.handle(rows, Action::ScrollByPixels(precise_step));
-            let after = state.offset(rows);
+            let precise_step = self.state.velocity_precise * dt;
+            let before = self.state.offset(rows);
+            self.state.handle(rows, Action::ScrollByPixels(precise_step));
+            let after = self.state.offset(rows);
             if before == after {
-                state.velocity_precise = 0.0;
+                self.state.velocity_precise = 0.0;
             } else {
-                state.velocity_precise *= (-DECAY_PER_SEC * dt).exp();
+                self.state.velocity_precise *= (-DECAY_PER_SEC * dt).exp();
             }
             ui.ctx().request_repaint();
         } else {
-            state.velocity_precise = 0.0;
+            self.state.velocity_precise = 0.0;
         }
         if self.touch_scroll && response.clicked() {
-            state.velocity_precise = 0.0;
+            self.state.velocity_precise = 0.0;
         }
 
         // Scrollbar drag/click. Drag deltas use the pre-input geometry
@@ -975,7 +1122,7 @@ where
             if bar_response.dragged() {
                 let drag_y = ui.input(|i| i.pointer.delta().y);
                 let approx_delta = bar_geom.pixel_to_approx(drag_y);
-                state.handle(rows, Action::ScrollByThumb(approx_delta));
+                self.state.handle(rows, Action::ScrollByThumb(approx_delta));
             } else if let Some(pos) = bar_response.interact_pointer_pos() {
                 let movable = bar_geom.track.height() - bar_geom.thumb.height();
                 let target_thumb_top =
@@ -987,19 +1134,17 @@ where
                     0.0
                 };
                 let delta = target_approx - bar_geom.thumb_approx;
-                state.handle(rows, Action::ScrollByThumb(delta));
+                self.state.handle(rows, Action::ScrollByThumb(delta));
             }
         }
 
-        let visible = state.visible(rows);
+        let visible = self.state.visible(rows);
         warm_around_visible(rows, &visible, rect.height());
 
         if scrollable {
-            let bar_after = state.scrollbar(rows, bar_track);
+            let bar_after = self.state.scrollbar(rows, bar_track);
             draw_scrollbar(ui, bar_after);
         }
-
-        self.write_state(ui.ctx(), state);
 
         ShowResponse { response, visible }
     }

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -474,6 +474,33 @@ mod affine {
             }
         }
     }
+
+    /// Approx-coordinate extent of one viewport's worth of content
+    /// starting from `first()`. Used as the thumb-sizing numerator —
+    /// gives a stable, scroll-position-independent measure of "how
+    /// much approx fits in a viewport". Bounded precise walk.
+    pub fn viewport_extent_in_approx<R: Rows>(rows: &R, viewport_height: f32) -> f32 {
+        let Some(mut id) = rows.first() else {
+            return 0.0;
+        };
+        let mut precise_acc = 0.0;
+        let mut approx_acc = 0.0;
+        loop {
+            let p = rows.precise(&id);
+            let a = rows.approx(&id);
+            if precise_acc + p >= viewport_height {
+                let remaining = viewport_height - precise_acc;
+                let slope = if p > 0.0 { a / p } else { 0.0 };
+                return approx_acc + remaining * slope;
+            }
+            precise_acc += p;
+            approx_acc += a;
+            match rows.next(&id) {
+                Some(next_id) => id = next_id,
+                None => return approx_acc,
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -951,8 +978,18 @@ impl<Id: Clone + Eq + std::fmt::Debug> ScrollArea<Id> {
             .max_offset(rows)
             .map(|off| affine::thumb_approx(rows, &off))
             .unwrap_or(0.0);
+        // Geometric model: thumb top travels [0, scrollable_approx],
+        // thumb body extends viewport_approx below it, so thumb bottom
+        // travels [viewport_approx, scrollable_approx + viewport_approx].
+        // The track represents that full range, so:
+        //     visible_fraction = viewport_approx / (scrollable_approx + viewport_approx)
+        // Edges: scrollable=0 → fraction=1 (thumb fills track). Doc
+        // shorter than viewport but pad makes things scrollable →
+        // scrollable>0, fraction<1 (thumb correctly shows headroom).
+        let viewport_approx = affine::viewport_extent_in_approx(rows, self.viewport_height);
+        let denom = scrollable_approx + viewport_approx;
         let visible_fraction =
-            if total > 0.0 { ((total - scrollable_approx) / total).clamp(0.0, 1.0) } else { 1.0 };
+            if denom > 0.0 { (viewport_approx / denom).clamp(0.0, 1.0) } else { 1.0 };
         let thumb_h = (track.height() * visible_fraction)
             .max(MIN_THUMB_PX)
             .min(track.height());
@@ -1141,12 +1178,10 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         let visible = self.state.visible(rows);
         warm_around_visible(rows, &visible, rect.height());
 
-        if scrollable {
-            let bar_after = self.state.scrollbar(rows, bar_track);
-            draw_scrollbar(ui, bar_after);
-        }
+        let bar_after = self.state.scrollbar(rows, bar_track);
+        draw_scrollbar(ui, bar_after);
 
-        ShowResponse { response, visible }
+        ShowResponse { response, visible, scrollbar_track: bar_track }
     }
 }
 
@@ -1159,6 +1194,11 @@ pub struct ShowResponse<Id> {
     /// Visible rows top-down. `top` is viewport-local; add `viewport.min.y`
     /// for screen coordinates.
     pub visible: Vec<VisibleRow<Id>>,
+    /// Track rect of the rendered scrollbar (window-local pixels).
+    /// Embedders register this with their touch-consuming surface so
+    /// taps on the scrollbar don't fall through to other touch handlers
+    /// (cursor placement, virtual keyboard).
+    pub scrollbar_track: Rect,
 }
 
 fn warm_around_visible<R: Rows>(rows: &R, visible: &[VisibleRow<R::RowId>], viewport_height: f32) {

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1078,6 +1078,18 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         self.state.reveal(rows, rect, align);
     }
 
+    /// Allocate the body's drag rect. Caller paints content widgets
+    /// between `begin` and [`AffineScrollAreaBegun::finish`]; those
+    /// land at higher z than the body, so click senses on the content
+    /// (e.g. cursor placement) win over the body's drag — see egui's
+    /// `hit_test`.
+    pub fn begin(&self, ui: &mut Ui) -> AffineScrollAreaBegun {
+        let rect = ui.max_rect();
+        let body_sense = if self.touch_scroll { Sense::drag() } else { Sense::hover() };
+        let body_response = ui.allocate_rect(rect, body_sense);
+        AffineScrollAreaBegun { rect, body_response }
+    }
+
     /// Per-frame: allocate body + scrollbar hit areas, process input,
     /// draw scrollbar, return body Response + visible rows. Caller
     /// paints rows into the body using the returned `top` offsets.
@@ -1086,12 +1098,17 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
     /// visible region, calling [`Rows::warm`] on each so impls can
     /// kick off background work for rows about to enter view.
     pub fn show<R: Rows<RowId = Id>>(&mut self, ui: &mut Ui, rows: &R) -> ShowResponse<Id> {
-        let rect = ui.max_rect();
-        let body_sense = if self.touch_scroll { Sense::click_and_drag() } else { Sense::hover() };
-        let response = ui.allocate_rect(rect, body_sense);
+        let begun = self.begin(ui);
+        self.finish(ui, begun, rows)
+    }
 
-        // Scrollbar hit area registered AFTER the body so it shadows
-        // body hover in z-order.
+    pub fn finish<R: Rows<RowId = Id>>(
+        &mut self, ui: &mut Ui, begun: AffineScrollAreaBegun, rows: &R,
+    ) -> ShowResponse<Id> {
+        let AffineScrollAreaBegun { rect, body_response: response } = begun;
+
+        // Scrollbar hit area registered after content so it shadows
+        // both the body and any embedder click rects in z-order.
         const BAR_WIDTH: f32 = 10.0;
         const BAR_INSET: f32 = 3.0;
         let bar_x = rect.max.x - BAR_WIDTH - BAR_INSET;
@@ -1146,7 +1163,11 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         } else {
             self.state.velocity_precise = 0.0;
         }
-        if self.touch_scroll && response.clicked() {
+        // Tap kills momentum without claiming the click.
+        let pressed_in_rect = ui.input(|i| {
+            i.pointer.any_pressed() && i.pointer.press_origin().is_some_and(|p| rect.contains(p))
+        });
+        if self.touch_scroll && pressed_in_rect {
             self.state.velocity_precise = 0.0;
         }
 
@@ -1198,6 +1219,13 @@ pub struct ShowResponse<Id> {
     /// taps on the scrollbar don't fall through to other touch handlers
     /// (cursor placement, virtual keyboard).
     pub scrollbar_track: Rect,
+}
+
+/// Returned by [`AffineScrollArea::begin`]; pass to `finish` after
+/// allocating content widgets.
+pub struct AffineScrollAreaBegun {
+    rect: Rect,
+    body_response: Response,
 }
 
 fn warm_around_visible<R: Rows>(rows: &R, visible: &[VisibleRow<R::RowId>], viewport_height: f32) {

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1048,11 +1048,7 @@ pub struct AffineScrollArea<Id: Clone + Eq + std::fmt::Debug> {
 
 impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
     pub fn new(id_salt: impl Hash) -> Self {
-        Self {
-            state: ScrollArea::default(),
-            touch_scroll: false,
-            id_salt: egui::Id::new(id_salt),
-        }
+        Self { state: ScrollArea::default(), touch_scroll: false, id_salt: egui::Id::new(id_salt) }
     }
 
     /// Touch-scroll velocity (precise px/sec). y is vertical; x is
@@ -1119,7 +1115,8 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         let raw_scroll_delta =
             if ui.rect_contains_pointer(rect) { ui.input(|i| i.raw_scroll_delta.y) } else { 0.0 };
         if raw_scroll_delta != 0.0 {
-            self.state.handle(rows, Action::ScrollByPixels(-raw_scroll_delta));
+            self.state
+                .handle(rows, Action::ScrollByPixels(-raw_scroll_delta));
         }
 
         // Touch body drag → scroll + velocity tracking.
@@ -1130,13 +1127,15 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         if scrollable && self.touch_scroll && response.dragged() {
             let drag_y = ui.input(|i| i.pointer.delta().y);
             let precise_delta = -drag_y;
-            self.state.handle(rows, Action::ScrollByPixels(precise_delta));
+            self.state
+                .handle(rows, Action::ScrollByPixels(precise_delta));
             self.state.record_drag_sample(precise_delta, dt);
         } else if self.state.velocity_precise.abs() > 1.0 && !response.dragged() {
             const DECAY_PER_SEC: f32 = 4.0;
             let precise_step = self.state.velocity_precise * dt;
             let before = self.state.offset(rows);
-            self.state.handle(rows, Action::ScrollByPixels(precise_step));
+            self.state
+                .handle(rows, Action::ScrollByPixels(precise_step));
             let after = self.state.offset(rows);
             if before == after {
                 self.state.velocity_precise = 0.0;

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -1184,9 +1184,27 @@ impl WsPersistentStore {
         let data = self.data.clone();
         let path = self.path.clone();
         spawn!({
+            let started = web_time::Instant::now();
             let data = data.read().unwrap().clone(); // clone to avoid holding lock during serialization or file write
             let content = serde_json::to_string(&data).unwrap();
-            let _ = fs::write(path, content);
+            let bytes = content.len();
+            match fs::write(&path, content) {
+                Ok(()) if started.elapsed() > Duration::from_millis(50) => {
+                    warn!(?path, bytes, "ws persistence written ({:?})", started.elapsed());
+                }
+                Ok(()) => {
+                    debug!(?path, bytes, "ws persistence written ({:?})", started.elapsed());
+                }
+                Err(err) => {
+                    error!(
+                        ?path,
+                        bytes,
+                        "ws persistence write failed ({:?}): {:?}",
+                        started.elapsed(),
+                        err
+                    );
+                }
+            }
         });
     }
 }


### PR DESCRIPTION
QA Checklist:

### Scroll input
- [x] Wheel / trackpad scroll at reasonable speed
- [x] Touch mode drag moves 1:1 with finger
- [x] Touch mode drag has momentum
- [x] Momentum cancels on tap
- [x] Momentum cancels on another drag
- [x] Momentum stays within doc bounds
- [x] Tap-to-cancel-momentum doesn't also place cursor
- [x] Scrollbar thumb movement adjusts scroll
- [x] Scrollbar track click snaps so thumb center lands at the click

<details>
<summary>Desktop</summary>

https://github.com/user-attachments/assets/30716c22-4cb0-493d-aae4-de1240ea4124

</details>

<details>
<summary>Mobile</summary>

https://github.com/user-attachments/assets/efc6ff6c-3154-44ab-a1d2-e00eb4efe39d

</details>

### Programmatic positioning
- [x] Cursor scroll is minimum to reveal cursor from top or bottom
- [x] Cursor scroll is no-op when cursor already visible
- [x] Find matches centered
- [x] Programmatic positioning stays within doc bounds

<details>
<summary>Desktop</summary>

https://github.com/user-attachments/assets/e7d41b41-569e-43f7-ab29-f82321175c9e

</details>

<details>
<summary>Details</summary>

https://github.com/user-attachments/assets/95bcfc4b-744f-4eec-9b96-6b4227313c60

</details>

### Rendering
- [x] Everything looks normal
- [x] Images appear to be already-loaded when scrolling at "reasonable" speed (cache warming)

<details>
<summary>Desktop</summary>

https://github.com/user-attachments/assets/66165146-2dd1-471c-a352-906ac4bdb7c6

</details>

### Scrollbar
- [x] Thumb size proportional to visible fraction
- [x] Thumb size floors at reasonable min size
- [x] Thumb fills track when the doc fits in the viewport
- [x] Thumb position approximately proportional to scroll progress

<details>
<summary>Desktop</summary>

https://github.com/user-attachments/assets/2bc11093-f0b8-4c81-ae0e-38f918ab90cb

</details>

### Persistence
- [x] Scroll is persisted
- [x] Scroll persistence reasonable when opening to new window width
- [x] Scroll persistence reasonable when doc has been edited

### Performance
- [x] Opening a reasonable size doc does not perceptibly hang the UI (tested 100KB on my M3 Max)