### PR TITLE
md: assorted fixes

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1332,6 +1332,9 @@ impl Editor {
         if find_output.scroll_to_match {
             self.edit.pending_scroll = Some(ScrollTarget::FindMatch);
         }
+        if find_output.closed {
+            self.focus(ui.ctx());
+        }
 
         let new_match = self.find.current_match_range();
         self.edit.renderer.find_current_match = new_match;

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -105,6 +105,8 @@ pub struct MdRender {
     // render output
     pub fragments: Vec<widget::utils::wrap_layout::Fragment>,
     pub text_areas: Vec<TextBufferArea>,
+    /// Strikethroughs and underlines painted on top of text
+    pub deco_lines: Vec<widget::utils::wrap_layout::DecoLine>,
     pub render_events: Vec<input::Event>,
     pub touch_consuming_rects: Vec<Rect>,
     /// Per-frame, keyed by `ui.id().with(salt)`; populated by
@@ -372,6 +374,7 @@ impl MdRender {
             bounds_seq: 0,
             fragments: Vec::new(),
             text_areas: Default::default(),
+            deco_lines: Default::default(),
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
             interaction_responses: Default::default(),
@@ -436,6 +439,7 @@ impl MdRender {
             buffer: md.into(),
             fragments: Vec::new(),
             text_areas: Default::default(),
+            deco_lines: Default::default(),
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
             interaction_responses: Default::default(),
@@ -580,6 +584,7 @@ impl Editor {
 
             fragments: Vec::new(),
             text_areas: Default::default(),
+            deco_lines: Default::default(),
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
             interaction_responses: Default::default(),
@@ -1174,6 +1179,7 @@ impl Editor {
                         self.edit.renderer.fragments.clear();
                         self.edit.renderer.bounds.wrap_lines.clear();
                         self.edit.renderer.text_areas.clear();
+                        self.edit.renderer.deco_lines.clear();
 
                         // Phase 1: drive scroll math + scrollbar, and
                         // pick up to one viewport's worth of rows above

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -149,6 +149,7 @@ impl MdEdit {
         self.renderer.fragments.clear();
         self.renderer.bounds.wrap_lines.clear();
         self.renderer.text_areas.clear();
+        self.renderer.deco_lines.clear();
         let height = self.renderer.height(root);
         let render_rect = Rect::from_min_size(rect.min, egui::Vec2::new(rect.width(), height));
         ui.scope_builder(UiBuilder::new().max_rect(render_rect), |ui| {
@@ -412,6 +413,12 @@ impl MdEdit {
                     ui.clip_rect(),
                     crate::GlyphonRendererCallback::new(text_areas),
                 ));
+        }
+
+        // strikethroughs and underlines painted on top of text
+        for deco in std::mem::take(&mut self.renderer.deco_lines) {
+            ui.painter()
+                .hline(deco.x, deco.y, Stroke::new(1.0, deco.color));
         }
 
         let has_selection_handles = !self.renderer.buffer.current.selection.is_empty()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
@@ -45,6 +45,9 @@ pub struct Find {
     select_all_on_focus: bool,
     pub open_requested: bool,
     was_focused: bool,
+    /// Whether a field held focus last frame. `begin_pass` clears live focus on
+    /// Esc before `show` runs, so the Esc-to-close check reads this (#4646).
+    prev_focused: bool,
     /// All match ranges in the document for the current search term.
     pub matches: Vec<(Grapheme, Grapheme)>,
     /// deps: `(text_seq, term, case_sensitive, whole_word, regex)`
@@ -66,6 +69,7 @@ impl Default for Find {
             select_all_on_focus: false,
             open_requested: false,
             was_focused: false,
+            prev_focused: false,
             matches: Vec::new(),
             matches_deps: (0, None, false, false, false),
             current_match: None,
@@ -107,6 +111,19 @@ impl Find {
     ) -> FindOutput {
         let mut output = FindOutput::default();
 
+        // Consume Esc before the text fields do (they only surrender their own
+        // focus), or the widget never closes (#4646).
+        let field_focused = self.prev_focused
+            || ui.memory(|m| m.has_focus(self.id) || m.has_focus(self.replace_id));
+        if self.term.is_some()
+            && field_focused
+            && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, Key::Escape))
+        {
+            self.close_to_match(&mut output);
+            ui.ctx().request_repaint();
+            return output;
+        }
+
         let open = std::mem::take(&mut self.open_requested)
             || ui.input(|i| i.key_pressed(Key::F) && i.modifiers.command && !i.modifiers.shift);
         if open {
@@ -121,14 +138,8 @@ impl Find {
                 return output;
             }
 
-            let find_focused = ui.memory(|m| m.has_focus(self.id));
-            let replace_focused = ui.memory(|m| m.has_focus(self.replace_id));
-            if find_focused || replace_focused {
-                self.close_state();
-                output.closed = true;
-                return output;
-            }
-
+            // Cmd+F on an open widget re-focuses and reselects the search
+            // field, adopting any fresh editor selection as the term.
             let selected = String::from(&buffer[buffer.current.selection]);
             if !selected.is_empty() {
                 *self.term.as_mut().unwrap() = selected;
@@ -154,6 +165,7 @@ impl Find {
         let find_focused = ui.memory(|m| m.has_focus(self.id));
         let replace_focused = ui.memory(|m| m.has_focus(self.replace_id));
         let focused = find_focused || replace_focused;
+        self.prev_focused = focused;
         if focused && !self.was_focused {
             ui.ctx().set_virtual_keyboard_shown(true);
         }
@@ -223,102 +235,89 @@ impl Find {
 
             // search row: RTL — draw buttons first, input fills remainder
             let mut input_width = 0f32;
-            let find_has_focus = ui
-                .with_layout(rtl, |ui| {
-                    ui.spacing_mut().item_spacing.x = 4.;
+            ui.with_layout(rtl, |ui| {
+                ui.spacing_mut().item_spacing.x = 4.;
 
-                    if action(Icon::CLOSE).tooltip("Close").show(ui).clicked() {
-                        closed = true;
+                if action(Icon::CLOSE).tooltip("Close").show(ui).clicked() {
+                    closed = true;
+                }
+                for (ic, tip, flag) in [
+                    (Icon::REGEX, "Regex", &mut self.regex),
+                    (Icon::WHOLE_WORD, "Whole Word", &mut self.whole_word),
+                    (Icon::CASE_SENSITIVE, "Match Case", &mut self.case_sensitive),
+                ] {
+                    if toggle(ic).tooltip(tip).colored(*flag).show(ui).clicked() {
+                        *flag = !*flag;
+                        term_changed = true;
                     }
-                    for (ic, tip, flag) in [
-                        (Icon::REGEX, "Regex", &mut self.regex),
-                        (Icon::WHOLE_WORD, "Whole Word", &mut self.whole_word),
-                        (Icon::CASE_SENSITIVE, "Match Case", &mut self.case_sensitive),
-                    ] {
-                        if toggle(ic).tooltip(tip).colored(*flag).show(ui).clicked() {
-                            *flag = !*flag;
-                            term_changed = true;
+                }
+
+                input_width = ui.available_width();
+                let input_resp = input_frame().show(ui, |ui| {
+                    ui.with_layout(rtl, |ui| {
+                        let label = match self.current_match {
+                            Some(idx) => format!("{} / {}", idx + 1, self.matches.len()),
+                            None if !term.is_empty() => "No results".into(),
+                            _ => String::new(),
+                        };
+                        if !label.is_empty() {
+                            Label::new(egui::RichText::new(label).small())
+                                .selectable(false)
+                                .ui(ui);
                         }
-                    }
 
-                    input_width = ui.available_width();
-                    let input_resp = input_frame().show(ui, |ui| {
-                        ui.with_layout(rtl, |ui| {
-                            let label = match self.current_match {
-                                Some(idx) => format!("{} / {}", idx + 1, self.matches.len()),
-                                None if !term.is_empty() => "No results".into(),
-                                _ => String::new(),
-                            };
-                            if !label.is_empty() {
-                                Label::new(egui::RichText::new(label).small())
-                                    .selectable(false)
-                                    .ui(ui);
-                            }
-
-                            let mut edit =
-                                GlyphonTextEdit::new(term).id(self.id).hint_text("Search");
-                            if self.select_all_on_focus {
-                                edit = edit.select_all();
-                                self.select_all_on_focus = false;
-                            }
-                            edit.show(ui);
-                        });
+                        let mut edit = GlyphonTextEdit::new(term).id(self.id).hint_text("Search");
+                        if self.select_all_on_focus {
+                            edit = edit.select_all();
+                            self.select_all_on_focus = false;
+                        }
+                        edit.show(ui);
                     });
-                    if input_resp.response.clicked() {
-                        ui.memory_mut(|m| m.request_focus(self.id));
-                    }
-
-                    ui.memory(|m| m.has_focus(self.id))
-                })
-                .inner;
+                });
+                if input_resp.response.clicked() {
+                    ui.memory_mut(|m| m.request_focus(self.id));
+                }
+            });
 
             ui.add_space(4.);
 
             // replace row: LTR — input at same width as search, then buttons
-            let replace_has_focus = ui
-                .horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 4.;
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = 4.;
 
-                    input_frame().show(ui, |ui| {
-                        ui.set_width(input_width - input_padding.sum().x);
-                        GlyphonTextEdit::new(&mut self.replace_term)
-                            .id(self.replace_id)
-                            .hint_text("Replace")
-                            .show(ui);
-                    });
+                input_frame().show(ui, |ui| {
+                    ui.set_width(input_width - input_padding.sum().x);
+                    GlyphonTextEdit::new(&mut self.replace_term)
+                        .id(self.replace_id)
+                        .hint_text("Replace")
+                        .show(ui);
+                });
 
-                    if toggle(Icon::REPLACE).tooltip("Replace").show(ui).clicked() {
-                        replace_one = true;
-                    }
-                    if toggle(Icon::REPLACE_ALL)
-                        .tooltip("Replace All")
-                        .show(ui)
-                        .clicked()
-                    {
-                        replace_all = true;
-                    }
-                    if action(Icon::CHEVRON_UP)
-                        .tooltip("Previous")
-                        .show(ui)
-                        .clicked()
-                    {
-                        navigate = Some(false);
-                    }
-                    if action(Icon::CHEVRON_DOWN)
-                        .tooltip("Next")
-                        .show(ui)
-                        .clicked()
-                    {
-                        navigate = Some(true);
-                    }
-
-                    ui.memory(|m| m.has_focus(self.replace_id))
-                })
-                .inner;
-
-            if ui.input(|i| i.key_pressed(Key::Escape)) && (find_has_focus || replace_has_focus) {
-                closed = true;
-            }
+                if toggle(Icon::REPLACE).tooltip("Replace").show(ui).clicked() {
+                    replace_one = true;
+                }
+                if toggle(Icon::REPLACE_ALL)
+                    .tooltip("Replace All")
+                    .show(ui)
+                    .clicked()
+                {
+                    replace_all = true;
+                }
+                if action(Icon::CHEVRON_UP)
+                    .tooltip("Previous")
+                    .show(ui)
+                    .clicked()
+                {
+                    navigate = Some(false);
+                }
+                if action(Icon::CHEVRON_DOWN)
+                    .tooltip("Next")
+                    .show(ui)
+                    .clicked()
+                {
+                    navigate = Some(true);
+                }
+            });
 
             // apply state transitions
             if term_changed {
@@ -355,11 +354,22 @@ impl Find {
                 }
             }
             if closed {
-                self.close_state();
-                output.closed = true;
+                self.close_to_match(output);
                 ui.ctx().request_repaint();
             }
         });
+    }
+
+    /// Close the widget, seeding the editor selection from the current match so
+    /// the user resumes editing where they searched (#4646).
+    fn close_to_match(&mut self, output: &mut FindOutput) {
+        if let Some(range) = self.current_match_range() {
+            output
+                .events
+                .push(Event::Select { region: Region::from(range) });
+        }
+        self.close_state();
+        output.closed = true;
     }
 
     /// Recompute `matches` for the current term, positioning `current_match`

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -57,8 +57,10 @@ impl<'ast> MdRender {
         egui::Id::new(("md_link", node_range))
     }
 
-    /// Emit a link as a circumfix. For empty/auto links with a fetched
-    /// title, swap the URL bytes for the title via `push_override`.
+    /// Emit a link as a circumfix. For autolinks with a fetched title,
+    /// swap the URL bytes for the title via `push_override`. Empty-text
+    /// links (`[](url)`) are not autolinks and have nothing to show, so
+    /// they render their raw source like other incomplete syntax.
     /// With cmd held, opens a `Sense::click` interaction scope so egui
     /// z-order routes cmd-click here; without cmd no scope is opened
     /// and clicks fall through to the editor.
@@ -79,15 +81,14 @@ impl<'ast> MdRender {
         }
 
         let trimmed = node_range.trim(&range);
-        let title =
-            if (node.children().next().is_none() || is_auto) && !revealed && !trimmed.is_empty() {
-                match self.get_link_title(&url) {
-                    DestinationTitle::Ready(t) => Some(t),
-                    DestinationTitle::Absent => None,
-                }
-            } else {
-                None
-            };
+        let title = if is_auto && !revealed && !trimmed.is_empty() {
+            match self.get_link_title(&url) {
+                DestinationTitle::Ready(t) => Some(t),
+                DestinationTitle::Absent => None,
+            }
+        } else {
+            None
+        };
         match title {
             Some(t) => {
                 layout.style_open(StyleInfo { format: link_fmt.clone(), source_range: node_range });
@@ -245,7 +246,7 @@ impl<'ast> MdRender {
         }
     }
 
-    // Resolves the display title for a link with empty text.
+    // Resolves the display title an autolink swaps in for its URL.
     // Internal links (lb:// or relative paths) resolve synchronously from the file cache.
     // External http/https links are fetched asynchronously; returns Absent until
     // the fetch completes (caller renders the original URL text in that case).

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -36,13 +36,14 @@ impl<'ast> MdRender {
         Format { color, underline: true, ..parent_text_format }
     }
 
-    /// Link-coloured `Icon` glyph (no underline) used for the touch-mode
-    /// "open link" affordance appended after each link.
-    pub fn text_format_link_button(&self, parent: &AstNode<'_>) -> Format {
+    /// `Icon` glyph (no underline) used for the touch-mode "open link"
+    /// affordance appended after each link. Coloured to match the link's
+    /// state so the button doesn't read as healthy-blue on a warning link.
+    pub fn text_format_link_button(&self, parent: &AstNode<'_>, state: LinkState) -> Format {
         Format {
             family: FontFamily::Icons,
             underline: false,
-            ..self.text_format_link(parent, LinkState::Normal)
+            ..self.text_format_link(parent, state)
         }
     }
 
@@ -71,7 +72,8 @@ impl<'ast> MdRender {
         let url = node_link_url(node);
         let is_auto = self.link_is_auto(node, &url);
         let parent = node.parent().unwrap();
-        let link_fmt = self.text_format_link(parent, self.link_state_for_url(&url));
+        let state = self.link_state_for_url(&url);
+        let link_fmt = self.text_format_link(parent, state.clone());
         let revealed = self.range_revealed(node_range, is_auto);
 
         let cmd = self.ctx.input(|i| i.modifiers.command);
@@ -104,8 +106,10 @@ impl<'ast> MdRender {
 
         // Touch-mode open-link affordance: tap the trailing icon to open
         // the link (no cmd modifier on mobile). Only emit on the row that
-        // contains the link's end.
-        if self.touch_mode && range.contains_inclusive(node_range.end()) {
+        // contains the link's end. Broken links have nothing to open, so
+        // they get no button.
+        let broken = matches!(state, LinkState::Broken { .. });
+        if self.touch_mode && !broken && range.contains_inclusive(node_range.end()) {
             let anchor = (node_range.end(), node_range.end());
             let parent_fmt = self.text_format(parent);
             layout.push_override(anchor, " ", parent_fmt);
@@ -113,7 +117,7 @@ impl<'ast> MdRender {
             layout.push_override(
                 anchor,
                 Icon::OPEN_IN_NEW.icon,
-                self.text_format_link_button(parent),
+                self.text_format_link_button(parent, state),
             );
             layout.interaction_close();
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
@@ -2,6 +2,7 @@ use comrak::nodes::AstNode;
 use lb_rs::Uuid;
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 
+use crate::resolvers::link::LinkState;
 use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Layout;
 use crate::theme::icons::Icon;
@@ -20,7 +21,8 @@ impl<'ast> MdRender {
         };
         let parent = node.parent().unwrap();
         let node_range = self.node_range(node);
-        let fmt = self.text_format_link(parent, self.link_state_for_wikilink(&url));
+        let state = self.link_state_for_wikilink(&url);
+        let fmt = self.text_format_link(parent, state.clone());
         let cmd = self.ctx.input(|i| i.modifiers.command);
         let salt = Self::link_interaction_id_salt(node_range);
         if cmd {
@@ -31,7 +33,8 @@ impl<'ast> MdRender {
             layout.interaction_close();
         }
 
-        if self.touch_mode && range.contains_inclusive(node_range.end()) {
+        let broken = matches!(state, LinkState::Broken { .. });
+        if self.touch_mode && !broken && range.contains_inclusive(node_range.end()) {
             let anchor = (node_range.end(), node_range.end());
             let parent_fmt = self.text_format(parent);
             layout.push_override(anchor, " ", parent_fmt);
@@ -39,7 +42,7 @@ impl<'ast> MdRender {
             layout.push_override(
                 anchor,
                 Icon::OPEN_IN_NEW.icon,
-                self.text_format_link_button(parent),
+                self.text_format_link_button(parent, state),
             );
             layout.interaction_close();
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -163,6 +163,15 @@ pub struct StyleInfo {
     pub source_range: (Grapheme, Grapheme),
 }
 
+/// A strike/underline rule. Deferred to a post-text paint pass so it
+/// lands on top of opaque emoji bitmaps instead of behind them (#4617).
+#[derive(Clone, Debug)]
+pub struct DecoLine {
+    pub x: std::ops::RangeInclusive<f32>,
+    pub y: f32,
+    pub color: egui::Color32,
+}
+
 /// One visual row of a wrap unit, emitted by `build_rows`.
 #[derive(Clone, Debug)]
 pub struct Row {
@@ -1689,22 +1698,26 @@ impl MdRender {
                     ));
                 }
 
-                // Decorations (strike / underline) at glyph baseline.
+                // Decorations (strike / underline): deferred to a paint
+                // pass after the glyphon text callback so they land on top
+                // of opaque emoji bitmaps instead of behind them (#4617).
                 if let Some(style) = frag.style_stack.last() {
                     let fmt = &style.format;
-                    let stroke = Stroke::new(1.0, fmt.color);
                     let baseline_top = screen_rect.min.y + frag.content_inset.top;
-                    let x_range = screen_rect.left()..=screen_rect.right();
+                    let x = screen_rect.left()..=screen_rect.right();
                     if fmt.strikethrough {
-                        ui.painter().hline(
-                            x_range.clone(),
-                            baseline_top + row_height * 0.55,
-                            stroke,
-                        );
+                        self.deco_lines.push(DecoLine {
+                            x: x.clone(),
+                            y: baseline_top + row_height * 0.55,
+                            color: fmt.color,
+                        });
                     }
                     if fmt.underline {
-                        ui.painter()
-                            .hline(x_range, baseline_top + row_height * 0.95, stroke);
+                        self.deco_lines.push(DecoLine {
+                            x,
+                            y: baseline_top + row_height * 0.95,
+                            color: fmt.color,
+                        });
                     }
                 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -163,8 +163,7 @@ pub struct StyleInfo {
     pub source_range: (Grapheme, Grapheme),
 }
 
-/// A strike/underline rule. Deferred to a post-text paint pass so it
-/// lands on top of opaque emoji bitmaps instead of behind them (#4617).
+/// A strike/underline rule, painted on top of text (see `deco_lines`).
 #[derive(Clone, Debug)]
 pub struct DecoLine {
     pub x: std::ops::RangeInclusive<f32>,
@@ -1698,9 +1697,7 @@ impl MdRender {
                     ));
                 }
 
-                // Decorations (strike / underline): deferred to a paint
-                // pass after the glyphon text callback so they land on top
-                // of opaque emoji bitmaps instead of behind them (#4617).
+                // Collected here, painted after the text callback (#4617).
                 if let Some(style) = frag.style_stack.last() {
                     let fmt = &style.format;
                     let baseline_top = screen_rect.min.y + frag.content_inset.top;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1111,18 +1111,11 @@ fn is_one_to_one_range(layout: &Layout, visible_lo: usize, visible_hi: usize) ->
 
 /// Whether grapheme `g` should shape against the emoji font (Twemoji) rather
 /// than the format's own font. Icon-family spans are excluded: Nerd Font icon
-/// glyphs sit in the supplementary PUA, which overlaps the emoji range below,
-/// and the emoji font carries no format color — so they'd render in the
-/// default fg instead of blue (#4653).
+/// glyphs sit in the supplementary PUA, which overlaps the emoji range, and the
+/// emoji font carries no format color — so they'd render in the default fg
+/// instead of blue (#4653).
 pub(crate) fn shape_as_emoji(family: &FontFamily, g: &str) -> bool {
-    !matches!(family, FontFamily::Icons)
-        && g.chars().any(|c| {
-            matches!(
-                c as u32,
-                0xFE0F  // variation selector-16: emoji presentation
-            | 0x1F000.. // supplementary multilingual plane: core emoji blocks
-            )
-        })
+    !matches!(family, FontFamily::Icons) && crate::widgets::glyphon_label::is_emoji_grapheme(g)
 }
 
 fn format_to_attrs(format: &Format, base_row_height: f32) -> glyphon::AttrsOwned {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -829,14 +829,11 @@ fn shape_chunk(
             );
             let text = text.to_string();
             let spans = text.graphemes(true).map(|g| {
-                let is_emoji = g.chars().any(|c| {
-                    matches!(
-                        c as u32,
-                        0xFE0F  // variation selector-16: emoji presentation
-                    | 0x1F000.. // supplementary multilingual plane: core emoji blocks
-                    )
-                });
-                if is_emoji { (g, emoji_attrs.as_attrs()) } else { (g, attrs.as_attrs()) }
+                if shape_as_emoji(&format.family, g) {
+                    (g, emoji_attrs.as_attrs())
+                } else {
+                    (g, attrs.as_attrs())
+                }
             });
             b.set_rich_text(&mut guard, spans, &attrs.as_attrs(), glyphon::Shaping::Advanced, None);
             b
@@ -1110,6 +1107,22 @@ fn is_one_to_one_range(layout: &Layout, visible_lo: usize, visible_hi: usize) ->
         }
     }
     true
+}
+
+/// Whether grapheme `g` should shape against the emoji font (Twemoji) rather
+/// than the format's own font. Icon-family spans are excluded: Nerd Font icon
+/// glyphs sit in the supplementary PUA, which overlaps the emoji range below,
+/// and the emoji font carries no format color — so they'd render in the
+/// default fg instead of blue (#4653).
+pub(crate) fn shape_as_emoji(family: &FontFamily, g: &str) -> bool {
+    !matches!(family, FontFamily::Icons)
+        && g.chars().any(|c| {
+            matches!(
+                c as u32,
+                0xFE0F  // variation selector-16: emoji presentation
+            | 0x1F000.. // supplementary multilingual plane: core emoji blocks
+            )
+        })
 }
 
 fn format_to_attrs(format: &Format, base_row_height: f32) -> glyphon::AttrsOwned {

--- a/libs/content/workspace/src/widgets/glyphon_label.rs
+++ b/libs/content/workspace/src/widgets/glyphon_label.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use egui::{Response, Sense, Ui};
 use glyphon::{Attrs, Buffer, Family, FontSystem, Metrics, Shaping, Weight};
+use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::widgets::glyphon_cache::{
     GlyphonCache, GlyphonCacheKey, GlyphonCacheSpan, GlyphonFontFamily,
@@ -376,9 +377,12 @@ impl<'a> GlyphonLabel<'a> {
                 buf.set_size(&mut fs, Some(max_width * ppi), None);
 
                 let base = Attrs::new().family(Family::SansSerif);
+                let emoji = Attrs::new().family(Family::Name("Twemoji Mozilla"));
+                // Route emoji graphemes to the color font; the rest keep the
+                // span's own attrs. Mirrors the editor's `shape_chunk`.
                 buf.set_rich_text(
                     &mut fs,
-                    spans.iter().map(|&(text, style)| {
+                    spans.iter().flat_map(|&(text, style)| {
                         let mut attrs = if style.bold {
                             base.clone().weight(Weight::BOLD)
                         } else {
@@ -387,7 +391,14 @@ impl<'a> GlyphonLabel<'a> {
                         if let Some(c) = style.color {
                             attrs = attrs.color(glyphon::Color::rgba(c.r(), c.g(), c.b(), c.a()));
                         }
-                        (text, attrs)
+                        let emoji = emoji.clone();
+                        text.graphemes(true).map(move |g| {
+                            if is_emoji_grapheme(g) {
+                                (g, emoji.clone())
+                            } else {
+                                (g, attrs.clone())
+                            }
+                        })
                     }),
                     &base,
                     Shaping::Advanced,
@@ -413,6 +424,20 @@ impl<'a> GlyphonLabel<'a> {
 struct OwnedSpan {
     text: String,
     style: SpanStyle,
+}
+
+/// Whether a grapheme should shape against the color emoji font (Twemoji)
+/// rather than the surrounding text font — VS-16 presentation sequences and
+/// the supplementary-plane emoji blocks. Without this, emoji fall back to the
+/// UI font and render as monochrome outlines.
+pub(crate) fn is_emoji_grapheme(g: &str) -> bool {
+    g.chars().any(|c| {
+        matches!(
+            c as u32,
+            0xFE0F  // variation selector-16: emoji presentation
+        | 0x1F000.. // supplementary multilingual plane: core emoji blocks
+        )
+    })
 }
 
 fn end_ellipsis_candidate(chars: &[char], keep: usize) -> String {


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4617
fixes https://github.com/lockbook/lockbook/issues/4630
fixes https://github.com/lockbook/lockbook/issues/4631
fixes https://github.com/lockbook/lockbook/issues/4646
fixes https://github.com/lockbook/lockbook/issues/4653

* fixes an issue where some emoji (e.g. ⚠️) were black & white on apple devices in non-editor contexts (file names, completions, etc).
* link buttons now match warning state coloring / are hidden in error state