### PR TITLE
android: don't minify jni functions

### DIFF
--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -37,7 +37,7 @@ android {
         release {
             signingConfig signingConfigs.release
 
-            minifyEnabled false
+            minifyEnabled true
 	        zipAlignEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/clients/android/app/proguard-rules.pro
+++ b/clients/android/app/proguard-rules.pro
@@ -20,6 +20,10 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
+# lb-rs calls into and constructs these Java classes through JNI. Keep this
+# boundary stable while allowing the rest of the app release build to be minified.
+-keep class net.lockbook.** { *; }
+
 # Keep `Companion` object fields of serializable classes.
 # This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
 -if @kotlinx.serialization.Serializable class **

--- a/clients/android/workspace/consumer-rules.pro
+++ b/clients/android/workspace/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class app.lockbook.workspace.** { *; }

--- a/clients/android/workspace/proguard-rules.pro
+++ b/clients/android/workspace/proguard-rules.pro
@@ -19,3 +19,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# This module exposes Kotlin classes directly to the app and to JNI. Keep the
+# package stable so release library minification cannot rename classes that the
+# app or native symbols resolve by their original names.
+-keep class app.lockbook.workspace.** { *; }


### PR DESCRIPTION
top level jni function were minified in release builds which caused the lockbook app to request undefined workspace functions. I've changed it such that all the app is minified except the top level workspace functions. 