### PR TITLE
lb: onboarding experimentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,6 +4217,8 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "similar",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "tempfile",
  "test_utils",
  "time",
@@ -4984,7 +4986,7 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.12",
  "unicode-ident",
 ]
@@ -7645,8 +7647,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -7658,6 +7666,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.104",
 ]
 

--- a/libs/lb/lb-rs/Cargo.toml
+++ b/libs/lb/lb-rs/Cargo.toml
@@ -57,6 +57,8 @@ unicode-segmentation = "1.10.0"
 usvg = "0.41.0"
 uuid = { version = "1.2.2", features = ["v4", "serde", "js"] }
 web-time = "1.1.0"
+strum = "0.28.0"
+strum_macros = "0.28"
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-logcat = "=0.1.0"

--- a/libs/lb/lb-rs/src/experiments.rs
+++ b/libs/lb/lb-rs/src/experiments.rs
@@ -1,0 +1,21 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+use strum::VariantArray;
+use strum_macros::VariantArray;
+
+#[derive(VariantArray, Clone, Copy)]
+pub enum WelcomeDoc {
+    NoWelcomeDoc,
+    OldWelcomeDoc,
+    HypeWelcomeDoc,
+    FramgentedArchetypes,
+}
+
+pub fn cohort<E: VariantArray + Copy>(username: &str) -> E {
+    let mut hasher = DefaultHasher::new();
+    username.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    let variant_id = (hash % E::VARIANTS.len() as u64) as usize;
+
+    E::VARIANTS[variant_id]
+}

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -19,13 +19,13 @@
 extern crate tracing;
 
 pub mod blocking;
+pub mod experiments;
 pub mod io;
 pub mod ipc;
 pub mod macros;
 pub mod model;
 pub mod service;
 pub mod subscribers;
-pub mod experiments;
 #[cfg(target_family = "wasm")]
 pub mod wasm;
 

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -25,6 +25,7 @@ pub mod macros;
 pub mod model;
 pub mod service;
 pub mod subscribers;
+pub mod experiments;
 #[cfg(target_family = "wasm")]
 pub mod wasm;
 

--- a/libs/lb/lb-rs/src/service/account.rs
+++ b/libs/lb/lb-rs/src/service/account.rs
@@ -1,3 +1,4 @@
+use crate::experiments::{WelcomeDoc, cohort};
 use crate::model::account::{Account, MAX_USERNAME_LENGTH};
 use crate::model::api::{
     DeleteAccountRequest, GetPublicKeyRequest, GetUsernameRequest, NewAccountRequestV2,
@@ -60,12 +61,20 @@ impl LocalLb {
         tx.end();
 
         if welcome_doc {
-            let welcome_doc = self
-                .create_file("welcome.md", &root_id, FileType::Document)
-                .await?;
-            self.write_document(welcome_doc.id, Self::WELCOME_MESSAGE.as_bytes())
-                .await?;
-            self.sync().await?;
+            let cohort: WelcomeDoc = cohort(&account.username);
+            match cohort {
+                WelcomeDoc::NoWelcomeDoc => {}
+                WelcomeDoc::OldWelcomeDoc => {
+                    let welcome_doc = self
+                        .create_file("welcome.md", &root_id, FileType::Document)
+                        .await?;
+                    self.write_document(welcome_doc.id, Self::WELCOME_MESSAGE.as_bytes())
+                        .await?;
+                    self.sync().await?;
+                }
+                WelcomeDoc::HypeWelcomeDoc => todo!(),
+                WelcomeDoc::FramgentedArchetypes => todo!(),
+            };
         }
 
         self.events.meta_changed(Actor::User);

--- a/libs/lb/lb-rs/src/service/account.rs
+++ b/libs/lb/lb-rs/src/service/account.rs
@@ -72,8 +72,9 @@ impl LocalLb {
                         .await?;
                     self.sync().await?;
                 }
-                WelcomeDoc::HypeWelcomeDoc => todo!(),
-                WelcomeDoc::FramgentedArchetypes => todo!(),
+                // WelcomeDoc::HypeWelcomeDoc => todo!(),
+                // WelcomeDoc::FramgentedArchetypes => todo!(),
+                _ => {}
             };
         }
 

--- a/libs/lb/lb-rs/tests/account_service_tests.rs
+++ b/libs/lb/lb-rs/tests/account_service_tests.rs
@@ -1,3 +1,4 @@
+use lb_rs::experiments::{WelcomeDoc, cohort};
 use lb_rs::model::account::{Account, MAX_USERNAME_LENGTH};
 use lb_rs::model::errors::LbErrKind;
 use lb_rs::model::pubkey;
@@ -14,9 +15,11 @@ async fn create_account_success() {
 #[tokio::test]
 async fn create_account_success_with_welcome() {
     let core = test_core().await;
-    core.create_account(&random_name(), &url(), true)
-        .await
-        .unwrap();
+    let mut name = random_name();
+    while !matches!(cohort::<WelcomeDoc>(&name), WelcomeDoc::OldWelcomeDoc) {
+        name = random_name();
+    }
+    core.create_account(&name, &url(), true).await.unwrap();
     core.get_by_path("welcome.md").await.unwrap();
 }
 


### PR DESCRIPTION
Creates the first bit of privacy-respecting-experimentation framework. Based on your username you'll get a different onboarding experience, and we're going to see which strategy leads to better long term outcomes for users.

Authoring new experiments should be a matter of creating a new enum, and then just asking `let group: Experiment = cohort(username);`. 

@ad-tra feel free to add your hype doc as a variant. I'll add mine as well, and I'll add some stuff to server to make it easy for us to track cohort success.

I'm going to wait for ad-tra to author his experiment to make sure mine is meaningfully different. And I predict my experiment is also going to benefit from #4362, but I think this is all scheduled to arrive at the same time.

fixes: #4648 