### PR TITLE
lb-rs, server: unlock larger files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ dependencies = [
  "bezier-rs",
  "bincode",
  "bip39-dict",
+ "bytes",
  "chrono",
  "criterion",
  "crossbeam",
@@ -6674,10 +6675,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url 2.5.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg 0.50.0",
@@ -8858,6 +8861,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4206,6 +4206,7 @@ dependencies = [
  "indicatif",
  "itertools 0.10.5",
  "lb-tantivy",
+ "libc",
  "libsecp256k1",
  "num_cpus",
  "qrcode-generator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
-# [profile.release]
-# debug = true
-# [profile.bench]
-# debug = true
+[profile.release]
+debug = true
+[profile.bench]
+debug = true
 
 # release-equivalent with debug symbols, for `samply` / `cargo flamegraph`.
 [profile.profiling]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ members = [
 ]
 
 # restore for big binaries but good backtraces
-[profile.release]
-debug = true
-[profile.bench]
-debug = true
+# [profile.release]
+# debug = true
+# [profile.bench]
+# debug = true
 
 # release-equivalent with debug symbols, for `samply` / `cargo flamegraph`.
 [profile.profiling]

--- a/clients/apple/Shared/State/HomeState.swift
+++ b/clients/apple/Shared/State/HomeState.swift
@@ -27,6 +27,7 @@ class HomeState: ObservableObject {
     @Published var showTabsSheet: Bool = false
 
     @Published var importsInProgress: Int = 0
+    @Published var exportsInProgress: Int = 0
 
     @Published private(set) var showOutOfSpaceAlert: Bool = false
     @AppStorage("hideOutOfSpaceSheet") private var hideOutOfSpaceSheet: Bool = false

--- a/clients/apple/Shared/Widgets/SyncButton.swift
+++ b/clients/apple/Shared/Widgets/SyncButton.swift
@@ -49,6 +49,8 @@ struct SyncButton: View {
                 syncButtonStatus = .outOfSpace
             } else if status.syncing {
                 syncButtonStatus = .syncing
+            } else if status.unexpectedSyncProblem != nil {
+                syncButtonStatus = .syncError
             } else {
                 syncButtonStatus = .canSync
             }

--- a/clients/apple/Shared/Widgets/SyncButton.swift
+++ b/clients/apple/Shared/Widgets/SyncButton.swift
@@ -37,6 +37,7 @@ struct SyncButton: View {
         .modifier(SyncButtonHelpMessage(statusMessage: $statusMessage))
         .buttonStyle(.borderless)
         .tint(getButtonTintColor())
+        .disabled(syncButtonStatus == .syncing)
         .onReceive(AppState.lb.events.$status, perform: { status in
             guard !isPreview else { return }
 

--- a/clients/apple/macOS/Widgets/FileTree/FileTreeView.swift
+++ b/clients/apple/macOS/Widgets/FileTree/FileTreeView.swift
@@ -2,6 +2,7 @@ import AppKit
 import Combine
 import SwiftUI
 import SwiftWorkspace
+import UniformTypeIdentifiers
 
 struct FileTreeView: NSViewRepresentable {
     @EnvironmentObject var homeState: HomeState
@@ -148,7 +149,7 @@ struct FileTreeView: NSViewRepresentable {
         .withCommonPreviewEnvironment()
 }
 
-class FileTreeDataSource: NSObject, NSOutlineViewDataSource, NSPasteboardItemDataProvider {
+class FileTreeDataSource: NSObject, NSOutlineViewDataSource {
     @ObservedObject var homeState: HomeState
     @ObservedObject var filesModel: FilesViewModel
 
@@ -193,13 +194,23 @@ class FileTreeDataSource: NSObject, NSOutlineViewDataSource, NSPasteboardItemDat
     }
 
     func outlineView(_: NSOutlineView, pasteboardWriterForItem item: Any) -> NSPasteboardWriting? {
-        let pb = NSPasteboardItem()
         let file = item as! File
 
-        pb.setData(try! JSONEncoder().encode(file), forType: NSPasteboard.PasteboardType(Self.REORDER_PASTEBOARD_TYPE))
-        pb.setDataProvider(self, forTypes: [NSPasteboard.PasteboardType(Self.REORDER_PASTEBOARD_TYPE), .fileURL])
+        // Pick a UTI from the file extension so destinations (e.g. Finder)
+        // know what kind of file to expect. Folders and unknown extensions
+        // fall back to public.data.
+        let ext = (file.name as NSString).pathExtension
+        let utType: UTType = {
+            if file.type == .folder { return .folder }
+            return UTType(filenameExtension: ext) ?? .data
+        }()
 
-        return pb
+        let provider = LbFilePromiseProvider(fileType: utType.identifier, delegate: self)
+        provider.userInfo = file
+        // Keep the internal-reorder type available on the same pasteboard
+        // item so drops within the outline view still recognize the drag.
+        provider.reorderData = try! JSONEncoder().encode(file)
+        return provider
     }
 
     func outlineView(_: NSOutlineView, draggingSession session: NSDraggingSession, willBeginAt _: NSPoint, forItems draggedItems: [Any]) {
@@ -252,25 +263,6 @@ class FileTreeDataSource: NSObject, NSOutlineViewDataSource, NSPasteboardItemDat
         }
     }
 
-    func pasteboard(_ pasteboard: NSPasteboard?, item: NSPasteboardItem, provideDataForType type: NSPasteboard.PasteboardType) {
-        if type == .fileURL {
-            let files = try! JSONDecoder().decode([File].self, from: item.data(forType: NSPasteboard.PasteboardType(Self.REORDER_PASTEBOARD_TYPE))!)
-
-            pasteboard?.clearContents()
-            var pasteboardItems: [NSPasteboardItem] = []
-
-            for file in files {
-                if let dest = ImportExportHelper.exportFilesToTempDir(homeState: homeState, file: file) {
-                    let newItem = NSPasteboardItem()
-                    newItem.setData(dest.dataRepresentation, forType: .fileURL)
-                    pasteboardItems.append(newItem)
-                }
-            }
-
-            pasteboard?.writeObjects(pasteboardItems)
-        }
-    }
-
     func outlineView(_: NSOutlineView, draggingSession _: NSDraggingSession, endedAt _: NSPoint, operation: NSDragOperation) {
         if operation == .move {
             dragged = nil
@@ -278,6 +270,83 @@ class FileTreeDataSource: NSObject, NSOutlineViewDataSource, NSPasteboardItemDat
     }
 
     static let REORDER_PASTEBOARD_TYPE = "net.lockbook.metadata"
+}
+
+extension FileTreeDataSource: NSFilePromiseProviderDelegate {
+    /// Off-main queue for `writePromiseTo` so a large decrypt + write
+    /// doesn't block the AppKit run loop during the drag-out.
+    static let exportQueue: OperationQueue = {
+        let q = OperationQueue()
+        q.qualityOfService = .userInitiated
+        return q
+    }()
+
+    func filePromiseProvider(_ provider: NSFilePromiseProvider, fileNameForType _: String) -> String {
+        return (provider.userInfo as? File)?.name ?? "untitled"
+    }
+
+    func filePromiseProvider(
+        _ provider: NSFilePromiseProvider,
+        writePromiseTo url: URL,
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        guard let file = provider.userInfo as? File else {
+            completionHandler(NSError(
+                domain: "net.lockbook",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Drag-out lost file context"]
+            ))
+            return
+        }
+
+        let homeState = self.homeState
+        DispatchQueue.main.async { homeState.exportsInProgress += 1 }
+
+        // `lb.exportFile` writes `file.name` into the destination directory,
+        // so pass the parent of the URL the system handed us.
+        let destDir = url.deletingLastPathComponent().path(percentEncoded: false)
+        let result = AppState.lb.exportFile(sourceId: file.id, dest: destDir, edit: true)
+
+        DispatchQueue.main.async {
+            homeState.exportsInProgress -= 1
+            if case let .failure(err) = result {
+                AppState.shared.error = .lb(error: err)
+            }
+        }
+
+        switch result {
+        case .success:
+            completionHandler(nil)
+        case let .failure(err):
+            completionHandler(err)
+        }
+    }
+
+    func operationQueue(for _: NSFilePromiseProvider) -> OperationQueue {
+        return Self.exportQueue
+    }
+}
+
+/// NSFilePromiseProvider that also exposes the internal reorder pasteboard
+/// type, so drag-and-drop within the outline view keeps working alongside
+/// the lazy file-promise mechanism used for drags out to Finder.
+class LbFilePromiseProvider: NSFilePromiseProvider {
+    var reorderData: Data?
+
+    override func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
+        var types = super.writableTypes(for: pasteboard)
+        if reorderData != nil {
+            types.append(NSPasteboard.PasteboardType(FileTreeDataSource.REORDER_PASTEBOARD_TYPE))
+        }
+        return types
+    }
+
+    override func pasteboardPropertyList(forType type: NSPasteboard.PasteboardType) -> Any? {
+        if type == NSPasteboard.PasteboardType(FileTreeDataSource.REORDER_PASTEBOARD_TYPE) {
+            return reorderData
+        }
+        return super.pasteboardPropertyList(forType: type)
+    }
 }
 
 protocol MenuOutlineViewDelegate: NSOutlineViewDelegate {

--- a/clients/apple/macOS/Widgets/StatusBarView.swift
+++ b/clients/apple/macOS/Widgets/StatusBarView.swift
@@ -21,6 +21,16 @@ struct StatusBarView: View {
                 .padding(.vertical, 5)
             }
 
+            if homeState.exportsInProgress > 0 {
+                Label(title: { Text("Exporting\u{2026}") }, icon: {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .controlSize(.small)
+                        .padding(.trailing, 1)
+                })
+                .padding(.vertical, 5)
+            }
+
             Spacer()
 
             fileActionButtons

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Events.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Events.swift
@@ -18,6 +18,7 @@ public struct Status {
     public var pullingFiles: [UUID]
     public var spaceUsed: UsageMetrics?
     public var message: String
+    public var unexpectedSyncProblem: String?
 
     init(_ status: LbStatus) {
         offline = status.offline
@@ -30,7 +31,7 @@ public struct Status {
         pullingFiles = Array(UnsafeBufferPointer(start: status.pulling_files.ids, count: Int(status.pulling_files.len))).toUUIDs()
         spaceUsed = status.space_used != nil ? UsageMetrics(status.space_used.move()) : nil
         message = status.msg != nil ? String(cString: status.msg) : ""
-
+        unexpectedSyncProblem = status.unexpected_sync_problem != nil ? String(cString: status.unexpected_sync_problem) : nil
     }
 
     init() {
@@ -44,5 +45,6 @@ public struct Status {
         pullingFiles = []
         spaceUsed = nil
         message = ""
+        unexpectedSyncProblem = nil
     }
 }

--- a/libs/lb/lb-c/src/lib.rs
+++ b/libs/lb/lb-c/src/lib.rs
@@ -997,6 +997,7 @@ pub struct LbStatus {
     pub pulling_files: LbIds,
     pub space_used: *mut LbUsageMetrics,
     pub msg: *mut c_char,
+    pub unexpected_sync_problem: *mut c_char,
 }
 
 #[unsafe(no_mangle)]
@@ -1006,6 +1007,11 @@ pub extern "C" fn lb_get_status(lb: *mut Lb) -> LbStatus {
 
     let msg = match status.msg() {
         Some(msg) => cstring(msg),
+        None => null_mut(),
+    };
+
+    let unexpected_sync_problem = match status.unexpected_sync_problem {
+        Some(err) => cstring(err),
         None => null_mut(),
     };
 
@@ -1039,6 +1045,7 @@ pub extern "C" fn lb_get_status(lb: *mut Lb) -> LbStatus {
         pulling_files,
         space_used,
         msg,
+        unexpected_sync_problem,
     }
 }
 

--- a/libs/lb/lb-c/src/mem_cleanup.rs
+++ b/libs/lb/lb-c/src/mem_cleanup.rs
@@ -305,5 +305,9 @@ pub extern "C" fn lb_free_status(status: LbStatus) {
         if !status.msg.is_null() {
             drop(CString::from_raw(status.msg));
         }
+
+        if !status.unexpected_sync_problem.is_null() {
+            drop(CString::from_raw(status.unexpected_sync_problem));
+        }
     }
 }

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -24,6 +24,7 @@ basic-human-duration = "0.2.0"
 bezier-rs = "0.2.0"
 bincode = "1.3.3"
 bip39-dict = "0.1.3"
+bytes = "1"
 chrono = "0.4"
 crossbeam = "0.8.1"
 db-rs-derive = "0.3.7"
@@ -41,6 +42,7 @@ rand = "0.8.4"
 reqwest = { version = "0.11.1", default-features = false, features = [
     "json",
     "rustls-tls",
+    "stream",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -88,6 +88,8 @@ num_cpus = "1.13.0"
 rand = "0.8.4"
 tempfile = { version = "3.1.0" }
 test_utils = { path = "../test_utils" }
+# Used by ingress_perf_tests to read peak RSS via getrusage(RUSAGE_SELF).
+libc = "0.2"
 
 [[bench]]
 name = "bench_main"

--- a/libs/lb/lb-rs/src/io/docs.rs
+++ b/libs/lb/lb-rs/src/io/docs.rs
@@ -33,6 +33,16 @@ impl AsyncDocs {
         Ok(())
     }
 
+    pub async fn insert_pending(
+        &self, _id: Uuid, _hmac: DocumentHmac, _document: &EncryptedDocument,
+    ) -> LbResult<()> {
+        Ok(())
+    }
+
+    pub async fn promote_pending(&self, _id: Uuid, _hmac: DocumentHmac) -> LbResult<()> {
+        Ok(())
+    }
+
     pub async fn get(&self, _id: Uuid, _hmac: Option<DocumentHmac>) -> LbResult<EncryptedDocument> {
         Err(LbErrKind::FileNonexistent.into())
     }
@@ -62,22 +72,34 @@ impl AsyncDocs {
         &self, id: Uuid, hmac: Option<DocumentHmac>, document: &EncryptedDocument,
     ) -> LbResult<()> {
         if let Some(hmac) = hmac {
-            let value = &bincode::serialize(document).map_unexpected()?;
-            let path_str = key_path(&self.location, id, hmac) + ".pending";
-            let path = Path::new(&path_str);
-            trace!("write\t{} {:?} bytes", &path_str, value.len());
-            fs::create_dir_all(path.parent().unwrap()).await?;
-            let mut f = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(path)
-                .await?;
-            f.write_all(value).await?;
-            Ok(fs::rename(path, key_path(&self.location, id, hmac)).await?)
-        } else {
-            Ok(())
+            self.insert_pending(id, hmac, document).await?;
+            self.promote_pending(id, hmac).await?;
         }
+        Ok(())
+    }
+
+    pub async fn insert_pending(
+        &self, id: Uuid, hmac: DocumentHmac, document: &EncryptedDocument,
+    ) -> LbResult<()> {
+        let value = &bincode::serialize(document).map_unexpected()?;
+        let path_str = pending_path(&self.location, id, hmac);
+        let path = Path::new(&path_str);
+        trace!("write pending\t{} {:?} bytes", &path_str, value.len());
+        fs::create_dir_all(path.parent().unwrap()).await?;
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+            .await?;
+        f.write_all(value).await?;
+        Ok(())
+    }
+
+    pub async fn promote_pending(&self, id: Uuid, hmac: DocumentHmac) -> LbResult<()> {
+        let pending = pending_path(&self.location, id, hmac);
+        let final_path = key_path(&self.location, id, hmac);
+        Ok(fs::rename(&pending, &final_path).await?)
     }
 
     pub fn exists(&self, id: Uuid, hmac: Option<DocumentHmac>) -> bool {
@@ -198,6 +220,10 @@ pub fn namespace_path(writeable_path: &Path) -> String {
 pub fn key_path(writeable_path: &Path, key: Uuid, hmac: DocumentHmac) -> String {
     let hmac = base64::encode_config(hmac, base64::URL_SAFE);
     format!("{}/{}-{}", namespace_path(writeable_path), key, hmac)
+}
+
+fn pending_path(writeable_path: &Path, key: Uuid, hmac: DocumentHmac) -> String {
+    key_path(writeable_path, key, hmac) + ".pending"
 }
 
 impl From<&Config> for AsyncDocs {

--- a/libs/lb/lb-rs/src/io/network.rs
+++ b/libs/lb/lb-rs/src/io/network.rs
@@ -123,15 +123,6 @@ impl Network {
     }
 }
 
-/// Pick a request body. Small payloads stay on the simple `Vec<u8>` path so
-/// the request goes out with `Content-Length` and identity encoding (which
-/// the server is happy with for GETs too). Only payloads above
-/// [`STREAM_BODY_THRESHOLD`] switch to a chunked stream of bounded `Bytes`
-/// pieces — that's what avoids the macOS `write(2)` `INT_MAX` cap, at the
-/// cost of `Transfer-Encoding: chunked`.
-///
-/// The `Bytes` chunks are `split_to` slices of one ref-counted backing
-/// allocation, so chunking doesn't copy the payload.
 fn body_for(serialized_request: Vec<u8>) -> Body {
     if serialized_request.len() < STREAM_BODY_THRESHOLD {
         return Body::from(serialized_request);

--- a/libs/lb/lb-rs/src/io/network.rs
+++ b/libs/lb/lb-rs/src/io/network.rs
@@ -66,10 +66,7 @@ impl Network {
 
         let wire_format = WireFormat::CLIENT_DEFAULT;
         let serialized_request = wire_format
-            .serialize(&RequestWrapper {
-                signed_request,
-                client_version: client_version.clone(),
-            })
+            .serialize(&RequestWrapper { signed_request, client_version: client_version.clone() })
             .map_err(|err| ApiError::Serialize(err.to_string()))?;
 
         if serialized_request.len() > 10 * 1024 * 1024 {

--- a/libs/lb/lb-rs/src/io/network.rs
+++ b/libs/lb/lb-rs/src/io/network.rs
@@ -87,7 +87,10 @@ impl Network {
             .header(WIRE_FORMAT_HEADER, wire_format.as_str())
             .send()
             .await
-            .map_err(|e| ApiError::SendFailed(e.to_string()))?;
+            .map_err(|e| {
+                warn!("send failed: {e:?}");
+                ApiError::SendFailed(e.to_string())
+            })?;
         if start.elapsed() > Duration::from_millis(1000) {
             warn!("network request took {:?}", start.elapsed());
         }

--- a/libs/lb/lb-rs/src/io/network.rs
+++ b/libs/lb/lb-rs/src/io/network.rs
@@ -12,18 +12,8 @@ use crate::model::errors::LbErr;
 use crate::model::pubkey;
 use crate::model::wire::{WIRE_FORMAT_HEADER, WireFormat};
 
-/// Cap on how many bytes hyper hands to a single `write()` syscall. macOS
-/// rejects writes larger than `INT_MAX` (~2 GiB) with EINVAL, so for
-/// large request bodies we feed reqwest a stream of bounded `Bytes` chunks
-/// instead of one giant slab.
 const STREAM_CHUNK_BYTES: usize = 4 * 1024 * 1024;
 
-/// Above this size we switch to a streaming body. Streaming forces
-/// `Transfer-Encoding: chunked`, which doesn't play nicely with GET requests
-/// (hyper-side handling for GET-with-chunked is iffy and the server returns
-/// BadRequest), so for ordinary small payloads we stay on the simple
-/// `Vec<u8>` path with `Content-Length`. 1 GiB is well below the macOS
-/// `INT_MAX` write cap and well above any normal metadata-shaped request.
 const STREAM_BODY_THRESHOLD: usize = 1024 * 1024 * 1024;
 
 impl<E> From<ErrorWrapper<E>> for ApiError<E> {

--- a/libs/lb/lb-rs/src/io/network.rs
+++ b/libs/lb/lb-rs/src/io/network.rs
@@ -1,6 +1,8 @@
 use web_time::{Duration, Instant};
 
-use reqwest::Client;
+use bytes::Bytes;
+use futures::stream;
+use reqwest::{Body, Client};
 
 use crate::get_code_version;
 use crate::model::account::Account;
@@ -9,6 +11,20 @@ use crate::model::clock::{Timestamp, get_time};
 use crate::model::errors::LbErr;
 use crate::model::pubkey;
 use crate::model::wire::{WIRE_FORMAT_HEADER, WireFormat};
+
+/// Cap on how many bytes hyper hands to a single `write()` syscall. macOS
+/// rejects writes larger than `INT_MAX` (~2 GiB) with EINVAL, so for
+/// large request bodies we feed reqwest a stream of bounded `Bytes` chunks
+/// instead of one giant slab.
+const STREAM_CHUNK_BYTES: usize = 4 * 1024 * 1024;
+
+/// Above this size we switch to a streaming body. Streaming forces
+/// `Transfer-Encoding: chunked`, which doesn't play nicely with GET requests
+/// (hyper-side handling for GET-with-chunked is iffy and the server returns
+/// BadRequest), so for ordinary small payloads we stay on the simple
+/// `Vec<u8>` path with `Content-Length`. 1 GiB is well below the macOS
+/// `INT_MAX` write cap and well above any normal metadata-shaped request.
+const STREAM_BODY_THRESHOLD: usize = 1024 * 1024 * 1024;
 
 impl<E> From<ErrorWrapper<E>> for ApiError<E> {
     fn from(err: ErrorWrapper<E>) -> Self {
@@ -79,10 +95,11 @@ impl Network {
 
         let url = &account.api_url;
         let start = Instant::now();
+        let body = body_for(serialized_request);
         let sent = self
             .client
             .request(T::METHOD, format!("{}{}", url, T::ROUTE).as_str())
-            .body(serialized_request)
+            .body(body)
             .header("Accept-Version", client_version)
             .header(WIRE_FORMAT_HEADER, wire_format.as_str())
             .send()
@@ -104,4 +121,27 @@ impl Network {
             .map_err(|err| ApiError::Deserialize(err.to_string()))?;
         response.map_err(ApiError::from)
     }
+}
+
+/// Pick a request body. Small payloads stay on the simple `Vec<u8>` path so
+/// the request goes out with `Content-Length` and identity encoding (which
+/// the server is happy with for GETs too). Only payloads above
+/// [`STREAM_BODY_THRESHOLD`] switch to a chunked stream of bounded `Bytes`
+/// pieces — that's what avoids the macOS `write(2)` `INT_MAX` cap, at the
+/// cost of `Transfer-Encoding: chunked`.
+///
+/// The `Bytes` chunks are `split_to` slices of one ref-counted backing
+/// allocation, so chunking doesn't copy the payload.
+fn body_for(serialized_request: Vec<u8>) -> Body {
+    if serialized_request.len() < STREAM_BODY_THRESHOLD {
+        return Body::from(serialized_request);
+    }
+    let mut buf = Bytes::from(serialized_request);
+    let mut chunks: Vec<Result<Bytes, std::io::Error>> =
+        Vec::with_capacity(buf.len().div_ceil(STREAM_CHUNK_BYTES));
+    while !buf.is_empty() {
+        let n = buf.len().min(STREAM_CHUNK_BYTES);
+        chunks.push(Ok(buf.split_to(n)));
+    }
+    Body::wrap_stream(stream::iter(chunks))
 }

--- a/libs/lb/lb-rs/src/io/network.rs
+++ b/libs/lb/lb-rs/src/io/network.rs
@@ -1,7 +1,6 @@
 use web_time::{Duration, Instant};
 
 use reqwest::Client;
-use tokio::time::sleep;
 
 use crate::get_code_version;
 use crate::model::account::Account;
@@ -9,6 +8,7 @@ use crate::model::api::*;
 use crate::model::clock::{Timestamp, get_time};
 use crate::model::errors::LbErr;
 use crate::model::pubkey;
+use crate::model::wire::{WIRE_FORMAT_HEADER, WireFormat};
 
 impl<E> From<ErrorWrapper<E>> for ApiError<E> {
     fn from(err: ErrorWrapper<E>) -> Self {
@@ -64,58 +64,44 @@ impl Network {
 
         let client_version = String::from((self.get_code_version)());
 
-        let serialized_request = serde_json::to_vec(&RequestWrapper {
-            signed_request,
-            client_version: client_version.clone(),
-        })
-        .map_err(|err| ApiError::Serialize(err.to_string()))?;
+        let wire_format = WireFormat::CLIENT_DEFAULT;
+        let serialized_request = wire_format
+            .serialize(&RequestWrapper {
+                signed_request,
+                client_version: client_version.clone(),
+            })
+            .map_err(|err| ApiError::Serialize(err.to_string()))?;
 
         if serialized_request.len() > 10 * 1024 * 1024 {
-            warn!("making network request with {} bytes", serialized_request.len());
+            warn!(
+                "making network request with {} bytes ({:?})",
+                serialized_request.len(),
+                wire_format
+            );
         }
 
-        let mut retries = 0;
+        let url = &account.api_url;
         let start = Instant::now();
-        let sent = loop {
-            let url = &account.api_url;
-            debug!("url {url}");
-            match self
-                .client
-                .request(T::METHOD, format!("{}{}", url, T::ROUTE).as_str())
-                .body(serialized_request.clone())
-                .header("Accept-Version", client_version.clone())
-                .send()
-                .await
-            {
-                Ok(o) => {
-                    if start.elapsed() > Duration::from_millis(1000) {
-                        warn!("network request took {:?}", start.elapsed());
-                    }
-                    break o;
-                }
-                Err(e) => {
-                    if retries < 3 {
-                        warn!(
-                            "network request send failed; retrying after {}ms; error = {:?}",
-                            retries * 100,
-                            e.to_string()
-                        );
-                        sleep(Duration::from_millis(retries * 100)).await;
-                        retries += 1;
-                        continue;
-                    } else {
-                        return Err(ApiError::SendFailed(e.to_string()));
-                    }
-                }
-            }
-        };
+        let sent = self
+            .client
+            .request(T::METHOD, format!("{}{}", url, T::ROUTE).as_str())
+            .body(serialized_request)
+            .header("Accept-Version", client_version)
+            .header(WIRE_FORMAT_HEADER, wire_format.as_str())
+            .send()
+            .await
+            .map_err(|e| ApiError::SendFailed(e.to_string()))?;
+        if start.elapsed() > Duration::from_millis(1000) {
+            warn!("network request took {:?}", start.elapsed());
+        }
+
         let serialized_response = sent
             .bytes()
             .await
             .map_err(|err| ApiError::ReceiveFailed(err.to_string()))?;
-        let response: Result<T::Response, ErrorWrapper<T::Error>> =
-            serde_json::from_slice(&serialized_response)
-                .map_err(|err| ApiError::Deserialize(err.to_string()))?;
+        let response: Result<T::Response, ErrorWrapper<T::Error>> = wire_format
+            .deserialize(&serialized_response)
+            .map_err(|err| ApiError::Deserialize(err.to_string()))?;
         response.map_err(ApiError::from)
     }
 }

--- a/libs/lb/lb-rs/src/model/api.rs
+++ b/libs/lb/lb-rs/src/model/api.rs
@@ -496,6 +496,59 @@ impl Request for GetSubscriptionInfoRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct GetSubscriptionInfoRequestV2 {}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct SubscriptionInfoV2 {
+    pub payment_platform: PaymentPlatformV2,
+    pub period_end: UnixTimeMillis,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum PaymentPlatformV2 {
+    Stripe { card_last_4_digits: String },
+    GooglePlay { account_state: GooglePlayAccountState },
+    AppStore { account_state: AppStoreAccountState },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct GetSubscriptionInfoResponseV2 {
+    pub subscription_info: Option<SubscriptionInfoV2>,
+}
+
+impl Request for GetSubscriptionInfoRequestV2 {
+    type Response = GetSubscriptionInfoResponseV2;
+    type Error = GetSubscriptionInfoError;
+    const METHOD: Method = Method::GET;
+    const ROUTE: &'static str = "/get-subscription-info-v2";
+}
+
+impl From<PaymentPlatformV2> for PaymentPlatform {
+    fn from(v: PaymentPlatformV2) -> Self {
+        match v {
+            PaymentPlatformV2::Stripe { card_last_4_digits } => {
+                PaymentPlatform::Stripe { card_last_4_digits }
+            }
+            PaymentPlatformV2::GooglePlay { account_state } => {
+                PaymentPlatform::GooglePlay { account_state }
+            }
+            PaymentPlatformV2::AppStore { account_state } => {
+                PaymentPlatform::AppStore { account_state }
+            }
+        }
+    }
+}
+
+impl From<SubscriptionInfoV2> for SubscriptionInfo {
+    fn from(v: SubscriptionInfoV2) -> Self {
+        SubscriptionInfo {
+            payment_platform: v.payment_platform.into(),
+            period_end: v.period_end,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct UpsertDebugInfoRequest {
     pub debug_info: DebugInfo,
 }

--- a/libs/lb/lb-rs/src/model/api.rs
+++ b/libs/lb/lb-rs/src/model/api.rs
@@ -541,10 +541,7 @@ impl From<PaymentPlatformV2> for PaymentPlatform {
 
 impl From<SubscriptionInfoV2> for SubscriptionInfo {
     fn from(v: SubscriptionInfoV2) -> Self {
-        SubscriptionInfo {
-            payment_platform: v.payment_platform.into(),
-            period_end: v.period_end,
-        }
+        SubscriptionInfo { payment_platform: v.payment_platform.into(), period_end: v.period_end }
     }
 }
 

--- a/libs/lb/lb-rs/src/model/compression_service.rs
+++ b/libs/lb/lb-rs/src/model/compression_service.rs
@@ -65,7 +65,9 @@ mod tests {
 
     #[test]
     fn roundtrips_binary_with_nul_bytes() {
-        let original: Vec<u8> = (0u32..4096).map(|i| (i.wrapping_mul(31) ^ 0x55) as u8).collect();
+        let original: Vec<u8> = (0u32..4096)
+            .map(|i| (i.wrapping_mul(31) ^ 0x55) as u8)
+            .collect();
         assert!(original.contains(&0u8), "expected sniff to see a NUL");
         let round_tripped = decompress(&compress(&original).unwrap()).unwrap();
         assert_eq!(round_tripped, original);

--- a/libs/lb/lb-rs/src/model/compression_service.rs
+++ b/libs/lb/lb-rs/src/model/compression_service.rs
@@ -6,8 +6,33 @@ use flate2::write::ZlibEncoder;
 
 use super::errors::{LbErrKind, LbResult};
 
+/// How many bytes of the payload to sniff for binary detection. Matches
+/// git's `buffer_is_binary`: a NUL byte in the first ~8 KiB is a strong
+/// signal the bytes won't deflate, so we skip compression.
+const SNIFF_BYTES: usize = 8000;
+
+const MIN_COMPRESS_SIZE: usize = 256;
+
+/// Pick a compression level by looking at the bytes we're about to write.
+/// `None` for binary-looking or tiny payloads; `Default` otherwise.
+pub fn level_for_content(content: &[u8]) -> Compression {
+    if content.len() < MIN_COMPRESS_SIZE {
+        debug!("no compression");
+        return Compression::none();
+    }
+    let sniff = &content[..content.len().min(SNIFF_BYTES)];
+    if sniff.contains(&0u8) {
+        debug!("no compression");
+        return Compression::none();
+    }
+
+    debug!("compression used");
+    Compression::default()
+}
+
 pub fn compress(content: &[u8]) -> LbResult<Vec<u8>> {
-    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    let level = level_for_content(content);
+    let mut encoder = ZlibEncoder::new(Vec::new(), level);
     encoder
         .write_all(content)
         .map_err(|err| LbErrKind::Unexpected(format!("unexpected compression error: {err:?}")))?;
@@ -26,7 +51,57 @@ pub fn decompress(content: &[u8]) -> LbResult<Vec<u8>> {
     Ok(result)
 }
 
-#[test]
-fn compress_decompress() {
-    assert_eq!(decompress(&compress(b"hello").unwrap()).unwrap(), b"hello");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips_text() {
+        let original = "hello world ".repeat(64);
+        let original = original.as_bytes();
+        let round_tripped = decompress(&compress(original).unwrap()).unwrap();
+        assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn roundtrips_binary_with_nul_bytes() {
+        let original: Vec<u8> = (0u32..4096).map(|i| (i.wrapping_mul(31) ^ 0x55) as u8).collect();
+        assert!(original.contains(&0u8), "expected sniff to see a NUL");
+        let round_tripped = decompress(&compress(&original).unwrap()).unwrap();
+        assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn roundtrips_small_payload() {
+        let original = b"tiny";
+        let round_tripped = decompress(&compress(original).unwrap()).unwrap();
+        assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn level_none_for_small_payload() {
+        let small = vec![b'a'; MIN_COMPRESS_SIZE - 1];
+        assert_eq!(level_for_content(&small).level(), Compression::none().level());
+    }
+
+    #[test]
+    fn level_none_when_nul_inside_sniff_window() {
+        let mut content = vec![b'a'; SNIFF_BYTES * 2];
+        content[100] = 0;
+        assert_eq!(level_for_content(&content).level(), Compression::none().level());
+    }
+
+    #[test]
+    fn level_default_for_text() {
+        let content = "the quick brown fox ".repeat(64);
+        assert_eq!(level_for_content(content.as_bytes()).level(), Compression::default().level());
+    }
+
+    #[test]
+    fn nul_after_sniff_window_does_not_skip_compression() {
+        // Only what's in the first SNIFF_BYTES matters.
+        let mut content = vec![b'a'; SNIFF_BYTES + 1024];
+        content[SNIFF_BYTES + 500] = 0;
+        assert_eq!(level_for_content(&content).level(), Compression::default().level());
+    }
 }

--- a/libs/lb/lb-rs/src/model/core_ops.rs
+++ b/libs/lb/lb-rs/src/model/core_ops.rs
@@ -461,4 +461,13 @@ where
         self.stage_validate_and_promote(Some(op), Owner(keychain.get_pk()?))?;
         Ok(document)
     }
+
+    pub fn overwrite_document_hmac(
+        &mut self, id: &Uuid, new_hmac: Option<DocumentHmac>, new_size: Option<usize>,
+        keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.overwrite_document_hmac_op(id, new_hmac, new_size, keychain)?;
+        self.stage_validate_and_promote(Some(op), Owner(keychain.get_pk()?))?;
+        Ok(())
+    }
 }

--- a/libs/lb/lb-rs/src/model/core_ops.rs
+++ b/libs/lb/lb-rs/src/model/core_ops.rs
@@ -3,7 +3,7 @@ use crate::model::api::METADATA_FEE;
 use crate::model::crypto::{AESKey, DecryptedDocument, EncryptedDocument};
 use crate::model::errors::{LbErrKind, LbResult};
 use crate::model::file::{File, Share, ShareMode};
-use crate::model::file_metadata::{FileType, Owner};
+use crate::model::file_metadata::{DocumentHmac, FileType, Owner};
 use crate::model::lazy::LazyTree;
 use crate::model::meta::Meta;
 use crate::model::secret_filename::{HmacSha256, SecretFileName};
@@ -318,6 +318,20 @@ where
 
         Ok((file, document))
     }
+
+    pub fn overwrite_document_hmac_op(
+        &mut self, id: &Uuid, new_hmac: Option<DocumentHmac>, new_size: Option<usize>,
+        keychain: &Keychain,
+    ) -> LbResult<SignedMeta> {
+        let id = match self.find(id)?.file_type() {
+            FileType::Document | FileType::Folder => *id,
+            FileType::Link { target } => target,
+        };
+        let mut file = self.find(&id)?.timestamped_value.value.clone();
+        validate::is_document(&file)?;
+        file.set_hmac_and_size(new_hmac, new_size);
+        file.sign(keychain)
+    }
 }
 
 impl<Base, Local, Staged> LazyTree<Staged>
@@ -429,6 +443,15 @@ where
         let (op, document) = self.update_document_op(id, document, keychain)?;
         self.stage_and_promote(Some(op))?;
         Ok(document)
+    }
+
+    pub fn overwrite_document_hmac_unvalidated(
+        &mut self, id: &Uuid, new_hmac: Option<DocumentHmac>, new_size: Option<usize>,
+        keychain: &Keychain,
+    ) -> LbResult<()> {
+        let op = self.overwrite_document_hmac_op(id, new_hmac, new_size, keychain)?;
+        self.stage_and_promote(Some(op))?;
+        Ok(())
     }
 
     pub fn update_document(

--- a/libs/lb/lb-rs/src/model/mod.rs
+++ b/libs/lb/lb-rs/src/model/mod.rs
@@ -40,5 +40,6 @@ pub mod text;
 pub mod tree_like;
 pub mod usage;
 pub mod validate;
+pub mod wire;
 
 pub use lazy::ValidationFailure;

--- a/libs/lb/lb-rs/src/model/wire.rs
+++ b/libs/lb/lb-rs/src/model/wire.rs
@@ -1,0 +1,119 @@
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// Header used by both client and server to negotiate body encoding.
+pub const WIRE_FORMAT_HEADER: &str = "X-Lockbook-Wire-Format";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireFormat {
+    Json,
+    Bincode,
+}
+
+impl WireFormat {
+    pub const CLIENT_DEFAULT: Self = WireFormat::Bincode;
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WireFormat::Json => "json",
+            WireFormat::Bincode => "bincode",
+        }
+    }
+
+    pub fn from_header(value: Option<&str>) -> Self {
+        match value.map(|v| v.trim()) {
+            Some(v) if v.eq_ignore_ascii_case("bincode") => WireFormat::Bincode,
+            _ => WireFormat::Json,
+        }
+    }
+
+    pub fn serialize<T: Serialize + ?Sized>(self, value: &T) -> Result<Vec<u8>, WireError> {
+        match self {
+            WireFormat::Json => {
+                serde_json::to_vec(value).map_err(|e| WireError::Serialize(e.to_string()))
+            }
+            WireFormat::Bincode => {
+                bincode::serialize(value).map_err(|e| WireError::Serialize(e.to_string()))
+            }
+        }
+    }
+
+    pub fn deserialize<T: DeserializeOwned>(self, bytes: &[u8]) -> Result<T, WireError> {
+        match self {
+            WireFormat::Json => {
+                serde_json::from_slice(bytes).map_err(|e| WireError::Deserialize(e.to_string()))
+            }
+            WireFormat::Bincode => {
+                bincode::deserialize(bytes).map_err(|e| WireError::Deserialize(e.to_string()))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum WireError {
+    Serialize(String),
+    Deserialize(String),
+}
+
+impl std::fmt::Display for WireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WireError::Serialize(e) => write!(f, "serialize: {e}"),
+            WireError::Deserialize(e) => write!(f, "deserialize: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for WireError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_header_handles_common_inputs() {
+        assert_eq!(WireFormat::from_header(None), WireFormat::Json);
+        assert_eq!(WireFormat::from_header(Some("")), WireFormat::Json);
+        assert_eq!(WireFormat::from_header(Some("json")), WireFormat::Json);
+        assert_eq!(WireFormat::from_header(Some("bincode")), WireFormat::Bincode);
+        assert_eq!(WireFormat::from_header(Some("BINCODE")), WireFormat::Bincode);
+        assert_eq!(WireFormat::from_header(Some(" bincode ")), WireFormat::Bincode);
+        // Unknown values fall back to JSON.
+        assert_eq!(WireFormat::from_header(Some("msgpack")), WireFormat::Json);
+    }
+
+    #[test]
+    fn roundtrip_byte_heavy_payload() {
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+        struct Doc {
+            #[serde(with = "serde_bytes")]
+            bytes: Vec<u8>,
+        }
+
+        let doc = Doc { bytes: vec![0u8, 1, 2, 200, 255] };
+
+        for fmt in [WireFormat::Json, WireFormat::Bincode] {
+            let encoded = fmt.serialize(&doc).unwrap();
+            let decoded: Doc = fmt.deserialize(&encoded).unwrap();
+            assert_eq!(doc, decoded, "{fmt:?} roundtrip mismatch");
+        }
+    }
+
+    #[test]
+    fn bincode_is_more_compact_for_bytes_than_json() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Doc {
+            #[serde(with = "serde_bytes")]
+            bytes: Vec<u8>,
+        }
+
+        let doc = Doc { bytes: (0u8..=255).collect() };
+        let json_len = WireFormat::Json.serialize(&doc).unwrap().len();
+        let bincode_len = WireFormat::Bincode.serialize(&doc).unwrap().len();
+        assert!(
+            bincode_len * 3 < json_len,
+            "bincode={bincode_len} json={json_len} — bincode should be much smaller"
+        );
+    }
+}

--- a/libs/lb/lb-rs/src/service/billing.rs
+++ b/libs/lb/lb-rs/src/service/billing.rs
@@ -1,7 +1,7 @@
 use crate::LocalLb;
 use crate::io::network::ApiError;
 use crate::model::api::{
-    CancelSubscriptionError, CancelSubscriptionRequest, GetSubscriptionInfoRequest,
+    CancelSubscriptionError, CancelSubscriptionRequest, GetSubscriptionInfoRequestV2,
     StripeAccountTier, SubscriptionInfo, UpgradeAccountAppStoreError,
     UpgradeAccountAppStoreRequest, UpgradeAccountGooglePlayError, UpgradeAccountGooglePlayRequest,
     UpgradeAccountStripeError, UpgradeAccountStripeRequest,
@@ -150,15 +150,15 @@ impl LocalLb {
     pub async fn get_subscription_info(&self) -> LbResult<Option<SubscriptionInfo>> {
         let account = self.get_account()?;
 
-        Ok(self
+        let response = self
             .client
-            .request(account, GetSubscriptionInfoRequest {})
+            .request(account, GetSubscriptionInfoRequestV2 {})
             .await
             .map_err(|err| match err {
                 ApiError::SendFailed(_) => LbErrKind::ServerUnreachable,
                 ApiError::ClientUpdateRequired => LbErrKind::ClientUpdateRequired,
                 _ => core_err_unexpected(err),
-            })?
-            .subscription_info)
+            })?;
+        Ok(response.subscription_info.map(Into::into))
     }
 }

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -2,12 +2,14 @@ use std::collections::HashSet;
 
 use crate::LocalLb;
 use crate::model::clock::get_time;
-use crate::model::crypto::DecryptedDocument;
+use crate::model::crypto::{AESKey, DecryptedDocument, EncryptedDocument};
 use crate::model::errors::{LbErrKind, LbResult};
 use crate::model::file_like::FileLike;
 use crate::model::file_metadata::{DocumentHmac, FileType};
+use crate::model::secret_filename::HmacSha256;
 use crate::model::tree_like::TreeLike;
-use crate::model::validate;
+use crate::model::{compression_service, symkey, validate};
+use hmac::{Mac, NewMac};
 use uuid::Uuid;
 
 use super::activity;
@@ -24,21 +26,35 @@ impl LocalLb {
 
     #[instrument(level = "debug", skip(self, content), err(Debug))]
     pub async fn write_document(&self, id: Uuid, content: &[u8]) -> LbResult<()> {
-        let mut tx = self.begin_tx().await;
-        let db = tx.db();
-
-        let mut tree = (&db.base_metadata)
-            .to_staged(&mut db.local_metadata)
-            .to_lazy();
-
-        let id = match tree.find(&id)?.file_type() {
-            FileType::Document | FileType::Folder => id,
-            FileType::Link { target } => target,
+        // get info so we can do operations while not holding lock
+        let (id, key) = {
+            let tx = self.ro_tx().await;
+            let db = tx.db();
+            let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
+            let id = match tree.find(&id)?.file_type() {
+                FileType::Document | FileType::Folder => id,
+                FileType::Link { target } => target,
+            };
+            validate::is_document(tree.find(&id)?)?;
+            (id, tree.decrypt_key(&id, &self.keychain)?)
         };
-        let encrypted_document = tree.update_document(&id, content, &self.keychain)?;
-        let hmac = tree.find(&id)?.document_hmac().copied();
-        self.docs.insert(id, hmac, &encrypted_document).await?;
-        tx.end();
+
+        // do the operations
+        let (hmac, encrypted) = compress_encrypt_document(&key, content)?;
+        let encrypted_size = encrypted.value.len();
+        self.docs.insert_pending(id, hmac, &encrypted).await?;
+
+        // commit the result
+        {
+            let mut tx = self.begin_tx().await;
+            let db = tx.db();
+            let mut tree = (&db.base_metadata)
+                .to_staged(&mut db.local_metadata)
+                .to_lazy();
+            self.docs.promote_pending(id, hmac).await?;
+            tree.overwrite_document_hmac(&id, Some(hmac), Some(encrypted_size), &self.keychain)?;
+            tx.end();
+        }
 
         self.events.doc_written(id, Actor::User);
         self.add_doc_event(activity::DocEvent::Write(id, get_time().0))
@@ -103,37 +119,55 @@ impl LocalLb {
     pub async fn safe_write(
         &self, id: Uuid, old_hmac: Option<DocumentHmac>, content: Vec<u8>,
     ) -> LbResult<DocumentHmac> {
-        let mut tx = self.begin_tx().await;
-        let db = tx.db();
-
-        let mut tree = (&db.base_metadata)
-            .to_staged(&mut db.local_metadata)
-            .to_lazy();
-
-        let file = tree.find(&id)?;
-        if file.document_hmac() != old_hmac.as_ref() {
-            return Err(LbErrKind::ReReadRequired.into());
-        }
-        let id = match file.file_type() {
-            FileType::Document | FileType::Folder => id,
-            FileType::Link { target } => target,
+        // get info so we can do operations while not holding lock
+        let (target_id, key) = {
+            let tx = self.ro_tx().await;
+            let db = tx.db();
+            let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
+            let file = tree.find(&id)?;
+            if file.document_hmac() != old_hmac.as_ref() {
+                return Err(LbErrKind::ReReadRequired.into());
+            }
+            let target_id = match file.file_type() {
+                FileType::Document | FileType::Folder => id,
+                FileType::Link { target } => target,
+            };
+            validate::is_document(tree.find(&target_id)?)?;
+            (target_id, tree.decrypt_key(&target_id, &self.keychain)?)
         };
-        // todo can we not borrow here?
-        let encrypted_document = tree.update_document(&id, &content, &self.keychain)?;
-        let hmac = tree.find(&id)?.document_hmac();
-        let hmac = *hmac.ok_or_else(|| {
-            LbErrKind::Unexpected(format!("hmac missing for a document we just wrote {id}"))
-        })?;
+
+        // do the operations
+        let (hmac, encrypted) = compress_encrypt_document(&key, &content)?;
+        let encrypted_size = encrypted.value.len();
         self.docs
-            .insert(id, Some(hmac), &encrypted_document)
+            .insert_pending(target_id, hmac, &encrypted)
             .await?;
-        tx.end();
+
+        // commit the result
+        {
+            let mut tx = self.begin_tx().await;
+            let db = tx.db();
+            let mut tree = (&db.base_metadata)
+                .to_staged(&mut db.local_metadata)
+                .to_lazy();
+            self.docs.promote_pending(target_id, hmac).await?;
+            if tree.find(&id)?.document_hmac() != old_hmac.as_ref() {
+                return Err(LbErrKind::ReReadRequired.into());
+            }
+            tree.overwrite_document_hmac(
+                &target_id,
+                Some(hmac),
+                Some(encrypted_size),
+                &self.keychain,
+            )?;
+            tx.end();
+        }
 
         // todo: when workspace isn't the only writer, this arg needs to be exposed
         // this will happen when lb-fs is integrated into an app and shares an lb-rs with ws
         // or it will happen when there are multiple co-operative core processes.
-        self.events.doc_written(id, Actor::User);
-        self.add_doc_event(activity::DocEvent::Write(id, get_time().0))
+        self.events.doc_written(target_id, Actor::User);
+        self.add_doc_event(activity::DocEvent::Write(target_id, get_time().0))
             .await?;
 
         Ok(hmac)
@@ -159,4 +193,19 @@ impl LocalLb {
 
         Ok(())
     }
+}
+
+fn compress_encrypt_document(
+    key: &AESKey, content: &[u8],
+) -> LbResult<(DocumentHmac, EncryptedDocument)> {
+    let hmac: DocumentHmac = {
+        let mut mac = HmacSha256::new_from_slice(key)
+            .map_err(|err| LbErrKind::Unexpected(format!("hmac creation error: {err:?}")))?;
+        mac.update(content);
+        mac.finalize().into_bytes()
+    }
+    .into();
+    let compressed = compression_service::compress(content)?;
+    let encrypted = symkey::encrypt(key, &compressed)?;
+    Ok((hmac, encrypted))
 }

--- a/libs/lb/lb-rs/src/service/documents.rs
+++ b/libs/lb/lb-rs/src/service/documents.rs
@@ -67,43 +67,46 @@ impl LocalLb {
     pub async fn read_document_with_hmac(
         &self, id: Uuid, user_activity: bool,
     ) -> LbResult<(Option<DocumentHmac>, DecryptedDocument)> {
-        let tx = self.ro_tx().await;
-        let db = tx.db();
+        // get info + on-disk bytes so we can decrypt without holding the lock
+        let info: Option<(DocumentHmac, AESKey, Option<EncryptedDocument>)> = {
+            let tx = self.ro_tx().await;
+            let db = tx.db();
+            let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
 
-        let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
+            let file = tree.find(&id)?;
+            validate::is_document(file)?;
+            let hmac = file.document_hmac().copied();
 
-        let file = tree.find(&id)?;
-        validate::is_document(file)?;
-        let hmac = file.document_hmac().copied();
-
-        if tree.calculate_deleted(&id)? {
-            return Err(LbErrKind::FileNonexistent.into());
-        }
-
-        let doc = match hmac {
-            Some(hmac) => {
-                if self.docs.exists(id, Some(hmac)) {
-                    let doc = self.docs.get(id, Some(hmac)).await?;
-                    let doc = tree.decrypt_document(&id, &doc, &self.keychain)?;
-                    drop(tx);
-                    doc
-                } else {
-                    drop(tx);
-                    // todo: if document not found -- need to trigger a pull
-                    let doc = self.fetch_doc(id, hmac).await?;
-
-                    let tx = self.ro_tx().await;
-                    let db = tx.db();
-                    let mut tree = (&db.base_metadata).to_staged(&db.local_metadata).to_lazy();
-                    let doc = tree.decrypt_document(&id, &doc, &self.keychain)?;
-                    drop(tx);
-
-                    doc
-                }
+            if tree.calculate_deleted(&id)? {
+                return Err(LbErrKind::FileNonexistent.into());
             }
-            None => {
-                drop(tx);
-                vec![]
+
+            match hmac {
+                Some(hmac) => {
+                    let key = tree.decrypt_key(&id, &self.keychain)?;
+                    let local_blob = if self.docs.exists(id, Some(hmac)) {
+                        Some(self.docs.get(id, Some(hmac)).await?)
+                    } else {
+                        None
+                    };
+                    Some((hmac, key, local_blob))
+                }
+                None => None,
+            }
+        };
+
+        // do decrypt + decompress without holding the lock; fetch from the
+        // server first if the blob wasn't already local.
+        let (hmac, doc) = match info {
+            None => (None, vec![]),
+            Some((hmac, key, local_blob)) => {
+                let encrypted = match local_blob {
+                    Some(blob) => blob,
+                    // todo: if document not found -- need to trigger a pull
+                    None => self.fetch_doc(id, hmac).await?,
+                };
+                let doc = decrypt_decompress_document(&key, &encrypted)?;
+                (Some(hmac), doc)
             }
         };
 
@@ -208,4 +211,12 @@ fn compress_encrypt_document(
     let compressed = compression_service::compress(content)?;
     let encrypted = symkey::encrypt(key, &compressed)?;
     Ok((hmac, encrypted))
+}
+
+fn decrypt_decompress_document(
+    key: &AESKey, encrypted: &EncryptedDocument,
+) -> LbResult<DecryptedDocument> {
+    let compressed = symkey::decrypt(key, encrypted)?;
+    let doc = compression_service::decompress(&compressed)?;
+    Ok(doc)
 }

--- a/libs/lb/lb-rs/src/service/import_export.rs
+++ b/libs/lb/lb-rs/src/service/import_export.rs
@@ -170,7 +170,7 @@ impl Lb {
                 .map_err(LbErr::from)?;
 
                 disk_file
-                    .write(self.read_document(file.id, true).await?.as_slice())
+                    .write_all(self.read_document(file.id, true).await?.as_slice())
                     .map_err(LbErr::from)?;
             }
             FileType::Folder => {

--- a/libs/lb/lb-rs/src/subscribers/syncer.rs
+++ b/libs/lb/lb-rs/src/subscribers/syncer.rs
@@ -728,11 +728,11 @@ impl LocalLb {
                                     }
                                 }
                             } else {
-                                // overwrite (todo: avoid reading/decrypting/encrypting document)
-                                let document = self.read_document_helper(id, &mut local).await?;
-                                merge.update_document_unvalidated(
+                                let local_file = local.find(&id)?;
+                                merge.overwrite_document_hmac_unvalidated(
                                     &id,
-                                    &document,
+                                    local_file.document_hmac().copied(),
+                                    local_file.doc_size(),
                                     &self.keychain,
                                 )?;
                             }

--- a/libs/lb/lb-rs/src/subscribers/syncer.rs
+++ b/libs/lb/lb-rs/src/subscribers/syncer.rs
@@ -1332,12 +1332,12 @@ impl LocalLb {
         #[cfg(not(target_family = "wasm"))]
         tokio::spawn(async move {
             loop {
-                self.sync().await.map_unexpected().log_and_ignore();
                 if self.user_active().await {
                     tokio::time::sleep(Duration::from_secs(3)).await;
                 } else {
                     tokio::time::sleep(Duration::from_secs(5 * 60)).await;
                 }
+                self.sync().await.map_unexpected().log_and_ignore();
             }
         });
     }

--- a/libs/lb/lb-rs/tests/api_get_subscription_info_tests.rs
+++ b/libs/lb/lb-rs/tests/api_get_subscription_info_tests.rs
@@ -1,4 +1,6 @@
-use lb_rs::model::api::{GetSubscriptionInfoRequest, UpgradeAccountStripeRequest};
+use lb_rs::model::api::{
+    GetSubscriptionInfoRequest, GetSubscriptionInfoRequestV2, UpgradeAccountStripeRequest,
+};
 use test_utils::local;
 use test_utils::{generate_premium_account_tier, test_core_with_account, test_credit_cards};
 
@@ -38,6 +40,49 @@ async fn get_subscription_info() {
         local(&core)
             .client
             .request(&account, GetSubscriptionInfoRequest {})
+            .await
+            .unwrap()
+            .subscription_info
+            .is_some()
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn get_subscription_info_v2() {
+    let core = test_core_with_account().await;
+    let account = core.get_account().unwrap();
+
+    assert!(
+        local(&core)
+            .client
+            .request(&account, GetSubscriptionInfoRequestV2 {})
+            .await
+            .unwrap()
+            .subscription_info
+            .is_none()
+    );
+
+    local(&core)
+        .client
+        .request(
+            &account,
+            UpgradeAccountStripeRequest {
+                account_tier: generate_premium_account_tier(
+                    test_credit_cards::GOOD,
+                    None,
+                    None,
+                    None,
+                ),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        local(&core)
+            .client
+            .request(&account, GetSubscriptionInfoRequestV2 {})
             .await
             .unwrap()
             .subscription_info

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -2,15 +2,10 @@ use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use lb_rs::Lb;
-use lb_rs::model::core_config::Config;
 use lb_rs::service::events::{Event, SyncIncrement};
 use lb_rs::service::import_export::ImportStatus;
 use rand::RngCore;
-use test_utils::{
-    generate_premium_account_tier, random_name, test_core_with_account, test_credit_cards, url,
-};
-use uuid::Uuid;
+use test_utils::{generate_premium_account_tier, test_core_with_account, test_credit_cards};
 
 const ONE_MIB: usize = 1024 * 1024;
 const ONE_GIB: usize = 1024 * ONE_MIB;
@@ -48,18 +43,6 @@ fn ensure_random_file(path: &Path, bytes: usize) {
 fn mib_per_sec(bytes: usize, elapsed: Duration) -> f64 {
     let secs = elapsed.as_secs_f64();
     if secs == 0.0 { 0.0 } else { (bytes as f64 / ONE_MIB as f64) / secs }
-}
-
-/// Like `test_utils::test_config` but with stdout logs on so the underlying
-/// reqwest error is visible when sync blows up.
-fn verbose_config() -> Config {
-    Config {
-        writeable_path: format!("/tmp/{}", Uuid::new_v4()),
-        background_work: false,
-        logs: true,
-        stdout_logs: true,
-        colored_logs: false,
-    }
 }
 
 #[tokio::test]

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -1,0 +1,202 @@
+//! Performance tests for ingressing large files into lockbook.
+//!
+//! These are `#[ignore]`d by default because they generate a 1 GiB file on
+//! disk and hit a real lockbook server. Run with:
+//!
+//!     cargo test -p lb-rs --test ingress_perf_tests -- --ignored --nocapture
+//!
+//! A lockbook server must be reachable at `$API_URL` (default
+//! `http://localhost:8000`) with Stripe test mode configured (the test
+//! upgrades the throwaway account to premium so the free-tier cap doesn't
+//! reject the 1 GiB upload).
+//!
+//! The 1 GiB fixture is written to `/tmp/lockbook-ingress-perf-1gib.bin` and
+//! reused across runs. Delete it to force regeneration.
+//!
+//! The test enables stdout tracing at DEBUG by default (override with
+//! `LOG_LEVEL=info|warn|...`). When a sync fails, this is what surfaces the
+//! underlying reqwest error — `LbErrKind::ServerUnreachable` discards it
+//! otherwise.
+
+use std::io::Write;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use lb_rs::Lb;
+use lb_rs::model::core_config::Config;
+use lb_rs::service::events::{Event, SyncIncrement};
+use lb_rs::service::import_export::ImportStatus;
+use rand::RngCore;
+use test_utils::{generate_premium_account_tier, random_name, test_credit_cards, url};
+use uuid::Uuid;
+
+const ONE_MIB: usize = 1024 * 1024;
+const ONE_GIB: usize = 1024 * ONE_MIB;
+
+/// Fixed path so reruns reuse the same file. Delete it to force regeneration.
+const FIXTURE_PATH: &str = "/tmp/lockbook-ingress-perf-1gib.bin";
+
+fn ensure_random_file(path: &Path, bytes: usize) {
+    if let Ok(meta) = std::fs::metadata(path) {
+        if meta.is_file() && meta.len() == bytes as u64 {
+            println!(
+                "reusing existing fixture at {} ({} bytes)",
+                path.display(),
+                meta.len()
+            );
+            return;
+        }
+        // Wrong size (likely a partial write from a previous run) — replace it.
+        let _ = std::fs::remove_file(path);
+    }
+
+    println!("generating {} byte random file at {}...", bytes, path.display());
+    let gen_start = Instant::now();
+    let mut file = std::fs::File::create(path).unwrap();
+    let mut rng = rand::thread_rng();
+    let mut buf = vec![0u8; 4 * ONE_MIB];
+    let mut remaining = bytes;
+    while remaining > 0 {
+        let chunk = remaining.min(buf.len());
+        rng.fill_bytes(&mut buf[..chunk]);
+        file.write_all(&buf[..chunk]).unwrap();
+        remaining -= chunk;
+    }
+    file.flush().unwrap();
+    let elapsed = gen_start.elapsed();
+    println!(
+        "  file generation: {:?} ({:.1} MiB/s)",
+        elapsed,
+        mib_per_sec(bytes, elapsed)
+    );
+}
+
+fn mib_per_sec(bytes: usize, elapsed: Duration) -> f64 {
+    let secs = elapsed.as_secs_f64();
+    if secs == 0.0 { 0.0 } else { (bytes as f64 / ONE_MIB as f64) / secs }
+}
+
+/// Like `test_utils::test_config` but with stdout logs on so the underlying
+/// reqwest error is visible when sync blows up.
+fn verbose_config() -> Config {
+    Config {
+        writeable_path: format!("/tmp/{}", Uuid::new_v4()),
+        background_work: false,
+        logs: true,
+        stdout_logs: true,
+        colored_logs: false,
+    }
+}
+
+#[tokio::test]
+#[ignore = "generates a 1 GiB file and contacts the server"]
+async fn ingress_one_gib_single_file() {
+    let doc_path = Path::new(FIXTURE_PATH);
+    ensure_random_file(doc_path, ONE_GIB);
+
+    // Build Lb manually (instead of `test_core_with_account`) so we control
+    // the config — specifically, so logs are on.
+    println!("api url: {}", url());
+    let core = Lb::init(verbose_config()).await.unwrap();
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
+
+    // Upgrade to premium so the upload doesn't trip the free-tier usage cap.
+    // Requires the server to have Stripe test mode configured.
+    core.upgrade_account_stripe(generate_premium_account_tier(
+        test_credit_cards::GOOD,
+        None,
+        None,
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let root = core.root().await.unwrap();
+
+    // Subscribe to sync events and print them with elapsed time so we can
+    // see exactly where push/pull stalls or fails. Spawned before sync so
+    // we don't miss SyncStarted.
+    let mut events = core.subscribe();
+    let watch_start = Instant::now();
+    let watcher = tokio::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(evt) => {
+                    if let Event::Sync(s) = evt {
+                        let stamp = watch_start.elapsed();
+                        match s {
+                            SyncIncrement::SyncStarted => println!("  [+{stamp:?}] sync started"),
+                            SyncIncrement::PullingDocument(id, started) => println!(
+                                "  [+{stamp:?}] pull doc {id} {}",
+                                if started { "start" } else { "done" }
+                            ),
+                            SyncIncrement::PushingDocument(id, started) => println!(
+                                "  [+{stamp:?}] push doc {id} {}",
+                                if started { "start" } else { "done" }
+                            ),
+                            SyncIncrement::SyncFinished(err) => {
+                                println!("  [+{stamp:?}] sync finished err={err:?}")
+                            }
+                        }
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    println!("  watcher lagged by {n} events");
+                }
+            }
+        }
+    });
+
+    println!("importing into lockbook...");
+    let import_start = Instant::now();
+    core.import_files(&[doc_path.to_path_buf()], root.id, &|status: ImportStatus| {
+        match status {
+            ImportStatus::CalculatedTotal(n) => println!("  import: total items = {n}"),
+            ImportStatus::StartingItem(p) => println!("  import: starting {p}"),
+            ImportStatus::FinishedItem(f) => {
+                println!("  import: finished id={} name={}", f.id, f.name)
+            }
+        }
+    })
+    .await
+    .unwrap();
+    let import_elapsed = import_start.elapsed();
+    println!(
+        "import_files:    {:?} ({:.1} MiB/s)",
+        import_elapsed,
+        mib_per_sec(ONE_GIB, import_elapsed)
+    );
+
+    // Pre-sync diagnostics so we know what sync is about to attempt.
+    let status = core.status().await;
+    println!("pre-sync status: {status:?}");
+    match core.get_usage().await {
+        Ok(usage) => println!("pre-sync server usage: {usage:?}"),
+        Err(e) => println!("pre-sync get_usage failed: {:?}", e.kind),
+    }
+
+    println!("syncing to server...");
+    let sync_start = Instant::now();
+    let result = core.sync().await;
+    let sync_elapsed = sync_start.elapsed();
+    println!(
+        "sync:            {:?} ({:.1} MiB/s)",
+        sync_elapsed,
+        mib_per_sec(ONE_GIB, sync_elapsed)
+    );
+
+    // Stop the watcher cleanly before asserting.
+    watcher.abort();
+
+    if let Err(e) = result {
+        // The `kind` is what classifies the failure; the long `backtrace`
+        // string isn't useful on its own (LbErrKind::ServerUnreachable
+        // discards the underlying reqwest cause). The actual cause appears
+        // in the tracing output above — search stdout for
+        // "network request send failed" or "network request took".
+        panic!("sync failed: kind = {:?}", e.kind);
+    }
+}

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -7,7 +7,9 @@ use lb_rs::model::core_config::Config;
 use lb_rs::service::events::{Event, SyncIncrement};
 use lb_rs::service::import_export::ImportStatus;
 use rand::RngCore;
-use test_utils::{generate_premium_account_tier, random_name, test_core_with_account, test_credit_cards, url};
+use test_utils::{
+    generate_premium_account_tier, random_name, test_core_with_account, test_credit_cards, url,
+};
 use uuid::Uuid;
 
 const ONE_MIB: usize = 1024 * 1024;

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -1,23 +1,3 @@
-//! Performance tests for ingressing large files into lockbook.
-//!
-//! These are `#[ignore]`d by default because they generate a 1 GiB file on
-//! disk and hit a real lockbook server. Run with:
-//!
-//!     cargo test -p lb-rs --test ingress_perf_tests -- --ignored --nocapture
-//!
-//! A lockbook server must be reachable at `$API_URL` (default
-//! `http://localhost:8000`) with Stripe test mode configured (the test
-//! upgrades the throwaway account to premium so the free-tier cap doesn't
-//! reject the 1 GiB upload).
-//!
-//! The 1 GiB fixture is written to `/tmp/lockbook-ingress-perf-1gib.bin` and
-//! reused across runs. Delete it to force regeneration.
-//!
-//! The test enables stdout tracing at DEBUG by default (override with
-//! `LOG_LEVEL=info|warn|...`). When a sync fails, this is what surfaces the
-//! underlying reqwest error — `LbErrKind::ServerUnreachable` discards it
-//! otherwise.
-
 use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -27,7 +7,7 @@ use lb_rs::model::core_config::Config;
 use lb_rs::service::events::{Event, SyncIncrement};
 use lb_rs::service::import_export::ImportStatus;
 use rand::RngCore;
-use test_utils::{generate_premium_account_tier, random_name, test_credit_cards, url};
+use test_utils::{generate_premium_account_tier, random_name, test_core_with_account, test_credit_cards, url};
 use uuid::Uuid;
 
 const ONE_MIB: usize = 1024 * 1024;
@@ -86,13 +66,7 @@ async fn ingress_one_gib_single_file() {
     let doc_path = Path::new(FIXTURE_PATH);
     ensure_random_file(doc_path, ONE_GIB);
 
-    // Build Lb manually (instead of `test_core_with_account`) so we control
-    // the config — specifically, so logs are on.
-    println!("api url: {}", url());
-    let core = Lb::init(verbose_config()).await.unwrap();
-    core.create_account(&random_name(), &url(), false)
-        .await
-        .unwrap();
+    let core = test_core_with_account().await;
 
     // Upgrade to premium so the upload doesn't trip the free-tier usage cap.
     // Requires the server to have Stripe test mode configured.

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -16,7 +16,17 @@ use uuid::Uuid;
 
 const ONE_MIB: usize = 1024 * 1024;
 
-const FIXTURE_PATH: &str = "/Users/parth/Downloads/egui.mov";
+/// 2.4 GiB — 20% above 2 GiB so we land comfortably past h2's
+/// `MAX_WINDOW_SIZE` (`(1<<31) - 1`, the single-`send_data` payload
+/// cap from RFC 7540 §6.9.1). Sized to exercise both the client-side
+/// `body_for` streaming path and the server-side `build_response`
+/// chunked path; encryption framing adds only a few hundred KB.
+const FIXTURE_SIZE: usize = (1024 * ONE_MIB * 2 * 12) / 10;
+
+/// Fixed path so reruns reuse the same generated fixture. Delete the
+/// file to force regeneration, or point `FIXTURE_PATH` at a real file
+/// (e.g. `~/Downloads/some.mov`) to skip generation entirely.
+const FIXTURE_PATH: &str = "/tmp/lockbook-ingress-perf-2gib4.bin";
 
 fn ensure_random_file(path: &Path, bytes: usize) {
     if let Ok(meta) = std::fs::metadata(path) {
@@ -92,6 +102,12 @@ fn verbose_config() -> Config {
 // network.rs
 async fn ingress_one_gib_single_file() {
     let doc_path = Path::new(FIXTURE_PATH);
+    ensure_random_file(doc_path, FIXTURE_SIZE);
+    // Read size from disk rather than reusing `FIXTURE_SIZE` so the test
+    // also works when `FIXTURE_PATH` points at a real on-disk file (in
+    // which case `ensure_random_file` no-ops if the size happens to
+    // match, or regenerates if it doesn't — for real files, prefer to
+    // also tweak `FIXTURE_SIZE` to match so generation isn't triggered).
     let file_size = std::fs::metadata(doc_path)
         .unwrap_or_else(|e| panic!("fixture {} not accessible: {e}", doc_path.display()))
         .len() as usize;

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -9,7 +9,7 @@ use lb_rs::service::events::{Event, SyncIncrement};
 use lb_rs::service::import_export::ImportStatus;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
-use test_utils::{generate_premium_account_tier, random_name, test_credit_cards, url};
+use test_utils::{generate_premium_account_tier, random_name, test_core_from, test_credit_cards, url};
 use uuid::Uuid;
 
 const ONE_MIB: usize = 1024 * 1024;
@@ -65,6 +65,8 @@ fn verbose_config() -> Config {
 
 #[tokio::test]
 #[ignore = "generates a 1 GiB file and contacts the server"]
+// this test cannot suceed on macOS until we do streaming sends from the server like we did for
+// network.rs
 async fn ingress_one_gib_single_file() {
     let doc_path = Path::new(FIXTURE_PATH);
     ensure_random_file(doc_path, TWO_GB);
@@ -183,12 +185,7 @@ async fn ingress_one_gib_single_file() {
         .expect("import never reported a FinishedItem");
 
     println!("starting fresh client to verify round-trip...");
-    let account_string = core.export_account_private_key().unwrap();
-    let core2 = Lb::init(verbose_config()).await.unwrap();
-    core2
-        .import_account(&account_string, Some(&url()))
-        .await
-        .unwrap();
+    let core2 = test_core_from(&core).await;
 
     let pull_start = Instant::now();
     core2.sync().await.unwrap();

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -2,13 +2,16 @@ use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use lb_rs::Lb;
+use lb_rs::model::core_config::Config;
 use lb_rs::service::events::{Event, SyncIncrement};
 use lb_rs::service::import_export::ImportStatus;
 use rand::RngCore;
-use test_utils::{generate_premium_account_tier, test_core_with_account, test_credit_cards};
+use test_utils::{generate_premium_account_tier, random_name, test_credit_cards, url};
+use uuid::Uuid;
 
 const ONE_MIB: usize = 1024 * 1024;
-const ONE_GIB: usize = 1024 * ONE_MIB;
+const TWO_GB: usize = 1024 * ONE_MIB * 2;
 
 /// Fixed path so reruns reuse the same file. Delete it to force regeneration.
 const FIXTURE_PATH: &str = "/tmp/lockbook-ingress-perf-1gib.bin";
@@ -45,13 +48,29 @@ fn mib_per_sec(bytes: usize, elapsed: Duration) -> f64 {
     if secs == 0.0 { 0.0 } else { (bytes as f64 / ONE_MIB as f64) / secs }
 }
 
+/// Like `test_utils::test_config` but with stdout logging on so the
+/// underlying reqwest error (e.g. the body that EINVAL'd) is visible when
+/// sync surfaces only `LbErrKind::ServerUnreachable`.
+fn verbose_config() -> Config {
+    Config {
+        writeable_path: format!("/tmp/{}", Uuid::new_v4()),
+        background_work: false,
+        logs: true,
+        stdout_logs: true,
+        colored_logs: false,
+    }
+}
+
 #[tokio::test]
 #[ignore = "generates a 1 GiB file and contacts the server"]
 async fn ingress_one_gib_single_file() {
     let doc_path = Path::new(FIXTURE_PATH);
-    ensure_random_file(doc_path, ONE_GIB);
+    ensure_random_file(doc_path, TWO_GB);
 
-    let core = test_core_with_account().await;
+    let core = Lb::init(verbose_config()).await.unwrap();
+    core.create_account(&random_name(), &url(), false)
+        .await
+        .unwrap();
 
     // Upgrade to premium so the upload doesn't trip the free-tier usage cap.
     // Requires the server to have Stripe test mode configured.
@@ -116,7 +135,7 @@ async fn ingress_one_gib_single_file() {
     println!(
         "import_files:    {:?} ({:.1} MiB/s)",
         import_elapsed,
-        mib_per_sec(ONE_GIB, import_elapsed)
+        mib_per_sec(TWO_GB, import_elapsed)
     );
 
     // Pre-sync diagnostics so we know what sync is about to attempt.
@@ -134,7 +153,7 @@ async fn ingress_one_gib_single_file() {
     println!(
         "sync:            {:?} ({:.1} MiB/s)",
         sync_elapsed,
-        mib_per_sec(ONE_GIB, sync_elapsed)
+        mib_per_sec(TWO_GB, sync_elapsed)
     );
 
     // Stop the watcher cleanly before asserting.

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -173,6 +173,7 @@ async fn ingress_one_gib_single_file() {
         import_elapsed,
         mib_per_sec(file_size, import_elapsed)
     );
+    print_rss("after import_files");
 
     // Pre-sync diagnostics so we know what sync is about to attempt.
     let status = core.status().await;
@@ -191,6 +192,7 @@ async fn ingress_one_gib_single_file() {
         sync_elapsed,
         mib_per_sec(file_size, sync_elapsed)
     );
+    print_rss("after core.sync (push)");
 
     // Stop the watcher cleanly before asserting.
     watcher.abort();
@@ -222,6 +224,7 @@ async fn ingress_one_gib_single_file() {
         pull_elapsed,
         mib_per_sec(file_size, pull_elapsed)
     );
+    print_rss("after core2.sync (pull metadata)");
 
     let read_start = Instant::now();
     let downloaded = core2.read_document(doc_id, false).await.unwrap();
@@ -231,6 +234,7 @@ async fn ingress_one_gib_single_file() {
         read_elapsed,
         mib_per_sec(file_size, read_elapsed)
     );
+    print_rss("after read_document (decrypted Vec in memory)");
 
     assert_eq!(downloaded.len(), file_size, "downloaded size differs from fixture");
 
@@ -300,6 +304,7 @@ async fn ingress_one_gib_single_file() {
     };
     assert_eq!(exported_hash, fixture_hash, "exported bytes don't match fixture");
     println!("on-disk export verified: sha256 = {:x}", exported_hash);
+    print_rss("after export_file (peak across whole test)");
 
     // Clean up the export tmp dir on success. (On failure we leave it for
     // post-mortem inspection.)

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -39,11 +39,7 @@ const FIXTURE_PATH: &str = "/tmp/lockbook-ingress-perf-1gib.bin";
 fn ensure_random_file(path: &Path, bytes: usize) {
     if let Ok(meta) = std::fs::metadata(path) {
         if meta.is_file() && meta.len() == bytes as u64 {
-            println!(
-                "reusing existing fixture at {} ({} bytes)",
-                path.display(),
-                meta.len()
-            );
+            println!("reusing existing fixture at {} ({} bytes)", path.display(), meta.len());
             return;
         }
         // Wrong size (likely a partial write from a previous run) — replace it.
@@ -64,11 +60,7 @@ fn ensure_random_file(path: &Path, bytes: usize) {
     }
     file.flush().unwrap();
     let elapsed = gen_start.elapsed();
-    println!(
-        "  file generation: {:?} ({:.1} MiB/s)",
-        elapsed,
-        mib_per_sec(bytes, elapsed)
-    );
+    println!("  file generation: {:?} ({:.1} MiB/s)", elapsed, mib_per_sec(bytes, elapsed));
 }
 
 fn mib_per_sec(bytes: usize, elapsed: Duration) -> f64 {
@@ -152,13 +144,11 @@ async fn ingress_one_gib_single_file() {
 
     println!("importing into lockbook...");
     let import_start = Instant::now();
-    core.import_files(&[doc_path.to_path_buf()], root.id, &|status: ImportStatus| {
-        match status {
-            ImportStatus::CalculatedTotal(n) => println!("  import: total items = {n}"),
-            ImportStatus::StartingItem(p) => println!("  import: starting {p}"),
-            ImportStatus::FinishedItem(f) => {
-                println!("  import: finished id={} name={}", f.id, f.name)
-            }
+    core.import_files(&[doc_path.to_path_buf()], root.id, &|status: ImportStatus| match status {
+        ImportStatus::CalculatedTotal(n) => println!("  import: total items = {n}"),
+        ImportStatus::StartingItem(p) => println!("  import: starting {p}"),
+        ImportStatus::FinishedItem(f) => {
+            println!("  import: finished id={} name={}", f.id, f.name)
         }
     })
     .await

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -1,5 +1,6 @@
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use lb_rs::Lb;
@@ -7,6 +8,7 @@ use lb_rs::model::core_config::Config;
 use lb_rs::service::events::{Event, SyncIncrement};
 use lb_rs::service::import_export::ImportStatus;
 use rand::RngCore;
+use sha2::{Digest, Sha256};
 use test_utils::{generate_premium_account_tier, random_name, test_credit_cards, url};
 use uuid::Uuid;
 
@@ -122,11 +124,16 @@ async fn ingress_one_gib_single_file() {
 
     println!("importing into lockbook...");
     let import_start = Instant::now();
+    // Capture the imported doc's id from the FinishedItem callback so the
+    // second client knows what to read back.
+    let imported_id: Arc<Mutex<Option<Uuid>>> = Arc::new(Mutex::new(None));
+    let imported_id_cb = Arc::clone(&imported_id);
     core.import_files(&[doc_path.to_path_buf()], root.id, &|status: ImportStatus| match status {
         ImportStatus::CalculatedTotal(n) => println!("  import: total items = {n}"),
         ImportStatus::StartingItem(p) => println!("  import: starting {p}"),
         ImportStatus::FinishedItem(f) => {
-            println!("  import: finished id={} name={}", f.id, f.name)
+            println!("  import: finished id={} name={}", f.id, f.name);
+            *imported_id_cb.lock().unwrap() = Some(f.id);
         }
     })
     .await
@@ -167,4 +174,62 @@ async fn ingress_one_gib_single_file() {
         // "network request send failed" or "network request took".
         panic!("sync failed: kind = {:?}", e.kind);
     }
+
+    // Round-trip check: spin up a fresh client, pull the doc, and confirm
+    // the bytes it reads match the fixture we uploaded.
+    let doc_id = imported_id
+        .lock()
+        .unwrap()
+        .expect("import never reported a FinishedItem");
+
+    println!("starting fresh client to verify round-trip...");
+    let account_string = core.export_account_private_key().unwrap();
+    let core2 = Lb::init(verbose_config()).await.unwrap();
+    core2
+        .import_account(&account_string, Some(&url()))
+        .await
+        .unwrap();
+
+    let pull_start = Instant::now();
+    core2.sync().await.unwrap();
+    let pull_elapsed = pull_start.elapsed();
+    println!(
+        "fresh-client sync: {:?} ({:.1} MiB/s)",
+        pull_elapsed,
+        mib_per_sec(TWO_GB, pull_elapsed)
+    );
+
+    let read_start = Instant::now();
+    let downloaded = core2.read_document(doc_id, false).await.unwrap();
+    let read_elapsed = read_start.elapsed();
+    println!(
+        "read_document:     {:?} ({:.1} MiB/s)",
+        read_elapsed,
+        mib_per_sec(TWO_GB, read_elapsed)
+    );
+
+    assert_eq!(downloaded.len(), TWO_GB, "downloaded size differs from fixture");
+
+    // Compare via SHA-256 so we don't have to hold two 2 GiB buffers in
+    // memory at once. Hash the downloaded buffer, drop it, then stream the
+    // fixture off disk.
+    let downloaded_hash = Sha256::digest(&downloaded);
+    drop(downloaded);
+
+    let fixture_hash = {
+        let mut h = Sha256::new();
+        let mut f = std::fs::File::open(doc_path).unwrap();
+        let mut buf = vec![0u8; 4 * ONE_MIB];
+        loop {
+            let n = f.read(&mut buf).unwrap();
+            if n == 0 {
+                break;
+            }
+            h.update(&buf[..n]);
+        }
+        h.finalize()
+    };
+
+    assert_eq!(downloaded_hash, fixture_hash, "round-tripped bytes don't match fixture");
+    println!("round-trip verified: sha256 = {:x}", fixture_hash);
 }

--- a/libs/lb/lb-rs/tests/ingress_perf_tests.rs
+++ b/libs/lb/lb-rs/tests/ingress_perf_tests.rs
@@ -6,17 +6,17 @@ use std::time::{Duration, Instant};
 use lb_rs::Lb;
 use lb_rs::model::core_config::Config;
 use lb_rs::service::events::{Event, SyncIncrement};
-use lb_rs::service::import_export::ImportStatus;
+use lb_rs::service::import_export::{ExportFileInfo, ImportStatus};
 use rand::RngCore;
 use sha2::{Digest, Sha256};
-use test_utils::{generate_premium_account_tier, random_name, test_core_from, test_credit_cards, url};
+use test_utils::{
+    generate_premium_account_tier, random_name, test_core_from, test_credit_cards, url,
+};
 use uuid::Uuid;
 
 const ONE_MIB: usize = 1024 * 1024;
-const TWO_GB: usize = 1024 * ONE_MIB * 2;
 
-/// Fixed path so reruns reuse the same file. Delete it to force regeneration.
-const FIXTURE_PATH: &str = "/tmp/lockbook-ingress-perf-1gib.bin";
+const FIXTURE_PATH: &str = "/Users/parth/Downloads/egui.mov";
 
 fn ensure_random_file(path: &Path, bytes: usize) {
     if let Ok(meta) = std::fs::metadata(path) {
@@ -50,6 +50,29 @@ fn mib_per_sec(bytes: usize, elapsed: Duration) -> f64 {
     if secs == 0.0 { 0.0 } else { (bytes as f64 / ONE_MIB as f64) / secs }
 }
 
+/// Peak resident-set size the kernel has observed for this process,
+/// in bytes. `getrusage`'s `ru_maxrss` is monotonically non-decreasing
+/// across calls, so polling it at phase boundaries gives a clean
+/// high-water mark without a separate sampling thread.
+///
+/// macOS reports `ru_maxrss` in bytes; Linux reports kilobytes.
+fn max_rss_bytes() -> u64 {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    let ret = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+    if ret != 0 {
+        return 0;
+    }
+    let usage = unsafe { usage.assume_init() };
+    let rss = usage.ru_maxrss as u64;
+    if cfg!(target_os = "linux") { rss * 1024 } else { rss }
+}
+
+fn print_rss(label: &str) {
+    let bytes = max_rss_bytes();
+    let mib = bytes as f64 / ONE_MIB as f64;
+    println!("  [peak rss] {label}: {mib:.1} MiB ({bytes} bytes)");
+}
+
 /// Like `test_utils::test_config` but with stdout logging on so the
 /// underlying reqwest error (e.g. the body that EINVAL'd) is visible when
 /// sync surfaces only `LbErrKind::ServerUnreachable`.
@@ -69,7 +92,11 @@ fn verbose_config() -> Config {
 // network.rs
 async fn ingress_one_gib_single_file() {
     let doc_path = Path::new(FIXTURE_PATH);
-    ensure_random_file(doc_path, TWO_GB);
+    let file_size = std::fs::metadata(doc_path)
+        .unwrap_or_else(|e| panic!("fixture {} not accessible: {e}", doc_path.display()))
+        .len() as usize;
+    println!("using fixture at {} ({} bytes)", doc_path.display(), file_size);
+    print_rss("baseline (before Lb::init)");
 
     let core = Lb::init(verbose_config()).await.unwrap();
     core.create_account(&random_name(), &url(), false)
@@ -144,7 +171,7 @@ async fn ingress_one_gib_single_file() {
     println!(
         "import_files:    {:?} ({:.1} MiB/s)",
         import_elapsed,
-        mib_per_sec(TWO_GB, import_elapsed)
+        mib_per_sec(file_size, import_elapsed)
     );
 
     // Pre-sync diagnostics so we know what sync is about to attempt.
@@ -162,7 +189,7 @@ async fn ingress_one_gib_single_file() {
     println!(
         "sync:            {:?} ({:.1} MiB/s)",
         sync_elapsed,
-        mib_per_sec(TWO_GB, sync_elapsed)
+        mib_per_sec(file_size, sync_elapsed)
     );
 
     // Stop the watcher cleanly before asserting.
@@ -193,7 +220,7 @@ async fn ingress_one_gib_single_file() {
     println!(
         "fresh-client sync: {:?} ({:.1} MiB/s)",
         pull_elapsed,
-        mib_per_sec(TWO_GB, pull_elapsed)
+        mib_per_sec(file_size, pull_elapsed)
     );
 
     let read_start = Instant::now();
@@ -202,10 +229,10 @@ async fn ingress_one_gib_single_file() {
     println!(
         "read_document:     {:?} ({:.1} MiB/s)",
         read_elapsed,
-        mib_per_sec(TWO_GB, read_elapsed)
+        mib_per_sec(file_size, read_elapsed)
     );
 
-    assert_eq!(downloaded.len(), TWO_GB, "downloaded size differs from fixture");
+    assert_eq!(downloaded.len(), file_size, "downloaded size differs from fixture");
 
     // Compare via SHA-256 so we don't have to hold two 2 GiB buffers in
     // memory at once. Hash the downloaded buffer, drop it, then stream the
@@ -229,4 +256,52 @@ async fn ingress_one_gib_single_file() {
 
     assert_eq!(downloaded_hash, fixture_hash, "round-tripped bytes don't match fixture");
     println!("round-trip verified: sha256 = {:x}", fixture_hash);
+
+    // Also exercise the on-disk export path. `read_document` returns a
+    // `Vec<u8>` so it can't catch the Linux short-write bug in
+    // `import_export::export_file_recursively` where a single `.write(...)`
+    // on a >2 GiB slice was capped at `MAX_RW_COUNT` (~2.15 GB). Doing a
+    // real export to disk and comparing the on-disk hash to the fixture
+    // hash proves the `write_all` fix actually flushes the full buffer.
+    let export_dir = std::path::PathBuf::from(format!("/tmp/{}", Uuid::new_v4()));
+    std::fs::create_dir(&export_dir).unwrap();
+    println!("exporting to disk at {} ...", export_dir.display());
+    let export_start = Instant::now();
+    core2
+        .export_file(doc_id, export_dir.clone(), false, &None::<fn(ExportFileInfo)>)
+        .await
+        .unwrap();
+    let export_elapsed = export_start.elapsed();
+    let exported_path = export_dir.join(doc_path.file_name().unwrap());
+    let exported_size = std::fs::metadata(&exported_path).unwrap().len() as usize;
+    println!(
+        "export_file:       {:?} ({:.1} MiB/s) -> {} bytes",
+        export_elapsed,
+        mib_per_sec(file_size, export_elapsed),
+        exported_size
+    );
+    assert_eq!(
+        exported_size, file_size,
+        "exported size differs from fixture (Linux short-write bug?)"
+    );
+
+    let exported_hash = {
+        let mut h = Sha256::new();
+        let mut f = std::fs::File::open(&exported_path).unwrap();
+        let mut buf = vec![0u8; 4 * ONE_MIB];
+        loop {
+            let n = f.read(&mut buf).unwrap();
+            if n == 0 {
+                break;
+            }
+            h.update(&buf[..n]);
+        }
+        h.finalize()
+    };
+    assert_eq!(exported_hash, fixture_hash, "exported bytes don't match fixture");
+    println!("on-disk export verified: sha256 = {:x}", exported_hash);
+
+    // Clean up the export tmp dir on success. (On failure we leave it for
+    // post-mortem inspection.)
+    let _ = std::fs::remove_dir_all(&export_dir);
 }

--- a/server/src/billing/billing_service.rs
+++ b/server/src/billing/billing_service.rs
@@ -16,8 +16,9 @@ use lb_rs::model::api::{
     AdminSetUserTierError, AdminSetUserTierInfo, AdminSetUserTierRequest, AdminSetUserTierResponse,
     AppStoreAccountState, CancelSubscriptionError, CancelSubscriptionRequest,
     CancelSubscriptionResponse, FREE_TIER_USAGE_SIZE, GetSubscriptionInfoError,
-    GetSubscriptionInfoRequest, GetSubscriptionInfoResponse, GooglePlayAccountState,
-    PaymentPlatform, StripeAccountState, SubscriptionInfo, UpgradeAccountAppStoreError,
+    GetSubscriptionInfoRequest, GetSubscriptionInfoRequestV2, GetSubscriptionInfoResponse,
+    GetSubscriptionInfoResponseV2, GooglePlayAccountState, PaymentPlatform, PaymentPlatformV2,
+    StripeAccountState, SubscriptionInfo, SubscriptionInfoV2, UpgradeAccountAppStoreError,
     UpgradeAccountAppStoreRequest, UpgradeAccountAppStoreResponse, UpgradeAccountGooglePlayError,
     UpgradeAccountGooglePlayRequest, UpgradeAccountGooglePlayResponse, UpgradeAccountStripeError,
     UpgradeAccountStripeRequest, UpgradeAccountStripeResponse,
@@ -234,18 +235,7 @@ where
     pub async fn get_subscription_info(
         &self, context: RequestContext<GetSubscriptionInfoRequest>,
     ) -> Result<GetSubscriptionInfoResponse, ServerError<GetSubscriptionInfoError>> {
-        let platform = self
-            .index_db
-            .lock()
-            .await
-            .accounts
-            .get()
-            .get(&Owner(context.public_key))
-            .ok_or(ClientError(GetSubscriptionInfoError::UserNotFound))?
-            .billing_info
-            .billing_platform
-            .clone();
-
+        let platform = self.read_billing_platform(&context.public_key).await?;
         let subscription_info = platform.map(|info| match info {
             BillingPlatform::Stripe(info) => SubscriptionInfo {
                 payment_platform: PaymentPlatform::Stripe { card_last_4_digits: info.last_4 },
@@ -260,8 +250,46 @@ where
                 period_end: info.expiration_time,
             },
         });
-
         Ok(GetSubscriptionInfoResponse { subscription_info })
+    }
+
+    pub async fn get_subscription_info_v2(
+        &self, context: RequestContext<GetSubscriptionInfoRequestV2>,
+    ) -> Result<GetSubscriptionInfoResponseV2, ServerError<GetSubscriptionInfoError>> {
+        let platform = self.read_billing_platform(&context.public_key).await?;
+        let subscription_info = platform.map(|info| match info {
+            BillingPlatform::Stripe(info) => SubscriptionInfoV2 {
+                payment_platform: PaymentPlatformV2::Stripe { card_last_4_digits: info.last_4 },
+                period_end: info.expiration_time,
+            },
+            BillingPlatform::GooglePlay(info) => SubscriptionInfoV2 {
+                payment_platform: PaymentPlatformV2::GooglePlay {
+                    account_state: info.account_state,
+                },
+                period_end: info.expiration_time,
+            },
+            BillingPlatform::AppStore(info) => SubscriptionInfoV2 {
+                payment_platform: PaymentPlatformV2::AppStore { account_state: info.account_state },
+                period_end: info.expiration_time,
+            },
+        });
+        Ok(GetSubscriptionInfoResponseV2 { subscription_info })
+    }
+
+    async fn read_billing_platform(
+        &self, public_key: &PublicKey,
+    ) -> Result<Option<BillingPlatform>, ServerError<GetSubscriptionInfoError>> {
+        Ok(self
+            .index_db
+            .lock()
+            .await
+            .accounts
+            .get()
+            .get(&Owner(*public_key))
+            .ok_or(ClientError(GetSubscriptionInfoError::UserNotFound))?
+            .billing_info
+            .billing_platform
+            .clone())
     }
 
     pub async fn cancel_subscription(

--- a/server/src/file_service.rs
+++ b/server/src/file_service.rs
@@ -270,8 +270,14 @@ where
                 }
             }
 
+            let old_usage = tree.calculate_usage(tree_owner)?;
             let mut tree = tree.stage(vec![new_meta]);
+            let new_usage = tree.calculate_usage(tree_owner)?;
             tree.validate(requester)?;
+            if new_usage > usage_cap && new_usage >= old_usage {
+                warn!("user over cap");
+                return Err(ClientError(UsageIsOverDataCap));
+            }
             tree.promote()?;
 
             if let Some(old_hmac) = diff.old.and_then(|old| old.document_hmac().copied()) {

--- a/server/src/loggers.rs
+++ b/server/src/loggers.rs
@@ -67,6 +67,14 @@ fn server_logs() -> FilterFn {
         metadata.target().starts_with("lockbook")
             || metadata.target().starts_with("dbrs")
             || metadata.target().starts_with("lb_rs")
+            // Temporarily widened so hyper/warp body-framing traces reach
+            // stdout. Set LOG_LEVEL=trace to see e.g. encoder decisions
+            // (Length vs Chunked), Content-Length values, per-write byte
+            // counts, and connection-close errors. Narrow back once
+            // diagnosis is done — these targets are noisy.
+            || metadata.target().starts_with("hyper")
+            || metadata.target().starts_with("warp")
+            || metadata.target().starts_with("h2")
     })
 }
 

--- a/server/src/loggers.rs
+++ b/server/src/loggers.rs
@@ -67,14 +67,6 @@ fn server_logs() -> FilterFn {
         metadata.target().starts_with("lockbook")
             || metadata.target().starts_with("dbrs")
             || metadata.target().starts_with("lb_rs")
-            // Temporarily widened so hyper/warp body-framing traces reach
-            // stdout. Set LOG_LEVEL=trace to see e.g. encoder decisions
-            // (Length vs Chunked), Content-Length values, per-write byte
-            // counts, and connection-close errors. Narrow back once
-            // diagnosis is done — these targets are noisy.
-            || metadata.target().starts_with("hyper")
-            || metadata.target().starts_with("warp")
-            || metadata.target().starts_with("h2")
     })
 }
 

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -159,15 +159,13 @@ macro_rules! core_req {
                                     Err(ErrorWrapper::InternalError)
                                 }
                             };
-                            let body = wire_format
-                                .serialize(&to_serialize)
-                                .unwrap_or_else(|e| {
-                                    tracing::error!(
-                                        "response serialize failed in {:?}: {e}",
-                                        wire_format
-                                    );
-                                    Vec::new()
-                                });
+                            let body = wire_format.serialize(&to_serialize).unwrap_or_else(|e| {
+                                tracing::error!(
+                                    "response serialize failed in {:?}: {e}",
+                                    wire_format
+                                );
+                                Vec::new()
+                            });
                             let response = warp::reply::with_status(body, status);
                             let log = format!("{status} {} {username}", &<$Req>::ROUTE);
                             let latency = timer.stop_and_record();

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -9,6 +9,7 @@ use crate::{ServerError, ServerState, handle_version_header, router_service, ver
 use lazy_static::lazy_static;
 use lb_rs::model::api::{ErrorWrapper, Request, RequestWrapper, *};
 use lb_rs::model::errors::{LbErrKind, SignError};
+use lb_rs::model::wire::WireFormat;
 use prometheus::{
     CounterVec, HistogramVec, TextEncoder, register_counter_vec, register_histogram_vec,
 };
@@ -41,6 +42,7 @@ macro_rules! core_req {
     ($Req: ty, $handler: path, $state: ident) => {{
         use lb_rs::model::api::{ErrorWrapper, Request};
         use lb_rs::model::file_metadata::Owner;
+        use lb_rs::model::wire::{WIRE_FORMAT_HEADER, WireFormat};
         use std::net::SocketAddr;
         use tracing::*;
         use $crate::router_service::{self, deserialize_and_check, method};
@@ -54,16 +56,19 @@ macro_rules! core_req {
             .and(warp::any().map(|| lb_rs::model::clock::get_time())) // Capture time before body
             .and(warp::body::bytes())
             .and(warp::header::optional::<String>("Accept-Version"))
+            .and(warp::header::optional::<String>(WIRE_FORMAT_HEADER))
             .and(warp::filters::addr::remote())
             .then(
                 |state: Arc<ServerState<S, A, G, D>>,
                  request_time: lb_rs::model::clock::Timestamp,
                  request: Bytes,
                  version: Option<String>,
+                 wire_format_header: Option<String>,
                  ip: Option<SocketAddr>| {
                     if ip.is_none() {
                         tracing::error!("ip not present in request");
                     }
+                    let wire_format = WireFormat::from_header(wire_format_header.as_deref());
                     let span1 = span!(
                         Level::INFO,
                         "matched_request",
@@ -75,6 +80,7 @@ macro_rules! core_req {
                         core_version = version
                             .clone()
                             .unwrap_or_else(|| String::from("not-present")),
+                        wire_format = wire_format.as_str(),
                     );
 
                     async move {
@@ -87,13 +93,17 @@ macro_rules! core_req {
                             &state.config,
                             request,
                             version,
+                            wire_format,
                             request_time,
                         ) {
                             Ok(req) => req,
                             Err(err) => {
                                 warn!("request failed to parse: {:?}", err);
+                                let body = wire_format
+                                    .serialize::<Result<RequestWrapper<$Req>, _>>(&Err(err))
+                                    .unwrap_or_default();
                                 return warp::reply::with_status(
-                                    warp::reply::json::<Result<RequestWrapper<$Req>, _>>(&Err(err)),
+                                    body,
                                     warp::http::StatusCode::BAD_REQUEST,
                                 );
                             }
@@ -149,8 +159,16 @@ macro_rules! core_req {
                                     Err(ErrorWrapper::InternalError)
                                 }
                             };
-                            let response =
-                                warp::reply::with_status(warp::reply::json(&to_serialize), status);
+                            let body = wire_format
+                                .serialize(&to_serialize)
+                                .unwrap_or_else(|e| {
+                                    tracing::error!(
+                                        "response serialize failed in {:?}: {e}",
+                                        wire_format
+                                    );
+                                    Vec::new()
+                                });
+                            let response = warp::reply::with_status(body, status);
                             let log = format!("{status} {} {username}", &<$Req>::ROUTE);
                             let latency = timer.stop_and_record();
                             match level {
@@ -477,7 +495,7 @@ pub fn method(name: Method) -> impl Filter<Extract = (), Error = Rejection> + Cl
 }
 
 pub fn deserialize_and_check<Req>(
-    config: &Config, request: Bytes, version: Option<String>,
+    config: &Config, request: Bytes, version: Option<String>, wire_format: WireFormat,
     request_time: lb_rs::model::clock::Timestamp,
 ) -> Result<RequestWrapper<Req>, ErrorWrapper<Req::Error>>
 where
@@ -485,8 +503,8 @@ where
 {
     handle_version_header::<Req>(config, &version)?;
 
-    let request = serde_json::from_slice(request.as_ref()).map_err(|err| {
-        warn!("Request parsing failure: {}", err);
+    let request = wire_format.deserialize(request.as_ref()).map_err(|err| {
+        warn!("Request parsing failure ({:?}): {}", wire_format, err);
         ErrorWrapper::<Req::Error>::BadRequest
     })?;
 

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -99,14 +99,12 @@ macro_rules! core_req {
                             Ok(req) => req,
                             Err(err) => {
                                 warn!("request failed to parse: {:?}", err);
-                                // If serializing the parse-error response itself fails,
-                                // fall back to `InternalError` + 500 so the client sees
-                                // a real `ApiError::InternalError` rather than
-                                // `Deserialize("io error: unexpected end of file")`
-                                // from an empty body.
-                                let (body, status) = match wire_format
-                                    .serialize::<Result<RequestWrapper<$Req>, _>>(&Err(err))
-                                {
+                                let (body, status) = match wire_format.serialize::<Result<
+                                    RequestWrapper<$Req>,
+                                    _,
+                                >>(
+                                    &Err(err)
+                                ) {
                                     Ok(body) => (body, warp::http::StatusCode::BAD_REQUEST),
                                     Err(e) => {
                                         error!(
@@ -118,10 +116,7 @@ macro_rules! core_req {
                                                 ErrorWrapper::InternalError,
                                             ))
                                             .unwrap_or_default();
-                                        (
-                                            fallback,
-                                            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
-                                        )
+                                        (fallback, warp::http::StatusCode::INTERNAL_SERVER_ERROR)
                                     }
                                 };
                                 return build_response(body, status);
@@ -181,23 +176,8 @@ macro_rules! core_req {
                             let body = match wire_format.serialize(&to_serialize) {
                                 Ok(body) => body,
                                 Err(e) => {
-                                    error!(
-                                        "response serialize failed in {:?}: {e}",
-                                        wire_format
-                                    );
-                                    // Fall back to a real `InternalError` body + 500
-                                    // status so the client sees `ApiError::InternalError`
-                                    // instead of `Deserialize("io error: unexpected end
-                                    // of file")` from an empty body. The bytes for
-                                    // `Result::<(), ErrorWrapper<()>>::Err(InternalError)`
-                                    // are identical to the bytes the client expects to
-                                    // deserialize into
-                                    // `Result::<T::Response, ErrorWrapper<T::Error>>`
-                                    // because `InternalError` is a unit variant whose
-                                    // wire form is independent of the surrounding
-                                    // generics (true in both bincode and JSON).
-                                    status =
-                                        warp::http::StatusCode::INTERNAL_SERVER_ERROR;
+                                    error!("response serialize failed in {:?}: {e}", wire_format);
+                                    status = warp::http::StatusCode::INTERNAL_SERVER_ERROR;
                                     level = tracing::Level::ERROR;
                                     wire_format
                                         .serialize::<Result<(), ErrorWrapper<()>>>(&Err(
@@ -206,14 +186,6 @@ macro_rules! core_req {
                                         .unwrap_or_default()
                                 }
                             };
-                            if body.len() > 10 * 1024 * 1024 {
-                                tracing::info!(
-                                    "handing warp a {} byte body for {} ({:?})",
-                                    body.len(),
-                                    &<$Req>::ROUTE,
-                                    wire_format
-                                );
-                            }
                             let response = build_response(body, status);
                             let log = format!("{status} {} {username}", &<$Req>::ROUTE);
                             let latency = timer.stop_and_record();

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -109,7 +109,7 @@ macro_rules! core_req {
                                 {
                                     Ok(body) => (body, warp::http::StatusCode::BAD_REQUEST),
                                     Err(e) => {
-                                        tracing::error!(
+                                        error!(
                                             "parse-error response serialize failed in {:?}: {e}",
                                             wire_format
                                         );
@@ -181,7 +181,7 @@ macro_rules! core_req {
                             let body = match wire_format.serialize(&to_serialize) {
                                 Ok(body) => body,
                                 Err(e) => {
-                                    tracing::error!(
+                                    error!(
                                         "response serialize failed in {:?}: {e}",
                                         wire_format
                                     );
@@ -206,6 +206,14 @@ macro_rules! core_req {
                                         .unwrap_or_default()
                                 }
                             };
+                            if body.len() > 10 * 1024 * 1024 {
+                                tracing::info!(
+                                    "handing warp a {} byte body for {} ({:?})",
+                                    body.len(),
+                                    &<$Req>::ROUTE,
+                                    wire_format
+                                );
+                            }
                             let response = warp::reply::with_status(body, status);
                             let log = format!("{status} {} {username}", &<$Req>::ROUTE);
                             let latency = timer.stop_and_record();

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -99,13 +99,32 @@ macro_rules! core_req {
                             Ok(req) => req,
                             Err(err) => {
                                 warn!("request failed to parse: {:?}", err);
-                                let body = wire_format
+                                // If serializing the parse-error response itself fails,
+                                // fall back to `InternalError` + 500 so the client sees
+                                // a real `ApiError::InternalError` rather than
+                                // `Deserialize("io error: unexpected end of file")`
+                                // from an empty body.
+                                let (body, status) = match wire_format
                                     .serialize::<Result<RequestWrapper<$Req>, _>>(&Err(err))
-                                    .unwrap_or_default();
-                                return warp::reply::with_status(
-                                    body,
-                                    warp::http::StatusCode::BAD_REQUEST,
-                                );
+                                {
+                                    Ok(body) => (body, warp::http::StatusCode::BAD_REQUEST),
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "parse-error response serialize failed in {:?}: {e}",
+                                            wire_format
+                                        );
+                                        let fallback = wire_format
+                                            .serialize::<Result<(), ErrorWrapper<()>>>(&Err(
+                                                ErrorWrapper::InternalError,
+                                            ))
+                                            .unwrap_or_default();
+                                        (
+                                            fallback,
+                                            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                        )
+                                    }
+                                };
+                                return warp::reply::with_status(body, status);
                             }
                         };
 
@@ -140,7 +159,7 @@ macro_rules! core_req {
                         };
 
                         async move {
-                            let status;
+                            let mut status;
                             let mut level = tracing::Level::INFO;
                             let to_serialize = match $handler(state, rc).await {
                                 Ok(response) => {
@@ -159,13 +178,34 @@ macro_rules! core_req {
                                     Err(ErrorWrapper::InternalError)
                                 }
                             };
-                            let body = wire_format.serialize(&to_serialize).unwrap_or_else(|e| {
-                                tracing::error!(
-                                    "response serialize failed in {:?}: {e}",
+                            let body = match wire_format.serialize(&to_serialize) {
+                                Ok(body) => body,
+                                Err(e) => {
+                                    tracing::error!(
+                                        "response serialize failed in {:?}: {e}",
+                                        wire_format
+                                    );
+                                    // Fall back to a real `InternalError` body + 500
+                                    // status so the client sees `ApiError::InternalError`
+                                    // instead of `Deserialize("io error: unexpected end
+                                    // of file")` from an empty body. The bytes for
+                                    // `Result::<(), ErrorWrapper<()>>::Err(InternalError)`
+                                    // are identical to the bytes the client expects to
+                                    // deserialize into
+                                    // `Result::<T::Response, ErrorWrapper<T::Error>>`
+                                    // because `InternalError` is a unit variant whose
+                                    // wire form is independent of the surrounding
+                                    // generics (true in both bincode and JSON).
+                                    status =
+                                        warp::http::StatusCode::INTERNAL_SERVER_ERROR;
+                                    level = tracing::Level::ERROR;
                                     wire_format
-                                );
-                                Vec::new()
-                            });
+                                        .serialize::<Result<(), ErrorWrapper<()>>>(&Err(
+                                            ErrorWrapper::InternalError,
+                                        ))
+                                        .unwrap_or_default()
+                                }
+                            };
                             let response = warp::reply::with_status(body, status);
                             let log = format!("{status} {} {username}", &<$Req>::ROUTE);
                             let latency = timer.stop_and_record();

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -45,7 +45,7 @@ macro_rules! core_req {
         use lb_rs::model::wire::{WIRE_FORMAT_HEADER, WireFormat};
         use std::net::SocketAddr;
         use tracing::*;
-        use $crate::router_service::{self, deserialize_and_check, method};
+        use $crate::router_service::{self, build_response, deserialize_and_check, method};
         use $crate::{RequestContext, ServerError};
 
         let cloned_state = $state.clone();
@@ -124,7 +124,7 @@ macro_rules! core_req {
                                         )
                                     }
                                 };
-                                return warp::reply::with_status(body, status);
+                                return build_response(body, status);
                             }
                         };
 
@@ -214,7 +214,7 @@ macro_rules! core_req {
                                     wire_format
                                 );
                             }
-                            let response = warp::reply::with_status(body, status);
+                            let response = build_response(body, status);
                             let log = format!("{status} {} {username}", &<$Req>::ROUTE);
                             let latency = timer.stop_and_record();
                             match level {
@@ -257,6 +257,30 @@ macro_rules! core_req {
                 },
             )
     }};
+}
+
+const RESPONSE_STREAM_CHUNK_BYTES: usize = 4 * 1024 * 1024;
+
+const RESPONSE_STREAM_THRESHOLD: usize = 1024 * 1024 * 1024;
+
+pub fn build_response(
+    body: Vec<u8>, status: StatusCode,
+) -> warp::http::Response<warp::hyper::Body> {
+    let response_body = if body.len() < RESPONSE_STREAM_THRESHOLD {
+        warp::hyper::Body::from(body)
+    } else {
+        let mut buf = Bytes::from(body);
+        let mut chunks: Vec<Result<Bytes, std::io::Error>> =
+            Vec::with_capacity(buf.len().div_ceil(RESPONSE_STREAM_CHUNK_BYTES));
+        while !buf.is_empty() {
+            let n = buf.len().min(RESPONSE_STREAM_CHUNK_BYTES);
+            chunks.push(Ok(buf.split_to(n)));
+        }
+        warp::hyper::Body::wrap_stream(futures::stream::iter(chunks))
+    };
+    let mut response = warp::http::Response::new(response_body);
+    *response.status_mut() = status;
+    response
 }
 
 pub fn core_routes<S, A, G, D>(

--- a/server/src/router_service.rs
+++ b/server/src/router_service.rs
@@ -248,6 +248,11 @@ where
         ))
         .or(core_req!(CancelSubscriptionRequest, ServerState::cancel_subscription, server_state))
         .or(core_req!(GetSubscriptionInfoRequest, ServerState::get_subscription_info, server_state))
+        .or(core_req!(
+            GetSubscriptionInfoRequestV2,
+            ServerState::get_subscription_info_v2,
+            server_state
+        ))
         .or(core_req!(DeleteAccountRequest, ServerState::delete_account, server_state))
         .or(core_req!(UpsertDebugInfoRequest, ServerState::upsert_debug_info, server_state))
         .or(core_req!(


### PR DESCRIPTION
This PR does a handful of no-regret-low-hanging things to squeeze out more milage out of our existing non-streaming setup:

# wire format

when you ingressed a file into lockbook, despite compression that file would balloon to about 4x the size upon json serializing. This PR adds an optional header to `server` and `lb-rs` which allows lb-rs to specify a wire-format. Once the server is deployed the default wire format will become bincode which is way faster and doesn't balloon like json does.

# compression level

based on the ext of the file we now choose a compression level. This is transparent to people on older code as the compression format doesn't change. Most of our ingress / egress time is spent negotiating compression. See the screenshot in #3277. 

# don't hold locks while doing compression & big crypto

two places we do compression on ingress. on initial write and once again during sync merge.

I updated it so we're not holding a lock while doing IO, compression and crypto during a write.

I also updated merge to enable transfering an edit to the merge changeset without having to do compression and encryption.

# QA

+ [x] check that older clients will be able to interact with the new server
+ [x] check that old clients will be able to uncompress any compression level
+ [x] import export of large folders and files

fixes https://github.com/lockbook/lockbook/issues/4620