### PR TITLE
egui, apple: file level status

### DIFF
--- a/clients/apple/Shared/State/FilesViewModel.swift
+++ b/clients/apple/Shared/State/FilesViewModel.swift
@@ -2,20 +2,6 @@ import Combine
 import SwiftUI
 import SwiftWorkspace
 
-enum SyncDot: Equatable {
-    case pushing
-    case dirty
-    case pulling
-
-    var rank: Int {
-        switch self {
-        case .pushing: return 0
-        case .dirty: return 1
-        case .pulling: return 2
-        }
-    }
-}
-
 class FilesViewModel: ObservableObject {
     @Published var root: File? = nil
     @Published var files: [File] = []
@@ -350,6 +336,20 @@ class FilesViewModel: ObservableObject {
     func rejectShare(id: UUID) {
         if case let .failure(err) = AppState.lb.deletePendingShare(id: id) {
             AppState.shared.error = .lb(error: err)
+        }
+    }
+}
+
+enum SyncDot: Equatable {
+    case pushing
+    case dirty
+    case pulling
+
+    var rank: Int {
+        switch self {
+        case .pushing: return 0
+        case .dirty: return 1
+        case .pulling: return 2
         }
     }
 }

--- a/clients/apple/Shared/State/FilesViewModel.swift
+++ b/clients/apple/Shared/State/FilesViewModel.swift
@@ -2,12 +2,28 @@ import Combine
 import SwiftUI
 import SwiftWorkspace
 
+enum SyncDot: Equatable {
+    case pushing
+    case dirty
+    case pulling
+
+    var rank: Int {
+        switch self {
+        case .pushing: return 0
+        case .dirty: return 1
+        case .pulling: return 2
+        }
+    }
+}
+
 class FilesViewModel: ObservableObject {
     @Published var root: File? = nil
     @Published var files: [File] = []
     var idsToFiles: [UUID: File] = [:]
     var childrens: [UUID: [File]] = [:]
     var pendingSharesAndChildren: [UUID] = []
+
+    @Published var statusDots: [UUID: SyncDot] = [:]
 
     @Published var pendingSharesByUsername: [String: [File]]? = nil
 
@@ -23,6 +39,50 @@ class FilesViewModel: ObservableObject {
             self?.loadFiles()
         }
         .store(in: &cancellables)
+
+        AppState.lb.events.$status.sink { [weak self] status in
+            self?.recomputeStatusDots(status: status)
+        }
+        .store(in: &cancellables)
+    }
+
+    func recomputeStatusDots(status: Status) {
+        let newDots = computeStatusDots(status: status)
+        if newDots != statusDots {
+            statusDots = newDots
+        }
+    }
+
+    private func computeStatusDots(status: Status) -> [UUID: SyncDot] {
+        var dots: [UUID: SyncDot] = [:]
+
+        func bump(_ id: UUID, _ dot: SyncDot) {
+            if let existing = dots[id], existing.rank <= dot.rank {
+                return
+            }
+            dots[id] = dot
+        }
+
+        func seed(_ ids: [UUID], _ dot: SyncDot) {
+            for id in ids {
+                bump(id, dot)
+
+                var current = id
+                while let file = idsToFiles[current], !file.isRoot {
+                    guard let parent = idsToFiles[file.parent], !parent.isRoot else {
+                        break
+                    }
+                    bump(parent.id, dot)
+                    current = parent.id
+                }
+            }
+        }
+
+        seed(status.pushingFiles, .pushing)
+        seed(status.dirtyLocally, .dirty)
+        seed(status.pullingFiles, .pulling)
+
+        return dots
     }
 
     func isFileInDeletion(id: UUID) -> Bool {
@@ -243,6 +303,10 @@ class FilesViewModel: ObservableObject {
                 case let .failure(err):
                     self.error = err.msg
                 }
+            }
+
+            DispatchQueue.main.async {
+                self.recomputeStatusDots(status: AppState.lb.events.status)
             }
         }
     }

--- a/clients/apple/iOS/Widgets/FileTreeView.swift
+++ b/clients/apple/iOS/Widgets/FileTreeView.swift
@@ -122,6 +122,12 @@ struct FileRowView: View {
                 .allowsTightening(true)
                 .foregroundColor(.primary)
 
+            if let dot = filesModel.statusDots[file.id] {
+                Circle()
+                    .fill(dot.color)
+                    .frame(width: 8, height: 8)
+            }
+
             Spacer()
 
             if !isLeaf {
@@ -179,6 +185,16 @@ struct FileRowView: View {
             if homeState.isSidebarFloating {
                 homeState.sidebarState = .closed
             }
+        }
+    }
+}
+
+extension SyncDot {
+    var color: Color {
+        switch self {
+        case .pushing: return .green
+        case .dirty: return .yellow
+        case .pulling: return .blue
         }
     }
 }

--- a/clients/apple/macOS/Widgets/FileTree/FileTreeView.swift
+++ b/clients/apple/macOS/Widgets/FileTree/FileTreeView.swift
@@ -114,6 +114,22 @@ struct FileTreeView: NSViewRepresentable {
                 treeView.selectRowIndexes([row], byExtendingSelection: false)
             }
             .store(in: &cancellables)
+
+            filesModel.$statusDots.sink { [weak treeView] newDots in
+                guard let treeView else { return }
+
+                let visible = treeView.rows(in: treeView.visibleRect)
+                guard visible.length > 0 else { return }
+
+                for row in visible.location ..< (visible.location + visible.length) {
+                    guard let file = treeView.item(atRow: row) as? File,
+                          let cell = treeView.view(atColumn: 0, row: row, makeIfNecessary: false) as? FileItemView
+                    else { continue }
+
+                    cell.setDot(color: newDots[file.id]?.nsColor)
+                }
+            }
+            .store(in: &cancellables)
         }
 
         func selectAndReveal(selected: UUID?, treeView: FileTreeOutlineView?) {
@@ -478,7 +494,7 @@ class FileTreeDelegate: NSObject, MenuOutlineViewDelegate {
         item: Any
     ) -> NSView? {
         let file = item as! File
-        return FileItemView(file: file)
+        return FileItemView(file: file, dotColor: filesModel.statusDots[file.id]?.nsColor)
     }
 
     func outlineViewSelectionIsChanging(_: Notification) {
@@ -506,9 +522,10 @@ class FileTreeDelegate: NSObject, MenuOutlineViewDelegate {
 }
 
 class FileItemView: NSTableCellView {
-    init(file: File) {
-        super.init(frame: .zero)
+    private let stackView: NSStackView
+    private var dotView: SyncDotView?
 
+    init(file: File, dotColor: NSColor?) {
         let image = NSImage(systemSymbolName: FileIconHelper.fileToSystemImageName(file: file), accessibilityDescription: nil)!
         image.isTemplate = true
 
@@ -533,6 +550,9 @@ class FileItemView: NSTableCellView {
         stackView.orientation = .horizontal
         stackView.spacing = 6
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        self.stackView = stackView
+
+        super.init(frame: .zero)
 
         addSubview(stackView)
 
@@ -542,6 +562,69 @@ class FileItemView: NSTableCellView {
             stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
+
+        setDot(color: dotColor)
+    }
+
+    func setDot(color: NSColor?) {
+        if let color {
+            if let dotView {
+                dotView.color = color
+            } else {
+                let dot = SyncDotView(color: color)
+                stackView.addArrangedSubview(dot)
+                dotView = dot
+            }
+        } else if let dotView {
+            stackView.removeArrangedSubview(dotView)
+            dotView.removeFromSuperview()
+            self.dotView = nil
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension SyncDot {
+    var nsColor: NSColor {
+        switch self {
+        case .pushing: return .systemGreen
+        case .dirty: return .systemYellow
+        case .pulling: return .systemBlue
+        }
+    }
+}
+
+class SyncDotView: NSView {
+    var color: NSColor {
+        didSet { needsDisplay = true }
+    }
+
+    init(color: NSColor) {
+        self.color = color
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        setContentHuggingPriority(.required, for: .horizontal)
+        setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 8, height: 8)
+    }
+
+    override func draw(_: NSRect) {
+        let diameter: CGFloat = 8
+        let rect = NSRect(
+            x: (bounds.width - diameter) / 2,
+            y: (bounds.height - diameter) / 2,
+            width: diameter,
+            height: diameter
+        )
+        color.setFill()
+        NSBezierPath(ovalIn: rect).fill()
     }
 
     @available(*, unavailable)

--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -461,7 +461,8 @@ impl AccountScreen {
                         .stroke(Stroke::NONE)
                         .show(ui, |ui| {
                             ui.allocate_space(Vec2 { x: ui.available_width(), y: 0. });
-                            self.tree.show(ui, max_rect, &mut self.toasts)
+                            self.tree
+                                .show(ui, max_rect, &mut self.toasts, &self.lb_status)
                         })
                 })
             })

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -12,12 +12,48 @@ use egui_notify::Toasts;
 use lb::Uuid;
 use lb::model::file::File;
 use lb::model::file_metadata::FileType;
+use lb::subscribers::status::Status;
 use rfd::FileDialog;
 use workspace_rs::file_cache::{FileCache, FilesExt};
 use workspace_rs::show::DocType;
 use workspace_rs::theme::icons::Icon;
-use workspace_rs::theme::palette_v2::ThemeExt as _;
+use workspace_rs::theme::palette_v2::{Palette, Theme, ThemeExt as _};
 use workspace_rs::widgets::{Button, GlyphonTextEdit, TextOverflow};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SyncDot {
+    Pushing,
+    Dirty,
+    Pulling,
+}
+
+impl SyncDot {
+    fn rank(self) -> u8 {
+        match self {
+            SyncDot::Pushing => 0,
+            SyncDot::Dirty => 1,
+            SyncDot::Pulling => 2,
+        }
+    }
+
+    fn color(self, theme: &Theme) -> Color32 {
+        let variant = theme.fg();
+        match self {
+            SyncDot::Pushing => variant.get_color(Palette::Green),
+            SyncDot::Dirty => variant.get_color(Palette::Yellow),
+            SyncDot::Pulling => variant.get_color(Palette::Blue),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SyncDots {
+    dots: HashMap<Uuid, SyncDot>,
+    pushing: Vec<Uuid>,
+    dirty: Vec<Uuid>,
+    pulling: Vec<Uuid>,
+    files_stale: bool,
+}
 
 #[derive(Debug)]
 pub struct FileTree {
@@ -64,6 +100,8 @@ pub struct FileTree {
     pub pending_shares: HashMap<String, ShareCell>,
     pub pending_shares_id: Uuid,
     pub pending_shares_height: f32,
+
+    sync_dots: SyncDots,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -97,6 +135,7 @@ impl FileTree {
             drop: Default::default(),
             scroll_to_cursor: Default::default(),
             pending_shares: Default::default(),
+            sync_dots: Default::default(),
         };
 
         s.update_files();
@@ -104,7 +143,11 @@ impl FileTree {
         s
     }
 
-    pub fn show(&mut self, ui: &mut Ui, max_rect: Rect, toasts: &mut Toasts) -> Response {
+    pub fn show(
+        &mut self, ui: &mut Ui, max_rect: Rect, toasts: &mut Toasts, status: &Status,
+    ) -> Response {
+        self.refresh_sync_dots(status);
+
         let mut resp = Response::default();
         let mut scroll_to_cursor = mem::take(&mut self.scroll_to_cursor);
 
@@ -1063,6 +1106,61 @@ impl FileTree {
         resp
     }
 
+    fn refresh_sync_dots(&mut self, status: &Status) {
+        let unchanged = !self.sync_dots.files_stale
+            && self.sync_dots.pushing == status.pushing_files
+            && self.sync_dots.dirty == status.dirty_locally
+            && self.sync_dots.pulling == status.pulling_files;
+        if unchanged {
+            return;
+        }
+        let dots = self.compute_sync_dots(status);
+        self.sync_dots = SyncDots {
+            dots,
+            pushing: status.pushing_files.clone(),
+            dirty: status.dirty_locally.clone(),
+            pulling: status.pulling_files.clone(),
+            files_stale: false,
+        };
+    }
+
+    fn compute_sync_dots(&self, status: &Status) -> HashMap<Uuid, SyncDot> {
+        let mut dots = HashMap::new();
+        for (ids, dot) in [
+            (&status.pushing_files, SyncDot::Pushing),
+            (&status.dirty_locally, SyncDot::Dirty),
+            (&status.pulling_files, SyncDot::Pulling),
+        ] {
+            for &id in ids {
+                Self::bump(&mut dots, id, dot);
+
+                let mut current = id;
+                while let Some(file) = self.files.get_by_id(current) {
+                    if file.is_root() {
+                        break;
+                    }
+                    match self.files.get_by_id(file.parent) {
+                        Some(parent) if !parent.is_root() => {
+                            Self::bump(&mut dots, file.parent, dot)
+                        }
+                        _ => break,
+                    }
+                    current = file.parent;
+                }
+            }
+        }
+        dots
+    }
+
+    fn bump(dots: &mut HashMap<Uuid, SyncDot>, id: Uuid, dot: SyncDot) {
+        let replace = dots
+            .get(&id)
+            .is_none_or(|existing| dot.rank() < existing.rank());
+        if replace {
+            dots.insert(id, dot);
+        }
+    }
+
     fn show_file_cell(
         &mut self, ui: &mut Ui, file: &File, indent: f32, focused: bool,
     ) -> egui::Response {
@@ -1125,7 +1223,13 @@ impl FileTree {
             .padding(vec2(15., 7.))
             .text_overflow(TextOverflow::EndEllipsis)
             .icon(&icon)
-            .icon_color(icon_color);
+            .icon_color(icon_color)
+            .trailing_dot(
+                self.sync_dots
+                    .dots
+                    .get(&file.id)
+                    .map(|dot| dot.color(&theme)),
+            );
 
         let button = if !is_renaming {
             let display_name = doc_type.display_name(&file.name);
@@ -1478,6 +1582,8 @@ impl FileTree {
 
         *self.suggested_docs.lock().unwrap() =
             file_cache.suggested.iter().take(5).copied().collect();
+
+        self.sync_dots.files_stale = true;
     }
 
     /// Expands `ids`. Does not select or deselect anything.

--- a/libs/content/workspace/src/widgets/button.rs
+++ b/libs/content/workspace/src/widgets/button.rs
@@ -21,8 +21,11 @@ pub struct Button<'a> {
     indent: f32,
     default_fill: Option<egui::Color32>,
     text_overflow: TextOverflow,
+    trailing_dot: Option<egui::Color32>,
 }
 const SPINNER_RADIUS: u32 = 5;
+const DOT_RADIUS: f32 = 4.0;
+const DOT_GAP: f32 = 8.0;
 
 impl<'a> Button<'a> {
     pub fn icon(self, icon: &'a Icon) -> Self {
@@ -89,6 +92,10 @@ impl<'a> Button<'a> {
         Self { text_overflow, ..self }
     }
 
+    pub fn trailing_dot(self, trailing_dot: Option<egui::Color32>) -> Self {
+        Self { trailing_dot, ..self }
+    }
+
     pub fn show(self, ui: &mut egui::Ui) -> egui::Response {
         egui::Frame::new()
             .outer_margin(self.margin)
@@ -141,9 +148,15 @@ impl<'a> Button<'a> {
                 let icon_width = maybe_icon_galley.as_ref().map_or(0.0, |icon| icon.size().x);
                 let icon_text_gap =
                     if self.icon.is_some() && has_text { padding.x / 2.0 } else { 0.0 };
-                let max_text_width =
-                    (wrap_width - padding.x * 2.0 - self.indent - icon_width - icon_text_gap)
-                        .max(0.0);
+                let dot_space =
+                    if self.trailing_dot.is_some() { DOT_GAP + 2.0 * DOT_RADIUS } else { 0.0 };
+                let max_text_width = (wrap_width
+                    - padding.x * 2.0
+                    - self.indent
+                    - icon_width
+                    - icon_text_gap
+                    - dot_space)
+                    .max(0.0);
 
                 // Measure once; reused below for text_rect to avoid a second shape pass.
                 let text_width = maybe_text_str.as_deref().map(|text_str| {
@@ -158,6 +171,8 @@ impl<'a> Button<'a> {
                     width += w;
                     w
                 });
+
+                width += dot_space;
 
                 if self.hexpand {
                     width = ui.available_size_before_wrap().x;
@@ -261,6 +276,13 @@ impl<'a> Button<'a> {
                                     GlyphonRendererCallback::new(vec![text_area]),
                                 ),
                             );
+                        }
+
+                        if let Some(dot_color) = self.trailing_dot {
+                            let dot_center =
+                                egui::pos2(text_pos.x + w + DOT_GAP + DOT_RADIUS, rect.center().y);
+                            ui.painter()
+                                .circle_filled(dot_center, DOT_RADIUS, dot_color);
                         }
                     }
                 }


### PR DESCRIPTION
While watching people test things like large files, lazy files, I've observed a strong need for a per file status. This information is already computed in core and is already consumed by android. This PR brings that same functionality to egui, macOS and iOS.

Now when a file is dirty locally it will show a yellow dot. 

Two situations where this dramatically improves the experience: 
* If you run out of space and are failing to push a file this will make that situation apparent.
* If you're offline it will show which files have not been synced
* if sync is taking a long time because you're pushing a massive file you'll have a more clear picture of what's going on. Same with a read operation.

<img width="900" alt="image" src="https://github.com/user-attachments/assets/39fa91c8-19cc-4612-9864-4894142d5489" />

file statuses roll up to their parents and are largely related to documents. Fun to delete the documents directory and watch lazy files fetch all of them:

<img width="900" alt="image" src="https://github.com/user-attachments/assets/6634d5c6-c626-46b0-a73f-b5d9fa74e287" />

macOS got some native treatment for statuses:

<img width="898" height="685" alt="image" src="https://github.com/user-attachments/assets/fa3ad878-cc19-4e91-8626-396c19b54221" />

same with iOS 

<img height="500" alt="image" src="https://github.com/user-attachments/assets/b6e79970-f668-4f9e-b189-8a4811d9df87" /> <img  height="500" alt="image" src="https://github.com/user-attachments/assets/ef27a2ff-f435-4476-a978-f882fd4f90a2" />

should contribute nicely to the #4672 journey