### PR TITLE
egui: fix theme switching weirdness

### DIFF
--- a/clients/desktop/src/lib.rs
+++ b/clients/desktop/src/lib.rs
@@ -98,10 +98,12 @@ impl ApplicationHandler<UserEvent> for App {
                 });
         }
 
-        let response = state.egui_winit.on_window_event(&state.window, &event);
+        if !matches!(event, WindowEvent::ThemeChanged(_)) {
+            let response = state.egui_winit.on_window_event(&state.window, &event);
 
-        if response.repaint && !matches!(event, WindowEvent::RedrawRequested) {
-            state.window.request_redraw();
+            if response.repaint && !matches!(event, WindowEvent::RedrawRequested) {
+                state.window.request_redraw();
+            }
         }
 
         match event {

--- a/clients/egui/src/theme.rs
+++ b/clients/egui/src/theme.rs
@@ -56,6 +56,10 @@ fn poll_system_theme(
                             // since updating from egui 0.28 to 0.30, this is
                             // necessary to prevent light/dark mode switching
                             // from resetting font sizes to default
+                            //
+                            // update -- this is only needed if you're running from eframe, and we
+                            // could consider removing this. I feel like it adds some latency but
+                            // I'm not sure, didn't measure.
                             visuals::init(&ctx);
 
                             ctx.request_repaint();


### PR DESCRIPTION
there was a latent bug hanging out in our codebase that was surfaced by @ad-tra taking #4551 for a spin.

if you were not following the system theme this code would never run: https://github.com/lockbook/lockbook/blob/master/clients/egui/src/theme.rs#L56-L59

and with egui adding theme switching in a recent version this code **would** run when you switched themes: https://github.com/emilk/egui/blob/07c6e0de0fdb2ee76e0c2ec546a1e8e6833e4b06/crates/egui-winit/src/lib.rs#L424-L430

blasting away our theme and messing up our font size. This never happens via integrations we control, and I updated the integration I wrote for windows and linux to make sure no one hits this codepath in the wild.