### PR TITLE
md: selectable block syntax

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -348,6 +348,24 @@ impl BoundExt for Grapheme {
             }
         };
 
+        // Gutter-aware line jump: a cursor in a line's captured prefix
+        // region (before the first wrap row, whose ranges exclude the
+        // prefix) targets the *source* line start on cmd+left and the
+        // wrap-row end on cmd+right. The prefix isn't part of any wrap
+        // line so the generic logic below can't express it.
+        if matches!(bound, Bound::Line) {
+            let (sl, _) = bounds.source_lines.find_containing(self, true, true);
+            if let Some(&source_line) = bounds.source_lines.get(sl) {
+                let (w0, w1) = bounds.wrap_lines.find_contained(source_line, true, true);
+                if w0 < w1 {
+                    let row0 = bounds.wrap_lines[w0];
+                    if self < row0.start() {
+                        return Some((source_line.start(), row0.end()));
+                    }
+                }
+            }
+        }
+
         let range_before = Bounds::range_before(ranges, self);
         let range_after = Bounds::range_after(ranges, self);
 

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -95,6 +95,46 @@ impl MdEdit {
             }
             result.push(rect);
         }
+
+        // Selected newlines / blank lines have no glyph to highlight. When
+        // the selection crosses a source line's end, add a fixed-width slab
+        // at that row's end so the captured `\n` reads as selected.
+        // (Soft-wrap whitespace shares its boundary offset with the next
+        // row's start, so it isn't covered here.)
+        if !range.is_empty() {
+            let slab_w = self.renderer.layout.row_height * 0.4;
+            let line_count = self.renderer.bounds.source_lines.len();
+            for i in 0..line_count.saturating_sub(1) {
+                // The `\n` grapheme sits at the line's end offset (source
+                // lines exclude their trailing newline).
+                let newline = self.renderer.bounds.source_lines[i].end();
+                if newline < range.start() || newline >= range.end() {
+                    continue;
+                }
+                // Match the row's content rects (bare fragment rect), not
+                // `cursor_line`'s caret-height-expanded range.
+                if let Some(frag) = self.renderer.fragment_at_offset(newline) {
+                    let x = self.renderer.fragment_x(frag, newline);
+                    let (top, bot) = (frag.rect.min.y, frag.rect.max.y);
+                    // Extend the row's content rect rightward into the slab so
+                    // the newline flows out of the row's highlight as one
+                    // rounded shape, rather than a separate notched rect.
+                    if let Some(r) = result.iter_mut().find(|r| {
+                        (r.top() - top).abs() < 0.001
+                            && (r.bottom() - bot).abs() < 0.001
+                            && (r.right() - x).abs() < 0.5
+                    }) {
+                        r.max.x = r.max.x.max(x + slab_w);
+                    } else {
+                        result.push(Rect::from_min_max(
+                            Pos2::new(x, top),
+                            Pos2::new(x + slab_w, bot),
+                        ));
+                    }
+                }
+            }
+        }
+
         result
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -994,7 +994,15 @@ impl<'ast> MdEdit {
     }
 
     pub fn location_to_char_offset(&self, location: Location) -> Grapheme {
-        self.location_to_range(location).0
+        match location {
+            // A pointer endpoint edge-snaps atomic fragments by x (see
+            // `pos_to_char_offset`), rather than collapsing to the range
+            // start — so a drag across an atomic span (e.g. a list marker
+            // or one indentation column) selects the whole span instead
+            // of an empty range.
+            Location::Pos(pos) => self.pos_to_char_offset(pos),
+            _ => self.location_to_range(location).0,
+        }
     }
 
     fn clipboard_current_line(&self) -> (Grapheme, Grapheme) {
@@ -1058,8 +1066,29 @@ impl<'ast> MdEdit {
         }
     }
 
+    /// Resolves a pointer position to a single cursor offset. Unlike
+    /// [`pos_to_range`] (which returns an atomic fragment's *whole*
+    /// range so a click selects it), this edge-snaps an atomic fragment
+    /// to the nearer edge by `pos.x` via [`fragment_offset`]. That lets
+    /// a drag's anchor and moving end land on opposite edges of a marker
+    /// / indentation column and select it, rather than both collapsing
+    /// to its start.
     pub fn pos_to_char_offset(&self, pos: Pos2) -> Grapheme {
-        self.pos_to_range(pos).0
+        let Some(frag_idx) = self.renderer.closest_fragment_at_pos(pos) else {
+            return Grapheme(0);
+        };
+        let frag = &self.renderer.fragments[frag_idx];
+
+        // Past the last fragment's bottom: jump to doc end.
+        let is_last = frag_idx + 1 == self.renderer.fragments.len();
+        if is_last && pos.y > frag.rect.max.y {
+            return self.renderer.buffer.current.segs.last_cursor_position();
+        }
+
+        // The hit-test inverse: edge-snaps atomic fragments by the rect
+        // midpoint, walks clusters otherwise, and collapses an empty
+        // range to its start.
+        self.renderer.fragment_offset(frag, pos.x)
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -511,6 +511,7 @@ impl MdRender {
             self.compute_bounds(root);
             self.bounds.inline_paragraphs.sort();
             self.calc_words();
+            self.calc_syntax_words(root);
             self.bounds.text_seq = self.text_seq;
             self.bounds_seq = self
                 .ws_seq

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -32,6 +32,11 @@ use super::input::{Bound, Event, Location, Region};
 /// Hand-off between [`MdEdit::pre_render`] and [`MdEdit::post_render`].
 pub struct PreRenderState {
     focused: bool,
+    /// Painter slot reserved before block rendering so the selection
+    /// highlight paints *behind* the block content drawn afterwards
+    /// (bullets, quote bars, checkboxes — painted immediately, not via
+    /// the deferred glyph callback). Filled in `post_render`.
+    selection_shape: egui::layers::ShapeIdx,
 }
 
 impl MdEdit {
@@ -343,7 +348,11 @@ impl MdEdit {
 
         self.renderer.in_progress_selection = self.in_progress_selection;
 
-        PreRenderState { focused }
+        // Reserved before block content so the highlight sits behind it;
+        // see the `selection_shape` field.
+        let selection_shape = ui.painter().add(egui::Shape::Noop);
+
+        PreRenderState { focused, selection_shape }
     }
 
     /// Per-frame teardown that runs after block rendering: cursor /
@@ -364,7 +373,17 @@ impl MdEdit {
                 .unwrap_or(self.renderer.buffer.current.selection);
             let theme = self.renderer.ctx.get_lb_theme();
             let color = theme.bg().get_color(theme.prefs().primary);
-            self.show_range(ui, selection, color.lerp_to_gamma(theme.neutral_bg(), 0.7));
+
+            // Fill the reserved slot so the highlight paints behind the
+            // markers (drawn during block render); the cursor stays on top.
+            let sel_color = color.lerp_to_gamma(theme.neutral_bg(), 0.7);
+            let shapes: Vec<egui::Shape> = self
+                .range_rects(selection)
+                .into_iter()
+                .map(|r| egui::Shape::rect_filled(r, 2.0, sel_color))
+                .collect();
+            ui.painter()
+                .set(pre.selection_shape, egui::Shape::Vec(shapes));
             self.show_offset(ui, selection.1, color);
 
             if focused {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
@@ -74,10 +74,11 @@ impl<'ast> MdRender {
 
         // title line is shown & revealed separately from block syntax as if
         // it's a child block - see also: special handling in spacing.rs
+        let first_line = self.node_first_line(node);
         self.show_alert_title_line(ui, node, top_left, node_alert);
+        self.show_block_line_prefixes(node, first_line, top_left, row_height);
         top_left.y += self.height_alert_title_line(node, node_alert);
 
-        let first_line = self.node_first_line(node);
         let any_children = node.children().next().is_some();
         if any_children {
             top_left.y += self.layout.block_spacing;
@@ -97,6 +98,7 @@ impl<'ast> MdRender {
                     );
                     let h = result.height;
                     self.show_wrap_layout(ui, top_left, &result);
+                    self.show_block_line_prefixes(node, line, top_left, row_height);
                     top_left.y += h;
                 }
             }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
@@ -3,7 +3,7 @@ use egui::{Pos2, Rect, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, Graphemes, RangeIterExt as _};
 
 use crate::tab::markdown_editor::MdRender;
-use crate::tab::markdown_editor::widget::utils::consume_indent_columns;
+use crate::tab::markdown_editor::widget::utils::consume_indent_columns_ceil;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Format;
 
 use crate::theme::palette_v2::ThemeExt as _;
@@ -80,6 +80,7 @@ impl<'ast> MdRender {
                 );
                 let h = result.height;
                 self.show_wrap_layout(ui, top_left, &result);
+                self.show_block_line_prefixes(node, line, top_left, row_height);
                 top_left.y += h;
             }
         }
@@ -121,12 +122,12 @@ impl<'ast> MdRender {
         // line in Ls is a block quote containing Bs."
         let text = &self.buffer[node_line];
 
-        // Up to 3 columns of leading whitespace before `>`. Tabs count via
-        // 4-column tab stops per CommonMark §2.2; a tab at column 0 expands
-        // to 4 columns and so cannot be leading-WS for a blockquote. Leading
-        // whitespace here is ' ' or '\t' only (both ASCII), so grapheme
-        // count equals byte count.
-        let lead = consume_indent_columns(text, 3);
+        // Up to 3 columns of leading whitespace before `>`. Ceil so a tab
+        // a parent level left straddling the boundary is claimed here
+        // rather than leaking into content (comrak already decided this is
+        // a blockquote; we just attribute the bytes). Leading whitespace is
+        // ' ' or '\t' only (both ASCII), so grapheme count equals byte count.
+        let lead = consume_indent_columns_ceil(text, 3);
         let after_lead = &text[lead..];
         if !after_lead.starts_with('>') {
             // "If a string of lines Ls constitute a block quote with contents Bs,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -5,8 +5,10 @@ use lb_rs::model::text::offset_types::{Grapheme, Graphemes, IntoRangeExt as _, R
 use crate::TextBufferArea;
 use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::bounds::RangesExt as _;
-use crate::tab::markdown_editor::widget::utils::consume_indent_columns;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{BufferExt as _, FontFamily};
+use crate::tab::markdown_editor::widget::utils::{
+    consume_indent_columns, consume_indent_columns_ceil,
+};
 
 use crate::theme::palette_v2::ThemeExt as _;
 
@@ -120,6 +122,12 @@ impl<'ast> MdRender {
                 self.text_format_syntax(),
             );
             self.show_wrap_layout(ui, top_left + self.layout.indent * Vec2::X, &result);
+            self.show_block_line_prefixes(
+                node,
+                line,
+                top_left + self.layout.indent * Vec2::X,
+                row_height,
+            );
             let item_rect =
                 Rect::from_min_size(top_left, Vec2::new(self.width(node), result.height));
             item_rect.contains(ui.input(|i| i.pointer.latest_pos().unwrap_or_default()))
@@ -165,16 +173,11 @@ impl<'ast> MdRender {
             let first_line = self.node_first_line(node);
             let first_node_line = self.node_line(node, first_line);
 
+            // 1-3 columns of relative indent before the marker. Ceil so a
+            // tab a parent level left straddling the boundary is claimed as
+            // this item's indent rather than leaking into content.
             let text = &self.buffer[first_node_line];
-            if text.starts_with("   ") {
-                "   ".len()
-            } else if text.starts_with("  ") {
-                "  ".len()
-            } else if text.starts_with(" ") {
-                " ".len()
-            } else {
-                0
-            }
+            consume_indent_columns_ceil(text, 3)
         };
         let NodeList { padding: marker_width_including_spaces, .. } = *node_list;
         if line == self.node_first_line(node) {
@@ -227,9 +230,24 @@ impl<'ast> MdRender {
                 // Indented code block line — leave stripping to
                 // `code_block.rs`.
             } else {
-                // Paragraph (or other non-code) continuation — strip
-                // all leading whitespace.
-                result += consume_indent_columns(text, usize::MAX);
+                // Per-level continuation indent. `has_deeper` tests raw
+                // sourcepos, not `node_range`/`node_line`, which recurse
+                // back into the `line_prefix_len` being computed here.
+                let has_deeper = node.descendants().skip(1).any(|d| {
+                    self.is_gutter_level(d) && {
+                        let sp = d.data.borrow().sourcepos;
+                        sp.start.line <= line_1_based && line_1_based <= sp.end.line
+                    }
+                });
+                if has_deeper {
+                    // Claim only this level's columns (ceil keeps a
+                    // straddling tab); the deeper level takes the rest.
+                    result += consume_indent_columns_ceil(text, marker_width_including_spaces);
+                } else {
+                    // Deepest gutter item — take the rest so content
+                    // isn't over-indented.
+                    result += consume_indent_columns(text, usize::MAX);
+                }
             }
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -4,13 +4,17 @@
 //! (`deindent_level_cols` + helpers in [`super::super::utils`]).
 
 use comrak::nodes::{AstNode, NodeValue};
-use egui::{Pos2, Ui};
+use egui::{Pos2, Rect, Ui};
 use lb_rs::model::text::offset_types::{
     Grapheme, Graphemes, IntoRangeExt, RangeExt as _, RangeIterExt as _,
 };
 
 use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::bounds::RangesExt as _;
+use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
+use crate::tab::markdown_editor::widget::utils::wrap_layout::{
+    Fragment, FragmentContent, FragmentInset,
+};
 
 pub(crate) mod alert;
 pub(crate) mod block_quote;
@@ -23,65 +27,6 @@ pub(crate) mod table_row;
 pub(crate) mod task_item;
 
 impl<'ast> MdRender {
-    pub fn indent(&self, node: &'ast AstNode<'ast>) -> f32 {
-        let value = &node.data.borrow().value;
-        let sp = &node.data.borrow().sourcepos;
-        match value {
-            NodeValue::FrontMatter(_) => 0.,
-            NodeValue::Raw(_) => unreachable!("can only be created programmatically"),
-
-            // container_block
-            NodeValue::Alert(_) => self.layout.indent,
-            NodeValue::BlockQuote => self.layout.indent,
-            NodeValue::DescriptionItem(_) => unimplemented!("extension disabled"),
-            NodeValue::DescriptionList => unimplemented!("extension disabled"),
-            NodeValue::Document => 0.,
-            NodeValue::FootnoteDefinition(_) => self.layout.indent,
-            NodeValue::Item(_) => self.layout.indent,
-            NodeValue::List(_) => 0., // indentation handled by items
-            NodeValue::MultilineBlockQuote(_) => unimplemented!("extension disabled"),
-            NodeValue::Table(_) => 0.,
-            NodeValue::TableRow(_) => 0.,
-            NodeValue::TaskItem(_) => self.layout.indent,
-
-            // inline
-            NodeValue::Image(_)
-            | NodeValue::Code(_)
-            | NodeValue::Emph
-            | NodeValue::Escaped
-            | NodeValue::EscapedTag(_)
-            | NodeValue::FootnoteReference(_)
-            | NodeValue::Highlight
-            | NodeValue::HtmlInline(_)
-            | NodeValue::LineBreak
-            | NodeValue::Link(_)
-            | NodeValue::Math(_)
-            | NodeValue::ShortCode(_)
-            | NodeValue::SoftBreak
-            | NodeValue::SpoileredText
-            | NodeValue::Strikethrough
-            | NodeValue::Strong
-            | NodeValue::Subscript
-            | NodeValue::Subtext
-            | NodeValue::Superscript
-            | NodeValue::Text(_)
-            | NodeValue::Underline
-            | NodeValue::WikiLink(_) => unreachable!("not a container block: {} {:?}", sp, value),
-
-            // leaf_block
-            NodeValue::CodeBlock(_)
-            | NodeValue::DescriptionDetails
-            | NodeValue::DescriptionTerm
-            | NodeValue::Heading(_)
-            | NodeValue::HtmlBlock(_)
-            | NodeValue::Paragraph
-            | NodeValue::TableCell
-            | NodeValue::ThematicBreak => {
-                unimplemented!("not a container block: {} {:?}", sp, value)
-            }
-        }
-    }
-
     // the height of a block that contains blocks is the sum of the heights of the blocks it contains
     pub fn block_children_height(&self, node: &'ast AstNode<'ast>) -> f32 {
         let mut height_sum = 0.0;
@@ -601,21 +546,212 @@ impl<'ast> MdRender {
         Some(result)
     }
 
-    /// returns true if the syntax for a container block should be revealed
-    pub fn reveal(&self, node: &'ast AstNode<'ast>) -> bool {
-        for line in self.node_lines(node).iter() {
-            let line = self.bounds.source_lines[line];
+    /// Whether `node` contributes an indent-width gutter column —
+    /// these are the containers a drag selects an indentation unit of.
+    /// `List`/`Table`/`TableRow`/`Document` nest without shifting, so
+    /// they own no column.
+    pub fn is_gutter_level(&self, node: &'ast AstNode<'ast>) -> bool {
+        matches!(
+            node.data.borrow().value,
+            NodeValue::Item(_)
+                | NodeValue::TaskItem(_)
+                | NodeValue::BlockQuote
+                | NodeValue::Alert(_)
+                | NodeValue::FootnoteDefinition(_)
+        )
+    }
 
-            let line_prefix = self.line_prefix(node, line);
-            if line_prefix.is_empty() {
+    /// The nearest gutter-contributing ancestor of `node` (excluding
+    /// `node` itself), i.e. the level whose column sits one to the left.
+    fn gutter_parent(&self, node: &'ast AstNode<'ast>) -> Option<&'ast AstNode<'ast>> {
+        node.ancestors().skip(1).find(|n| self.is_gutter_level(n))
+    }
+
+    /// The innermost gutter level on `line` (the deepest column), or
+    /// `None` if the line has no gutter. This is the level whose
+    /// `line_own_prefix` absorbs any indentation past the levels' own
+    /// columns (a straddling tab's residual, over-indentation) so the
+    /// columns tile the prefix.
+    pub fn deepest_gutter_level(
+        &self, node: &'ast AstNode<'ast>, line: (Grapheme, Grapheme),
+    ) -> Option<&'ast AstNode<'ast>> {
+        let root = node.ancestors().last()?;
+        let deepest = self.deepest_container_block_at_offset(root, line.end());
+        deepest.ancestors().find(|n| self.is_gutter_level(n))
+    }
+
+    /// Fills `map[line_idx]` with the deepest gutter container covering
+    /// each source line, via a single pre-order DFS: a deeper container is
+    /// visited after its ancestor, so it overwrites the ancestor on any
+    /// line they share (compact nesting).
+    fn assign_deepest_gutter(
+        &self, node: &'ast AstNode<'ast>, map: &mut [Option<&'ast AstNode<'ast>>],
+    ) {
+        for child in node.children() {
+            if !child.is_container_block() {
                 continue;
             }
+            if self.is_gutter_level(child) {
+                for i in self.node_lines(child).iter() {
+                    if let Some(slot) = map.get_mut(i) {
+                        *slot = Some(child);
+                    }
+                }
+            }
+            self.assign_deepest_gutter(child, map);
+        }
+    }
 
-            if self.range_contains_reveal_endpoint(line_prefix, true, false) {
-                return true;
+    /// returns true if the syntax for a container block should be revealed
+    ///
+    /// Reveal `node` when a reveal-range endpoint lands strictly inside a
+    /// gutter column `node` *owns the source for*. Columns render as
+    /// atomic fragments, so a drag snaps to their edges and never reaches
+    /// an interior — only keyboard navigation or edits do, so a
+    /// click-drag never reveals syntax.
+    ///
+    /// An endpoint can only reveal the column it sits in, so the scan is
+    /// over the (typically 0–2) reveal endpoints, one line each.
+    pub fn reveal(&self, node: &'ast AstNode<'ast>) -> bool {
+        for reveal_range in self.reveal_ranges() {
+            for endpoint in [reveal_range.start(), reveal_range.end()] {
+                let (line_idx, _) = self
+                    .bounds
+                    .source_lines
+                    .find_containing(endpoint, true, true);
+                let Some(&line) = self.bounds.source_lines.get(line_idx) else {
+                    continue;
+                };
+                if !self.node_contains_line(node, line) {
+                    continue;
+                }
+                // `node` owns exactly its own column (its per-level
+                // `line_own_prefix`); reveal when an endpoint is strictly
+                // inside it.
+                let own = self.line_own_prefix(node, line);
+                if !own.is_empty() && own.contains(endpoint, false, false) {
+                    return true;
+                }
             }
         }
         false
+    }
+
+    /// Registers an atomic, selectable [`Fragment`] for each gutter
+    /// column (marker / per-level indentation) on `line`, laid out in
+    /// the indent-width columns left of `content_top_left` (the content
+    /// origin, after every prefix shift).
+    ///
+    /// Each column's [`line_own_prefix`] becomes one `Spacer`: a drag
+    /// lands only at its edges (so a click-drag never reveals syntax —
+    /// see [`reveal`]) and a selection highlights the whole column. The
+    /// columns are non-atomic, so a single click places the cursor at the
+    /// nearer edge rather than selecting the column; drag or double-click
+    /// selects it. Marker glyphs are still painted by the per-container
+    /// `show_*`; these fragments carry none and exist only for
+    /// hit-testing and selection highlighting.
+    ///
+    /// Called from the non-revealed block-line renderers, including the
+    /// pre/post spacing renderers whose blank lines can still carry a
+    /// container's indentation. A revealed container renders its prefix
+    /// as ordinary source text instead, so this is not called for it.
+    ///
+    /// Resolves the line's columns from its [`deepest_gutter_level`], not
+    /// `node`'s ancestors: a spacing line sits in a shallower node than
+    /// the content it spaces, so walking up from `node` would miss the
+    /// deeper columns. For content lines `node` is already on the line, so
+    /// the two agree.
+    pub fn show_block_line_prefixes(
+        &mut self, node: &'ast AstNode<'ast>, line: (Grapheme, Grapheme), content_top_left: Pos2,
+        row_height: f32,
+    ) {
+        let Some(deepest) = self.deepest_gutter_level(node, line) else {
+            return;
+        };
+        let indent = self.layout.indent;
+        let mut levels: Vec<_> = deepest
+            .ancestors()
+            .filter(|n| self.is_gutter_level(n))
+            .collect();
+        levels.reverse();
+        let base_x = content_top_left.x - indent * levels.len() as f32;
+        for (k, level) in levels.iter().enumerate() {
+            let range = self.line_own_prefix(level, line);
+            if range.is_empty() {
+                continue;
+            }
+            let left = base_x + indent * k as f32;
+            let rect = Rect::from_min_max(
+                Pos2::new(left, content_top_left.y),
+                Pos2::new(left + indent, content_top_left.y + row_height),
+            );
+            self.fragments.push(Fragment {
+                rect,
+                content_inset: FragmentInset::default(),
+                source_range: range,
+                style_stack: Vec::new(),
+                content: FragmentContent::Spacer,
+                // Non-atomic: a click places the cursor at the nearer
+                // edge. A drag still selects the whole column (an empty-
+                // glyph `Spacer` midpoint-snaps to an edge either way, so
+                // a drag never lands interior — see [`reveal`]); a double-
+                // click selects it via `bounds.words`.
+                atomic: false,
+                interaction: None,
+            });
+        }
+    }
+
+    /// Makes each gutter column (marker / per-level indentation) a word
+    /// for word navigation and double-click. Replaces the default
+    /// unicode-segmented words inside each line's prefix region — which
+    /// would split a marker like `* ` into `*` + ` ` and drop
+    /// indentation — with the per-level [`line_own_prefix`] columns. Call after
+    /// `calc_words`, with the parsed `root`.
+    pub fn calc_syntax_words(&mut self, root: &'ast AstNode<'ast>) {
+        let n = self.bounds.source_lines.len();
+        if n == 0 {
+            return;
+        }
+        // One DFS resolves every line's deepest gutter container; a
+        // per-line `deepest_container_block_at_offset` lookup would be
+        // quadratic, and this runs every reparse.
+        let mut deepest_by_line: Vec<Option<&'ast AstNode<'ast>>> = vec![None; n];
+        self.assign_deepest_gutter(root, &mut deepest_by_line);
+
+        let mut prefix_regions: Vec<(Grapheme, Grapheme)> = Vec::new();
+        let mut columns: Vec<(Grapheme, Grapheme)> = Vec::new();
+        for (line_idx, &deepest) in deepest_by_line.iter().enumerate() {
+            let Some(deepest) = deepest else {
+                continue;
+            };
+            let line = self.bounds.source_lines[line_idx];
+            let (prefix_len, _) = self.line_prefix_len(deepest, line);
+            if prefix_len.0 == 0 {
+                continue;
+            }
+            prefix_regions.push((line.start(), line.start() + prefix_len));
+            let mut level = Some(deepest);
+            while let Some(node) = level {
+                let range = self.line_own_prefix(node, line);
+                if !range.is_empty() {
+                    columns.push(range);
+                }
+                level = self.gutter_parent(node);
+            }
+        }
+        if columns.is_empty() {
+            return;
+        }
+        // Drop unicode words that fell in a prefix region; the columns
+        // replace them. Both sets are non-overlapping and the regions are
+        // disjoint from content, so the merged list stays sorted and
+        // non-overlapping as `range_bound` requires.
+        self.bounds
+            .words
+            .retain(|w| !prefix_regions.iter().any(|p| w.intersects(p, false)));
+        self.bounds.words.extend(columns);
+        self.bounds.words.sort();
     }
 
     /// Returns whether the given line is one of the source lines of the given node

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -2,7 +2,7 @@ use comrak::nodes::{AstNode, NodeTaskItem, NodeValue};
 use egui::{CursorIcon, Pos2, Rect, Sense, Shape, Stroke, StrokeKind, Ui, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, Graphemes, RangeExt as _};
 
-use crate::tab::markdown_editor::widget::utils::consume_indent_columns;
+use crate::tab::markdown_editor::widget::utils::consume_indent_columns_ceil;
 use crate::tab::markdown_editor::{Event, MdRender};
 use crate::theme::palette_v2::ThemeExt;
 
@@ -124,6 +124,12 @@ impl<'ast> MdRender {
                 self.text_format_document(),
             );
             self.show_wrap_layout(ui, top_left + self.layout.indent * Vec2::X, &result);
+            self.show_block_line_prefixes(
+                node,
+                line,
+                top_left + self.layout.indent * Vec2::X,
+                row_height,
+            );
             false
         };
 
@@ -167,16 +173,10 @@ impl<'ast> MdRender {
             let first_line = self.node_first_line(node);
             let node_line = self.node_line(node, first_line);
 
+            // 1-3 columns of relative indent before the marker; ceil so a
+            // straddling tab is claimed rather than leaking into content.
             let text = &self.buffer[(node_line.start(), node_line.end())];
-            if text.starts_with("   ") {
-                "   ".len()
-            } else if text.starts_with("  ") {
-                "  ".len()
-            } else if text.starts_with(" ") {
-                " ".len()
-            } else {
-                0
-            }
+            consume_indent_columns_ceil(text, 3)
         };
         let marker_width_including_spaces: usize = {
             // task items don't have a NodeList so we have to do this ourselves
@@ -239,7 +239,9 @@ impl<'ast> MdRender {
                 _ => marker_width_including_spaces, // fallback, shouldn't happen
             };
             let text = &self.buffer[node_line];
-            result += consume_indent_columns(text, indentation + parent_padding);
+            // Ceil so a straddling tab is claimed here rather than leaking
+            // into a nested block's prefix (per-level tab attribution).
+            result += consume_indent_columns_ceil(text, indentation + parent_padding);
         }
 
         Some(result)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
@@ -151,6 +151,9 @@ impl<'ast> MdRender {
         );
 
         width -= 2. * self.layout.block_padding;
+        // Container gutter columns sit at the code block's outer left (the
+        // deepest container's content origin), not inside the padded box.
+        let content_left = top_left.x;
         top_left.x += self.layout.block_padding;
         top_left.y += self.layout.block_padding;
         top_left.y -= self.layout.row_spacing; // makes spacing logic simpler
@@ -178,11 +181,23 @@ impl<'ast> MdRender {
                     );
                     let h = fence_layout.height;
                     self.show_wrap_layout(ui, top_left, &fence_layout);
+                    self.show_block_line_prefixes(
+                        node,
+                        line,
+                        Pos2::new(content_left, top_left.y),
+                        row_height,
+                    );
                     top_left.y += h;
                 }
             } else {
                 top_left.y += self.layout.row_spacing;
                 self.show_code_block_line(ui, node, top_left, node_code_block, line, false);
+                self.show_block_line_prefixes(
+                    node,
+                    line,
+                    Pos2::new(content_left, top_left.y),
+                    row_height,
+                );
                 top_left.y += self.height_code_block_line(node, node_code_block, line, false);
             }
         }
@@ -203,7 +218,14 @@ impl<'ast> MdRender {
             return true; // only opening + closing fence: always reveal
         }
 
-        self.node_lines_intersect_selection(node) // selection-based reveal
+        // Reveal when a reveal range touches any of the block's source
+        // lines, *including* a container prefix (`> `): a cursor on the
+        // prefix of an otherwise-collapsed fence line would otherwise have
+        // no fragment, since the fence line isn't rendered.
+        self.node_lines(node).iter().any(|line_idx| {
+            let line = self.bounds.source_lines[line_idx];
+            self.range_revealed(line, true)
+        })
     }
 
     pub fn height_indented_code_block(
@@ -260,6 +282,9 @@ impl<'ast> MdRender {
             egui::epaint::StrokeKind::Inside,
         );
 
+        // Container gutter columns sit at the code block's outer left (the
+        // deepest container's content origin), not inside the padded box.
+        let content_left = top_left.x;
         top_left.x += self.layout.block_padding;
         top_left.y += self.layout.block_padding;
 
@@ -279,9 +304,21 @@ impl<'ast> MdRender {
                 );
                 let h = l.height;
                 self.show_wrap_layout(ui, top_left, &l);
+                self.show_block_line_prefixes(
+                    node,
+                    line,
+                    Pos2::new(content_left, top_left.y),
+                    row_height,
+                );
                 top_left.y += h;
             } else {
                 self.show_code_block_line(ui, node, top_left, node_code_block, line, synthetic);
+                self.show_block_line_prefixes(
+                    node,
+                    line,
+                    Pos2::new(content_left, top_left.y),
+                    row_height,
+                );
                 top_left.y += self.height_code_block_line(node, node_code_block, line, synthetic);
             }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -237,6 +237,7 @@ impl<'ast> MdRender {
                 let result = self.compute_layout_from(layout, width, row_height);
                 let h = result.height;
                 self.show_wrap_layout(ui, top_left, &result);
+                self.show_block_line_prefixes(node, line, top_left, row_height);
                 top_left.y += h;
                 top_left.y += self.layout.row_spacing;
             } else if reveal {
@@ -275,6 +276,7 @@ impl<'ast> MdRender {
         let result = self.compute_layout_from(layout, width, row_height);
         let height = result.height;
         self.show_wrap_layout(ui, top_left, &result);
+        self.show_block_line_prefixes(node, line, top_left, row_height);
 
         top_left.y += height;
         if level <= 2 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
@@ -97,6 +97,7 @@ impl<'ast> MdRender {
             let line_height = self.height_paragraph_line(node, node_line);
 
             self.show_paragraph_line(ui, node, top_left, node_line);
+            self.show_block_line_prefixes(node, line, top_left, self.layout.row_height);
             top_left.y += line_height;
 
             top_left.y += self.layout.block_spacing;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/thematic_break.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/thematic_break.rs
@@ -14,10 +14,16 @@ impl<'ast> MdRender {
 
     pub fn show_thematic_break(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2) {
         let width = self.width(node);
-        let node_line = self.node_line(node, self.node_first_line(node));
+        let line = self.node_first_line(node);
+        let node_line = self.node_line(node, line);
         let row_height = self.layout.row_height;
 
-        if self.node_revealed(node) {
+        // Reveal on the node's *line* range, not `node_range`: comrak
+        // reports a thematic break's sourcepos as a single column, so
+        // inside a container the cursor on a later `*`/`-` wouldn't
+        // intersect it and the row's interior offsets would have no
+        // fragment.
+        if self.range_revealed(node_line, true) {
             let result = self.compute_section_layout_new(
                 node_line,
                 width,
@@ -25,6 +31,7 @@ impl<'ast> MdRender {
                 self.text_format_syntax(),
             );
             self.show_wrap_layout(ui, top_left, &result);
+            self.show_block_line_prefixes(node, line, top_left, row_height);
         } else {
             // Painted as a horizontal rule, with zero-visible anchors
             // at each endpoint so cursor placement at the row's edges
@@ -45,6 +52,7 @@ impl<'ast> MdRender {
             layout.push_override(node_line.end().into_range(), "", self.text_format_syntax());
             let result = self.compute_layout_from(layout, width, row_height);
             self.show_wrap_layout(ui, top_left, &result);
+            self.show_block_line_prefixes(node, line, top_left, row_height);
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -25,7 +25,10 @@ impl<'ast> MdRender {
     pub fn width(&self, node: &'ast AstNode<'ast>) -> f32 {
         let parent = || node.parent().unwrap();
         let parent_width = || self.width(parent());
-        let parent_indent = || self.indent(parent());
+        // A container shifts its content by one indent unit iff it paints
+        // a gutter column.
+        let parent_indent =
+            || if self.is_gutter_level(parent()) { self.layout.indent } else { 0.0 };
         // Clamp at 0: deeply nested containers at narrow doc widths
         // can drive `parent_width - parent_indent` negative; `show_block`
         // / `height` bail separately when width is genuinely too small.

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
@@ -147,6 +147,7 @@ impl<'ast> MdRender {
             );
             let h = result.height;
             self.show_wrap_layout(ui, top_left, &result);
+            self.show_block_line_prefixes(node, line, top_left, row_height);
             top_left.y += h;
             top_left.y += self.layout.block_spacing;
         }
@@ -201,6 +202,7 @@ impl<'ast> MdRender {
             );
             let h = result.height;
             self.show_wrap_layout(ui, top_left, &result);
+            self.show_block_line_prefixes(node, line, top_left, row_height);
             top_left.y += h;
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/code.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/code.rs
@@ -10,7 +10,13 @@ impl<'ast> MdRender {
         let theme = self.ctx.get_lb_theme();
         Format {
             color: theme.fg().get_color(theme.prefs().primary),
-            background: theme.neutral_bg_secondary(),
+            // Translucent fill that matches the opaque look over the page
+            // but lets a selection behind it show through.
+            background: crate::theme::palette_v2::translucent_over(
+                theme.neutral_bg_secondary(),
+                theme.neutral_bg(),
+                0.5,
+            ),
             border: theme.neutral_bg_tertiary(),
             bold: false, // SF Mono does not have bold variants for numbers (it does have italic)
             ..self.text_format_code_block(parent)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/mod.rs
@@ -53,6 +53,37 @@ pub fn consume_indent_columns(text: &str, target_columns: usize) -> usize {
     graphemes
 }
 
+/// Like [`consume_indent_columns`] but a tab straddling `target_columns`
+/// is claimed *whole* rather than refused. Used to split a continuation
+/// indent run per nesting level: the indentation must be fully
+/// attributed, so a tab that overshoots a level's band goes to the level
+/// whose band it starts in (the next level then finds its band already
+/// consumed and claims nothing). With spaces it's identical to
+/// [`consume_indent_columns`].
+pub fn consume_indent_columns_ceil(text: &str, target_columns: usize) -> usize {
+    let mut cols = 0;
+    let mut graphemes = 0;
+    for c in text.chars() {
+        if cols >= target_columns {
+            break;
+        }
+        match c {
+            ' ' => {
+                cols += 1;
+                graphemes += 1;
+            }
+            // Still under target, so claim the whole tab even though it
+            // overshoots — it can't be split across the boundary.
+            '\t' => {
+                cols = (cols / 4 + 1) * 4;
+                graphemes += 1;
+            }
+            _ => break,
+        }
+    }
+    graphemes
+}
+
 /// Grapheme range of the leading ` ` / `\t` run. Lexical, not
 /// structural — see [`consume_indent_columns`] for why ownership
 /// is ambiguous.

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1869,6 +1869,8 @@ impl MdRender {
     /// non-atomic, sum cluster advances from `source_range.start`.
     pub fn fragment_x(&self, fragment: &Fragment, offset: Grapheme) -> f32 {
         if fragment.atomic {
+            // Absolute midpoint offset of the range; offsets in the first
+            // half snap to the left edge, the rest to the right edge.
             let mid = fragment.source_range.start().0
                 + (fragment
                     .source_range
@@ -1876,7 +1878,7 @@ impl MdRender {
                     .0
                     .saturating_sub(fragment.source_range.start().0))
                     / 2;
-            if offset.0 < mid + fragment.source_range.start().0 {
+            if offset.0 < mid {
                 fragment.rect.min.x + fragment.content_inset.left
             } else {
                 fragment.rect.max.x - fragment.content_inset.right

--- a/libs/content/workspace/src/theme/palette_v2.rs
+++ b/libs/content/workspace/src/theme/palette_v2.rs
@@ -166,6 +166,29 @@ impl Theme {
     }
 }
 
+/// Returns the color that, painted at opacity `alpha` over `background`,
+/// composites to `target` (`target = alpha·x + (1−alpha)·background`,
+/// solved for `x`). Painting the result over a *different* background lets
+/// that background show through while keeping the `target` look over
+/// `background` — e.g. a code pill that matches its opaque appearance over
+/// the page yet lets a selection behind it bleed through. Solved in egui's
+/// gamma (sRGB-byte) blend space; channels clamp to `[0, 255]`, so an
+/// `alpha` too low to reach `target` degrades gracefully.
+pub fn translucent_over(target: Color32, background: Color32, alpha: f32) -> Color32 {
+    let a = alpha.clamp(f32::EPSILON, 1.0);
+    let solve = |t: u8, b: u8| {
+        (((t as f32) - (1.0 - a) * (b as f32)) / a)
+            .round()
+            .clamp(0.0, 255.0) as u8
+    };
+    Color32::from_rgba_unmultiplied(
+        solve(target.r(), background.r()),
+        solve(target.g(), background.g()),
+        solve(target.b(), background.b()),
+        (a * 255.0).round() as u8,
+    )
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Mode {
     #[default]
@@ -494,4 +517,38 @@ pub fn username_color(name: &str) -> Palette {
         .bytes()
         .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
     COLORS[hash as usize % COLORS.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Composite `src` over `dst` the way egui blends premultiplied colors
+    /// in gamma space: `out = src_premul + (1 − src_a)·dst`.
+    fn over(src: Color32, dst: Color32) -> [u8; 3] {
+        let sa = src.a() as f32 / 255.0;
+        let f = |s: u8, d: u8| (s as f32 + (1.0 - sa) * d as f32).round() as u8;
+        [f(src.r(), dst.r()), f(src.g(), dst.g()), f(src.b(), dst.b())]
+    }
+
+    /// `translucent_over` must reproduce `target` when composited back over
+    /// `background` — verified for the actual code-pill colors in both
+    /// themes so clamping never silently shifts the unselected look.
+    #[test]
+    fn translucent_over_round_trips_code_pill() {
+        for (label, mode) in [("light", Mode::Light), ("dark", Mode::Dark)] {
+            let theme = Theme::default(mode);
+            let target = theme.neutral_bg_secondary();
+            let bg = theme.neutral_bg();
+            let x = translucent_over(target, bg, 0.5);
+            let got = over(x, bg);
+            for (g, t) in got.iter().zip([target.r(), target.g(), target.b()]) {
+                assert!(
+                    (*g as i32 - t as i32).abs() <= 2,
+                    "{label}: composite {got:?} != target {:?}",
+                    [target.r(), target.g(), target.b()]
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Each column of block annotation/indentation is a selectable unit
* Drag-selecting never reveals block syntax
* Selection highlights paint behind block annotations

https://github.com/user-attachments/assets/cd4ae30f-f0e7-4ab5-89c9-b4c839d41d05

fixes #4362 