### PR TITLE
egui: fix alignment of sync loading icon

### DIFF
--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -20,7 +20,7 @@ pub struct Button<'a> {
     indent: f32,
     default_fill: Option<egui::Color32>,
 }
-const SPINNER_RADIUS: u32 = 6;
+const SPINNER_RADIUS: u32 = 5;
 
 impl<'a> Button<'a> {
     pub fn icon(self, icon: &'a Icon) -> Self {
@@ -189,7 +189,7 @@ impl<'a> Button<'a> {
 
                     if self.is_loading {
                         let spinner_pos = egui::pos2(
-                            rect.max.x - padding.x - (SPINNER_RADIUS * 2) as f32,
+                            rect.max.x - padding.x / 2.0 - (SPINNER_RADIUS * 2) as f32,
                             rect.center().y,
                         );
 


### PR DESCRIPTION
<img width="120" height="71" alt="image" src="https://github.com/user-attachments/assets/868c90f7-b338-40bb-b82f-7f69c8d2a15a" />
