### PR TITLE
md: assorted fixes

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -233,6 +233,7 @@ pub struct Editor {
     // change detection
     pub unprocessed_scroll: Option<Instant>,
     prev_dimensions: Option<Vec2>,
+    prev_virtual_keyboard_shown: bool,
     embeds_seq: u64,
 
     // interaction widgets (toolbar + find are Editor-owned; completion
@@ -631,6 +632,7 @@ impl Editor {
             unprocessed_scroll: Default::default(),
 
             prev_dimensions: None,
+            prev_virtual_keyboard_shown: cfg!(target_os = "android"),
 
             next_resp: Default::default(),
         }
@@ -988,7 +990,16 @@ impl Editor {
         } else if resp.selection_updated {
             ui.ctx().request_repaint();
         }
-        if self.initialized && self.edit.renderer.touch_mode && height_updated {
+        // Pull the cursor out from behind the virtual keyboard: scroll on
+        // its rising edge, and keep re-asserting while `height_updated`
+        // fires across the keyboard animation so the final settled
+        // viewport also scrolls.
+        let keyboard_just_shown = self.virtual_keyboard_shown && !self.prev_virtual_keyboard_shown;
+        self.prev_virtual_keyboard_shown = self.virtual_keyboard_shown;
+        if self.initialized
+            && self.edit.renderer.touch_mode
+            && (height_updated || keyboard_just_shown)
+        {
             self.edit.pending_scroll = Some(ScrollTarget::Cursor);
             ui.ctx().request_repaint();
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/emoji_completions.rs
@@ -6,6 +6,7 @@ use crate::TextBufferArea;
 use crate::tab::markdown_editor::MdEdit;
 use crate::tab::markdown_editor::bounds::{Paragraphs, RangesExt as _};
 use crate::tab::markdown_editor::input::{Event, Location, Region};
+use crate::tab::markdown_editor::widget::completion_popup_rect;
 use crate::widgets::GlyphonLabel;
 
 const MAX_RESULTS: usize = 5;
@@ -419,16 +420,13 @@ impl MdEdit {
         // -- Position popup --------------------------------------------------------
         let popup_width = max_width + POPUP_PADDING;
         let popup_height = results.len() as f32 * self.renderer.layout.completion_row_height;
-        let screen_rect = ui.ctx().screen_rect();
-        let popup_y = if cursor_top.y - popup_height >= screen_rect.min.y {
-            cursor_top.y - popup_height
-        } else {
-            cursor_bot.y
-        };
-        let popup_rect = Rect::from_min_size(
-            Pos2::new(cursor_top.x, popup_y),
+        let popup_rect = completion_popup_rect(
+            cursor_top,
+            cursor_bot,
             Vec2::new(popup_width, popup_height),
+            ui.ctx().screen_rect(),
         );
+        let popup_width = popup_rect.width();
         self.renderer.touch_consuming_rects.push(popup_rect);
 
         let row_rects: Vec<Rect> = (0..results.len())

--- a/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
@@ -13,6 +13,7 @@ use crate::tab::image_viewer::is_supported_image_fmt;
 use crate::tab::markdown_editor::MdEdit;
 use crate::tab::markdown_editor::bounds::{Paragraphs, RangesExt as _};
 use crate::tab::markdown_editor::input::{Event, Location, Region};
+use crate::tab::markdown_editor::widget::completion_popup_rect;
 use crate::theme::palette_v2::ThemeExt as _;
 use crate::widgets::GlyphonLabel;
 
@@ -751,16 +752,13 @@ impl MdEdit {
             .fold(0.0_f32, f32::max);
 
         let popup_height = results.len() as f32 * self.renderer.layout.completion_row_height;
-        let screen_rect = ui.ctx().screen_rect();
-        let popup_y = if cursor_top.y - popup_height >= screen_rect.min.y {
-            cursor_top.y - popup_height
-        } else {
-            cursor_bot.y
-        };
-        let popup_rect = Rect::from_min_size(
-            Pos2::new(cursor_top.x, popup_y),
+        let popup_rect = completion_popup_rect(
+            cursor_top,
+            cursor_bot,
             Vec2::new(popup_width, popup_height),
+            ui.ctx().screen_rect(),
         );
+        let popup_width = popup_rect.width();
         self.renderer.touch_consuming_rects.push(popup_rect);
 
         let row_rects: Vec<Rect> = (0..results.len())

--- a/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/mod.rs
@@ -1,5 +1,5 @@
 use comrak::nodes::{AstNode, NodeHeading, NodeValue};
-use egui::{CornerRadius, Rect, Stroke, StrokeKind, Ui, UiBuilder};
+use egui::{CornerRadius, Pos2, Rect, Stroke, StrokeKind, Ui, UiBuilder, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _, RangeIterExt as _};
 
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
@@ -485,4 +485,37 @@ impl<'ast> MdRender {
             }
         }
     }
+}
+
+/// Gap kept between the completion popup and every window edge. Matches
+/// the scroll area's scrollbar footprint (`BAR_WIDTH` 10 + `BAR_INSET` 3
+/// in `affine_scroll.rs`) so the popup also clears the scrollbar.
+const COMPLETION_POPUP_MARGIN: f32 = 13.0;
+
+/// Positions a completion popup near the text cursor while keeping it
+/// inside the visible window with a [`COMPLETION_POPUP_MARGIN`] gap from
+/// every edge. Prefers placing the popup above the cursor, falls back to
+/// below, and clamps both axes (and the width) so it never draws
+/// off-screen or up against an edge.
+pub(crate) fn completion_popup_rect(
+    cursor_top: Pos2, cursor_bot: Pos2, size: Vec2, screen_rect: Rect,
+) -> Rect {
+    let area = screen_rect.shrink(COMPLETION_POPUP_MARGIN);
+
+    let width = size.x.min(area.width());
+    let height = size.y;
+
+    let x = cursor_top.x.min(area.max.x - width).max(area.min.x);
+
+    let fits_above = cursor_top.y - height >= area.min.y;
+    let fits_below = cursor_bot.y + height <= area.max.y;
+    let y = if fits_above {
+        cursor_top.y - height
+    } else if fits_below {
+        cursor_bot.y
+    } else {
+        cursor_bot.y.min(area.max.y - height).max(area.min.y)
+    };
+
+    Rect::from_min_size(Pos2::new(x, y), Vec2::new(width, height))
 }

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -654,16 +654,27 @@ impl Workspace {
                     let files_guard = files_clone.read().unwrap();
 
                     let account = &self.account;
-                    let Some(file) = files_guard.get_by_id(id) else { continue };
+                    let (name, read_only) = if let Some(file) = files_guard.get_by_id(id) {
+                        (file.name.clone(), files_guard.access(id, account) == UserAccessMode::Read)
+                    } else if let Ok(file) = core.get_file_by_id(id) {
+                        // read-through (can remove when we master cache
+                        // refreshes): a freshly created file isn't in the
+                        // async-rebuilt cache yet; without this the
+                        // completed load is discarded and the tab is stuck
+                        // loading forever. New/owned files are writable.
+                        (file.name, false)
+                    } else {
+                        // genuinely gone (e.g. deleted): fail the tab
+                        // rather than discard the load and hang in Loading.
+                        let msg = format!("failed to load file: {id} not found");
+                        error!(msg);
+                        tab.content = ContentState::Failed(TabFailure::SimpleMisc(msg.clone()));
+                        self.out.failure_messages.push(msg);
+                        continue;
+                    };
 
-                    let doc_type = DocType::from_name(&file.name);
-                    let read_only = files_guard.access(id, account) == UserAccessMode::Read;
-                    let ext = file
-                        .name
-                        .split('.')
-                        .next_back()
-                        .unwrap_or_default()
-                        .to_owned();
+                    let doc_type = DocType::from_name(&name);
+                    let ext = name.split('.').next_back().unwrap_or_default().to_owned();
 
                     let (maybe_hmac, bytes) = match content_result {
                         Ok((hmac, bytes)) => (hmac, bytes),


### PR DESCRIPTION
- clamp link/emoji popup within the window, with a margin that also clears the scrollbar
- read through to core when opening a file so newly created files don't hang forever on the loading spinner
- scroll the cursor into view when the virtual keyboard appears

related: https://github.com/lockbook/lockbook/issues/4539