### PR TITLE
md: assorted fixes

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -161,6 +161,8 @@
                 break
             case .began:
                 interactiveRefinementInProgress = true
+                // drop the editor touch so it can't start a competing scroll
+                mtkView.cancelActiveTouches()
             case .changed:
                 let location = recognizer.location(in: recognizer.view)
                 scrollTo(location.y)
@@ -181,6 +183,8 @@
                 return
             case .began:
                 rangeAdjustmentInProgress = true
+                // drop the editor touch so it can't start a competing scroll
+                mtkView.cancelActiveTouches()
             case .changed:
                 let location = recognizer.location(in: recognizer.view)
                 scrollTo(location.y)
@@ -202,11 +206,20 @@
         }
 
         override public func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+            // The loupe / selection handle owns the gesture; forwarding the
+            // drag would start a touch-scroll that moves the document and, via
+            // `checkCancelCursorPlacement`, dismisses the loupe.
+            if interactiveRefinementInProgress || rangeAdjustmentInProgress {
+                return
+            }
             mtkView.touchesMoved(touches, with: event)
             checkCancelCursorPlacement(touches)
         }
 
         override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+            if interactiveRefinementInProgress || rangeAdjustmentInProgress {
+                return
+            }
             mtkView.touchesEnded(touches, with: event)
             checkCancelCursorPlacement(touches)
         }
@@ -1744,6 +1757,17 @@
                 )
             }
 
+            setNeedsDisplay(frame)
+        }
+
+        /// Cancel every in-flight editor touch, so a UIKit text interaction
+        /// taking over a gesture mid-drag doesn't leave a pressed pointer
+        /// behind to start a touch-scroll.
+        func cancelActiveTouches() {
+            for value in touchMap.values {
+                touches_cancelled(wsHandle, value, 0, 0, 0)
+            }
+            touchMap.removeAll()
             setNeedsDisplay(frame)
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -750,8 +750,11 @@ impl<'ast> MdEdit {
                 // levels above the selected Paragraph.
                 let mut maybe = if node.is_container_block() { Some(node) } else { node.parent() };
                 while let Some(ancestor) = maybe {
-                    if &ancestor.node_type() == style {
-                        unapply = true;
+                    let ancestor_type = ancestor.node_type();
+                    if std::mem::discriminant(&ancestor_type) == std::mem::discriminant(style) {
+                        if &ancestor_type == style {
+                            unapply = true;
+                        }
                         break;
                     }
                     maybe = ancestor.parent();

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -1208,6 +1208,42 @@ fn toggle_list_style_on_empty_item_switches() {
     }
 }
 
+/// Regression: changing the list type of a *nested* item used to read
+/// the wrong list. `unapply_block` walked the whole ancestor chain, so a
+/// nested task item under a bullet list matched the outer bullet list and
+/// the toggle removed the inner item's marker instead of converting it.
+/// It must stop at the nearest enclosing list (the inner task list) and,
+/// since that's a different type, perform a type change.
+#[test]
+fn toggle_bullet_on_nested_task_item_changes_type() {
+    use comrak::nodes::{ListType, NodeList, NodeValue};
+
+    let to_bullet = Event::ToggleStyle {
+        region: Region::Selection,
+        style: NodeValue::List(NodeList {
+            list_type: ListType::Bullet,
+            is_task_list: false,
+            ..Default::default()
+        }),
+    };
+
+    let doc = "* x\n  * [x] y";
+    let mut ws = TestEditor::new(doc);
+    ws.enter_frame();
+    // cursor inside "y"
+    let cursor = Grapheme(13);
+    ws.push(Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(cursor),
+            end: Location::Grapheme(cursor),
+        },
+    });
+    ws.enter_frame();
+    ws.push(to_bullet);
+    ws.enter_frame();
+    assert_eq!(ws.get_text(), "* x\n  * y");
+}
+
 /// Regression for the user-reported "shift-tab then tab needs many
 /// undos with cursor-only steps". With per-frame undo units, the two
 /// commands are independent: one undo restores the post-shift-tab

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/footnote_definition.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/footnote_definition.rs
@@ -25,7 +25,7 @@ impl<'ast> MdRender {
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 
         // when revealed, the raw `[^x]:` marker occupies this column instead
-        if !self.reveal(node) {
+        if !self.reveal_line(node, self.node_first_line(node)) {
             let color = self.ctx.get_lb_theme().neutral_fg_secondary();
             let text = format!("{}.", self.definition_number(node));
             let layout_job = LayoutJob::single_section(

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -48,7 +48,7 @@ impl<'ast> MdRender {
         let annotation_color = self.ctx.get_lb_theme().neutral_fg_secondary();
 
         // when revealed, the raw marker occupies this column instead
-        if !self.reveal(node) {
+        if !self.reveal_line(node, first_line) {
             match list_type {
                 ListType::Bullet => {
                     ui.painter().circle_filled(
@@ -135,7 +135,7 @@ impl<'ast> MdRender {
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
         let show_fold_button = self.interactive
-            && !self.reveal(node) // the revealed marker occupies the gutter
+            && !self.reveal_line(node, first_line) // the revealed marker occupies the gutter
             && (self.touch_mode
                 || hovered
                 || fold_button_space.contains(pointer)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -564,6 +564,31 @@ impl<'ast> MdRender {
         )
     }
 
+    /// A gutter level whose marker lives only on its first line; later
+    /// lines carry pure indentation. Such a level must reveal per-line
+    /// (see [`reveal_line`]) so cursoring into a continuation line's
+    /// indentation doesn't also reveal the first-line marker. Block quotes
+    /// and alerts mark every line, so they reveal node-wide.
+    pub fn marks_first_line_only(&self, node: &'ast AstNode<'ast>) -> bool {
+        matches!(
+            node.data.borrow().value,
+            NodeValue::Item(_) | NodeValue::TaskItem(_) | NodeValue::FootnoteDefinition(_)
+        )
+    }
+
+    /// Whether the gutter column `level` owns on `line` should render its
+    /// raw source. First-line-marker levels scope to the line; block
+    /// quotes/alerts reveal node-wide.
+    pub fn reveal_gutter_column(
+        &self, level: &'ast AstNode<'ast>, line: (Grapheme, Grapheme),
+    ) -> bool {
+        if self.marks_first_line_only(level) {
+            self.reveal_line(level, line)
+        } else {
+            self.reveal(level)
+        }
+    }
+
     /// The nearest gutter-contributing ancestor of `node` (excluding
     /// `node` itself), i.e. the level whose column sits one to the left.
     fn gutter_parent(&self, node: &'ast AstNode<'ast>) -> Option<&'ast AstNode<'ast>> {
@@ -628,22 +653,38 @@ impl<'ast> MdRender {
                 if !self.node_contains_line(node, line) {
                     continue;
                 }
-                // `node` owns its per-level `line_own_prefix`, but reveal
-                // only from the marker, not the leading indentation: trim
-                // leading whitespace; an indentation-only own-prefix (a
-                // nested continuation line) has no marker and never reveals.
-                let own = self.line_own_prefix(node, line);
-                let indent = self.buffer[own]
-                    .chars()
-                    .take_while(|c| *c == ' ' || *c == '\t')
-                    .count();
-                let marker = (own.start() + indent, own.end());
-                if !marker.is_empty() && marker.contains(endpoint, false, false) {
+                if self.reveal_line(node, line) {
                     return true;
                 }
             }
         }
         false
+    }
+
+    /// Like [`reveal`] but scoped to a single `line`: true when a reveal
+    /// endpoint lands strictly inside the gutter column `node` owns on
+    /// `line` — marker *or* leading indentation.
+    ///
+    /// An indentation-only own-prefix (a nested continuation line) renders
+    /// collapsed to a single indent-wide column, so its interior cursor
+    /// positions can't be distinguished until it reveals into per-grapheme
+    /// source. Strict interiority keeps level-boundary edges (and drag,
+    /// which snaps to edges) non-revealing.
+    ///
+    /// Line scoping matters for first-line-marker containers (items, task
+    /// items, footnotes): the cursor inside a continuation line's
+    /// indentation must reveal that indentation without also revealing the
+    /// node's marker, which lives on a different line.
+    pub fn reveal_line(&self, node: &'ast AstNode<'ast>, line: (Grapheme, Grapheme)) -> bool {
+        let own = self.line_own_prefix(node, line);
+        if own.is_empty() {
+            return false;
+        }
+        self.reveal_ranges().any(|rr| {
+            [rr.start(), rr.end()]
+                .into_iter()
+                .any(|ep| own.contains(ep, false, false))
+        })
     }
 
     /// Registers an atomic, selectable [`Fragment`] for each gutter
@@ -697,7 +738,7 @@ impl<'ast> MdRender {
             // aligned to the column's content edge so the marker sits about
             // where its decoration was; a marker wider than the column
             // overflows left (into the gutter) rather than over the content.
-            if self.reveal(level) {
+            if self.reveal_gutter_column(level, line) {
                 let afs = self.layout.annotation_font_size;
                 let result = self.compute_section_layout_new(
                     range,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -25,7 +25,7 @@ impl<'ast> MdRender {
         let annotation_size = Vec2 { x: self.layout.indent, y: row_height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
         // when revealed, the raw `- [ ]` marker occupies this column instead
-        if !self.reveal(node) {
+        if !self.reveal_line(node, first_line) {
             let mut checkbox_space = Rect::from_center_size(
                 annotation_space.center(),
                 Vec2::splat(annotation_space.size().min_elem()),
@@ -144,7 +144,7 @@ impl<'ast> MdRender {
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
         let show_fold_button = self.interactive
-            && !self.reveal(node) // the revealed marker occupies the gutter
+            && !self.reveal_line(node, first_line) // the revealed marker occupies the gutter
             && (self.touch_mode
                 || hovered
                 || fold_button_space.contains(pointer)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -193,7 +193,7 @@ impl<'ast> MdRender {
     /// in a new tab. The producer only opens an interaction scope when
     /// cmd is held (desktop) or for the trailing open-link affordance
     /// (touch); the response's presence is the gate.
-    pub fn handle_link_interactions(&self, root: &'ast AstNode<'ast>, ui: &egui::Ui) {
+    pub fn handle_link_interactions(&mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui) {
         let parent_base = ui.id();
         for node in root.descendants() {
             let (url, is_wikilink) = match &node.data.borrow().value {
@@ -205,6 +205,11 @@ impl<'ast> MdRender {
             let Some(response) = self.interaction_responses.get(&id) else {
                 continue;
             };
+
+            // iOS routes touches through `touch_consuming_rects` —
+            // without this entry a tap on the open-link button would
+            // place the cursor instead of reaching the click handler below.
+            self.touch_consuming_rects.push(response.rect);
 
             if response.hovered() {
                 ui.ctx()


### PR DESCRIPTION
* fixes an issue where tapping link buttons on ios places the cursor instead
* fixes an issue where there appear to be duplicate cursor positions in list indentation
* fixes an issue where changing a list item type would remove the list item style if the style matched any outer list item (e.g. changing a bullet to a number in an outer numbered list would just remove the bullet)
* fixes #4683 