### PR TITLE
md: layout update fixes

### DIFF
--- a/libs/content/workspace/src/lib.rs
+++ b/libs/content/workspace/src/lib.rs
@@ -5,6 +5,7 @@ pub mod landing;
 pub mod mind_map;
 pub mod output;
 pub mod resolvers;
+pub mod seq;
 pub mod show;
 pub mod space_inspector;
 pub mod tab;

--- a/libs/content/workspace/src/resolvers/embed.rs
+++ b/libs/content/workspace/src/resolvers/embed.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use egui::{Rect, Ui, Vec2};
 
 /// Resolves embedded content (images, etc.) for the markdown editor.
@@ -16,9 +14,6 @@ pub trait EmbedResolver {
 
     /// Increment this to signal when any return value could change.
     fn seq(&self) -> u64;
-
-    /// Temporary hack that supports persisting image dimensions.
-    fn image_dims(&self) -> HashMap<String, [f32; 2]>;
 }
 
 impl EmbedResolver for () {
@@ -29,8 +24,5 @@ impl EmbedResolver for () {
     fn warm(&self, _url: &str) {}
     fn seq(&self) -> u64 {
         0
-    }
-    fn image_dims(&self) -> HashMap<String, [f32; 2]> {
-        HashMap::new()
     }
 }

--- a/libs/content/workspace/src/resolvers/embed.rs
+++ b/libs/content/workspace/src/resolvers/embed.rs
@@ -3,13 +3,21 @@ use std::collections::HashMap;
 use egui::{Rect, Ui, Vec2};
 
 /// Resolves embedded content (images, etc.) for the markdown editor.
-/// The editor calls `size` during layout and `show` during rendering.
-/// `()` is the no-op implementation.
 pub trait EmbedResolver {
+    /// Returns the size of the content at the url.
     fn size(&self, url: &str) -> Vec2;
+
+    /// Shows the content in the provided Ui at the provided Rect.
     fn show(&self, ui: &mut Ui, url: &str, rect: Rect);
+
+    /// Called per-frame while content may be shown soon so loading can start
+    /// before it's time to show.
     fn warm(&self, url: &str);
-    fn last_modified(&self) -> u64;
+
+    /// Increment this to signal when any return value could change.
+    fn seq(&self) -> u64;
+
+    /// Temporary hack that supports persisting image dimensions.
     fn image_dims(&self) -> HashMap<String, [f32; 2]>;
 }
 
@@ -19,7 +27,7 @@ impl EmbedResolver for () {
     }
     fn show(&self, _ui: &mut Ui, _url: &str, _rect: Rect) {}
     fn warm(&self, _url: &str) {}
-    fn last_modified(&self) -> u64 {
+    fn seq(&self) -> u64 {
         0
     }
     fn image_dims(&self) -> HashMap<String, [f32; 2]> {

--- a/libs/content/workspace/src/resolvers/image_embed.rs
+++ b/libs/content/workspace/src/resolvers/image_embed.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
 use std::ops::Deref as _;
-use std::sync::Mutex;
 
 use egui::{
     Align2, Color32, CursorIcon, FontId, Id, OpenUrl, Pos2, Rect, Sense, Stroke, Ui, UiBuilder,
@@ -17,29 +15,17 @@ use crate::widgets::image_cache::{ImageCache, ImageState};
 pub struct ImageEmbedResolver {
     images: ImageCache,
     file_id: Uuid,
-    dims: Mutex<HashMap<String, Vec2>>,
 }
 
 impl ImageEmbedResolver {
-    pub fn new(
-        images: ImageCache, file_id: Uuid, persisted_dims: HashMap<String, [f32; 2]>,
-    ) -> Self {
-        let dims = persisted_dims
-            .into_iter()
-            .map(|(url, [w, h])| (url, Vec2::new(w, h)))
-            .collect();
-        Self { images, file_id, dims: Mutex::new(dims) }
+    pub fn new(images: ImageCache, file_id: Uuid) -> Self {
+        Self { images, file_id }
     }
 }
 
 impl EmbedResolver for ImageEmbedResolver {
     fn size(&self, url: &str) -> Vec2 {
-        self.dims
-            .lock()
-            .unwrap()
-            .get(url)
-            .copied()
-            .unwrap_or(Vec2::splat(200.))
+        self.images.dims(url).unwrap_or(Vec2::splat(200.))
     }
 
     fn show(&self, ui: &mut Ui, url: &str, rect: Rect) {
@@ -50,15 +36,6 @@ impl EmbedResolver for ImageEmbedResolver {
                 show_placeholder(ui, rect, Icon::IMAGE, "Loading image...");
             }
             ImageState::Loaded(texture_id) => {
-                let [w, h] = ui.ctx().tex_manager().read().meta(texture_id).unwrap().size;
-                let dims = Vec2::new(w as f32, h as f32);
-                {
-                    let mut cache = self.dims.lock().unwrap();
-                    if cache.get(url) != Some(&dims) {
-                        cache.insert(url.to_string(), dims);
-                    }
-                }
-
                 let resp = ui.interact(rect, Id::new(texture_id), Sense::click());
                 if resp.hovered() {
                     ui.output_mut(|o| o.cursor_icon = CursorIcon::PointingHand);
@@ -84,36 +61,11 @@ impl EmbedResolver for ImageEmbedResolver {
     }
 
     fn warm(&self, url: &str) {
-        let state = self.images.get_or_load(url, self.file_id, false);
-        let guard = state.lock().unwrap();
-        if let ImageState::Loaded(texture_id) = *guard {
-            let [w, h] = self
-                .images
-                .ctx()
-                .tex_manager()
-                .read()
-                .meta(texture_id)
-                .unwrap()
-                .size;
-            let dims = Vec2::new(w as f32, h as f32);
-            let mut cache = self.dims.lock().unwrap();
-            if cache.get(url) != Some(&dims) {
-                cache.insert(url.to_string(), dims);
-            }
-        }
+        self.images.get_or_load(url, self.file_id, false);
     }
 
     fn seq(&self) -> u64 {
         self.images.seq()
-    }
-
-    fn image_dims(&self) -> HashMap<String, [f32; 2]> {
-        self.dims
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(url, v)| (url.clone(), [v.x, v.y]))
-            .collect()
     }
 }
 

--- a/libs/content/workspace/src/resolvers/image_embed.rs
+++ b/libs/content/workspace/src/resolvers/image_embed.rs
@@ -103,8 +103,8 @@ impl EmbedResolver for ImageEmbedResolver {
         }
     }
 
-    fn last_modified(&self) -> u64 {
-        self.images.last_modified()
+    fn seq(&self) -> u64 {
+        self.images.seq()
     }
 
     fn image_dims(&self) -> HashMap<String, [f32; 2]> {

--- a/libs/content/workspace/src/seq.rs
+++ b/libs/content/workspace/src/seq.rs
@@ -1,0 +1,23 @@
+//! Workspace-wide monotonic sequence counter.
+//!
+//! Sources (inputs that downstream caches depend on) bump this counter on
+//! write and store the resulting value in a sibling `_seq` field. Caches
+//! stamp the seq values they observed at compute time; on lookup, they
+//! compare stamps against current values and recompute on mismatch. One
+//! counter per [`egui::Context`], cloned to constructors that bump.
+//!
+//! No callbacks, no observers — pull-based, checked at read.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+use egui::{Context, Id};
+
+/// Returns the workspace counter, creating it on first call. Cache the
+/// returned `Arc` at construction; bumps are `arc.fetch_add(1, Relaxed)`.
+pub fn ws_seq(ctx: &Context) -> Arc<AtomicU64> {
+    ctx.data_mut(|d| {
+        d.get_temp_mut_or_insert_with(Id::new("ws_seq"), || Arc::new(AtomicU64::new(1)))
+            .clone()
+    })
+}

--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -14,8 +14,10 @@ pub type Paragraphs = Vec<(Grapheme, Grapheme)>;
 
 /// Represents bounds of various text regions in the buffer. Region bounds are (inclusive, exclusive). Regions do not
 /// overlap, have region.0 <= region.1, and are sorted ascending.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Bounds {
+    pub text_seq: u64,
+
     /// Source lines are separated by newline characters and include all characters in the document except the newline
     /// characters. These accelerate translating AST source positions to character offsets and back and are computed
     /// early in the frame using few dependencies.
@@ -47,6 +49,18 @@ pub struct Bounds {
     /// * Inline paragraphs can be empty.
     /// * Inline paragraphs cannot touch.
     pub inline_paragraphs: Paragraphs,
+}
+
+impl Default for Bounds {
+    fn default() -> Self {
+        Self {
+            text_seq: u64::MAX,
+            source_lines: SourceLines::default(),
+            words: Words::default(),
+            wrap_lines: Lines::default(),
+            inline_paragraphs: Paragraphs::default(),
+        }
+    }
 }
 
 impl MdRender {

--- a/libs/content/workspace/src/tab/markdown_editor/md_label.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/md_label.rs
@@ -73,6 +73,7 @@ impl MdLabel {
     fn prepare(&mut self, md: &str, width: f32) {
         self.renderer.set_width(width);
         self.renderer.buffer = Buffer::from(md);
+        self.renderer.bump_text_seq();
     }
 
     /// Widest galley rect from the last render — for callers that size a

--- a/libs/content/workspace/src/tab/markdown_editor/md_label.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/md_label.rs
@@ -73,7 +73,6 @@ impl MdLabel {
     fn prepare(&mut self, md: &str, width: f32) {
         self.renderer.set_width(width);
         self.renderer.buffer = Buffer::from(md);
-        self.renderer.layout_cache.invalidate_text_change();
     }
 
     /// Widest galley rect from the last render — for callers that size a

--- a/libs/content/workspace/src/tab/markdown_editor/md_label.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/md_label.rs
@@ -71,7 +71,7 @@ impl MdLabel {
     }
 
     fn prepare(&mut self, md: &str, width: f32) {
-        self.renderer.width = width;
+        self.renderer.set_width(width);
         self.renderer.buffer = Buffer::from(md);
         self.renderer.layout_cache.invalidate_text_change();
     }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::io::{BufReader, Cursor};
 use std::mem;
 use std::sync::OnceLock;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use web_time::Instant;
 
@@ -99,8 +98,10 @@ pub struct MdRender {
     pub touch_mode: bool,
 
     // document
-    pub bounds: Bounds,
     pub buffer: Buffer,
+
+    pub bounds: Bounds,
+    pub bounds_seq: u64,
 
     // render output
     pub galleys: Galleys,
@@ -111,27 +112,26 @@ pub struct MdRender {
     // render input
     pub in_progress_selection: Option<(Grapheme, Grapheme)>,
     pub find_current_match: Option<(Grapheme, Grapheme)>,
-    /// Gates fold UI. Stays true in readonly — fold is the one mutation
-    /// allowed there (saves are gated separately).
-    pub interactive: bool,
-    /// Gates click on interactive render elements that mutate the doc
-    /// (task checkbox). Fold clicks ignore it (changes aren't saved)
-    pub readonly: bool,
-    /// When true, render via the per-line source text — no markdown block
-    /// parsing, no fold UI, no completion popups. Set at construction from
-    /// the non-`md` ext check; callers may also flip it directly.
-    pub plaintext: bool,
-    pub reveal_ranges: Vec<(Grapheme, Grapheme)>,
-    pub text_highlight_range: Option<(Grapheme, Grapheme)>,
-    /// Toolbar settings menu: render image nodes as inline link text only,
-    /// skipping the block preview and its reserved space.
-    pub render_images_as_text: bool,
+    pub interactive: bool,    // enables fold buttons
+    pub readonly: bool,       // disables task checkboxes and saving
+    pub plaintext: bool,      // render as source text, not parsed markdown
+    pub disable_images: bool, // skip image rendering (e.g. for the mobile toolbar)
+
+    /// Selection contribution to the reveal set. Updated in
+    /// [`MdEdit::handle_input`] alongside the `reveal_seq` bump on
+    /// change. The other contribution is `find_current_match`. Readers
+    /// chain both via [`MdRender::reveal_ranges`].
+    pub reveal_selection: Option<(Grapheme, Grapheme)>,
+    pub reveal_seq: u64,
+
+    pub search_range: Option<(Grapheme, Grapheme)>, // drawn in accent color for completions
 
     // capabilities
     pub embeds: Box<dyn EmbedResolver>,
     pub link_resolver: Box<dyn LinkResolver>,
     pub client: HttpClient,
     pub files: Arc<RwLock<FileCache>>,
+    pub ws_seq: Arc<std::sync::atomic::AtomicU64>,
 
     // caches
     pub layout_cache: LayoutCache,
@@ -139,10 +139,9 @@ pub struct MdRender {
 
     // viewport
     pub width: f32,
+    pub width_seq: u64,
+
     pub viewport_height: f32,
-    /// Width the layout cache was last populated for; `reparse`
-    /// clears the cache when `width` diverges.
-    last_layout_width: f32,
 
     // debug
     pub debug: bool,
@@ -236,7 +235,10 @@ pub struct Editor {
     pub hmac: Option<DocumentHmac>,
     pub initialized: bool,
 
-    embeds_last_seen: u64,
+    // change detection
+    pub unprocessed_scroll: Option<Instant>,
+    prev_dimensions: Option<Vec2>,
+    embeds_seq: u64,
 
     // interaction widgets (toolbar + find are Editor-owned; completion
     // widgets moved onto MdEdit so a standalone composer inherits them)
@@ -245,12 +247,6 @@ pub struct Editor {
 
     // misc
     pub virtual_keyboard_shown: bool,
-    pub unprocessed_scroll: Option<Instant>,
-
-    /// Last frame's available render area, for change detection. Tracked
-    /// separately from `renderer.width` (the centered content-column width,
-    /// which on wide windows is strictly less than the available width).
-    prev_dimensions: Option<Vec2>,
 
     // outputs from drawing a frame need an additional frame to process before reporting
     next_resp: Response,
@@ -372,44 +368,62 @@ impl MdRender {
         let touch_mode = matches!(ctx.os(), OperatingSystem::Android | OperatingSystem::IOS);
         let layout = if touch_mode { MdLayout::mobile() } else { MdLayout::desktop() };
         let dark_mode = ctx.style().visuals.dark_mode;
+        let ws_seq = crate::seq::ws_seq(&ctx);
         Self {
             ctx,
             layout,
             dark_mode,
             ext: "md".into(),
             touch_mode,
-            bounds: Default::default(),
             buffer: "".into(),
+            bounds: Default::default(),
+            bounds_seq: 0,
             galleys: Default::default(),
             text_areas: Default::default(),
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
-            reveal_ranges: Vec::new(),
-            text_highlight_range: None,
-            render_images_as_text: false,
             in_progress_selection: None,
             find_current_match: None,
             interactive: false,
             readonly: true,
             plaintext: false,
+            disable_images: false,
+            reveal_selection: None,
+            reveal_seq: 0,
+            search_range: None,
             embeds: Box::new(()),
             link_resolver: Box::new(()),
             client: Default::default(),
             files: Arc::new(RwLock::new(FileCache::empty())),
+            ws_seq,
             layout_cache: Default::default(),
             syntax: Default::default(),
             width: Default::default(),
+            width_seq: 0,
             viewport_height: Default::default(),
-            last_layout_width: f32::NAN,
             debug: false,
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
         }
     }
 
+    /// Setter for `width` that bumps `width_seq` only when the value
+    /// actually changes — frame-scoped writers reassign every frame even
+    /// when the layout hasn't moved, and an unconditional bump would
+    /// invalidate every cached height.
+    pub fn set_width(&mut self, width: f32) {
+        if self.width.to_bits() != width.to_bits() {
+            self.width = width;
+            self.width_seq = self
+                .ws_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn test(md: &str) -> Self {
         let ctx = Context::default();
+        let ws_seq = crate::seq::ws_seq(&ctx);
         Self {
             ctx,
             layout: MdLayout::desktop(),
@@ -422,9 +436,9 @@ impl MdRender {
             text_areas: Default::default(),
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
-            reveal_ranges: Vec::new(),
-            text_highlight_range: None,
-            render_images_as_text: false,
+            reveal_selection: None,
+            search_range: None,
+            disable_images: false,
             in_progress_selection: None,
             find_current_match: None,
             interactive: false,
@@ -437,8 +451,11 @@ impl MdRender {
             layout_cache: Default::default(),
             syntax: Default::default(),
             width: Default::default(),
+            width_seq: 0,
             viewport_height: Default::default(),
-            last_layout_width: f32::NAN,
+            reveal_seq: 0,
+            bounds_seq: 0,
+            ws_seq,
             debug: false,
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
@@ -450,37 +467,39 @@ impl MdRender {
     /// [`Arena`] — comrak's AST is arena-allocated. Callers who need heights
     /// also invoke [`MdRender::height`] on the returned root.
     pub fn reparse<'a>(&mut self, arena: &'a Arena<'a>) -> &'a AstNode<'a> {
-        // Layout-cache keys are node-range, not width-aware; clear on
-        // width change. Bit-equality covers the initial NaN.
-        if self.width.to_bits() != self.last_layout_width.to_bits() {
-            self.layout_cache.clear();
-            self.last_layout_width = self.width;
-        }
-
-        // File cache refresh or async link-title fetch may have changed a
-        // link's resolved width; drop heights so the next render recomputes.
-        if self
-            .layout_cache
-            .link_layout_dirty
-            .swap(false, Ordering::Relaxed)
-        {
-            self.layout_cache.invalidate_link_layout_change();
-        }
+        // Width / link / embed / reveal invalidation flows through
+        // dep-stamp mismatch in the height + spacing caches; nothing to
+        // clear here. `reveal_seq` is bumped at its writers (selection
+        // in `MdEdit::handle_input`, find-match in `Editor::show`).
 
         let options = Self::comrak_options();
         let text_with_newline = format!("{}\n", self.buffer.current.text);
         let root = comrak::parse_document(arena, &text_with_newline, &options);
 
-        self.bounds.inline_paragraphs.clear();
-        self.calc_source_lines();
-        // Populate before compute_bounds: pre_spacing_lines (called
-        // from compute_bounds_block_pre_spacing) queries
-        // hidden_by_fold, which now expects every node already
-        // cached.
-        self.populate_hidden_by_fold(root);
-        self.compute_bounds(root);
-        self.bounds.inline_paragraphs.sort();
-        self.calc_words();
+        // Bounds depend only on text. Skip rebuild + bump bounds_seq
+        // when buffer.seq hasn't advanced.
+        let text_seq = self.buffer.current.seq as u64;
+        if self.bounds.text_seq != text_seq {
+            self.bounds.inline_paragraphs.clear();
+            self.calc_source_lines();
+            // Populate before compute_bounds: pre_spacing_lines (called
+            // from compute_bounds_block_pre_spacing) queries
+            // hidden_by_fold, which now expects every node already
+            // cached.
+            self.populate_hidden_by_fold(root);
+            self.compute_bounds(root);
+            self.bounds.inline_paragraphs.sort();
+            self.calc_words();
+            self.bounds.text_seq = text_seq;
+            self.bounds_seq = self
+                .ws_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            // Still call populate — its own deps check skips when
+            // text+reveal haven't moved, but this catches reveal-only
+            // changes (text seq same, reveal_seq advanced).
+            self.populate_hidden_by_fold(root);
+        }
 
         root
     }
@@ -530,6 +549,7 @@ impl Editor {
         let layout = if touch_mode { MdLayout::mobile() } else { MdLayout::desktop() };
 
         let client: HttpClient = Default::default();
+        let ws_seq = crate::seq::ws_seq(&ctx);
 
         let renderer = MdRender {
             ctx,
@@ -551,9 +571,9 @@ impl Editor {
             interactive: true,
             readonly,
             plaintext,
-            reveal_ranges: Vec::new(),
-            text_highlight_range: None,
-            render_images_as_text: false,
+            reveal_selection: None,
+            search_range: None,
+            disable_images: false,
 
             embeds,
             link_resolver,
@@ -564,8 +584,11 @@ impl Editor {
             syntax: Default::default(),
 
             width: Default::default(),
+            width_seq: 0,
             viewport_height: Default::default(),
-            last_layout_width: f32::NAN,
+            reveal_seq: 0,
+            bounds_seq: 0,
+            ws_seq,
 
             debug: false,
             frame_times: [Instant::now(); 10],
@@ -593,8 +616,7 @@ impl Editor {
             id_salt: Id::NULL,
             hmac,
             initialized: Default::default(),
-
-            embeds_last_seen: 0,
+            embeds_seq: 0,
 
             toolbar: Default::default(),
             find: Default::default(),
@@ -701,19 +723,14 @@ impl Editor {
         }
 
         let start = web_time::Instant::now();
-        let embeds_updated = {
-            let current = self.edit.renderer.embeds.last_modified();
-            let changed = current != self.embeds_last_seen;
-            self.embeds_last_seen = current;
-            changed
-        };
 
-        // Heights depend on `viewport_height` (image clamping) and on
-        // resolved embed dimensions; clear so this frame paints the
-        // updated values. (Width invalidation lives in `reparse`.)
-        if height_updated || embeds_updated {
+        if height_updated {
             self.edit.renderer.layout_cache.clear();
         }
+
+        let embeds_seq = self.edit.renderer.embeds.seq();
+        let embeds_updated = embeds_seq != self.embeds_seq;
+        self.embeds_seq = embeds_seq;
 
         // --- input phase ------------------------------------------------------
         // Route workspace-origin events (toolbar Markdown, Undo/Redo) through
@@ -728,17 +745,7 @@ impl Editor {
 
         if !self.initialized || buf_resp.text_updated {
             resp.text_updated = true;
-            // recompute find matches when text changes
-            if let Some(term) = self.find.term.clone() {
-                self.find.matches = self.find.find_all(&self.edit.renderer.buffer, &term);
-                if self.find.matches.is_empty() {
-                    self.find.current_match = None;
-                } else if let Some(idx) = self.find.current_match {
-                    if idx >= self.find.matches.len() {
-                        self.find.current_match = Some(self.find.matches.len() - 1);
-                    }
-                }
-            }
+            self.find.ensure_matches(&self.edit.renderer.buffer);
             ui.ctx().request_repaint();
         }
         resp.selection_updated = prior_selection
@@ -906,6 +913,11 @@ impl Editor {
                     .buffer
                     .queue(vec![lb_rs::model::text::operation_types::Operation::Select(selection)]);
                 self.edit.renderer.buffer.update();
+                self.edit.renderer.reveal_seq = self
+                    .edit
+                    .renderer
+                    .ws_seq
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
         }
 
@@ -953,18 +965,8 @@ impl Editor {
             if embeds_updated {
                 self.unprocessed_scroll = Some(Instant::now());
             }
-            // Schedule a follow-up frame for the persistence write
-            // path keyed off `unprocessed_scroll`.
             ui.ctx().request_repaint();
         } else if resp.selection_updated {
-            let new_selection = self
-                .edit
-                .in_progress_selection
-                .unwrap_or(self.edit.renderer.buffer.current.selection);
-            self.edit
-                .renderer
-                .layout_cache
-                .invalidate_reveal_change(prior_selection, new_selection);
             ui.ctx().request_repaint();
         }
         if self.initialized && resp.selection_updated && !all_selected {
@@ -1082,7 +1084,6 @@ impl Editor {
     }
 
     fn show_scrollable_editor<'a>(&mut self, ui: &mut Ui, _root: &'a AstNode<'a>) {
-        let prev_seq = self.edit.renderer.buffer.current.seq;
         let scroll_id = self.id();
 
         // Captured by the Frame::canvas closure so post-render code
@@ -1110,7 +1111,7 @@ impl Editor {
                 // at the canvas right edge.
                 let max_width = self.edit.renderer.layout.max_width;
                 let col_width = (canvas_width - 2.0 * layout_margin).min(max_width).max(0.0);
-                self.edit.renderer.width = col_width;
+                self.edit.renderer.set_width(col_width);
 
                 // Paint find-match highlights first so the editor's text
                 // callback (submitted via post_render) lands on a layer
@@ -1202,20 +1203,7 @@ impl Editor {
                 ui.advance_cursor_after_rect(canvas_rect);
             });
 
-        // if text changed during MdEdit::show, recompute find matches
-        // before painting match highlights (which index by offset).
-        if self.edit.renderer.buffer.current.seq != prev_seq {
-            if let Some(term) = self.find.term.clone() {
-                self.find.matches = self.find.find_all(&self.edit.renderer.buffer, &term);
-                if self.find.matches.is_empty() {
-                    self.find.current_match = None;
-                } else if let Some(idx) = self.find.current_match {
-                    if idx >= self.find.matches.len() {
-                        self.find.current_match = Some(self.find.matches.len() - 1);
-                    }
-                }
-            }
-        }
+        self.find.ensure_matches(&self.edit.renderer.buffer);
 
         if matches!(self.edit.pending_scroll, Some(ScrollTarget::FindMatch)) {
             self.edit.pending_scroll = None;
@@ -1251,33 +1239,14 @@ impl Editor {
             self.edit.pending_scroll = Some(ScrollTarget::FindMatch);
         }
 
-        // match-driven reveal-cache invalidation, mirroring the cursor-selection path
         let new_match = self.find.current_match_range();
-        if prev_match != new_match {
-            if let Some(old) = prev_match {
-                self.edit
-                    .renderer
-                    .layout_cache
-                    .invalidate_reveal_change(old, old);
-            }
-            if let Some(new) = new_match {
-                self.edit
-                    .renderer
-                    .layout_cache
-                    .invalidate_reveal_change(new, new);
-            }
-        }
-        if find_output.closed {
-            self.edit.renderer.layout_cache.clear();
-        }
-
-        // bridge find state → renderer inputs for this frame's editor render.
-        // Must happen after Find::show so galley_required_ranges and
-        // reveal_ranges reflect the new current_match; otherwise the match
-        // galley isn't built and scroll_to_find_match has nothing to scroll to.
         self.edit.renderer.find_current_match = new_match;
-        if let Some(range) = new_match {
-            self.edit.renderer.reveal_ranges.push(range);
+        if prev_match != new_match {
+            self.edit.renderer.reveal_seq = self
+                .edit
+                .renderer
+                .ws_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -257,15 +257,6 @@ pub struct MdPersistence {
     file: HashMap<Uuid, MdFilePersistence>,
 }
 
-impl MdPersistence {
-    pub fn image_dims(&self, file_id: &Uuid) -> HashMap<String, [f32; 2]> {
-        self.file
-            .get(file_id)
-            .map(|f| f.image_dims.clone())
-            .unwrap_or_default()
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct MdFilePersistence {
     /// `(anchor_block_idx, intra_precise)` — the row index and precise
@@ -275,8 +266,6 @@ pub struct MdFilePersistence {
     #[serde(default)]
     anchor: Option<(usize, f32)>,
     selection: (Grapheme, Grapheme),
-    #[serde(default)]
-    image_dims: HashMap<String, [f32; 2]>,
 }
 
 pub struct MdResources {
@@ -1044,7 +1033,6 @@ impl Editor {
                         });
                 drop(content);
 
-                let image_dims = self.edit.renderer.embeds.image_dims();
                 let mut persistence = self.persistence.data.write().unwrap();
                 persistence
                     .markdown
@@ -1052,13 +1040,8 @@ impl Editor {
                     .entry(self.edit.file_id)
                     .and_modify(|f| {
                         f.anchor = anchor;
-                        f.image_dims = image_dims.clone();
                     })
-                    .or_insert(MdFilePersistence {
-                        anchor,
-                        selection: Default::default(),
-                        image_dims,
-                    });
+                    .or_insert(MdFilePersistence { anchor, selection: Default::default() });
                 persistence_updated = true;
 
                 scroll_end_processed = true;

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -468,9 +468,13 @@ impl MdRender {
     /// also invoke [`MdRender::height`] on the returned root.
     pub fn reparse<'a>(&mut self, arena: &'a Arena<'a>) -> &'a AstNode<'a> {
         // Width / link / embed / reveal invalidation flows through
-        // dep-stamp mismatch in the height + spacing caches; nothing to
-        // clear here. `reveal_seq` is bumped at its writers (selection
-        // in `MdEdit::handle_input`, find-match in `Editor::show`).
+        // dep-stamp mismatch in the height + spacing caches. Text changes
+        // can affect any entry (fold-tag-driven cascades, sourcepos shifts),
+        // so the layout cache wipes wholesale here before any reads.
+        // `reveal_seq` is bumped at its writers (selection in
+        // `MdEdit::handle_input`, find-match in `Editor::show`).
+        let text_seq = self.buffer.current.seq as u64;
+        self.layout_cache.ensure_text_consistent(text_seq);
 
         let options = Self::comrak_options();
         let text_with_newline = format!("{}\n", self.buffer.current.text);
@@ -478,7 +482,6 @@ impl MdRender {
 
         // Bounds depend only on text. Skip rebuild + bump bounds_seq
         // when buffer.seq hasn't advanced.
-        let text_seq = self.buffer.current.seq as u64;
         if self.bounds.text_seq != text_seq {
             self.bounds.inline_paragraphs.clear();
             self.calc_source_lines();

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -768,7 +768,7 @@ impl Editor {
 
         let all_selected = self.edit.renderer.buffer.current.selection
             == (0.into(), self.edit.renderer.last_cursor_position());
-        if self.initialized && resp.selection_updated && !all_selected {
+        if self.initialized && buf_resp.selection_user_moved && !all_selected {
             self.edit.pending_scroll = Some(ScrollTarget::Cursor);
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -754,6 +754,12 @@ impl Editor {
                 .in_progress_selection
                 .unwrap_or(self.edit.renderer.buffer.current.selection);
 
+        let all_selected = self.edit.renderer.buffer.current.selection
+            == (0.into(), self.edit.renderer.last_cursor_position());
+        if self.initialized && resp.selection_updated && !all_selected {
+            self.edit.pending_scroll = Some(ScrollTarget::Cursor);
+        }
+
         let ast_elapsed = start.elapsed();
         let print_elapsed = std::time::Duration::ZERO;
         let start = web_time::Instant::now();
@@ -959,18 +965,12 @@ impl Editor {
         }
 
         // post-frame bookkeeping
-        let all_selected = self.edit.renderer.buffer.current.selection
-            == (0.into(), self.edit.renderer.last_cursor_position());
         if embeds_updated || height_updated || width_updated {
             if embeds_updated {
                 self.unprocessed_scroll = Some(Instant::now());
             }
             ui.ctx().request_repaint();
         } else if resp.selection_updated {
-            ui.ctx().request_repaint();
-        }
-        if self.initialized && resp.selection_updated && !all_selected {
-            self.edit.pending_scroll = Some(ScrollTarget::Cursor);
             ui.ctx().request_repaint();
         }
         if self.initialized && self.edit.renderer.touch_mode && height_updated {

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -99,6 +99,7 @@ pub struct MdRender {
 
     // document
     pub buffer: Buffer,
+    pub text_seq: u64, // buffer.seq includes selection changes
 
     pub bounds: Bounds,
     pub bounds_seq: u64,
@@ -117,12 +118,8 @@ pub struct MdRender {
     pub plaintext: bool,      // render as source text, not parsed markdown
     pub disable_images: bool, // skip image rendering (e.g. for the mobile toolbar)
 
-    /// Selection contribution to the reveal set. Updated in
-    /// [`MdEdit::handle_input`] alongside the `reveal_seq` bump on
-    /// change. The other contribution is `find_current_match`. Readers
-    /// chain both via [`MdRender::reveal_ranges`].
     pub reveal_selection: Option<(Grapheme, Grapheme)>,
-    pub reveal_seq: u64,
+    pub reveal_seq: u64, // includes selection and find matches
 
     pub search_range: Option<(Grapheme, Grapheme)>, // drawn in accent color for completions
 
@@ -390,6 +387,7 @@ impl MdRender {
             disable_images: false,
             reveal_selection: None,
             reveal_seq: 0,
+            text_seq: 0,
             search_range: None,
             embeds: Box::new(()),
             link_resolver: Box::new(()),
@@ -454,12 +452,22 @@ impl MdRender {
             width_seq: 0,
             viewport_height: Default::default(),
             reveal_seq: 0,
+            text_seq: 0,
             bounds_seq: 0,
             ws_seq,
             debug: false,
             frame_times: [Instant::now(); 10],
             frame_times_idx: 0,
         }
+    }
+
+    /// Bump `text_seq`. Call after any buffer mutation that may change
+    /// text — `LayoutCache::ensure_text_consistent`, `bounds.text_seq`,
+    /// and find-match invalidation all key off this counter.
+    pub fn bump_text_seq(&mut self) {
+        self.text_seq = self
+            .ws_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Re-parse the buffer into a fresh AST and rebuild all text-derived
@@ -473,16 +481,15 @@ impl MdRender {
         // so the layout cache wipes wholesale here before any reads.
         // `reveal_seq` is bumped at its writers (selection in
         // `MdEdit::handle_input`, find-match in `Editor::show`).
-        let text_seq = self.buffer.current.seq as u64;
-        self.layout_cache.ensure_text_consistent(text_seq);
+        self.layout_cache.ensure_text_consistent(self.text_seq);
 
         let options = Self::comrak_options();
         let text_with_newline = format!("{}\n", self.buffer.current.text);
         let root = comrak::parse_document(arena, &text_with_newline, &options);
 
         // Bounds depend only on text. Skip rebuild + bump bounds_seq
-        // when buffer.seq hasn't advanced.
-        if self.bounds.text_seq != text_seq {
+        // when text hasn't changed.
+        if self.bounds.text_seq != self.text_seq {
             self.bounds.inline_paragraphs.clear();
             self.calc_source_lines();
             // Populate before compute_bounds: pre_spacing_lines (called
@@ -493,7 +500,7 @@ impl MdRender {
             self.compute_bounds(root);
             self.bounds.inline_paragraphs.sort();
             self.calc_words();
-            self.bounds.text_seq = text_seq;
+            self.bounds.text_seq = self.text_seq;
             self.bounds_seq = self
                 .ws_seq
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -590,6 +597,7 @@ impl Editor {
             width_seq: 0,
             viewport_height: Default::default(),
             reveal_seq: 0,
+            text_seq: 0,
             bounds_seq: 0,
             ws_seq,
 
@@ -748,7 +756,8 @@ impl Editor {
 
         if !self.initialized || buf_resp.text_updated {
             resp.text_updated = true;
-            self.find.ensure_matches(&self.edit.renderer.buffer);
+            self.find
+                .ensure_matches(&self.edit.renderer.buffer, self.edit.renderer.text_seq);
             ui.ctx().request_repaint();
         }
         resp.selection_updated = prior_selection
@@ -1206,7 +1215,8 @@ impl Editor {
                 ui.advance_cursor_after_rect(canvas_rect);
             });
 
-        self.find.ensure_matches(&self.edit.renderer.buffer);
+        self.find
+            .ensure_matches(&self.edit.renderer.buffer, self.edit.renderer.text_seq);
 
         if matches!(self.edit.pending_scroll, Some(ScrollTarget::FindMatch)) {
             self.edit.pending_scroll = None;
@@ -1229,8 +1239,12 @@ impl Editor {
             Rect::from_min_size(egui::pos2(content_left, top), egui::vec2(content_width, 0.));
         let prev_match = self.find.current_match_range();
         let scope_resp = ui.scope_builder(egui::UiBuilder::new().max_rect(find_rect), |ui| {
-            self.find
-                .show(&self.edit.renderer.buffer, self.virtual_keyboard_shown, ui)
+            self.find.show(
+                &self.edit.renderer.buffer,
+                self.edit.renderer.text_seq,
+                self.virtual_keyboard_shown,
+                ui,
+            )
         });
         let find_output = scope_resp.inner;
         let rendered_rect = scope_resp.response.rect;

--- a/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
@@ -266,7 +266,19 @@ pub fn paint_row<'ast>(
     blocks: &[&'ast AstNode<'ast>], id: &DocRowId, top_left: Pos2, content_x: f32,
 ) {
     match id {
-        DocRowId::Leading | DocRowId::Trailing => {} // virtual padding
+        DocRowId::Leading => {} // virtual padding
+        DocRowId::Trailing => {
+            // Empty non-plaintext doc — `DocScrollContent` yields no
+            // Block rows, so `show_document` would never be called and
+            // the cursor would have no galley anchor. Route through
+            // it here so its empty-doc sentinel galley fires. Trailing
+            // sits at the content origin (canvas + leading_precise)
+            // for an empty doc, so painting at `top_left` is correct.
+            if blocks.is_empty() && !renderer.plaintext {
+                let tl = Pos2::new(content_x, top_left.y);
+                renderer.show_block(ui, root, tl);
+            }
+        }
         DocRowId::Block(i) => {
             let node = blocks[*i];
             let mut tl = Pos2::new(content_x, top_left.y);

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -112,9 +112,9 @@ impl MdEdit {
         buf_resp |= self.renderer.buffer.update();
 
         if buf_resp.text_updated {
-            self.renderer.layout_cache.invalidate_text_change();
             // reparse to refresh bounds; the new root isn't needed here —
-            // `show` re-parses for rendering.
+            // `show` re-parses for rendering. `reparse` also wipes the
+            // layout cache via `ensure_text_consistent`.
             self.renderer.reparse(&arena);
         }
 
@@ -440,7 +440,6 @@ impl MdEdit {
     /// `true`.
     pub fn clear(&mut self) {
         self.renderer.buffer = Buffer::from("");
-        self.renderer.layout_cache.invalidate_text_change();
         self.in_progress_selection = None;
         self.event.internal_events.clear();
     }

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -112,6 +112,7 @@ impl MdEdit {
         buf_resp |= self.renderer.buffer.update();
 
         if buf_resp.text_updated {
+            self.renderer.bump_text_seq();
             // reparse to refresh bounds; the new root isn't needed here —
             // `show` re-parses for rendering. `reparse` also wipes the
             // layout cache via `ensure_text_consistent`.
@@ -440,6 +441,7 @@ impl MdEdit {
     /// `true`.
     pub fn clear(&mut self) {
         self.renderer.buffer = Buffer::from("");
+        self.renderer.bump_text_seq();
         self.in_progress_selection = None;
         self.event.internal_events.clear();
     }

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -47,6 +47,8 @@ impl MdEdit {
     /// `Event::Newline`).
     pub fn handle_input(&mut self, ctx: &Context, id: Id) -> buffer::Response {
         let focused = ctx.memory(|m| m.has_focus(id));
+        let prior_reveal_selection =
+            (!self.renderer.readonly && focused).then_some(self.renderer.buffer.current.selection);
 
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
@@ -118,17 +120,16 @@ impl MdEdit {
             self.renderer.reparse(&arena);
         }
 
-        // Populate reveal_ranges with the current selection. The caller may
-        // append additional ranges (e.g. Editor appends the find-match range)
-        // after this returns and before `show` — those append-only additions
-        // survive into render. `show` itself doesn't touch reveal_ranges.
-        self.renderer.reveal_ranges.clear();
-        if !self.renderer.readonly && ctx.memory(|m| m.has_focus(id)) {
-            self.renderer
-                .reveal_ranges
-                .push(self.renderer.buffer.current.selection);
+        let new_reveal_selection = (!self.renderer.readonly && ctx.memory(|m| m.has_focus(id)))
+            .then_some(self.renderer.buffer.current.selection);
+        if prior_reveal_selection != new_reveal_selection {
+            self.renderer.reveal_selection = new_reveal_selection;
+            self.renderer.reveal_seq = self
+                .renderer
+                .ws_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
-        self.renderer.text_highlight_range = self
+        self.renderer.search_range = self
             .emoji_completions
             .search_term_range
             .or(self.link_completions.search_term_range);
@@ -418,7 +419,7 @@ impl MdEdit {
     /// memoized by `LayoutCache`, so the subsequent `show` re-uses the
     /// cached work.
     pub fn measure_height(&mut self, width: f32) -> f32 {
-        self.renderer.width = width;
+        self.renderer.set_width(width);
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
         self.renderer.height(root)

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -47,8 +47,6 @@ impl MdEdit {
     /// `Event::Newline`).
     pub fn handle_input(&mut self, ctx: &Context, id: Id) -> buffer::Response {
         let focused = ctx.memory(|m| m.has_focus(id));
-        let prior_reveal_selection =
-            (!self.renderer.readonly && focused).then_some(self.renderer.buffer.current.selection);
 
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
@@ -122,7 +120,7 @@ impl MdEdit {
 
         let new_reveal_selection = (!self.renderer.readonly && ctx.memory(|m| m.has_focus(id)))
             .then_some(self.renderer.buffer.current.selection);
-        if prior_reveal_selection != new_reveal_selection {
+        if self.renderer.reveal_selection != new_reveal_selection {
             self.renderer.reveal_selection = new_reveal_selection;
             self.renderer.reveal_seq = self
                 .renderer

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/document.rs
@@ -1,11 +1,14 @@
 use crate::tab::markdown_editor::{syntax_set, syntax_theme};
 use comrak::nodes::AstNode;
-use egui::{Color32, Pos2, Ui};
-use lb_rs::model::text::offset_types::{IntoRangeExt as _, RangeExt as _, RangeIterExt as _};
+use egui::{Color32, Pos2, Rect, Ui, Vec2};
+use lb_rs::model::text::offset_types::{
+    Grapheme, IntoRangeExt as _, RangeExt as _, RangeIterExt as _,
+};
 use syntect::easy::HighlightLines;
 
 use crate::show::syntax_ext_for;
 use crate::tab::markdown_editor::MdRender;
+use crate::tab::markdown_editor::galleys::GalleyInfo;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
 use crate::theme::palette_v2::ThemeExt as _;
 
@@ -48,6 +51,7 @@ impl<'ast> MdRender {
     pub fn show_document(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2) {
         let width = self.width(node);
 
+        let pre_galleys = self.galleys.len();
         let any_children = node.children().next().is_some();
         if any_children && !self.plaintext {
             self.show_block_children(ui, node, top_left);
@@ -60,6 +64,27 @@ impl<'ast> MdRender {
                     top_left.y += self.layout.row_spacing;
                 }
             }
+        }
+
+        // Empty doc renders nothing — the cursor at (0, 0) needs a galley
+        // to anchor against. Push a zero-width sentinel so `cursor_line`
+        // returns Some.
+        if self.galleys.len() == pre_galleys {
+            let row_height = self.layout.row_height;
+            let buffer = self.upsert_glyphon_buffer_unwrapped(
+                "",
+                row_height,
+                row_height,
+                width,
+                &self.text_format_document(),
+            );
+            self.galleys.push(GalleyInfo {
+                is_override: false,
+                range: (Grapheme(0), Grapheme(0)),
+                buffer,
+                rect: Rect::from_min_size(top_left, Vec2::new(0.0, row_height)),
+                padded: false,
+            });
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
@@ -7,8 +7,7 @@ use crate::tab::markdown_editor::MdRender;
 impl<'ast> MdRender {
     pub fn height_paragraph(&self, node: &'ast AstNode<'ast>) -> f32 {
         let mut result = 0.;
-        // toolbar text-only mode: skip block image; inline path renders alt as link
-        if !self.render_images_as_text {
+        if !self.disable_images {
             for descendant in node.descendants() {
                 if let NodeValue::Image(node_link) = &descendant.data.borrow().value {
                     let NodeLink { url, .. } = &**node_link;
@@ -70,8 +69,7 @@ impl<'ast> MdRender {
             let line = self.bounds.source_lines[line];
             let node_line = self.node_line(node, line);
 
-            // mirror `height_paragraph` text-only mode
-            if !self.render_images_as_text {
+            if !self.disable_images {
                 for descendant in node.descendants() {
                     if let NodeValue::Image(node_link) = &descendant.data.borrow().value {
                         let NodeLink { url, .. } = &**node_link;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -742,13 +742,13 @@ pub type HeightDeps = [u64; 4];
 
 #[derive(Default)]
 pub struct LayoutCache {
-    pub height: RefCell<HashMap<(Grapheme, Grapheme), (f32, HeightDeps)>>,
-    pub height_approx: RefCell<HashMap<(Grapheme, Grapheme), (f32, HeightDeps)>>,
+    pub height: RefCell<HashMap<u64, (f32, HeightDeps)>>,
+    pub height_approx: RefCell<HashMap<u64, (f32, HeightDeps)>>,
     pub line_prefix_len: RefCell<HashMap<LinePrefixKey, LinePrefixValue>>,
     pub node_range: RefCell<HashMap<u64, (Grapheme, Grapheme)>>,
 
-    // deps: `reveal_seq` last populated, or `None` if never
-    pub hidden_by_fold: RefCell<HashMap<(Grapheme, Grapheme), bool>>,
+    // deps: `reveal_seq` last populated, or `None` if never.
+    pub hidden_by_fold: RefCell<HashMap<u64, bool>>,
     pub hidden_by_fold_deps: std::cell::Cell<Option<u64>>,
 
     // deps: title load state
@@ -948,37 +948,37 @@ impl<'ast> MdRender {
     }
 
     pub fn get_cached_node_height(&self, node: &'ast AstNode<'ast>) -> Option<f32> {
-        let range = self.node_range(node);
+        let key = Self::pack_node_key(node);
         let deps = self.height_deps();
         let cache = self.layout_cache.height.borrow();
-        let (v, stamps) = cache.get(&range)?;
+        let (v, stamps) = cache.get(&key)?;
         (*stamps == deps).then_some(*v)
     }
 
     pub fn set_cached_node_height(&self, node: &'ast AstNode<'ast>, height: f32) {
-        let range = self.node_range(node);
+        let key = Self::pack_node_key(node);
         let deps = self.height_deps();
         self.layout_cache
             .height
             .borrow_mut()
-            .insert(range, (height, deps));
+            .insert(key, (height, deps));
     }
 
     pub fn get_cached_node_height_approx(&self, node: &'ast AstNode<'ast>) -> Option<f32> {
-        let range = self.node_range(node);
+        let key = Self::pack_node_key(node);
         let deps = self.height_deps();
         let cache = self.layout_cache.height_approx.borrow();
-        let (v, stamps) = cache.get(&range)?;
+        let (v, stamps) = cache.get(&key)?;
         (*stamps == deps).then_some(*v)
     }
 
     pub fn set_cached_node_height_approx(&self, node: &'ast AstNode<'ast>, height: f32) {
-        let range = self.node_range(node);
+        let key = Self::pack_node_key(node);
         let deps = self.height_deps();
         self.layout_cache
             .height_approx
             .borrow_mut()
-            .insert(range, (height, deps));
+            .insert(key, (height, deps));
     }
 
     pub fn get_cached_line_prefix_len(
@@ -1022,20 +1022,16 @@ impl<'ast> MdRender {
     }
 
     pub fn get_cached_hidden_by_fold(&self, node: &'ast AstNode<'ast>) -> Option<bool> {
-        let range = self.node_range(node);
-        self.layout_cache
-            .hidden_by_fold
-            .borrow()
-            .get(&range)
-            .copied()
+        let key = Self::pack_node_key(node);
+        self.layout_cache.hidden_by_fold.borrow().get(&key).copied()
     }
 
     pub fn set_cached_hidden_by_fold(&self, node: &'ast AstNode<'ast>, hidden: bool) {
-        let range = self.node_range(node);
+        let key = Self::pack_node_key(node);
         self.layout_cache
             .hidden_by_fold
             .borrow_mut()
-            .insert(range, hidden);
+            .insert(key, hidden);
     }
 
     /// Pack node info into u64 using bit manipulation - ultra fast cache key
@@ -1049,14 +1045,10 @@ impl<'ast> MdRender {
             sp.end.column as u64,
             node_value_to_discriminant_id(&borrowed.value) as u64,
         );
-
-        // Pack into 64 bits: 15 bits each for start_line, start_column, end_line, end_column
-        // and 4 bits for discriminant (total: 15+15+15+15+4 = 64 bits exactly)
-        // Use bitwise AND for fastest truncation
-        ((start_line & 0x7FFF) << 49)
-            | ((start_column & 0x7FFF) << 34)
-            | ((end_line & 0x7FFF) << 19)
-            | ((end_column & 0x7FFF) << 4)
-            | (discriminant & 0xF)
+        ((start_line & 0x3FFF) << 50)
+            | ((start_column & 0x3FFF) << 36)
+            | ((end_line & 0x3FFF) << 22)
+            | ((end_column & 0x3FFF) << 8)
+            | (discriminant & 0xFF)
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex, RwLock};
 use unicode_segmentation::UnicodeSegmentation as _;
 
@@ -611,6 +611,12 @@ impl<'ast> MdRender {
     /// maintains a stack of currently-open headings as we walk
     /// children left-to-right; each entry is `(level, folded_unrevealed)`.
     pub fn populate_hidden_by_fold(&self, root: &'ast AstNode<'ast>) {
+        let deps = (self.buffer.current.seq as u64, self.reveal_seq);
+        if self.layout_cache.hidden_by_fold_deps.get() == Some(deps) {
+            return;
+        }
+        self.layout_cache.hidden_by_fold_deps.set(Some(deps));
+
         // The root is never hidden; cache it directly so a query for
         // `hidden_by_fold(root)` doesn't fall back to the unwrap
         // default.
@@ -729,21 +735,25 @@ pub enum TitleState {
 type LinePrefixKey = (u64, (Grapheme, Grapheme));
 type LinePrefixValue = (Graphemes, bool);
 
+/// height inputs: `[text_seq, width_seq, embeds_seq, link_seq, reveal_seq]`.
+/// Covers spacing too — spacing is folded into `height()` and shares
+/// these dep stamps.
+pub type HeightDeps = [u64; 5];
+
 #[derive(Default)]
 pub struct LayoutCache {
-    pub height: RefCell<HashMap<(Grapheme, Grapheme), f32>>,
-    pub height_approx: RefCell<HashMap<(Grapheme, Grapheme), f32>>,
+    pub height: RefCell<HashMap<(Grapheme, Grapheme), (f32, HeightDeps)>>,
+    pub height_approx: RefCell<HashMap<(Grapheme, Grapheme), (f32, HeightDeps)>>,
     pub line_prefix_len: RefCell<HashMap<LinePrefixKey, LinePrefixValue>>,
     pub node_range: RefCell<HashMap<u64, (Grapheme, Grapheme)>>,
-    pub hidden_by_fold: RefCell<HashMap<(Grapheme, Grapheme), bool>>,
-    pub link_titles: RefCell<HashMap<String, Arc<Mutex<TitleState>>>>,
 
-    /// Set when something outside the editor (file cache refresh, async link
-    /// title fetch completion) changes the resolved width of a link's display
-    /// text. The next reparse drops cached heights so the new width takes
-    /// effect; without this, heights keyed only by node range stay stale.
-    /// Shared via `Arc` so async fetch closures can signal from any thread.
-    pub link_layout_dirty: Arc<AtomicBool>,
+    // deps: `(text_seq, reveal_seq)` last populated, or `None` if never
+    pub hidden_by_fold: RefCell<HashMap<(Grapheme, Grapheme), bool>>,
+    pub hidden_by_fold_deps: std::cell::Cell<Option<(u64, u64)>>,
+
+    // deps: title load state
+    pub link_titles: RefCell<HashMap<String, Arc<Mutex<TitleState>>>>,
+    pub link_seq: Arc<AtomicU64>,
 }
 
 impl LayoutCache {
@@ -754,6 +764,7 @@ impl LayoutCache {
         self.line_prefix_len.borrow_mut().clear();
         self.node_range.borrow_mut().clear();
         self.hidden_by_fold.borrow_mut().clear();
+        self.hidden_by_fold_deps.set(None);
         // link_titles intentionally not cleared: fetched titles persist across layout invalidations
     }
 
@@ -767,57 +778,11 @@ impl LayoutCache {
         self.height.borrow_mut().clear();
         self.height_approx.borrow_mut().clear();
         self.hidden_by_fold.borrow_mut().clear();
+        self.hidden_by_fold_deps.set(None);
         self.line_prefix_len.borrow_mut().clear();
         self.node_range.borrow_mut().clear();
 
         // glyphon_buffers: content-addressed, preserved across text changes
-    }
-
-    /// Drop heights only. Used when link title resolution changes (file cache
-    /// refresh or async fetch completion): node ranges, fold state, and line
-    /// prefixes are unaffected, but a link's display-text width may differ.
-    pub fn invalidate_link_layout_change(&self) {
-        self.height.borrow_mut().clear();
-        self.height_approx.borrow_mut().clear();
-    }
-
-    /// Invalidates height entries affected by a reveal range change (cursor
-    /// movement or find match change). A node's height depends on its reveal
-    /// state, so we evict nodes intersecting either range plus their ancestors.
-    pub fn invalidate_reveal_change(
-        &self, old_range: (Grapheme, Grapheme), new_range: (Grapheme, Grapheme),
-    ) {
-        let mut cache = self.height.borrow_mut();
-
-        // first pass: find ranges directly affected
-        let mut invalidated: Vec<(Grapheme, Grapheme)> = Vec::new();
-        for range in cache.keys() {
-            if range.intersects(&old_range, true) || range.intersects(&new_range, true) {
-                invalidated.push(*range);
-            }
-        }
-
-        if invalidated.is_empty() {
-            return;
-        }
-
-        // second pass: evict directly affected nodes and their ancestors
-        cache.retain(|range, _| {
-            if range.intersects(&old_range, true) || range.intersects(&new_range, true) {
-                return false;
-            }
-            for inv in &invalidated {
-                if range.contains_range(inv, true, true) {
-                    return false;
-                }
-            }
-            true
-        });
-
-        // hidden_by_fold depends on selection through fold reveal;
-        // a node's visibility can change due to a distant heading/item
-        // becoming revealed, so clear the whole cache
-        self.hidden_by_fold.borrow_mut().clear();
     }
 }
 
@@ -971,31 +936,50 @@ impl MdRender {
 }
 
 impl<'ast> MdRender {
+    fn height_deps(&self) -> HeightDeps {
+        [
+            self.buffer.current.seq as u64,
+            self.width_seq,
+            self.embeds.seq(),
+            self.layout_cache
+                .link_seq
+                .load(std::sync::atomic::Ordering::Relaxed),
+            self.reveal_seq,
+        ]
+    }
+
     pub fn get_cached_node_height(&self, node: &'ast AstNode<'ast>) -> Option<f32> {
         let range = self.node_range(node);
-        self.layout_cache.height.borrow().get(&range).copied()
+        let deps = self.height_deps();
+        let cache = self.layout_cache.height.borrow();
+        let (v, stamps) = cache.get(&range)?;
+        (*stamps == deps).then_some(*v)
     }
 
     pub fn set_cached_node_height(&self, node: &'ast AstNode<'ast>, height: f32) {
         let range = self.node_range(node);
-        self.layout_cache.height.borrow_mut().insert(range, height);
+        let deps = self.height_deps();
+        self.layout_cache
+            .height
+            .borrow_mut()
+            .insert(range, (height, deps));
     }
 
     pub fn get_cached_node_height_approx(&self, node: &'ast AstNode<'ast>) -> Option<f32> {
         let range = self.node_range(node);
-        self.layout_cache
-            .height_approx
-            .borrow()
-            .get(&range)
-            .copied()
+        let deps = self.height_deps();
+        let cache = self.layout_cache.height_approx.borrow();
+        let (v, stamps) = cache.get(&range)?;
+        (*stamps == deps).then_some(*v)
     }
 
     pub fn set_cached_node_height_approx(&self, node: &'ast AstNode<'ast>, height: f32) {
         let range = self.node_range(node);
+        let deps = self.height_deps();
         self.layout_cache
             .height_approx
             .borrow_mut()
-            .insert(range, height);
+            .insert(range, (height, deps));
     }
 
     pub fn get_cached_line_prefix_len(

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -611,7 +611,7 @@ impl<'ast> MdRender {
     /// maintains a stack of currently-open headings as we walk
     /// children left-to-right; each entry is `(level, folded_unrevealed)`.
     pub fn populate_hidden_by_fold(&self, root: &'ast AstNode<'ast>) {
-        let deps = (self.buffer.current.seq as u64, self.reveal_seq);
+        let deps = self.reveal_seq;
         if self.layout_cache.hidden_by_fold_deps.get() == Some(deps) {
             return;
         }
@@ -735,10 +735,10 @@ pub enum TitleState {
 type LinePrefixKey = (u64, (Grapheme, Grapheme));
 type LinePrefixValue = (Graphemes, bool);
 
-/// height inputs: `[text_seq, width_seq, embeds_seq, link_seq, reveal_seq]`.
-/// Covers spacing too — spacing is folded into `height()` and shares
-/// these dep stamps.
-pub type HeightDeps = [u64; 5];
+/// height inputs: `[width_seq, embeds_seq, link_seq, reveal_seq]`. Text-
+/// change invalidation is handled wholesale by [`LayoutCache::ensure_text_consistent`]
+/// before any read, so text_seq isn't part of the per-entry stamp.
+pub type HeightDeps = [u64; 4];
 
 #[derive(Default)]
 pub struct LayoutCache {
@@ -747,13 +747,20 @@ pub struct LayoutCache {
     pub line_prefix_len: RefCell<HashMap<LinePrefixKey, LinePrefixValue>>,
     pub node_range: RefCell<HashMap<u64, (Grapheme, Grapheme)>>,
 
-    // deps: `(text_seq, reveal_seq)` last populated, or `None` if never
+    // deps: `reveal_seq` last populated, or `None` if never
     pub hidden_by_fold: RefCell<HashMap<(Grapheme, Grapheme), bool>>,
-    pub hidden_by_fold_deps: std::cell::Cell<Option<(u64, u64)>>,
+    pub hidden_by_fold_deps: std::cell::Cell<Option<u64>>,
 
     // deps: title load state
     pub link_titles: RefCell<HashMap<String, Arc<Mutex<TitleState>>>>,
     pub link_seq: Arc<AtomicU64>,
+
+    /// `buffer.seq` this cache was last consistent with. Drives wholesale
+    /// invalidation in [`Self::ensure_text_consistent`] — text changes
+    /// can affect any entry (fold tag insertions move distant sibling
+    /// heights, AST re-parse shifts sourcepos keys), so per-entry
+    /// stamping wouldn't help.
+    pub text_seq: std::cell::Cell<u64>,
 }
 
 impl LayoutCache {
@@ -768,21 +775,14 @@ impl LayoutCache {
         // link_titles intentionally not cleared: fetched titles persist across layout invalidations
     }
 
-    /// Invalidation for text changes. Height and hidden_by_fold depend on
-    /// fold state (fold tags in text) and on each other (height returns 0
-    /// for hidden nodes), so both must be fully cleared — a fold tag
-    /// insertion at one point changes heights of distant sibling nodes.
-    /// Sourcepos-keyed caches are cleared because the AST is re-parsed.
-    /// Glyphon buffers are content-addressed and survive.
-    pub fn invalidate_text_change(&self) {
-        self.height.borrow_mut().clear();
-        self.height_approx.borrow_mut().clear();
-        self.hidden_by_fold.borrow_mut().clear();
-        self.hidden_by_fold_deps.set(None);
-        self.line_prefix_len.borrow_mut().clear();
-        self.node_range.borrow_mut().clear();
-
-        // glyphon_buffers: content-addressed, preserved across text changes
+    /// Wipe and re-stamp if `current` differs from the cache's recorded
+    /// text_seq. Called once per [`MdRender::reparse`] so reads in the
+    /// rest of the frame can rely on the cache reflecting current text.
+    pub fn ensure_text_consistent(&self, current: u64) {
+        if self.text_seq.get() != current {
+            self.clear();
+            self.text_seq.set(current);
+        }
     }
 }
 
@@ -938,7 +938,6 @@ impl MdRender {
 impl<'ast> MdRender {
     fn height_deps(&self) -> HeightDeps {
         [
-            self.buffer.current.seq as u64,
             self.width_seq,
             self.embeds.seq(),
             self.layout_cache

--- a/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
@@ -47,6 +47,8 @@ pub struct Find {
     was_focused: bool,
     /// All match ranges in the document for the current search term.
     pub matches: Vec<(Grapheme, Grapheme)>,
+    /// deps: `(buffer.seq, term, case_sensitive, whole_word, regex)`
+    matches_deps: (usize, Option<String>, bool, bool, bool),
     /// Index into `matches` for the currently focused match, if any.
     pub current_match: Option<usize>,
 }
@@ -65,6 +67,7 @@ impl Default for Find {
             open_requested: false,
             was_focused: false,
             matches: Vec::new(),
+            matches_deps: (0, None, false, false, false),
             current_match: None,
         }
     }
@@ -362,11 +365,8 @@ impl Find {
     /// Recompute `matches` for the current term, positioning `current_match`
     /// at the first match at or after `anchor`.
     fn refresh_matches(&mut self, buffer: &Buffer, anchor: Grapheme) {
-        let term = self.term.clone().unwrap_or_default();
-        self.matches = self.find_all(buffer, &term);
-        if self.matches.is_empty() {
-            self.current_match = None;
-        } else {
+        self.ensure_matches(buffer);
+        if !self.matches.is_empty() {
             let idx = self.matches.iter().position(|m| m.0 >= anchor).unwrap_or(0);
             self.current_match = Some(idx);
         }
@@ -376,6 +376,33 @@ impl Find {
         self.term = None;
         self.matches.clear();
         self.current_match = None;
+    }
+
+    /// Recompute `matches` if any input (buffer text, term, search flags)
+    /// has advanced since last compute.
+    pub fn ensure_matches(&mut self, buffer: &Buffer) {
+        let deps = (
+            buffer.current.seq,
+            self.term.clone(),
+            self.case_sensitive,
+            self.whole_word,
+            self.regex,
+        );
+        if deps == self.matches_deps {
+            return;
+        }
+        self.matches = match &self.term {
+            Some(term) => self.find_all(buffer, term),
+            None => Vec::new(),
+        };
+        if self.matches.is_empty() {
+            self.current_match = None;
+        } else if let Some(idx) = self.current_match {
+            if idx >= self.matches.len() {
+                self.current_match = Some(self.matches.len() - 1);
+            }
+        }
+        self.matches_deps = deps;
     }
 
     /// Compute all match ranges in the document for the given search term.

--- a/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
@@ -47,8 +47,8 @@ pub struct Find {
     was_focused: bool,
     /// All match ranges in the document for the current search term.
     pub matches: Vec<(Grapheme, Grapheme)>,
-    /// deps: `(buffer.seq, term, case_sensitive, whole_word, regex)`
-    matches_deps: (usize, Option<String>, bool, bool, bool),
+    /// deps: `(text_seq, term, case_sensitive, whole_word, regex)`
+    matches_deps: (u64, Option<String>, bool, bool, bool),
     /// Index into `matches` for the currently focused match, if any.
     pub current_match: Option<usize>,
 }
@@ -103,7 +103,7 @@ impl Find {
     /// transitions happen inside this call; [`FindOutput`] carries only the
     /// effects the caller must apply (buffer events, scroll hint, close).
     pub fn show(
-        &mut self, buffer: &Buffer, virtual_keyboard_shown: bool, ui: &mut Ui,
+        &mut self, buffer: &Buffer, text_seq: u64, virtual_keyboard_shown: bool, ui: &mut Ui,
     ) -> FindOutput {
         let mut output = FindOutput::default();
 
@@ -116,7 +116,7 @@ impl Find {
                 self.select_all_on_focus = true;
                 ui.memory_mut(|m| m.request_focus(self.id));
                 ui.ctx().set_virtual_keyboard_shown(true);
-                self.refresh_matches(buffer, buffer.current.selection.start());
+                self.refresh_matches(buffer, text_seq, buffer.current.selection.start());
                 output.scroll_to_match = !self.matches.is_empty();
                 return output;
             }
@@ -136,7 +136,7 @@ impl Find {
                     .current_match_range()
                     .map(|m| m.start())
                     .unwrap_or(buffer.current.selection.start());
-                self.refresh_matches(buffer, anchor);
+                self.refresh_matches(buffer, text_seq, anchor);
                 output.scroll_to_match = !self.matches.is_empty();
             }
             self.select_all_on_focus = true;
@@ -146,7 +146,7 @@ impl Find {
         if self.term.is_some() {
             Frame::NONE
                 .inner_margin(Margin::symmetric(10, 10))
-                .show(ui, |ui| self.show_inner(buffer, ui, &mut output));
+                .show(ui, |ui| self.show_inner(buffer, text_seq, ui, &mut output));
         }
 
         let focus_filter =
@@ -175,7 +175,7 @@ impl Find {
         output
     }
 
-    fn show_inner(&mut self, buffer: &Buffer, ui: &mut Ui, output: &mut FindOutput) {
+    fn show_inner(&mut self, buffer: &Buffer, text_seq: u64, ui: &mut Ui, output: &mut FindOutput) {
         ui.vertical(|ui| {
             let Some(term) = &mut self.term else {
                 return;
@@ -326,7 +326,7 @@ impl Find {
                     .current_match_range()
                     .map(|m| m.start())
                     .unwrap_or(buffer.current.selection.start());
-                self.refresh_matches(buffer, anchor);
+                self.refresh_matches(buffer, text_seq, anchor);
                 if !self.matches.is_empty() {
                     output.scroll_to_match = true;
                 }
@@ -364,8 +364,8 @@ impl Find {
 
     /// Recompute `matches` for the current term, positioning `current_match`
     /// at the first match at or after `anchor`.
-    fn refresh_matches(&mut self, buffer: &Buffer, anchor: Grapheme) {
-        self.ensure_matches(buffer);
+    fn refresh_matches(&mut self, buffer: &Buffer, text_seq: u64, anchor: Grapheme) {
+        self.ensure_matches(buffer, text_seq);
         if !self.matches.is_empty() {
             let idx = self.matches.iter().position(|m| m.0 >= anchor).unwrap_or(0);
             self.current_match = Some(idx);
@@ -380,14 +380,8 @@ impl Find {
 
     /// Recompute `matches` if any input (buffer text, term, search flags)
     /// has advanced since last compute.
-    pub fn ensure_matches(&mut self, buffer: &Buffer) {
-        let deps = (
-            buffer.current.seq,
-            self.term.clone(),
-            self.case_sensitive,
-            self.whole_word,
-            self.regex,
-        );
+    pub fn ensure_matches(&mut self, buffer: &Buffer, text_seq: u64) {
+        let deps = (text_seq, self.term.clone(), self.case_sensitive, self.whole_word, self.regex);
         if deps == self.matches_deps {
             return;
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -296,7 +296,8 @@ impl<'ast> MdRender {
                 let client = self.client.clone();
                 let ctx = self.ctx.clone();
                 let title_state = arc.clone();
-                let layout_dirty = self.layout_cache.link_layout_dirty.clone();
+                let link_seq = self.layout_cache.link_seq.clone();
+                let ws_seq = self.ws_seq.clone();
                 spawn!({
                     const CHROME: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
                     const GOOGLEBOT: &str =
@@ -324,7 +325,7 @@ impl<'ast> MdRender {
                         .and_then(|h| extract_html_title(&h))
                         .map(TitleState::Loaded)
                         .unwrap_or(TitleState::Failed);
-                    layout_dirty.store(true, Ordering::Relaxed);
+                    link_seq.store(ws_seq.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
                     ctx.request_repaint();
                 });
                 arc

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
@@ -442,7 +442,9 @@ impl<'ast> MdRender {
     }
 
     pub fn reveal_ranges(&self) -> impl Iterator<Item = (Grapheme, Grapheme)> + '_ {
-        self.reveal_ranges.iter().copied()
+        self.reveal_selection
+            .into_iter()
+            .chain(self.find_current_match)
     }
 
     /// Returns true if `range` intersects any reveal range.

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
@@ -438,7 +438,7 @@ impl<'ast> MdRender {
     /// Returns true if the node's range intersects any reveal range. Drop-in
     /// replacement for `node_intersects_selection` in reveal contexts.
     pub fn node_revealed(&self, node: &'ast AstNode<'ast>) -> bool {
-        self.range_revealed(self.node_range(node), false)
+        self.range_revealed(self.node_range(node), true)
     }
 
     pub fn reveal_ranges(&self) -> impl Iterator<Item = (Grapheme, Grapheme)> + '_ {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/text.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/text.rs
@@ -26,7 +26,7 @@ impl<'ast> MdRender {
             return Default::default();
         }
 
-        if let Some(search_range) = self.text_highlight_range {
+        if let Some(search_range) = self.search_range {
             let start = search_range.0.max(node_range.0);
             let end = search_range.1.min(node_range.1);
             if start < end {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
@@ -609,7 +609,7 @@ impl<'ast> Editor {
                             // menu labels: force blue links + plain image-link text
                             let link_resolver =
                                 mem::replace(&mut self.edit.renderer.link_resolver, Box::new(()));
-                            self.edit.renderer.render_images_as_text = true;
+                            self.edit.renderer.disable_images = true;
 
                             self.edit.renderer.layout_cache.clear();
 
@@ -1052,7 +1052,7 @@ impl<'ast> Editor {
                             self.edit.renderer.touch_consuming_rects = touch_consuming_rects;
 
                             self.edit.renderer.link_resolver = link_resolver;
-                            self.edit.renderer.render_images_as_text = false;
+                            self.edit.renderer.disable_images = false;
                         });
                 });
             });

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -344,6 +344,17 @@ impl MdRender {
             }
         }
 
+        // Cosmic-text emits no glyphs for combining-mark-only input (e.g. a
+        // standalone `\u{fe0f}`), leaving source bytes uncovered. Extend the
+        // last row's range so every source grapheme has a galley anchor.
+        if !is_override {
+            if let Some(last) = split.last_mut() {
+                if last.range.1 < range.end() {
+                    last.range.1 = range.end();
+                }
+            }
+        }
+
         split
     }
 

--- a/libs/content/workspace/src/widgets/image_cache.rs
+++ b/libs/content/workspace/src/widgets/image_cache.rs
@@ -16,7 +16,7 @@ use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
-use egui::{ColorImage, Context, TextureId};
+use egui::{ColorImage, Context, TextureId, Vec2};
 use image::{DynamicImage, ImageDecoder};
 use lb_rs::blocking::Lb;
 use lb_rs::{Uuid, spawn};
@@ -26,6 +26,7 @@ use resvg::usvg::{self, Transform};
 use crate::file_cache::{FileCache, FilesExt as _, ResolvedLink};
 use crate::seq::ws_seq;
 use crate::tab::markdown_editor::HttpClient;
+use crate::workspace::WsPersistentStore;
 
 /// Wraps a block in an `async` closure on wasm, a plain closure on native.
 /// Allows the same source to await async HTTP on wasm while running
@@ -68,10 +69,14 @@ pub struct ImageCache {
     client: HttpClient,
     core: Lb,
     files: Arc<RwLock<FileCache>>,
+    persistence: WsPersistentStore, // persist image dims
 }
 
 impl ImageCache {
-    pub fn new(ctx: Context, client: HttpClient, core: Lb, files: Arc<RwLock<FileCache>>) -> Self {
+    pub fn new(
+        ctx: Context, client: HttpClient, core: Lb, files: Arc<RwLock<FileCache>>,
+        persistence: WsPersistentStore,
+    ) -> Self {
         let ws_seq = ws_seq(&ctx);
         Self {
             inner: Default::default(),
@@ -81,15 +86,12 @@ impl ImageCache {
             client,
             core,
             files,
+            persistence,
         }
     }
 
     pub fn seq(&self) -> u64 {
         self.seq.load(Ordering::Relaxed)
-    }
-
-    pub fn ctx(&self) -> &Context {
-        &self.ctx
     }
 
     pub fn begin_frame(&self) {
@@ -131,26 +133,55 @@ impl ImageCache {
         }
 
         let state: Arc<Mutex<ImageState>> = Default::default();
-        self.spawn_load(
-            url,
-            from_file_id,
-            user_activity,
-            state.clone(),
-            self.seq.clone(),
-            self.ws_seq.clone(),
-        );
+        self.spawn_load(url, from_file_id, user_activity, state.clone());
         inner.current.insert(url.to_string(), state.clone());
         state
     }
 
+    /// Real texture dimensions for `url`, if known.
+    pub fn dims(&self, url: &str) -> Option<Vec2> {
+        self.persistence
+            .image_dims()
+            .get(url)
+            .copied()
+            .map(|[w, h]| Vec2::new(w, h))
+    }
+
+    /// Test helper: directly install a `Loaded`/`Failed` state for `url`,
+    /// populate dims from texture metadata (when `Ok`), and bump `seq` —
+    /// mimicking a worker thread completing a load. The dims insert
+    /// happens before the state flip to match the spawn_load ordering.
+    #[cfg(test)]
+    pub fn complete_load(&self, url: &str, result: Result<TextureId, String>) {
+        let state = match result {
+            Ok(tid) => {
+                if let Some(meta) = self.ctx.tex_manager().read().meta(tid) {
+                    let [w, h] = meta.size;
+                    self.persistence
+                        .merge_image_dims(HashMap::from([(url.to_string(), [w as f32, h as f32])]));
+                }
+                ImageState::Loaded(tid)
+            }
+            Err(err) => ImageState::Failed(err),
+        };
+        let mut inner = self.inner.lock().unwrap();
+        inner
+            .current
+            .insert(url.to_string(), Arc::new(Mutex::new(state)));
+        self.seq
+            .store(self.ws_seq.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
+    }
+
     fn spawn_load(
         &self, url: &str, from_file_id: Uuid, user_activity: bool, state: Arc<Mutex<ImageState>>,
-        embeds_seq: Arc<AtomicU64>, ws_seq: Arc<AtomicU64>,
     ) {
         let url = url.to_string();
         let ctx = self.ctx.clone();
         let client = self.client.clone();
         let core = self.core.clone();
+        let embeds_seq = self.seq.clone();
+        let ws_seq = self.ws_seq.clone();
+        let persistence = self.persistence.clone();
 
         let maybe_lb_id = {
             let guard = self.files.read().unwrap();
@@ -225,6 +256,11 @@ impl ImageCache {
 
             match result {
                 Ok(texture_id) => {
+                    if let Some(meta) = texture_manager.read().meta(texture_id) {
+                        let [w, h] = meta.size;
+                        persistence
+                            .merge_image_dims(HashMap::from([(url.clone(), [w as f32, h as f32])]));
+                    }
                     *state.lock().unwrap() = ImageState::Loaded(texture_id);
                 }
                 Err(err) => {

--- a/libs/content/workspace/src/widgets/image_cache.rs
+++ b/libs/content/workspace/src/widgets/image_cache.rs
@@ -24,6 +24,7 @@ use resvg::tiny_skia::Pixmap;
 use resvg::usvg::{self, Transform};
 
 use crate::file_cache::{FileCache, FilesExt as _, ResolvedLink};
+use crate::seq::ws_seq;
 use crate::tab::markdown_editor::HttpClient;
 
 /// Wraps a block in an `async` closure on wasm, a plain closure on native.
@@ -60,10 +61,8 @@ struct Inner {
 #[derive(Clone)]
 pub struct ImageCache {
     inner: Arc<Mutex<Inner>>,
-    /// Monotonic generation counter, bumped every time a load completes.
-    /// Clients cache their last-observed value and invalidate layout when
-    /// it changes. Supports any number of independent consumers.
-    last_modified: Arc<AtomicU64>,
+    seq: Arc<AtomicU64>,
+    ws_seq: Arc<AtomicU64>,
 
     ctx: Context,
     client: HttpClient,
@@ -73,9 +72,11 @@ pub struct ImageCache {
 
 impl ImageCache {
     pub fn new(ctx: Context, client: HttpClient, core: Lb, files: Arc<RwLock<FileCache>>) -> Self {
+        let ws_seq = ws_seq(&ctx);
         Self {
             inner: Default::default(),
-            last_modified: Arc::new(AtomicU64::new(0)),
+            seq: Arc::new(AtomicU64::new(0)),
+            ws_seq,
             ctx,
             client,
             core,
@@ -83,10 +84,8 @@ impl ImageCache {
         }
     }
 
-    /// Current generation. Bumped each time a load completes. Callers can
-    /// compare against a previously-observed value to detect new data.
-    pub fn last_modified(&self) -> u64 {
-        self.last_modified.load(Ordering::Relaxed)
+    pub fn seq(&self) -> u64 {
+        self.seq.load(Ordering::Relaxed)
     }
 
     pub fn ctx(&self) -> &Context {
@@ -137,7 +136,8 @@ impl ImageCache {
             from_file_id,
             user_activity,
             state.clone(),
-            self.last_modified.clone(),
+            self.seq.clone(),
+            self.ws_seq.clone(),
         );
         inner.current.insert(url.to_string(), state.clone());
         state
@@ -145,7 +145,7 @@ impl ImageCache {
 
     fn spawn_load(
         &self, url: &str, from_file_id: Uuid, user_activity: bool, state: Arc<Mutex<ImageState>>,
-        last_modified: Arc<AtomicU64>,
+        embeds_seq: Arc<AtomicU64>, ws_seq: Arc<AtomicU64>,
     ) {
         let url = url.to_string();
         let ctx = self.ctx.clone();
@@ -232,7 +232,7 @@ impl ImageCache {
                 }
             }
 
-            last_modified.fetch_add(1, Ordering::Relaxed);
+            embeds_seq.store(ws_seq.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
             ctx.request_repaint();
         });
     }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -508,15 +508,13 @@ impl Workspace {
             *self.files.write().unwrap() =
                 FileCache::new(&self.core).expect("failed to refresh file cache");
 
-            // A file appearing/disappearing/renaming changes link resolution
-            // and titles, which the markdown layout cache keys can't see.
             for tab in self.tabs.values_mut() {
                 if let Some(md) = tab.markdown_mut() {
-                    md.edit
-                        .renderer
+                    let renderer = &md.edit.renderer;
+                    renderer
                         .layout_cache
-                        .link_layout_dirty
-                        .store(true, Ordering::Relaxed);
+                        .link_seq
+                        .store(renderer.ws_seq.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
                 }
             }
         }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -13,6 +13,7 @@ use lb_rs::model::svg::buffer::Buffer;
 use lb_rs::service::events::{self, Actor, Event};
 use lb_rs::{Uuid, spawn};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
@@ -95,10 +96,14 @@ impl Workspace {
         let writeable_path = writeable_dir.join("ws_persistence.json");
         let files =
             Arc::new(RwLock::new(FileCache::new(core).expect("failed to initialize file cache")));
-        let images =
-            ImageCache::new(ctx.clone(), HttpClient::default(), core.clone(), Arc::clone(&files));
-
         let cfg = WsPersistentStore::new(core.recent_panic().unwrap_or(true), writeable_path);
+        let images = ImageCache::new(
+            ctx.clone(),
+            HttpClient::default(),
+            core.clone(),
+            Arc::clone(&files),
+            cfg.clone(),
+        );
         ctx.set_zoom_factor(cfg.get_zoom_factor());
         let mut ws = Self {
             tabs: TabCache::new(),
@@ -744,7 +749,6 @@ impl Workspace {
                                             embeds: Box::new(ImageEmbedResolver::new(
                                                 self.images.clone(),
                                                 id,
-                                                self.cfg.get_markdown().image_dims(&id),
                                             )),
                                         },
                                         MdConfig {
@@ -1063,6 +1067,8 @@ pub struct WsPresistentData {
     auto_sync: bool,
     landing_page: LandingPage,
     zoom_factor: f32,
+    #[serde(default)]
+    image_dims: HashMap<String, [f32; 2]>,
 }
 
 impl Default for WsPresistentData {
@@ -1076,6 +1082,7 @@ impl Default for WsPresistentData {
             markdown: MdPersistence::default(),
             landing_page: LandingPage::default(),
             zoom_factor: 1.,
+            image_dims: HashMap::default(),
         }
     }
 }
@@ -1175,6 +1182,17 @@ impl WsPersistentStore {
     pub fn set_zoom_factor(&mut self, zoom_factor: f32) {
         let mut data_lock = self.data.write().unwrap();
         data_lock.zoom_factor = zoom_factor;
+        self.write_to_file();
+    }
+
+    pub fn image_dims(&self) -> HashMap<String, [f32; 2]> {
+        self.data.read().unwrap().image_dims.clone()
+    }
+
+    pub fn merge_image_dims(&self, new_dims: HashMap<String, [f32; 2]>) {
+        let mut data_lock = self.data.write().unwrap();
+        data_lock.image_dims.extend(new_dims);
+        drop(data_lock);
         self.write_to_file();
     }
 

--- a/libs/lb/lb-rs/src/model/text/buffer.rs
+++ b/libs/lb/lb-rs/src/model/text/buffer.rs
@@ -77,7 +77,7 @@ pub struct Snapshot {
 impl Snapshot {
     fn apply_select(&mut self, range: (Grapheme, Grapheme)) -> Response {
         self.selection = range;
-        Response::default()
+        Response { selection_user_moved: true, ..Response::default() }
     }
 
     fn apply_replace(&mut self, replace: &Replace) -> (Response, Graphemes) {
@@ -216,6 +216,13 @@ struct External {
 #[derive(Default)]
 pub struct Response {
     pub text_updated: bool,
+    /// True iff the selection was set by an explicit `Select` op or by
+    /// `undo`/`redo` restoring a historical selection. False when the
+    /// selection moved only because a `Replace` op OT-shifted its
+    /// offsets — that's a side effect of editing, not a user navigation.
+    /// Callers use this to gate scroll-to-cursor: programmatic edits
+    /// (e.g. fold-button taps) shouldn't pull the viewport.
+    pub selection_user_moved: bool,
     pub open_camera: bool,
     /// Sequence range of operations applied this frame. Use
     /// `buffer.replacements_since(seq_before)` to get the edits.
@@ -226,6 +233,7 @@ pub struct Response {
 impl std::ops::BitOrAssign for Response {
     fn bitor_assign(&mut self, other: Response) {
         self.text_updated |= other.text_updated;
+        self.selection_user_moved |= other.selection_user_moved;
         self.open_camera |= other.open_camera;
         // keep the earliest seq_before and latest seq_after
         if self.seq_before == self.seq_after {

--- a/public-site/trunk/src/app.rs
+++ b/public-site/trunk/src/app.rs
@@ -93,6 +93,7 @@ impl eframe::App for LbWebApp {
                         HttpClient::default(),
                         self.core.clone(),
                         Arc::clone(&files),
+                        self.cfg.clone(),
                     );
                     self.images = Some(images.clone());
                     self.editor = Some(Editor::new(
@@ -105,11 +106,7 @@ impl eframe::App for LbWebApp {
                             persistence: self.cfg.clone(),
                             files,
                             link_resolver: Box::new(()),
-                            embeds: Box::new(ImageEmbedResolver::new(
-                                images,
-                                file_id,
-                                Default::default(),
-                            )),
+                            embeds: Box::new(ImageEmbedResolver::new(images, file_id)),
                         },
                         MdConfig { readonly: false, ext: "md".into(), tablet_or_desktop: true },
                     ));


### PR DESCRIPTION
An overall pass on cache invalidation in the editor, fixing:
* issues with folded sections not being folded (node id collisions)
* issues with layout not responding to image / link loads completing
* issues where caches were recomputed more often than needed

...and a few other bonus fixes (see commit msg's)