### PR TITLE
macos: background import

### DIFF
--- a/clients/apple/Shared/State/HomeState.swift
+++ b/clients/apple/Shared/State/HomeState.swift
@@ -26,6 +26,8 @@ class HomeState: ObservableObject {
 
     @Published var showTabsSheet: Bool = false
 
+    @Published var importsInProgress: Int = 0
+
     @Published private(set) var showOutOfSpaceAlert: Bool = false
     @AppStorage("hideOutOfSpaceSheet") private var hideOutOfSpaceSheet: Bool = false
 

--- a/clients/apple/Shared/Utils/ImportExportHelper.swift
+++ b/clients/apple/Shared/Utils/ImportExportHelper.swift
@@ -4,19 +4,23 @@ import SwiftWorkspace
 class ImportExportHelper {
     static let TMP_DIR = "lb-tmp"
 
-    static func importFiles(homeState: HomeState, filesModel: FilesViewModel, sources: [String], destination: UUID) -> Bool {
-        let operation = AppState.lb.importFiles(sources: sources, dest: destination)
+    static func importFiles(homeState: HomeState, filesModel: FilesViewModel, sources: [String], destination: UUID) {
+        homeState.importsInProgress += 1
 
-        switch operation {
-        case .success:
-            homeState.fileActionCompleted = .importFiles
-            filesModel.loadFiles()
+        DispatchQueue.global(qos: .userInitiated).async {
+            let operation = AppState.lb.importFiles(sources: sources, dest: destination)
 
-            return true
-        case let .failure(err):
-            AppState.shared.error = .lb(error: err)
+            DispatchQueue.main.async {
+                homeState.importsInProgress -= 1
 
-            return false
+                switch operation {
+                case .success:
+                    homeState.fileActionCompleted = .importFiles
+                    filesModel.loadFiles()
+                case let .failure(err):
+                    AppState.shared.error = .lb(error: err)
+                }
+            }
         }
     }
 

--- a/clients/apple/macOS/Widgets/FileTree/FileTreeView.swift
+++ b/clients/apple/macOS/Widgets/FileTree/FileTreeView.swift
@@ -238,7 +238,8 @@ class FileTreeDataSource: NSObject, NSOutlineViewDataSource, NSPasteboardItemDat
                 return false
             }
 
-            return ImportExportHelper.importFiles(homeState: homeState, filesModel: filesModel, sources: urls.map { url in url.path(percentEncoded: false) }, destination: parent.id)
+            ImportExportHelper.importFiles(homeState: homeState, filesModel: filesModel, sources: urls.map { url in url.path(percentEncoded: false) }, destination: parent.id)
+            return true
         }
     }
 

--- a/clients/apple/macOS/Widgets/StatusBarView.swift
+++ b/clients/apple/macOS/Widgets/StatusBarView.swift
@@ -11,6 +11,16 @@ struct StatusBarView: View {
         HStack {
             SyncButton()
 
+            if homeState.importsInProgress > 0 {
+                Label(title: { Text("Importing\u{2026}") }, icon: {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .controlSize(.small)
+                        .padding(.trailing, 1)
+                })
+                .padding(.vertical, 5)
+            }
+
             Spacer()
 
             fileActionButtons


### PR DESCRIPTION
backgrounds the import computation on macOS. 

Previously I struggled to import a 0.5g tax folder without having beachballs or any hangs. Now this folder imports relatively seamlessly. With no beachballs or hangs. This is now the worst case scenario if you try to push into the single digit gigabyte range:

<img width="1074" height="1061" alt="image" src="https://github.com/user-attachments/assets/d5627932-a46a-4cd8-a6da-bf3333d32a63" />

I'm going to pull on this thread a bit more. Seems like the next bottleneck is something like #3277, but most of it is actually blocked on CPU because of the way the merge code is written -- it re-does a bunch of crypto while draining creations, and relies on an error that is actually somewhat expensive to generate because it does backtrace things. These are all just wasteful low hanging fruit that we could improve pretty easily (without something like #3401).

It also seems that we're not handling the memory involved in this situation well, importing a 2g file baloons my memory usage to 15g. It may be caused by something like https://github.com/lockbook/lockbook/issues/3241 but I'd like to get to the bottom of it.

But I'll do this separately and I'll stop at the point someone can import a roughly 2g video without any problems.

fixes #4553, but see #4672 