### PR TITLE
md: assorted fixes

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -728,9 +728,20 @@ impl<'ast> MdEdit {
             if self.renderer.selected_block(node) {
                 any_selected_blocks = true;
 
-                let target_node =
-                    if node.is_container_block() { node } else { node.parent().unwrap() };
-                unapply |= &target_node.node_type() == style
+                // Walk up the ancestor chain: the selected block (a leaf
+                // like Paragraph, or its immediate container) may sit
+                // several levels below the structural container that
+                // bears the toggled style. `* foo` has `List > Item >
+                // Paragraph` — the bullet style lives on `List`, two
+                // levels above the selected Paragraph.
+                let mut maybe = if node.is_container_block() { Some(node) } else { node.parent() };
+                while let Some(ancestor) = maybe {
+                    if &ancestor.node_type() == style {
+                        unapply = true;
+                        break;
+                    }
+                    maybe = ancestor.parent();
+                }
             }
         }
 
@@ -1253,8 +1264,20 @@ impl NodeType for NodeValue {
             NodeValue::Document => NodeValue::Document,
             NodeValue::FrontMatter(_) => NodeValue::FrontMatter(Default::default()),
             NodeValue::BlockQuote => NodeValue::BlockQuote,
-            NodeValue::List(_) => NodeValue::List(Default::default()),
-            NodeValue::Item(_) => NodeValue::Item(Default::default()),
+            // Preserve the discriminating fields so toggle-style
+            // comparisons can tell bullet / ordered / task lists apart.
+            // Other NodeList fields (padding, start, etc.) are layout
+            // and shouldn't affect type equality.
+            NodeValue::List(l) => NodeValue::List(NodeList {
+                list_type: l.list_type,
+                is_task_list: l.is_task_list,
+                ..Default::default()
+            }),
+            NodeValue::Item(l) => NodeValue::Item(NodeList {
+                list_type: l.list_type,
+                is_task_list: l.is_task_list,
+                ..Default::default()
+            }),
             NodeValue::DescriptionList => NodeValue::DescriptionList,
             NodeValue::DescriptionItem(_) => NodeValue::DescriptionItem(Default::default()),
             NodeValue::DescriptionTerm => NodeValue::DescriptionTerm,

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1174,32 +1174,74 @@ impl Editor {
                         self.edit.renderer.bounds.wrap_lines.clear();
                         self.edit.renderer.text_areas.clear();
 
-                        // Phase 1: drive scroll math + scrollbar. The
-                        // immutable `DocScrollContent` borrow is released
-                        // before phase 2's mutable renderer paint.
-                        let visible = {
+                        // Phase 1: drive scroll math + scrollbar, and
+                        // pick up to one viewport's worth of rows above
+                        // and below the visible window so navigation
+                        // (advance_by_line) finds fragments on off-
+                        // screen rows. Without this buffer, holding
+                        // up/down arrow at a viewport edge sticks
+                        // because `fragments` only contains visible-row
+                        // entries. The immutable `DocScrollContent`
+                        // borrow is released here before phase 2's
+                        // mutable renderer paint.
+                        let (visible, neighbors, scrollbar_track) = {
+                            use crate::widgets::affine_scroll::{Rows as _, VisibleRow};
+
                             let content = scroll_content::DocScrollContent::for_frame(
                                 &self.edit.renderer,
                                 root,
                                 canvas_rect.height(),
                             );
                             let resp = self.edit.scroll_area.finish(ui, begun, &content);
-                            // Register the scrollbar's track so iOS taps
-                            // on it don't fall through to cursor-placement
-                            // / keyboard-summon handlers.
-                            self.edit
-                                .renderer
-                                .touch_consuming_rects
-                                .push(resp.scrollbar_track);
-                            resp.visible
+
+                            let viewport_height = canvas_rect.height();
+                            let mut neighbors: Vec<VisibleRow<scroll_content::DocRowId>> =
+                                Vec::new();
+                            if let Some(first) = resp.visible.first() {
+                                let mut id = first.id;
+                                let mut top = first.top;
+                                let mut walked = 0.0f32;
+                                while walked < viewport_height {
+                                    let Some(prev_id) = content.prev(&id) else { break };
+                                    let height = content.precise(&prev_id);
+                                    top -= height;
+                                    neighbors.push(VisibleRow { id: prev_id, top, height });
+                                    walked += height;
+                                    id = prev_id;
+                                }
+                            }
+                            if let Some(last) = resp.visible.last() {
+                                let mut id = last.id;
+                                let mut top = last.top + last.height;
+                                let mut walked = 0.0f32;
+                                while walked < viewport_height {
+                                    let Some(next_id) = content.next(&id) else { break };
+                                    let height = content.precise(&next_id);
+                                    neighbors.push(VisibleRow { id: next_id, top, height });
+                                    top += height;
+                                    walked += height;
+                                    id = next_id;
+                                }
+                            }
+                            (resp.visible, neighbors, resp.scrollbar_track)
                         };
+                        // Register the scrollbar's track so iOS taps
+                        // on it don't fall through to cursor-placement
+                        // / keyboard-summon handlers.
+                        self.edit
+                            .renderer
+                            .touch_consuming_rects
+                            .push(scrollbar_track);
 
                         // Phase 2: paint each visible row with a mutable
                         // renderer borrow. Block list re-collected
                         // because the immutable borrow that held
                         // `DocScrollContent`'s copy was just dropped.
+                        // Neighbor rows paint off-screen — clipped by
+                        // the canvas — only to register fragments and
+                        // wrap-line bounds for navigation.
                         let blocks: Vec<_> = root.children().collect();
-                        for vrow in &visible {
+                        for vrow in visible.iter().chain(neighbors.iter()) {
                             let top_left =
                                 Pos2::new(canvas_rect.min.x, canvas_rect.min.y + vrow.top);
                             scroll_content::paint_row(
@@ -1233,6 +1275,11 @@ impl Editor {
                     })
                     .inner;
                 self.edit.renderer.fragments.sort_by_key(|f| f.source_range);
+                // Neighbor rows above the visible window paint after
+                // visible rows, so wrap-lines lose their natural source
+                // order. `Bound::Line` lookup is a linear `range_before`
+                // / `range_after` walk that assumes sorted ranges.
+                self.edit.renderer.bounds.wrap_lines.sort_by_key(|r| r.0);
 
                 self.edit.post_render(ui, canvas_rect, scroll_id, pre);
                 ui.advance_cursor_after_rect(canvas_rect);

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/table.rs
@@ -1,6 +1,6 @@
 use comrak::nodes::AstNode;
 use egui::{Pos2, Rect, Stroke, Ui, Vec2};
-use lb_rs::model::text::offset_types::{RangeExt, RangeIterExt as _};
+use lb_rs::model::text::offset_types::RangeIterExt as _;
 
 use crate::tab::markdown_editor::MdRender;
 
@@ -67,26 +67,16 @@ impl<'ast> MdRender {
         }
     }
 
-    /// Reveal table syntax when cursor is on the delimiter row or at
-    /// the start of any line in the table. Reads `reveal_selection`
-    /// rather than `buffer.current.selection` so unfocused frames see
-    /// stable layout.
+    /// Reveal the whole table as source only when the cursor is on the
+    /// delimiter row — it has no AST node, so per-row reveal can't
+    /// surface it. Cursor inside a cell (boundaries included) and
+    /// cursor in pipe gutters are handled by `reveal_table_row`.
     fn reveal_table(&self, node: &'ast AstNode<'ast>) -> bool {
         let delimiter_row_line_idx = self.node_first_line_idx(node) + 1;
-        for line_idx in self.node_lines(node).iter() {
-            let line = self.bounds.source_lines[line_idx];
-            let node_line = self.node_line(node, line);
-
-            if line_idx == delimiter_row_line_idx && self.range_revealed(node_line, true) {
-                return true;
-            }
-            if self
-                .reveal_ranges()
-                .any(|r| node_line.contains(r.start(), true, true))
-            {
-                return true;
-            }
-        }
-        false
+        let Some(&delimiter_line) = self.bounds.source_lines.get(delimiter_row_line_idx) else {
+            return false;
+        };
+        let node_line = self.node_line(node, delimiter_line);
+        self.range_revealed(node_line, true)
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1320,6 +1320,21 @@ pub fn build_rows(
         for (rel_idx, it) in items[start..end].iter().enumerate() {
             let abs_idx = start + rel_idx;
             let is_wrap_break = wrap_break_idx == Some(abs_idx);
+            // Super/sub shrink glyphs to 75% of the row metric; shift
+            // the fragment rect vertically so the smaller glyph sits at
+            // the top of the row (super) or the bottom (sub). Glue/Box
+            // only — Pads and Breaks inherit full row height so
+            // surrounding pills/decorations stay aligned with siblings.
+            let (item_y_min, item_y_max) = {
+                let f = style_stack.last().map(|s| &s.format);
+                let full = ascent + descent;
+                let small = full * 0.75;
+                match f {
+                    Some(f) if f.superscript => (y_top, y_top + small),
+                    Some(f) if f.subscript => (y_top + (full - small), y_top + full),
+                    _ => (y_top, y_top + full),
+                }
+            };
             match it {
                 InlineItem::Box {
                     advance,
@@ -1333,8 +1348,8 @@ pub fn build_rows(
                     // time only; it extends outside the rect and fits
                     // into `row_spacing` (= 2 × inline_pad).
                     let rect = Rect::from_min_max(
-                        Pos2::new(x, y_top),
-                        Pos2::new(x + advance, y_top + ascent + descent),
+                        Pos2::new(x, item_y_min),
+                        Pos2::new(x + advance, item_y_max),
                     );
                     src_lo = src_lo.min(source_range.start());
                     src_hi = src_hi.max(source_range.end());
@@ -1371,8 +1386,8 @@ pub fn build_rows(
                 } => {
                     let effective_advance = if is_wrap_break { 0.0 } else { *natural };
                     let rect = Rect::from_min_max(
-                        Pos2::new(x, y_top),
-                        Pos2::new(x + effective_advance, y_top + ascent + descent),
+                        Pos2::new(x, item_y_min),
+                        Pos2::new(x + effective_advance, item_y_max),
                     );
                     // Wrap-break-glue contributes zero-width fragment
                     // but DOES claim its source range so a char-arrow

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -126,8 +126,13 @@ pub enum InlineItem {
     },
     /// Rigid advance with no glyphs and no break opportunity.
     /// Emitted around backgrounded-inline-scope boundaries so
-    /// `Fragment::rect` includes the bg breathing room.
-    Pad(f32),
+    /// `Fragment::rect` includes the bg breathing room. `source_pos`
+    /// is where a click on the pad should place the cursor — the
+    /// scope's start for a leading pad, its end for a trailing pad.
+    Pad {
+        advance: f32,
+        source_pos: Grapheme,
+    },
     /// Forced row break. Emitted by `<br>` (line_break) and bare
     /// newlines (soft_break). Has a source range for cursor
     /// positioning; treated by the row builder like a wrap-break-
@@ -542,46 +547,58 @@ fn shape_to_items(
 ) -> Option<Vec<InlineItem>> {
     use std::sync::{Arc, Mutex};
 
-    // Track which open scopes have a bg, so the matching close can
-    // emit the trailing `Pad`. AST guarantees LIFO nesting.
-    let mut scope_has_bg: Vec<bool> = Vec::new();
-    let emit_event =
-        |items: &mut Vec<InlineItem>, scope_has_bg: &mut Vec<bool>, pos: usize, ev: &FlowEvent| {
-            let p = pos as u32;
-            match ev {
-                FlowEvent::Open(s) => {
-                    let bg = s.format.background != egui::Color32::TRANSPARENT;
-                    items.push(InlineItem::StyleOpen(s.clone()));
-                    if bg {
-                        items.push(InlineItem::Pad(inline_pad));
-                    }
-                    scope_has_bg.push(bg);
-                }
-                FlowEvent::Close => {
-                    let bg = scope_has_bg.pop().unwrap_or(false);
-                    if bg {
-                        items.push(InlineItem::Pad(inline_pad));
-                    }
-                    items.push(InlineItem::StyleClose);
-                }
-                FlowEvent::Break(r) => {
-                    items.push(InlineItem::Break { source_range: *r, visible_byte_range: p..p });
-                }
-                FlowEvent::InteractionOpen(id, sense) => {
-                    items.push(InlineItem::InteractionOpen(*id, *sense));
-                }
-                FlowEvent::InteractionClose => {
-                    items.push(InlineItem::InteractionClose);
+    // Track open bg-scopes' source ranges, so the matching close can
+    // emit the trailing `Pad` with the scope's end as its source
+    // position. `None` entries hold place for non-bg scopes (Pad not
+    // emitted, but stack depth must mirror StyleOpen/Close). AST
+    // guarantees LIFO nesting.
+    let mut bg_scope_stack: Vec<Option<(Grapheme, Grapheme)>> = Vec::new();
+    let emit_event = |items: &mut Vec<InlineItem>,
+                      bg_scope_stack: &mut Vec<Option<(Grapheme, Grapheme)>>,
+                      pos: usize,
+                      ev: &FlowEvent| {
+        let p = pos as u32;
+        match ev {
+            FlowEvent::Open(s) => {
+                let bg = s.format.background != egui::Color32::TRANSPARENT;
+                items.push(InlineItem::StyleOpen(s.clone()));
+                if bg {
+                    items.push(InlineItem::Pad {
+                        advance: inline_pad,
+                        source_pos: s.source_range.start(),
+                    });
+                    bg_scope_stack.push(Some(s.source_range));
+                } else {
+                    bg_scope_stack.push(None);
                 }
             }
-        };
+            FlowEvent::Close => {
+                if let Some(Some(scope_range)) = bg_scope_stack.pop() {
+                    items.push(InlineItem::Pad {
+                        advance: inline_pad,
+                        source_pos: scope_range.end(),
+                    });
+                }
+                items.push(InlineItem::StyleClose);
+            }
+            FlowEvent::Break(r) => {
+                items.push(InlineItem::Break { source_range: *r, visible_byte_range: p..p });
+            }
+            FlowEvent::InteractionOpen(id, sense) => {
+                items.push(InlineItem::InteractionOpen(*id, *sense));
+            }
+            FlowEvent::InteractionClose => {
+                items.push(InlineItem::InteractionClose);
+            }
+        }
+    };
 
     if layout.visible.is_empty() {
         // Still emit flow events so the row stack reflects open/close
         // and any naked break carries through.
         let mut items = Vec::new();
         for (pos, ev) in &layout.events {
-            emit_event(&mut items, &mut scope_has_bg, *pos, ev);
+            emit_event(&mut items, &mut bg_scope_stack, *pos, ev);
         }
         return Some(items);
     }
@@ -651,7 +668,7 @@ fn shape_to_items(
         // Flush flow events at positions in [prev_chunk_end, chunk_lo].
         while ev_idx < layout.events.len() && layout.events[ev_idx].0 <= chunk_lo {
             let (pos, ev) = &layout.events[ev_idx];
-            emit_event(&mut items, &mut scope_has_bg, *pos, ev);
+            emit_event(&mut items, &mut bg_scope_stack, *pos, ev);
             ev_idx += 1;
         }
 
@@ -762,7 +779,7 @@ fn shape_to_items(
     // Flush trailing flow events.
     while ev_idx < layout.events.len() {
         let (pos, ev) = &layout.events[ev_idx];
-        emit_event(&mut items, &mut scope_has_bg, *pos, ev);
+        emit_event(&mut items, &mut bg_scope_stack, *pos, ev);
         ev_idx += 1;
     }
 
@@ -1183,7 +1200,7 @@ pub fn greedy_break(items: &[InlineItem], width: f32, inline_pad: f32) -> Vec<us
                 }
                 i += 1;
             }
-            InlineItem::Pad(advance) => {
+            InlineItem::Pad { advance, .. } => {
                 cur_width += advance;
                 i += 1;
             }
@@ -1215,7 +1232,7 @@ fn item_advance(item: &InlineItem) -> f32 {
     match item {
         InlineItem::Box { advance, .. } => *advance,
         InlineItem::Glue { natural, .. } => *natural,
-        InlineItem::Pad(a) => *a,
+        InlineItem::Pad { advance, .. } => *advance,
         InlineItem::Break { .. }
         | InlineItem::StyleOpen(_)
         | InlineItem::StyleClose
@@ -1396,7 +1413,7 @@ pub fn build_rows(
                             .map_or(visible_byte_range.end, |v| v.max(visible_byte_range.end)),
                     );
                 }
-                InlineItem::Pad(advance) => {
+                InlineItem::Pad { advance, source_pos } => {
                     let rect = Rect::from_min_max(
                         Pos2::new(x, y_top),
                         Pos2::new(x + advance, y_top + ascent + descent),
@@ -1404,10 +1421,7 @@ pub fn build_rows(
                     row_fragments.push(Fragment {
                         rect,
                         content_inset: FragmentInset::default(),
-                        source_range: style_stack
-                            .last()
-                            .map(|s| (s.source_range.start(), s.source_range.start()))
-                            .unwrap_or((layout.source_range.start(), layout.source_range.start())),
+                        source_range: (*source_pos, *source_pos),
                         style_stack: style_stack.clone(),
                         content: FragmentContent::Spacer,
                         atomic: false,
@@ -1455,12 +1469,19 @@ pub fn build_rows(
 
         // Per-row pills: if this row ends still inside a bg scope (the
         // StyleClose lives in a future row), append a synthetic right-
-        // pad fragment so the row's pill has a right edge.
+        // pad fragment so the row's pill has a right edge. Source-
+        // position resolves to the end of this row's last fragment so
+        // a click on the pad lands at the row's end rather than
+        // jumping to the bg scope's start on an earlier row.
         if style_stack
             .last()
             .is_some_and(|s| s.format.background != egui::Color32::TRANSPARENT)
         {
             let info = style_stack.last().unwrap();
+            let source_pos = row_fragments
+                .last()
+                .map(|f| f.source_range.end())
+                .unwrap_or(info.source_range.start());
             let rect = Rect::from_min_max(
                 Pos2::new(x, y_top),
                 Pos2::new(x + inline_pad, y_top + ascent + descent),
@@ -1468,7 +1489,7 @@ pub fn build_rows(
             row_fragments.push(Fragment {
                 rect,
                 content_inset: FragmentInset::default(),
-                source_range: (info.source_range.start(), info.source_range.start()),
+                source_range: (source_pos, source_pos),
                 style_stack: style_stack.clone(),
                 content: FragmentContent::Spacer,
                 atomic: false,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1290,7 +1290,11 @@ pub fn build_rows(
         // (the StyleOpen was processed in a prior row), prepend a
         // synthetic left-pad fragment so the row's pill has a left
         // edge. The matching scope-close-side pad is the walker's
-        // explicit `Pad` item before `StyleClose`.
+        // explicit `Pad` item before `StyleClose`. `source_range` is
+        // patched to `(src_lo, src_lo)` after the item loop so a
+        // click on the pad lands at the row's first visible offset,
+        // not back at the bg scope's start on a previous row.
+        let mut left_pad_idx: Option<usize> = None;
         if style_stack
             .last()
             .is_some_and(|s| s.format.background != egui::Color32::TRANSPARENT)
@@ -1300,6 +1304,7 @@ pub fn build_rows(
                 Pos2::new(x, y_top),
                 Pos2::new(x + inline_pad, y_top + ascent + descent),
             );
+            left_pad_idx = Some(row_fragments.len());
             row_fragments.push(Fragment {
                 rect,
                 content_inset: FragmentInset::default(),
@@ -1467,21 +1472,29 @@ pub fn build_rows(
             }
         }
 
+        // Patch the row's synthetic left-pad source position to the
+        // first visible offset on this row (excluding wrap-break-glue,
+        // which `src_lo` already skips). A click on the pad lands at
+        // row start instead of the scope's start on a previous row.
+        if let Some(idx) = left_pad_idx {
+            if src_lo <= src_hi {
+                row_fragments[idx].source_range = (src_lo, src_lo);
+            }
+        }
+
         // Per-row pills: if this row ends still inside a bg scope (the
         // StyleClose lives in a future row), append a synthetic right-
-        // pad fragment so the row's pill has a right edge. Source-
-        // position resolves to the end of this row's last fragment so
-        // a click on the pad lands at the row's end rather than
-        // jumping to the bg scope's start on an earlier row.
+        // pad fragment so the row's pill has a right edge. Source
+        // position is `src_hi` — the row's last visible offset within
+        // the scope, excluding wrap-break-glue — so a click on the
+        // pad lands at the row's end rather than the wrap boundary
+        // (which renders on the next row).
         if style_stack
             .last()
             .is_some_and(|s| s.format.background != egui::Color32::TRANSPARENT)
         {
             let info = style_stack.last().unwrap();
-            let source_pos = row_fragments
-                .last()
-                .map(|f| f.source_range.end())
-                .unwrap_or(info.source_range.start());
+            let source_pos = if src_lo <= src_hi { src_hi } else { info.source_range.start() };
             let rect = Rect::from_min_max(
                 Pos2::new(x, y_top),
                 Pos2::new(x + inline_pad, y_top + ascent + descent),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1705,7 +1705,11 @@ impl MdRender {
             // zero-width Spacer fragments in screen coords so cursor
             // / hit-test lookups can resolve them via the same
             // `fragments` list. They have empty `style_stack` so paint
-            // doesn't draw anything for them.
+            // doesn't draw anything for them. `atomic` so a click on
+            // an invisible override (e.g. the fold-tag HTML comment at
+            // a heading's end) selects the whole source range —
+            // typing then replaces the tag and unfolds the section
+            // rather than inserting next to it.
             for anchor in &row.anchors {
                 let pos = paint_top_left + Vec2::new(anchor.x, anchor.y_top);
                 let rect = Rect::from_min_size(pos, Vec2::new(0.0, anchor.height));
@@ -1715,7 +1719,7 @@ impl MdRender {
                     source_range: anchor.source_range,
                     style_stack: Vec::new(),
                     content: FragmentContent::Spacer,
-                    atomic: false,
+                    atomic: true,
                     interaction: None,
                 });
             }
@@ -1791,8 +1795,12 @@ impl MdRender {
     }
 
     /// Find the closest fragment to `pos` by (y_dist, x_dist), with
-    /// preference for empty-range fragments (anchors). Returns
-    /// `None` only when `self.fragments` is empty.
+    /// preference for empty-range fragments (anchors) and for
+    /// atomic Spacer anchors (invisible-override markers like the
+    /// fold tag, which need to win the tie against the adjacent text
+    /// box so a click resolves to "select the whole override" via
+    /// `pos_to_range`'s atomic branch). Returns `None` only when
+    /// `self.fragments` is empty.
     pub fn closest_fragment_at_pos(&self, pos: Pos2) -> Option<usize> {
         let mut closest: Option<usize> = None;
         let mut closest_dist = (f32::INFINITY, f32::INFINITY);
@@ -1815,9 +1823,10 @@ impl MdRender {
                     .min((pos.x - f.rect.right()).abs())
             };
             let dist = (y_dist, x_dist);
-            let prefer_empty =
-                dist == closest_dist && f.source_range.start() == f.source_range.end();
-            if dist < closest_dist || prefer_empty {
+            let prefer = dist == closest_dist
+                && (f.source_range.start() == f.source_range.end()
+                    || (f.atomic && matches!(f.content, FragmentContent::Spacer)));
+            if dist < closest_dist || prefer {
                 closest = Some(i);
                 closest_dist = dist;
             }

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1129,11 +1129,14 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         // Wheel: precise pixels. egui convention: positive y = scroll up
         // (content moves down). We want offset to grow when user scrolls
         // down (content moves up), so negate.
-        let raw_scroll_delta =
-            if ui.rect_contains_pointer(rect) { ui.input(|i| i.raw_scroll_delta.y) } else { 0.0 };
-        if raw_scroll_delta != 0.0 {
+        let smooth_scroll_delta = if ui.rect_contains_pointer(rect) {
+            ui.input(|i| i.smooth_scroll_delta.y)
+        } else {
+            0.0
+        };
+        if smooth_scroll_delta != 0.0 {
             self.state
-                .handle(rows, Action::ScrollByPixels(-raw_scroll_delta));
+                .handle(rows, Action::ScrollByPixels(-smooth_scroll_delta));
         }
 
         // Touch body drag → scroll + velocity tracking.


### PR DESCRIPTION
bugs identified during QA on 2026-05-22
- [x] tables reveal too eagerly; any cursor pos in a table reveals syntax
- [x] subscripts render as superscripts
- [x] clicking past end of row ending with background inline puts cursor at start of that inline
- [x] clicking end of line or cmd+right to end of line puts you at start of next line if this one wraps on a bg inline
- [x] holding up arrow gets stuck on the first line of a code block at the top of the scroll area, sometimes between GFM alerts as well
- [x] toggling a list item style cannot remove the style
- [x] scroll momentum is stuttery
- [x] tapping the end of the first row of a folded heading or item does not select the fold tag