### PR TITLE
egui: tighten up clipboard ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,7 +4576,6 @@ dependencies = [
  "eframe",
  "egui",
  "egui-notify",
- "egui-winit",
  "egui_extras",
  "egui_wgpu_renderer",
  "env_logger",

--- a/clients/desktop/Cargo.toml
+++ b/clients/desktop/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 arboard = { version = "3.6", features = ["image", "wayland-data-control"] }
 dark-light = "2.0.0"
 egui = "0.32.3"
-egui-winit = "0.32.3"
+egui-winit = { version = "0.32.3", default-features = false, features = ["links", "wayland", "x11"] }
 egui_wgpu_renderer = { path = "../../libs/content/egui_wgpu_renderer" }
 env_logger = "0.10"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/clients/desktop/src/lib.rs
+++ b/clients/desktop/src/lib.rs
@@ -22,6 +22,8 @@ impl ApplicationHandler<UserEvent> for App {
 
         let window_attrs = Window::default_attributes()
             .with_title("Lockbook")
+            // todo: respect or deprecate setting for
+            // starting maximized
             .with_inner_size(LogicalSize::new(1300, 800))
             .with_window_icon(load_icon());
 
@@ -183,17 +185,25 @@ impl ApplicationHandler<UserEvent> for App {
 
 impl AppState {
     fn render(&mut self, _event_loop: &ActiveEventLoop) {
-        let paste_intercepted = self.pending_paste && {
+        // Take over paste from egui-winit (default `clipboard` feature is off
+        // in Cargo.toml). On Cmd+V we own both image and text routing here;
+        // egui-winit no longer reads the clipboard or queues Event::Paste.
+        let mut pending_text_paste: Option<String> = None;
+        if self.pending_paste {
             self.pending_paste = false;
-            self.handle_image_paste()
-        };
+            if !self.handle_image_paste() {
+                if let Ok(text) = self.clipboard.get_text() {
+                    if !text.is_empty() {
+                        pending_text_paste = Some(text);
+                    }
+                }
+            }
+        }
 
         let mut raw_input = self.egui_winit.take_egui_input(&self.window);
 
-        if paste_intercepted {
-            raw_input
-                .events
-                .retain(|e| !matches!(e, egui::Event::Paste(_)));
+        if let Some(text) = pending_text_paste {
+            raw_input.events.push(egui::Event::Paste(text));
         }
 
         if self.close_requested {
@@ -202,12 +212,48 @@ impl AppState {
             }
         }
 
+        // Carry forward events queued during the previous frame — handle_paste
+        // (called for ViewportCommand::RequestPaste from the right-click menu)
+        // pushes Event::Paste(text) onto renderer.raw_input.events after
+        // lb.frame() has already taken its input for the current frame.
+        let mut carried = std::mem::take(&mut self.lb.renderer.raw_input.events);
+        carried.append(&mut raw_input.events);
+        raw_input.events = carried;
+
         self.lb.renderer.raw_input = raw_input;
 
-        let Output { platform, viewport, app: lbeguiapp::Response { close } } = self.lb.frame();
+        let Output { mut platform, viewport, app: lbeguiapp::Response { close } } = self.lb.frame();
 
         if close {
             std::process::exit(0);
+        }
+
+        // Mirror Copy/Cut to our clipboard (egui-winit can't anymore). Strip
+        // the clipboard commands afterward so handle_platform_output doesn't
+        // log "Copying images is not supported" for CopyImage.
+        for command in &platform.commands {
+            match command {
+                egui::OutputCommand::CopyText(text) => {
+                    let _ = self.clipboard.set_text(text.clone());
+                }
+                egui::OutputCommand::CopyImage(image) => {
+                    let _ = self.clipboard.set_image(arboard::ImageData {
+                        width: image.width(),
+                        height: image.height(),
+                        bytes: std::borrow::Cow::Borrowed(image.as_raw()),
+                    });
+                }
+                _ => {}
+            }
+        }
+        platform.commands.retain(|c| {
+            !matches!(c, egui::OutputCommand::CopyText(_) | egui::OutputCommand::CopyImage(_))
+        });
+        #[allow(deprecated)]
+        if !platform.copied_text.is_empty() {
+            let _ = self
+                .clipboard
+                .set_text(std::mem::take(&mut platform.copied_text));
         }
 
         self.egui_winit

--- a/clients/desktop/src/lib.rs
+++ b/clients/desktop/src/lib.rs
@@ -101,6 +101,8 @@ impl ApplicationHandler<UserEvent> for App {
         }
 
         if !matches!(event, WindowEvent::ThemeChanged(_)) {
+            // todo: check this -- if there's no clipboard it falls back to a "manual" string which
+            // may be populated by egui itself and result in double paste.
             let response = state.egui_winit.on_window_event(&state.window, &event);
 
             if response.repaint && !matches!(event, WindowEvent::RedrawRequested) {
@@ -185,25 +187,18 @@ impl ApplicationHandler<UserEvent> for App {
 
 impl AppState {
     fn render(&mut self, _event_loop: &ActiveEventLoop) {
-        // Take over paste from egui-winit (default `clipboard` feature is off
-        // in Cargo.toml). On Cmd+V we own both image and text routing here;
-        // egui-winit no longer reads the clipboard or queues Event::Paste.
-        let mut pending_text_paste: Option<String> = None;
+        let mut raw_input = self.egui_winit.take_egui_input(&self.window);
+
+        // we do clipboard things ourselves because we do image things
         if self.pending_paste {
             self.pending_paste = false;
             if !self.handle_image_paste() {
                 if let Ok(text) = self.clipboard.get_text() {
                     if !text.is_empty() {
-                        pending_text_paste = Some(text);
+                        raw_input.events.push(egui::Event::Paste(text));
                     }
                 }
             }
-        }
-
-        let mut raw_input = self.egui_winit.take_egui_input(&self.window);
-
-        if let Some(text) = pending_text_paste {
-            raw_input.events.push(egui::Event::Paste(text));
         }
 
         if self.close_requested {
@@ -228,9 +223,6 @@ impl AppState {
             std::process::exit(0);
         }
 
-        // Mirror Copy/Cut to our clipboard (egui-winit can't anymore). Strip
-        // the clipboard commands afterward so handle_platform_output doesn't
-        // log "Copying images is not supported" for CopyImage.
         for command in &platform.commands {
             match command {
                 egui::OutputCommand::CopyText(text) => {
@@ -249,12 +241,6 @@ impl AppState {
         platform.commands.retain(|c| {
             !matches!(c, egui::OutputCommand::CopyText(_) | egui::OutputCommand::CopyImage(_))
         });
-        #[allow(deprecated)]
-        if !platform.copied_text.is_empty() {
-            let _ = self
-                .clipboard
-                .set_text(std::mem::take(&mut platform.copied_text));
-        }
 
         self.egui_winit
             .handle_platform_output(&self.window, platform);

--- a/clients/egui/Cargo.toml
+++ b/clients/egui/Cargo.toml
@@ -11,7 +11,6 @@ eframe = { version = "0.32.3", default-features = false, features = [
     "wgpu",
 ], optional = true } # dependency for binary only
 egui-notify = "0.20.0"
-egui-winit = "0.32.3" # todo possibly removable
 egui_extras = { version = "0.32.3", features = ["image"] }
 env_logger = "0.10"
 glyphon = "0.9.0"

--- a/clients/egui/src/main.rs
+++ b/clients/egui/src/main.rs
@@ -3,7 +3,6 @@
 use std::{io::Cursor, ops::DerefMut};
 
 use egui::ViewportCommand;
-use egui_winit::egui;
 use image::ImageDecoder as _;
 use lockbook_egui::Lockbook;
 


### PR DESCRIPTION
- restores support for this bad boy: <img width="215" height="98" alt="image" src="https://github.com/user-attachments/assets/d520b7e5-5e84-49c7-a347-2d055f606fb4" />
- adds support for more sophisticated clipboard behaviors like preview apps (finder on macOS or cosmic image preview on popOS) that put both the image as well as the path in the clipboard
