### PR TITLE
md: cache wrap layout

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/code_block.rs
@@ -139,7 +139,7 @@ impl<'ast> MdRender {
         node_code_block: &NodeCodeBlock,
     ) {
         let mut width = self.width(node);
-        let height = self.height_fenced_code_block(node, node_code_block);
+        let height = self.height(node);
         let row_height = self.layout.row_height;
 
         let rect = Rect::from_min_size(top_left, Vec2::new(width, height));
@@ -274,7 +274,7 @@ impl<'ast> MdRender {
         let width = self.width(node);
         let inner_width = width - 2. * self.layout.block_padding;
         let row_height = self.layout.row_height;
-        let height = self.height_indented_code_block(node, node_code_block, synthetic);
+        let height = self.height(node);
 
         let rect = Rect::from_min_size(top_left, Vec2::new(width, height));
         ui.painter().rect_stroke(
@@ -467,20 +467,33 @@ impl<'ast> MdRender {
         &self, node: &'ast AstNode<'ast>, node_code_block: &NodeCodeBlock,
         line: (Grapheme, Grapheme), synthetic: bool,
     ) -> f32 {
+        let node_line = self.node_line(node, line);
+        if let Some(height) = self.cached_line_height(node, node_line) {
+            return height;
+        }
         let width = self.width(node) - 2. * self.layout.block_padding;
         let layout = self.layout_code_block_line(node, node_code_block, line, synthetic);
-        self.compute_layout_from(layout, width, self.layout.row_height)
-            .height
+        let layout = self.compute_layout_from(layout, width, self.layout.row_height);
+        let height = layout.height;
+        self.set_cached_line_layout(node, node_line, layout);
+        height
     }
 
     fn show_code_block_line(
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2,
         node_code_block: &NodeCodeBlock, line: (Grapheme, Grapheme), synthetic: bool,
     ) {
-        let width = self.width(node) - 2. * self.layout.block_padding;
-        let layout = self.layout_code_block_line(node, node_code_block, line, synthetic);
-        let result = self.compute_layout_from(layout, width, self.layout.row_height);
-        self.show_wrap_layout(ui, top_left, &result);
+        let node_line = self.node_line(node, line);
+        let layout = match self.take_cached_line_layout(node, node_line) {
+            Some(layout) => layout,
+            None => {
+                let width = self.width(node) - 2. * self.layout.block_padding;
+                let layout = self.layout_code_block_line(node, node_code_block, line, synthetic);
+                self.compute_layout_from(layout, width, self.layout.row_height)
+            }
+        };
+        self.show_wrap_layout(ui, top_left, &layout);
+        self.set_cached_line_layout(node, node_line, layout);
     }
 
     // "The closing code fence may be indented up to three spaces, and may be

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
@@ -70,10 +70,15 @@ impl<'ast> MdRender {
     pub fn height_paragraph_line(
         &self, node: &'ast AstNode<'ast>, node_line: (Grapheme, Grapheme),
     ) -> f32 {
+        if let Some(height) = self.cached_line_height(node, node_line) {
+            return height;
+        }
         let width = self.width(node);
         let layout = self.layout_paragraph_line(node, node_line);
-        self.compute_layout_from(layout, width, self.layout.row_height)
-            .height
+        let layout = self.compute_layout_from(layout, width, self.layout.row_height);
+        let height = layout.height;
+        self.set_cached_line_layout(node, node_line, layout);
+        height
     }
 
     pub fn show_paragraph(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, mut top_left: Pos2) {
@@ -109,10 +114,16 @@ impl<'ast> MdRender {
         &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2,
         node_line: (Grapheme, Grapheme),
     ) {
-        let width = self.width(node);
-        let layout = self.layout_paragraph_line(node, node_line);
-        let result = self.compute_layout_from(layout, width, self.layout.row_height);
-        self.show_wrap_layout(ui, top_left, &result);
+        let layout = match self.take_cached_line_layout(node, node_line) {
+            Some(layout) => layout,
+            None => {
+                let width = self.width(node);
+                let layout = self.layout_paragraph_line(node, node_line);
+                self.compute_layout_from(layout, width, self.layout.row_height)
+            }
+        };
+        self.show_wrap_layout(ui, top_left, &layout);
+        self.set_cached_line_layout(node, node_line, layout);
     }
 
     pub fn compute_bounds_paragraph(&mut self, node: &'ast AstNode<'ast>) {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex, RwLock};
 use unicode_segmentation::UnicodeSegmentation as _;
 
-use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
+use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format, WrapUnitLayout};
 
 use comrak::nodes::{AstNode, NodeHeading, NodeLink, NodeValue};
 use egui::ahash::HashMap;
@@ -707,12 +707,18 @@ type LinePrefixValue = (Graphemes, bool);
 /// before any read, so text_seq isn't part of the per-entry stamp.
 pub type HeightDeps = [u64; 4];
 
+type LineLayoutKey = (u64, (Grapheme, Grapheme));
+
+/// line-layout inputs: `HeightDeps` + `dark_mode` (layout contains colors)
+pub type LineLayoutDeps = (HeightDeps, bool);
+
 #[derive(Default)]
 pub struct LayoutCache {
     pub height: RefCell<HashMap<u64, (f32, HeightDeps)>>,
     pub height_approx: RefCell<HashMap<u64, (f32, HeightDeps)>>,
     pub line_prefix_len: RefCell<HashMap<LinePrefixKey, LinePrefixValue>>,
     pub node_range: RefCell<HashMap<u64, (Grapheme, Grapheme)>>,
+    pub line_layout: RefCell<HashMap<LineLayoutKey, (WrapUnitLayout, LineLayoutDeps)>>,
 
     // deps: `reveal_seq` last populated, or `None` if never.
     pub hidden_by_fold: RefCell<HashMap<u64, bool>>,
@@ -737,6 +743,7 @@ impl LayoutCache {
         self.height_approx.borrow_mut().clear();
         self.line_prefix_len.borrow_mut().clear();
         self.node_range.borrow_mut().clear();
+        self.line_layout.borrow_mut().clear();
         self.hidden_by_fold.borrow_mut().clear();
         self.hidden_by_fold_deps.set(None);
         // link_titles intentionally not cleared: fetched titles persist across layout invalidations
@@ -912,6 +919,47 @@ impl<'ast> MdRender {
                 .load(std::sync::atomic::Ordering::Relaxed),
             self.reveal_seq,
         ]
+    }
+
+    fn line_layout_deps(&self) -> LineLayoutDeps {
+        (self.height_deps(), self.dark_mode)
+    }
+
+    /// Read the cached height for one line if present.
+    pub fn cached_line_height(
+        &self, node: &'ast AstNode<'ast>, node_line: (Grapheme, Grapheme),
+    ) -> Option<f32> {
+        let key = (Self::pack_node_key(node), node_line);
+        let deps = self.line_layout_deps();
+        let cache = self.layout_cache.line_layout.borrow();
+        let (layout, stamp) = cache.get(&key)?;
+        (*stamp == deps).then_some(layout.height)
+    }
+
+    /// Take the cached layout for one line if present, removing it from the
+    /// cache. You should generally put it back when you're done. This works
+    /// around borrow checking issues. This cache is special because its values
+    /// aren't cheap to copy.
+    pub fn take_cached_line_layout(
+        &self, node: &'ast AstNode<'ast>, node_line: (Grapheme, Grapheme),
+    ) -> Option<WrapUnitLayout> {
+        let key = (Self::pack_node_key(node), node_line);
+        let deps = self.line_layout_deps();
+        match self.layout_cache.line_layout.borrow_mut().remove(&key) {
+            Some((layout, stamp)) if stamp == deps => Some(layout),
+            _ => None,
+        }
+    }
+
+    pub fn set_cached_line_layout(
+        &self, node: &'ast AstNode<'ast>, node_line: (Grapheme, Grapheme), layout: WrapUnitLayout,
+    ) {
+        let key = (Self::pack_node_key(node), node_line);
+        let deps = self.line_layout_deps();
+        self.layout_cache
+            .line_layout
+            .borrow_mut()
+            .insert(key, (layout, deps));
     }
 
     pub fn get_cached_node_height(&self, node: &'ast AstNode<'ast>) -> Option<f32> {


### PR DESCRIPTION
After caching shaped text, the new warm render bottleneck is the wrap logic introduced in #4576.

hopefully fixes https://github.com/lockbook/lockbook/issues/4715