### PR TITLE
egui: add a right import menu

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -547,6 +547,10 @@ impl AccountScreen {
         if let Some((f, dest)) = resp.export_file {
             self.export_file(f, dest);
         }
+
+        if let Some((paths, parent_id)) = resp.import_files {
+            self.import_paths(ui.ctx(), paths, parent_id);
+        }
     }
 
     fn show_icon_shelf(&mut self, ui: &mut egui::Ui, anchor_rect: egui::Rect) {
@@ -755,16 +759,20 @@ impl AccountScreen {
     }
 
     fn dropped_files(&self, ctx: &egui::Context, drops: Vec<egui::DroppedFile>, parent: File) {
-        let core = self.core.clone();
-        let ctx = ctx.clone();
-        let update_tx = self.update_tx.clone();
         let paths = drops
             .into_iter()
             .filter_map(|d| d.path)
             .collect::<Vec<path::PathBuf>>();
+        self.import_paths(ctx, paths, parent.id);
+    }
+
+    fn import_paths(&self, ctx: &egui::Context, paths: Vec<path::PathBuf>, parent_id: Uuid) {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let update_tx = self.update_tx.clone();
 
         thread::spawn(move || {
-            let result = core.import_files(&paths, parent.id, &|status| match status {
+            let result = core.import_files(&paths, parent_id, &|status| match status {
                 ImportStatus::CalculatedTotal(count) => {
                     println!("importing {count} files");
                 }

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -1310,20 +1310,37 @@ impl FileTree {
                 ui.close();
             }
 
-            if ui.button("Import").clicked() {
+            ui.menu_button("Import", |ui| {
                 let parent_id = if file.is_folder() { file.id } else { file.parent };
-                let import = self.import.clone();
-                let ctx = ui.ctx().clone();
 
-                thread::spawn(move || {
-                    if let Some(paths) = FileDialog::new().pick_files() {
-                        let mut import = import.lock().unwrap();
-                        *import = Some((paths, parent_id));
-                    }
-                    ctx.request_repaint();
-                });
-                ui.close();
-            }
+                if ui.button("Files").clicked() {
+                    let import = self.import.clone();
+                    let ctx = ui.ctx().clone();
+
+                    thread::spawn(move || {
+                        if let Some(paths) = FileDialog::new().pick_files() {
+                            let mut import = import.lock().unwrap();
+                            *import = Some((paths, parent_id));
+                        }
+                        ctx.request_repaint();
+                    });
+                    ui.close();
+                }
+
+                if ui.button("Folder").clicked() {
+                    let import = self.import.clone();
+                    let ctx = ui.ctx().clone();
+
+                    thread::spawn(move || {
+                        if let Some(paths) = FileDialog::new().pick_folders() {
+                            let mut import = import.lock().unwrap();
+                            *import = Some((paths, parent_id));
+                        }
+                        ctx.request_repaint();
+                    });
+                    ui.close();
+                }
+            });
 
             if self.descends_from_root(file.id) && ui.button("Share").clicked() {
                 let file = self.files.get_by_id(file.id).unwrap().clone();

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -52,6 +52,7 @@ pub struct FileTree {
     pub export: Arc<Mutex<Option<(File, PathBuf)>>>,
 
     /// File import sources are selected asynchronously using the system file dialog.
+    #[allow(clippy::type_complexity)]
     pub import: Arc<Mutex<Option<(Vec<PathBuf>, Uuid)>>>,
 
     /// Which file is the drag 'n' drop payload being hovered over and since when? Used to expand folders during dnd.

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -51,6 +51,9 @@ pub struct FileTree {
     /// File export targets are selected asynchronously using the system file dialog.
     pub export: Arc<Mutex<Option<(File, PathBuf)>>>,
 
+    /// File import sources are selected asynchronously using the system file dialog.
+    pub import: Arc<Mutex<Option<(Vec<PathBuf>, Uuid)>>>,
+
     /// Which file is the drag 'n' drop payload being hovered over and since when? Used to expand folders during dnd.
     pub drop: Option<(Uuid, Instant)>,
 
@@ -89,6 +92,7 @@ impl FileTree {
             rename_target: Default::default(),
             rename_buffer: Default::default(),
             export: Default::default(),
+            import: Default::default(),
             drop: Default::default(),
             scroll_to_cursor: Default::default(),
             pending_shares: Default::default(),
@@ -890,6 +894,14 @@ impl FileTree {
         }
         mem::drop(export);
 
+        // file import
+        let mut import = self.import.lock().unwrap();
+        if import.is_some() {
+            resp.import_files = import.clone();
+            *import = None;
+        }
+        mem::drop(import);
+
         // drag 'n' drop:
         // when drag starts, dragged file sets dnd payload
         if self.descends_from_root(file.id) && file_resp.dragged()
@@ -1298,6 +1310,21 @@ impl FileTree {
                 ui.close();
             }
 
+            if ui.button("Import").clicked() {
+                let parent_id = if file.is_folder() { file.id } else { file.parent };
+                let import = self.import.clone();
+                let ctx = ui.ctx().clone();
+
+                thread::spawn(move || {
+                    if let Some(paths) = FileDialog::new().pick_files() {
+                        let mut import = import.lock().unwrap();
+                        *import = Some((paths, parent_id));
+                    }
+                    ctx.request_repaint();
+                });
+                ui.close();
+            }
+
             if self.descends_from_root(file.id) && ui.button("Share").clicked() {
                 let file = self.files.get_by_id(file.id).unwrap().clone();
                 resp.create_share_modal = Some(file);
@@ -1675,6 +1702,7 @@ pub struct Response {
     pub new_file: Option<bool>,
     pub new_drawing: Option<bool>,
     pub export_file: Option<(File, PathBuf)>,
+    pub import_files: Option<(Vec<PathBuf>, Uuid)>,
     pub new_folder_modal: Option<File>,
     pub create_share_modal: Option<File>,
     pub move_requests: Vec<(Uuid, Uuid)>,
@@ -1712,6 +1740,7 @@ impl Response {
         this.new_folder_modal = this.new_folder_modal.or(other.new_folder_modal);
         this.create_share_modal = this.create_share_modal.or(other.create_share_modal);
         this.export_file = this.export_file.or(other.export_file);
+        this.import_files = this.import_files.or(other.import_files);
         this.open_requests.extend(other.open_requests);
         this.move_requests.extend(other.move_requests);
         this.rename_request = this.rename_request.or(other.rename_request);


### PR DESCRIPTION
for instances where drag and drop is not reliable or it's just cumbersome.
<img width="318" height="430" alt="image" src="https://github.com/user-attachments/assets/d159b2cf-c661-458c-8ac7-107191600dab" />

personally a big believer in supporting a diverse set of ingress & egress flows.

I would like to not split the experience by files & folders, but it's an underlying limitation of [`rfd`'s api](https://docs.rs/rfd/latest/rfd/). 