### PR TITLE
ws: don't get stuck saving ws persistence

### DIFF
--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -62,6 +62,7 @@ impl Workspace {
         }
         if self.out.tabs_changed || self.current_tab_changed {
             self.cfg.set_tabs(&self.tab_strip, &self.current_tab);
+            self.current_tab_changed = false;
         }
 
         let zoom = self.ctx.zoom_factor();


### PR DESCRIPTION
i qa'd that persistence is still written when a new tab is opened, when cursor position changes, scroll position changes, and I ensured that it's only written once per file