### PR TITLE
md: reveal syntax only for container blocks

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -871,76 +871,130 @@ fn drag_across_marker_selects_it() {
     assert!(widest > marker.width() * 0.5, "marker highlight too narrow: {widest}");
 }
 
-/// Reveal flipping must invalidate cached container heights:
-/// `height()`'s reveal=true (source-lines) and reveal=false (formatted)
-/// branches can disagree by tens of px, so a stale cache leaves the
-/// next sibling at the wrong y.
-///
-/// Sequence is crafted so the in-flight invalidation between frames 2
-/// and 3 doesn't touch the block quote (the selection delta misses
-/// its range), forcing the stale cache through into frame 3.
+/// Revealing a container's prefix swaps its gutter decoration for the raw
+/// marker in the same column; the content stays formatted. So the block's
+/// height — and the y of everything below it — must be identical revealed
+/// or not. A heading inside the quote makes any height regression large
+/// and obvious, and would also expose a stale cached height across the
+/// reveal flip.
 #[test]
 fn reveal_change_layout_consistent() {
     let doc = "> # heading inside block quote\n\nfollowing paragraph.\n";
     let mut ws = TestEditor::new(doc);
 
     let following = doc.find("following").unwrap();
-    ws.push(Event::Select {
-        region: Region::BetweenLocations {
-            start: Location::Grapheme(Grapheme(following)),
-            end: Location::Grapheme(Grapheme(following)),
-        },
-    });
+
+    // (heading content top y, trailing paragraph top y) with the cursor at
+    // `cursor`. Source offset 4 starts the heading text (after `> # `) and 32
+    // starts "following paragraph"; both render the same whether or not the
+    // `>` prefix is revealed, so both y's must be reveal-invariant.
+    let layout = |ws: &mut TestEditor, cursor: usize| -> (f32, f32) {
+        ws.push(Event::Select {
+            region: Region::BetweenLocations {
+                start: Location::Grapheme(Grapheme(cursor)),
+                end: Location::Grapheme(Grapheme(cursor)),
+            },
+        });
+        ws.enter_frame();
+        let fragments = &ws.editor.edit.renderer.fragments;
+        let top_of = |offset: usize| {
+            fragments
+                .iter()
+                .find(|f| f.source_range.0.0 == offset)
+                .unwrap_or_else(|| panic!("no fragment starting at offset {offset}"))
+                .rect
+                .min
+                .y
+        };
+        (top_of(4), top_of(32))
+    };
+
+    // Cursor outside the quote reveals nothing. Offset 1 sits strictly
+    // inside the `> ` marker (between `>` and the space) — the interior
+    // position that reveals the blockquote syntax.
+    let (heading_plain, following_plain) = layout(&mut ws, following);
+    let (heading_revealed, following_revealed) = layout(&mut ws, 1);
+
+    assert!(
+        (heading_revealed - heading_plain).abs() < 0.5,
+        "revealing the prefix moved the heading: {heading_plain:.1} -> {heading_revealed:.1}"
+    );
+    assert!(
+        (following_revealed - following_plain).abs() < 0.5,
+        "revealing the prefix moved the trailing paragraph: \
+         {following_plain:.1} -> {following_revealed:.1}"
+    );
+}
+
+/// A revealed marker is right-aligned to its column's content edge by the
+/// laid-out marker width. Using the layout's available width (≫ the marker)
+/// instead pushes it far off the left edge, so the marker vanishes even
+/// though its fragments still exist. Asserts the marker renders on-screen,
+/// just left of the content.
+#[test]
+fn revealed_marker_on_screen() {
+    let mut ws = TestEditor::new("12. item\n");
     ws.enter_frame();
 
+    // Offset 2 sits strictly inside the `12. ` marker, revealing it.
     ws.push(Event::Select {
         region: Region::BetweenLocations {
-            start: Location::Grapheme(Grapheme(following + 1)),
-            end: Location::Grapheme(Grapheme(following + 1)),
-        },
-    });
-    ws.enter_frame();
-
-    // Offset 1 sits strictly inside the blockquote's `> ` marker (between
-    // `>` and the space) — the interior position that reveals the syntax.
-    // Offset 0 is the marker's left edge, which (being drag-accessible)
-    // stays captured under the current reveal rule.
-    ws.push(Event::Select {
-        region: Region::BetweenLocations {
-            start: Location::Grapheme(Grapheme(1)),
-            end: Location::Grapheme(Grapheme(1)),
+            start: Location::Grapheme(Grapheme(2)),
+            end: Location::Grapheme(Grapheme(2)),
         },
     });
     ws.enter_frame();
 
     let fragments = &ws.editor.edit.renderer.fragments;
-    let bq_frag = fragments
+    let marker = fragments
         .iter()
         .find(|f| f.source_range.0.0 == 0)
-        .expect("blockquote source-line fragment");
-    let following_frag = fragments
+        .expect("revealed marker fragment");
+    let content = fragments
         .iter()
-        .find(|f| f.source_range.0.0 == 32)
-        .expect("trailing paragraph fragment");
-    let gap = following_frag.rect.min.y - bq_frag.rect.max.y;
-    // Empirically ~28 px when cache is fresh; ~62 when stale.
-    const MAX_GAP: f32 = 45.0;
+        .find(|f| f.source_range.0.0 == 4)
+        .expect("content fragment");
+
+    assert!(marker.rect.left() >= 0.0, "marker off the left edge: left={}", marker.rect.left());
     assert!(
-        gap <= MAX_GAP,
-        "trailing paragraph too far below blockquote: gap={gap:.1} px (max {MAX_GAP})\n\
-         blockquote rect={:?} trailing rect={:?}\n\
-         all fragments:\n{}",
-        bq_frag.rect,
-        following_frag.rect,
-        fragments
-            .iter()
-            .enumerate()
-            .map(|(k, f)| format!(
-                "  [{k}] range={}..{} y=[{:.1}..{:.1}]",
-                f.source_range.0.0, f.source_range.1.0, f.rect.min.y, f.rect.max.y,
-            ))
-            .collect::<Vec<_>>()
-            .join("\n"),
+        marker.rect.right() <= content.rect.left() + 0.5,
+        "marker overlaps content: marker right={} content left={}",
+        marker.rect.right(),
+        content.rect.left(),
+    );
+}
+
+/// A cursor in a container's leading indentation must not reveal its
+/// marker — only a cursor in the marker itself reveals. Here the inner
+/// item's line begins with the outer item's continuation indentation; a
+/// cursor there must not reveal the outer marker (on the line above).
+#[test]
+fn indentation_cursor_does_not_reveal_marker() {
+    let mut ws = TestEditor::new("- a\n  - b\n");
+    ws.enter_frame();
+
+    // Offset 5 is interior to the two-space indentation on line 2 (the
+    // outer item's continuation prefix), not any marker.
+    ws.push(Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(Grapheme(5)),
+            end: Location::Grapheme(Grapheme(5)),
+        },
+    });
+    ws.enter_frame();
+
+    // The outer marker (offset 0) stays a decoration spacer, not raw glyphs.
+    let marker = ws
+        .editor
+        .edit
+        .renderer
+        .fragments
+        .iter()
+        .find(|f| f.source_range.0.0 == 0)
+        .expect("outer marker fragment");
+    assert!(
+        matches!(marker.content, FragmentContent::Spacer),
+        "cursor in indentation revealed the marker"
     );
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/alert.rs
@@ -62,11 +62,14 @@ impl<'ast> MdRender {
         let annotation_size = Vec2 { x: self.layout.indent, y: height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 
-        ui.painter().vline(
-            annotation_space.center().x,
-            annotation_space.y_range(),
-            Stroke::new(3., self.text_format(node).color),
-        );
+        // when revealed, the raw `>` prefix occupies this column instead
+        if !self.reveal(node) {
+            ui.painter().vline(
+                annotation_space.center().x,
+                annotation_space.y_range(),
+                Stroke::new(3., self.text_format(node).color),
+            );
+        }
 
         top_left.x += self.layout.indent;
         let width = self.width(node) - self.layout.indent;
@@ -76,7 +79,7 @@ impl<'ast> MdRender {
         // it's a child block - see also: special handling in spacing.rs
         let first_line = self.node_first_line(node);
         self.show_alert_title_line(ui, node, top_left, node_alert);
-        self.show_block_line_prefixes(node, first_line, top_left, row_height);
+        self.show_block_line_prefixes(ui, node, first_line, top_left, row_height);
         top_left.y += self.height_alert_title_line(node, node_alert);
 
         let any_children = node.children().next().is_some();
@@ -98,7 +101,7 @@ impl<'ast> MdRender {
                     );
                     let h = result.height;
                     self.show_wrap_layout(ui, top_left, &result);
-                    self.show_block_line_prefixes(node, line, top_left, row_height);
+                    self.show_block_line_prefixes(ui, node, line, top_left, row_height);
                     top_left.y += h;
                 }
             }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/block_quote.rs
@@ -49,11 +49,14 @@ impl<'ast> MdRender {
         let annotation_size = Vec2 { x: self.layout.indent, y: height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 
-        ui.painter().vline(
-            annotation_space.center().x,
-            annotation_space.y_range(),
-            Stroke::new(3., self.ctx.get_lb_theme().neutral_bg_tertiary()),
-        );
+        // when revealed, the raw `>` prefix occupies this column instead
+        if !self.reveal(node) {
+            ui.painter().vline(
+                annotation_space.center().x,
+                annotation_space.y_range(),
+                Stroke::new(3., self.ctx.get_lb_theme().neutral_bg_tertiary()),
+            );
+        }
 
         top_left.x += annotation_space.width();
         let width = self.width(node);
@@ -80,7 +83,7 @@ impl<'ast> MdRender {
                 );
                 let h = result.height;
                 self.show_wrap_layout(ui, top_left, &result);
-                self.show_block_line_prefixes(node, line, top_left, row_height);
+                self.show_block_line_prefixes(ui, node, line, top_left, row_height);
                 top_left.y += h;
             }
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/footnote_definition.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/footnote_definition.rs
@@ -24,19 +24,22 @@ impl<'ast> MdRender {
         let annotation_size = Vec2 { x: self.layout.indent, y: self.layout.row_height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 
-        let color = self.ctx.get_lb_theme().neutral_fg_secondary();
-        let text = format!("{}.", self.definition_number(node));
-        let layout_job = LayoutJob::single_section(
-            text,
-            TextFormat {
-                font_id: FontId::new(self.layout.row_height, FontFamily::Monospace),
-                color,
-                ..Default::default()
-            },
-        );
-        let galley = ui.fonts(|fonts| fonts.layout_job(layout_job));
-        ui.painter()
-            .galley(annotation_space.left_top(), galley, Default::default());
+        // when revealed, the raw `[^x]:` marker occupies this column instead
+        if !self.reveal(node) {
+            let color = self.ctx.get_lb_theme().neutral_fg_secondary();
+            let text = format!("{}.", self.definition_number(node));
+            let layout_job = LayoutJob::single_section(
+                text,
+                TextFormat {
+                    font_id: FontId::new(self.layout.row_height, FontFamily::Monospace),
+                    color,
+                    ..Default::default()
+                },
+            );
+            let galley = ui.fonts(|fonts| fonts.layout_job(layout_job));
+            ui.painter()
+                .galley(annotation_space.left_top(), galley, Default::default());
+        }
 
         // debug
         // ui.painter()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -46,59 +46,53 @@ impl<'ast> MdRender {
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 
         let annotation_color = self.ctx.get_lb_theme().neutral_fg_secondary();
-        match list_type {
-            ListType::Bullet => {
-                ui.painter().circle_filled(
-                    annotation_space.center(),
-                    self.layout.bullet_radius * row_height / self.layout.row_height,
-                    annotation_color,
-                );
-            }
-            ListType::Ordered => {
-                let mut sibling_index = 0usize;
-                let mut prev = node.previous_sibling();
-                while let Some(p) = prev {
-                    sibling_index += 1;
-                    prev = p.previous_sibling();
+
+        // when revealed, the raw marker occupies this column instead
+        if !self.reveal(node) {
+            match list_type {
+                ListType::Bullet => {
+                    ui.painter().circle_filled(
+                        annotation_space.center(),
+                        self.layout.bullet_radius * row_height / self.layout.row_height,
+                        annotation_color,
+                    );
                 }
-                let number = start + sibling_index;
+                ListType::Ordered => {
+                    let mut sibling_index = 0usize;
+                    let mut prev = node.previous_sibling();
+                    while let Some(p) = prev {
+                        sibling_index += 1;
+                        prev = p.previous_sibling();
+                    }
+                    let number = start + sibling_index;
 
-                let text = format!("{number}.");
-                let ppi = self.ctx.pixels_per_point();
-                let [r, g, b, a] = annotation_color.to_array();
-                let color = glyphon::Color::rgba(r, g, b, a);
-                let mut format = self.text_format_document();
-                format.family = FontFamily::Mono;
-                format.color = annotation_color;
-                let gap = 5.0;
-                let afs = self.layout.annotation_font_size;
-                let buffer = self.upsert_glyphon_buffer(&text, afs, afs, f32::MAX, &format);
-                let size = buffer.read().unwrap().shaped_size(ppi);
+                    // Trailing space included, as in source, so this matches
+                    // the marker the reveal path draws from the source bytes.
+                    let text = format!("{number}. ");
+                    let ppi = self.ctx.pixels_per_point();
+                    let [r, g, b, a] = annotation_color.to_array();
+                    let color = glyphon::Color::rgba(r, g, b, a);
+                    let mut format = self.text_format_document();
+                    format.family = FontFamily::Mono;
+                    format.color = annotation_color;
+                    let afs = self.layout.annotation_font_size;
+                    let buffer = self.upsert_glyphon_buffer(&text, afs, afs, f32::MAX, &format);
+                    let size = buffer.read().unwrap().shaped_size(ppi);
 
-                // align baseline with content row by comparing line_y from
-                // a content-sized buffer and the annotation-sized buffer
-                let content_line_y = {
-                    let tmp =
-                        self.upsert_glyphon_buffer(" ", row_height, row_height, f32::MAX, &format);
-                    let tmp = tmp.read().unwrap();
-                    tmp.layout_runs().next().map(|r| r.line_y).unwrap_or(0.0) / ppi
-                };
-                let number_line_y = {
-                    let buf = buffer.read().unwrap();
-                    buf.layout_runs().next().map(|r| r.line_y).unwrap_or(0.0) / ppi
-                };
-
-                // right-pad from content, overflow left if needed
-                let x = annotation_space.right() - size.x - gap;
-                let y = annotation_space.top() + content_line_y - number_line_y;
-                let rect = Rect::from_min_size(Pos2::new(x, y), size);
-                self.text_areas.push(TextBufferArea::new(
-                    buffer,
-                    rect,
-                    color,
-                    ui.ctx(),
-                    ui.clip_rect(),
-                ));
+                    // Right-align to the content edge, baseline-shifted into the
+                    // row, identically to the revealed marker (overflow left) so
+                    // revealing the item doesn't shift the number.
+                    let x = annotation_space.right() - size.x;
+                    let y = annotation_space.top() + (row_height - afs) * 0.8;
+                    let rect = Rect::from_min_size(Pos2::new(x, y), size);
+                    self.text_areas.push(TextBufferArea::new(
+                        buffer,
+                        rect,
+                        color,
+                        ui.ctx(),
+                        ui.clip_rect(),
+                    ));
+                }
             }
         }
 
@@ -123,6 +117,7 @@ impl<'ast> MdRender {
             );
             self.show_wrap_layout(ui, top_left + self.layout.indent * Vec2::X, &result);
             self.show_block_line_prefixes(
+                ui,
                 node,
                 line,
                 top_left + self.layout.indent * Vec2::X,
@@ -140,6 +135,7 @@ impl<'ast> MdRender {
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
         let show_fold_button = self.interactive
+            && !self.reveal(node) // the revealed marker occupies the gutter
             && (self.touch_mode
                 || hovered
                 || fold_button_space.contains(pointer)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -625,11 +625,17 @@ impl<'ast> MdRender {
                 if !self.node_contains_line(node, line) {
                     continue;
                 }
-                // `node` owns exactly its own column (its per-level
-                // `line_own_prefix`); reveal when an endpoint is strictly
-                // inside it.
+                // `node` owns its per-level `line_own_prefix`, but reveal
+                // only from the marker, not the leading indentation: trim
+                // leading whitespace; an indentation-only own-prefix (a
+                // nested continuation line) has no marker and never reveals.
                 let own = self.line_own_prefix(node, line);
-                if !own.is_empty() && own.contains(endpoint, false, false) {
+                let indent = self.buffer[own]
+                    .chars()
+                    .take_while(|c| *c == ' ' || *c == '\t')
+                    .count();
+                let marker = (own.start() + indent, own.end());
+                if !marker.is_empty() && marker.contains(endpoint, false, false) {
                     return true;
                 }
             }
@@ -651,10 +657,10 @@ impl<'ast> MdRender {
     /// `show_*`; these fragments carry none and exist only for
     /// hit-testing and selection highlighting.
     ///
-    /// Called from the non-revealed block-line renderers, including the
-    /// pre/post spacing renderers whose blank lines can still carry a
-    /// container's indentation. A revealed container renders its prefix
-    /// as ordinary source text instead, so this is not called for it.
+    /// Called from the block-line renderers, including the pre/post
+    /// spacing renderers whose blank lines can still carry a container's
+    /// indentation. A revealed level renders its own column as ordinary
+    /// source syntax in place of the `Spacer` and its decoration.
     ///
     /// Resolves the line's columns from its [`deepest_gutter_level`], not
     /// `node`'s ancestors: a spacing line sits in a shallower node than
@@ -662,8 +668,8 @@ impl<'ast> MdRender {
     /// deeper columns. For content lines `node` is already on the line, so
     /// the two agree.
     pub fn show_block_line_prefixes(
-        &mut self, node: &'ast AstNode<'ast>, line: (Grapheme, Grapheme), content_top_left: Pos2,
-        row_height: f32,
+        &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, line: (Grapheme, Grapheme),
+        content_top_left: Pos2, row_height: f32,
     ) {
         let Some(deepest) = self.deepest_gutter_level(node, line) else {
             return;
@@ -681,6 +687,43 @@ impl<'ast> MdRender {
                 continue;
             }
             let left = base_x + indent * k as f32;
+
+            // Revealed: the cursor is in this level's syntax, so render its
+            // prefix bytes as monospace source, sized and baseline-aligned to
+            // match the gutter annotation (e.g. an ordered marker). Right-
+            // aligned to the column's content edge so the marker sits about
+            // where its decoration was; a marker wider than the column
+            // overflows left (into the gutter) rather than over the content.
+            if self.reveal(level) {
+                let afs = self.layout.annotation_font_size;
+                let result = self.compute_section_layout_new(
+                    range,
+                    self.width(level),
+                    afs,
+                    self.text_format_syntax(),
+                );
+                let baseline_shift = (row_height - afs) * 0.8;
+                // `result.width` is the available width, not the laid-out
+                // marker width; measure the rightmost glyph edge instead.
+                let marker_width = result
+                    .rows
+                    .iter()
+                    .flat_map(|row| &row.fragments)
+                    .fold(0.0_f32, |w, frag| w.max(frag.rect.right()));
+                let marker_left = left + indent - marker_width;
+                let top = Pos2::new(marker_left, content_top_left.y + baseline_shift);
+                let first = self.fragments.len();
+                self.show_wrap_layout(ui, top, &result);
+                // Cursor reads `rect`: give the small marker the row's full
+                // height so an offset inside it shares the row's center y
+                // (vertical nav round-trips).
+                for frag in &mut self.fragments[first..] {
+                    frag.rect.min.y = content_top_left.y;
+                    frag.rect.max.y = content_top_left.y + row_height;
+                }
+                continue;
+            }
+
             let rect = Rect::from_min_max(
                 Pos2::new(left, content_top_left.y),
                 Pos2::new(left + indent, content_top_left.y + row_height),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -24,85 +24,88 @@ impl<'ast> MdRender {
 
         let annotation_size = Vec2 { x: self.layout.indent, y: row_height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
-        let mut checkbox_space = Rect::from_center_size(
-            annotation_space.center(),
-            Vec2::splat(annotation_space.size().min_elem()),
-        );
-        let border_radius = 2.0;
+        // when revealed, the raw `- [ ]` marker occupies this column instead
+        if !self.reveal(node) {
+            let mut checkbox_space = Rect::from_center_size(
+                annotation_space.center(),
+                Vec2::splat(annotation_space.size().min_elem()),
+            );
+            let border_radius = 2.0;
 
-        let checkbox_id = ui.id().with(self.node_range(node));
+            let checkbox_id = ui.id().with(self.node_range(node));
 
-        // allocate a slightly larger clickable space that makes the checkbox
-        // easier to tap without overflowing the annotation space horizontally
-        // or overlapping with another row vertically.
-        let extra_width = (annotation_space.width() - checkbox_space.width()) / 2.;
-        let extra_height = self.layout.row_spacing / 2.;
-        let clickable_space = checkbox_space.expand(extra_width.min(extra_height));
+            // allocate a slightly larger clickable space that makes the checkbox
+            // easier to tap without overflowing the annotation space horizontally
+            // or overlapping with another row vertically.
+            let extra_width = (annotation_space.width() - checkbox_space.width()) / 2.;
+            let extra_height = self.layout.row_spacing / 2.;
+            let clickable_space = checkbox_space.expand(extra_width.min(extra_height));
 
-        let sense = if self.readonly { Sense::hover() } else { Sense::click() };
-        let checkbox_response =
+            let sense = if self.readonly { Sense::hover() } else { Sense::click() };
+            let checkbox_response =
             // ui.id().with() instead of Id::new() so two views of the same document
             // get distinct checkbox IDs
             ui.interact(clickable_space, checkbox_id, sense);
-        if checkbox_response.clicked() {
-            let check_offset = self.check_offset(node);
-            let new_check = if checked { ' ' } else { 'x' };
-            self.render_events.push(Event::Replace {
-                region: (check_offset, check_offset + 1).into(),
-                text: new_check.into(),
-                advance_cursor: false,
-            });
-        }
-        if checkbox_response.hovered() && !self.readonly {
-            ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
-            checkbox_space = checkbox_space.expand(0.5);
-        }
-        self.touch_consuming_rects.push(clickable_space);
+            if checkbox_response.clicked() {
+                let check_offset = self.check_offset(node);
+                let new_check = if checked { ' ' } else { 'x' };
+                self.render_events.push(Event::Replace {
+                    region: (check_offset, check_offset + 1).into(),
+                    text: new_check.into(),
+                    advance_cursor: false,
+                });
+            }
+            if checkbox_response.hovered() && !self.readonly {
+                ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
+                checkbox_space = checkbox_space.expand(0.5);
+            }
+            self.touch_consuming_rects.push(clickable_space);
 
-        let how_on = ui.ctx().animate_value_with_time(
-            checkbox_id.with("animation"),
-            if checked { 1.0 } else { 0.0 },
-            0.2,
-        );
+            let how_on = ui.ctx().animate_value_with_time(
+                checkbox_id.with("animation"),
+                if checked { 1.0 } else { 0.0 },
+                0.2,
+            );
 
-        // draw rect background for checkbox
-        ui.painter().rect(
-            checkbox_space.shrink(2. * how_on), // anticipation for the main animation
-            border_radius,
-            theme
-                .bg()
-                .get_color(theme.prefs().primary)
-                .gamma_multiply(0.1),
-            Stroke::new(0.5, theme.fg().get_color(theme.prefs().primary)),
-            StrokeKind::Inside,
-        );
-
-        // animate filled in rect for checked state
-        ui.painter().rect_filled(
-            checkbox_space.expand2(checkbox_space.size() * how_on - checkbox_space.size()),
-            border_radius,
-            theme.fg().get_color(theme.prefs().primary),
-        );
-
-        // draw check
-        let check_space = checkbox_space.shrink(4.5);
-        ui.painter().add(Shape::line(
-            vec![
-                egui::pos2(check_space.left(), check_space.center().y),
-                egui::pos2(
-                    check_space.center().x - check_space.width() / 7.0,
-                    check_space.bottom(),
-                ),
-                egui::pos2(check_space.right(), check_space.top()),
-            ],
-            Stroke::new(
-                2.,
+            // draw rect background for checkbox
+            ui.painter().rect(
+                checkbox_space.shrink(2. * how_on), // anticipation for the main animation
+                border_radius,
                 theme
-                    .fg()
-                    .get_color(crate::theme::palette_v2::Palette::White)
-                    .linear_multiply(how_on),
-            ),
-        ));
+                    .bg()
+                    .get_color(theme.prefs().primary)
+                    .gamma_multiply(0.1),
+                Stroke::new(0.5, theme.fg().get_color(theme.prefs().primary)),
+                StrokeKind::Inside,
+            );
+
+            // animate filled in rect for checked state
+            ui.painter().rect_filled(
+                checkbox_space.expand2(checkbox_space.size() * how_on - checkbox_space.size()),
+                border_radius,
+                theme.fg().get_color(theme.prefs().primary),
+            );
+
+            // draw check
+            let check_space = checkbox_space.shrink(4.5);
+            ui.painter().add(Shape::line(
+                vec![
+                    egui::pos2(check_space.left(), check_space.center().y),
+                    egui::pos2(
+                        check_space.center().x - check_space.width() / 7.0,
+                        check_space.bottom(),
+                    ),
+                    egui::pos2(check_space.right(), check_space.top()),
+                ],
+                Stroke::new(
+                    2.,
+                    theme
+                        .fg()
+                        .get_color(crate::theme::palette_v2::Palette::White)
+                        .linear_multiply(how_on),
+                ),
+            ));
+        }
 
         let any_children = node.children().next().is_some();
         let hovered = if any_children {
@@ -125,6 +128,7 @@ impl<'ast> MdRender {
             );
             self.show_wrap_layout(ui, top_left + self.layout.indent * Vec2::X, &result);
             self.show_block_line_prefixes(
+                ui,
                 node,
                 line,
                 top_left + self.layout.indent * Vec2::X,
@@ -140,6 +144,7 @@ impl<'ast> MdRender {
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
         let show_fold_button = self.interactive
+            && !self.reveal(node) // the revealed marker occupies the gutter
             && (self.touch_mode
                 || hovered
                 || fold_button_space.contains(pointer)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
@@ -182,6 +182,7 @@ impl<'ast> MdRender {
                     let h = fence_layout.height;
                     self.show_wrap_layout(ui, top_left, &fence_layout);
                     self.show_block_line_prefixes(
+                        ui,
                         node,
                         line,
                         Pos2::new(content_left, top_left.y),
@@ -193,6 +194,7 @@ impl<'ast> MdRender {
                 top_left.y += self.layout.row_spacing;
                 self.show_code_block_line(ui, node, top_left, node_code_block, line, false);
                 self.show_block_line_prefixes(
+                    ui,
                     node,
                     line,
                     Pos2::new(content_left, top_left.y),
@@ -305,6 +307,7 @@ impl<'ast> MdRender {
                 let h = l.height;
                 self.show_wrap_layout(ui, top_left, &l);
                 self.show_block_line_prefixes(
+                    ui,
                     node,
                     line,
                     Pos2::new(content_left, top_left.y),
@@ -314,6 +317,7 @@ impl<'ast> MdRender {
             } else {
                 self.show_code_block_line(ui, node, top_left, node_code_block, line, synthetic);
                 self.show_block_line_prefixes(
+                    ui,
                     node,
                     line,
                     Pos2::new(content_left, top_left.y),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -237,7 +237,7 @@ impl<'ast> MdRender {
                 let result = self.compute_layout_from(layout, width, row_height);
                 let h = result.height;
                 self.show_wrap_layout(ui, top_left, &result);
-                self.show_block_line_prefixes(node, line, top_left, row_height);
+                self.show_block_line_prefixes(ui, node, line, top_left, row_height);
                 top_left.y += h;
                 top_left.y += self.layout.row_spacing;
             } else if reveal {
@@ -276,7 +276,7 @@ impl<'ast> MdRender {
         let result = self.compute_layout_from(layout, width, row_height);
         let height = result.height;
         self.show_wrap_layout(ui, top_left, &result);
-        self.show_block_line_prefixes(node, line, top_left, row_height);
+        self.show_block_line_prefixes(ui, node, line, top_left, row_height);
 
         top_left.y += height;
         if level <= 2 {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
@@ -98,7 +98,7 @@ impl<'ast> MdRender {
             let line_height = self.height_paragraph_line(node, node_line);
 
             self.show_paragraph_line(ui, node, top_left, node_line);
-            self.show_block_line_prefixes(node, line, top_left, self.layout.row_height);
+            self.show_block_line_prefixes(ui, node, line, top_left, self.layout.row_height);
             top_left.y += line_height;
 
             top_left.y += self.layout.block_spacing;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/thematic_break.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/thematic_break.rs
@@ -31,7 +31,7 @@ impl<'ast> MdRender {
                 self.text_format_syntax(),
             );
             self.show_wrap_layout(ui, top_left, &result);
-            self.show_block_line_prefixes(node, line, top_left, row_height);
+            self.show_block_line_prefixes(ui, node, line, top_left, row_height);
         } else {
             // Painted as a horizontal rule, with zero-visible anchors
             // at each endpoint so cursor placement at the row's edges
@@ -52,7 +52,7 @@ impl<'ast> MdRender {
             layout.push_override(node_line.end().into_range(), "", self.text_format_syntax());
             let result = self.compute_layout_from(layout, width, row_height);
             self.show_wrap_layout(ui, top_left, &result);
-            self.show_block_line_prefixes(node, line, top_left, row_height);
+            self.show_block_line_prefixes(ui, node, line, top_left, row_height);
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -8,9 +8,7 @@ use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format
 use comrak::nodes::{AstNode, NodeHeading, NodeLink, NodeValue};
 use egui::ahash::HashMap;
 use egui::{Pos2, Ui};
-use lb_rs::model::text::offset_types::{
-    Grapheme, Graphemes, IntoRangeExt as _, RangeExt as _, RangeIterExt as _,
-};
+use lb_rs::model::text::offset_types::{Grapheme, Graphemes, IntoRangeExt as _, RangeExt as _};
 
 use crate::tab::markdown_editor::bounds::RangesExt as _;
 use crate::tab::markdown_editor::widget::inline::html_inline::FOLD_TAG;
@@ -101,34 +99,6 @@ impl<'ast> MdRender {
         if self.width(node) < self.layout.row_height {
             self.set_cached_node_height(node, 0.0);
             return 0.0;
-        }
-
-        // container blocks: if revealed, show source lines instead
-        if node.parent().is_some()
-            && node.data.borrow().value.is_container_block()
-            && self.reveal(node)
-        {
-            let mut height = 0.;
-
-            let width = self.width(node);
-            let row_height = self.layout.row_height;
-            for line in self.node_lines(node).iter() {
-                let line = self.bounds.source_lines[line];
-                let node_line = self.node_line(node, line);
-                let l = self.compute_section_layout_new(
-                    node_line,
-                    width,
-                    row_height,
-                    self.text_format_syntax(),
-                );
-                height += l.height;
-                height += self.layout.block_spacing;
-            }
-            if height > 0. {
-                height -= self.layout.block_spacing;
-            }
-
-            return height;
         }
 
         // hide folded nodes only if they are not revealed
@@ -308,40 +278,12 @@ impl<'ast> MdRender {
         self.approx_y_top_last_block(root) + viewport_height
     }
 
-    pub(crate) fn show_block(
-        &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2,
-    ) {
+    pub(crate) fn show_block(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2) {
         let ui = &mut self.node_ui(ui, node);
 
         // Block too narrow to fit anything meaningful: skip. `height`
         // returns 0 for the same condition so the layout stays aligned.
         if self.width(node) < self.layout.row_height {
-            return;
-        }
-
-        // container blocks: if revealed, show source lines instead
-        if node.parent().is_some()
-            && node.data.borrow().value.is_container_block()
-            && self.reveal(node)
-        {
-            let width = self.width(node);
-            let row_height = self.layout.row_height;
-            for line in self.node_lines(node).iter() {
-                let line = self.bounds.source_lines[line];
-                let node_line = self.node_line(node, line);
-
-                let result = self.compute_section_layout_new(
-                    node_line,
-                    width,
-                    row_height,
-                    self.text_format_syntax(),
-                );
-                let h = result.height;
-                self.show_wrap_layout(ui, top_left, &result);
-                top_left.y += h;
-                top_left.y += self.layout.block_spacing;
-            }
-
             return;
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/spacing.rs
@@ -147,7 +147,7 @@ impl<'ast> MdRender {
             );
             let h = result.height;
             self.show_wrap_layout(ui, top_left, &result);
-            self.show_block_line_prefixes(node, line, top_left, row_height);
+            self.show_block_line_prefixes(ui, node, line, top_left, row_height);
             top_left.y += h;
             top_left.y += self.layout.block_spacing;
         }
@@ -202,7 +202,7 @@ impl<'ast> MdRender {
             );
             let h = result.height;
             self.show_wrap_layout(ui, top_left, &result);
-            self.show_block_line_prefixes(node, line, top_left, row_height);
+            self.show_block_line_prefixes(ui, node, line, top_left, row_height);
             top_left.y += h;
         }
     }


### PR DESCRIPTION

https://github.com/user-attachments/assets/d58d8c21-a7b8-41e2-82f6-68ff6dd33bdc

