### PR TITLE
md: fix unresponsive bottom region on ios

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceView.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceView.swift
@@ -280,27 +280,12 @@ import SwiftUI
                     currentWrapper = textWrapper
                     mtkView.currentWrapper = textWrapper
 
-                    textWrapper.translatesAutoresizingMaskIntoConstraints =
-                        false
+                    // Frame-positioned from Rust's reported interaction rect
+                    // each frame (see iOSMTKViewDelegate). Seed with the full
+                    // view until the first rect arrives.
+                    textWrapper.translatesAutoresizingMaskIntoConstraints = true
+                    textWrapper.frame = mtkView.frame
                     addSubview(textWrapper)
-                    let topConstraint = textWrapper.topAnchor.constraint(
-                        equalTo: topAnchor,
-                        constant: headerSize
-                    )
-                    textWrapper.topConstraint = topConstraint
-                    NSLayoutConstraint.activate([
-                        topConstraint,
-                        textWrapper.leftAnchor.constraint(
-                            equalTo: leftAnchor
-                        ),
-                        textWrapper.rightAnchor.constraint(
-                            equalTo: rightAnchor
-                        ),
-                        textWrapper.bottomAnchor.constraint(
-                            equalTo: keyboardLayoutGuide.topAnchor,
-                            constant: mtkView.isCompact() ? -MdView.TOOL_BAR_HEIGHT : 0
-                        ),
-                    ])
 
                     if GCKeyboard.coalesced != nil {
                         textWrapper.becomeFirstResponder()

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -10,7 +10,6 @@
     // MARK: - MdView
 
     public class MdView: UIView, UITextInput {
-        public static let TOOL_BAR_HEIGHT: CGFloat = 42
         public static let FLOATING_CURSOR_OFFSET_HEIGHT: CGFloat = 0.6
 
         let mtkView: iOSMTK
@@ -37,12 +36,14 @@
 
         /// ?
         let currentHeaderSize: Double
-        /// constraint adjusted each frame to keep text interaction below the find widget
-        var topConstraint: NSLayoutConstraint?
-        /// current find widget height, used for coordinate transforms
-        var textInputTopOffset: Double = 0
-        /// total y offset for converting between viewport and MdView coordinates
-        var yOffset: Double { mtkView.docHeaderSize + textInputTopOffset }
+        /// Interaction region in container coords (egui points) — Rust's single
+        /// source of truth, set each frame from `output.text_interaction_rect`.
+        /// Drives both this view's frame and cursor coordinate conversion.
+        var interactionRect: CGRect = .zero
+        /// offsets for converting egui-global cursor coords into this view's
+        /// frame-local space — the interaction rect's origin
+        var xOffset: Double { Double(interactionRect.minX) }
+        var yOffset: Double { Double(interactionRect.minY) }
 
         // interactive refinement (floating cursor)
         var interactiveRefinementInProgress = false
@@ -722,7 +723,7 @@
             let range = (range as! LBTextRange).c
             let result = first_rect(wsHandle, range)
             return CGRect(
-                x: result.min_x, y: result.min_y - yOffset,
+                x: result.min_x - xOffset, y: result.min_y - yOffset,
                 width: result.max_x - result.min_x, height: result.max_y - result.min_y
             )
         }
@@ -731,7 +732,7 @@
             let position = (position as! LBTextPos).c
             let result = cursor_rect_at_position(wsHandle, position)
             return CGRect(
-                x: result.min_x, y: result.min_y - yOffset, width: 1,
+                x: result.min_x - xOffset, y: result.min_y - yOffset, width: 1,
                 height: result.max_y - result.min_y
             )
         }
@@ -746,8 +747,8 @@
 
             return buffer.enumerated().map { index, rect in
                 let new_rect = CRect(
-                    min_x: rect.min_x, min_y: rect.min_y - yOffset, max_x: rect.max_x,
-                    max_y: rect.max_y - yOffset
+                    min_x: rect.min_x - xOffset, min_y: rect.min_y - yOffset,
+                    max_x: rect.max_x - xOffset, max_y: rect.max_y - yOffset
                 )
 
                 return LBTextSelectionRect(cRect: new_rect, loc: index, size: buffer.count)
@@ -760,7 +761,7 @@
                     ? (point.x, point.y)
                     : (point.x - floatingCursorNewStartX, point.y - floatingCursorNewStartY)
 
-            let point = CPoint(x: x, y: y + yOffset)
+            let point = CPoint(x: x + xOffset, y: y + yOffset)
             let result = position_at_point(wsHandle, point)
 
             return LBTextPos(c: result)
@@ -1370,12 +1371,21 @@
                     mtkView.onSelectionChanged?()
                 }
 
-                // adjust text interaction region to exclude find widget
-                let findHeight = CGFloat(output.text_input_top_offset)
-                currentWrapper.textInputTopOffset = findHeight
-                let newTopOffset = currentWrapper.currentHeaderSize + findHeight
-                if let tc = currentWrapper.topConstraint, tc.constant != newTopOffset {
-                    tc.constant = newTopOffset
+                // Position the interaction overlay to the rect Rust reports
+                if output.has_text_interaction_rect {
+                    let r = output.text_interaction_rect
+                    // Round to whole points: egui emits sub-pixel-jittery f32
+                    // rects, and re-setting the frame every draw resets the
+                    // UITextInteraction (caret stops tracking scroll).
+                    let rect = CGRect(
+                        x: r.min_x.rounded(), y: r.min_y.rounded(),
+                        width: (r.max_x - r.min_x).rounded(),
+                        height: (r.max_y - r.min_y).rounded()
+                    )
+                    currentWrapper.interactionRect = rect
+                    if currentWrapper.frame != rect {
+                        currentWrapper.frame = rect
+                    }
                 }
 
                 let keyboard_shown = currentWrapper.isFirstResponder && GCKeyboard.coalesced == nil

--- a/libs/content/workspace-ffi/src/android/response.rs
+++ b/libs/content/workspace-ffi/src/android/response.rs
@@ -41,7 +41,7 @@ impl From<crate::Response> for AndroidResponse {
                     markdown_editor_text_updated,
                     markdown_editor_selection_updated,
                     markdown_editor_scroll_updated: _,
-                    markdown_editor_find_widget_height: _,
+                    text_interaction_rect: _,
                     tabs_changed,
                     failure_messages: _,
                     selected_folder_changed: _,

--- a/libs/content/workspace-ffi/src/apple/ios/response.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/response.rs
@@ -27,9 +27,10 @@ pub struct IOSResponse {
     pub tab_title_clicked: bool,
     pub selected_folder_changed: bool,
 
-    /// Height in points of content above the editor (find widget) that the
-    /// text interaction overlay should not cover.
-    pub text_input_top_offset: f32,
+    /// Screen rect (points) the native text-interaction overlay (`MdView`)
+    /// should occupy — the editor viewport minus the find widget and toolbar.
+    pub has_text_interaction_rect: bool,
+    pub text_interaction_rect: CRect,
 }
 
 impl From<crate::Response> for IOSResponse {
@@ -47,7 +48,7 @@ impl From<crate::Response> for IOSResponse {
                     markdown_editor_text_updated,
                     markdown_editor_selection_updated,
                     markdown_editor_scroll_updated,
-                    markdown_editor_find_widget_height,
+                    text_interaction_rect,
                     tabs_changed,
                     failure_messages: _,
                     selected_folder_changed,
@@ -91,7 +92,15 @@ impl From<crate::Response> for IOSResponse {
             has_virtual_keyboard_shown: virtual_keyboard_shown.is_some(),
             virtual_keyboard_shown: virtual_keyboard_shown.unwrap_or_default(),
             selected_folder_changed,
-            text_input_top_offset: markdown_editor_find_widget_height,
+            has_text_interaction_rect: text_interaction_rect.is_some(),
+            text_interaction_rect: text_interaction_rect
+                .map(|r| CRect {
+                    min_x: r.min.x as f64,
+                    min_y: r.min.y as f64,
+                    max_x: r.max.x as f64,
+                    max_y: r.max.y as f64,
+                })
+                .unwrap_or_default(),
         }
     }
 }

--- a/libs/content/workspace-ffi/src/apple/macos/response.rs
+++ b/libs/content/workspace-ffi/src/apple/macos/response.rs
@@ -42,7 +42,7 @@ impl From<crate::Response> for MacOSResponse {
                     markdown_editor_text_updated: _,
                     markdown_editor_selection_updated: _,
                     markdown_editor_scroll_updated: _,
-                    markdown_editor_find_widget_height: _,
+                    text_interaction_rect: _,
                     tabs_changed,
                     failure_messages: _,
                     selected_folder_changed,

--- a/libs/content/workspace/src/output.rs
+++ b/libs/content/workspace/src/output.rs
@@ -21,7 +21,8 @@ pub struct Response {
     pub markdown_editor_text_updated: bool,
     pub markdown_editor_selection_updated: bool,
     pub markdown_editor_scroll_updated: bool,
-    pub markdown_editor_find_widget_height: f32,
+    /// Screen rect (egui points) for the native iOS text-interaction overlay.
+    pub text_interaction_rect: Option<egui::Rect>,
 
     pub tabs_changed: bool,
 

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -235,7 +235,7 @@ impl Workspace {
             if resp.selection_updated {
                 self.out.markdown_editor_selection_updated = true;
             }
-            self.out.markdown_editor_find_widget_height = resp.find_widget_height;
+            self.out.text_interaction_rect = resp.text_interaction_rect;
             if resp.scroll_updated {
                 self.out.markdown_editor_scroll_updated = true;
             }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -86,8 +86,10 @@ pub struct Response {
     pub scroll_updated: bool,
     pub open_camera: bool,
 
-    // Used to restrict iOS TextInteraction area
-    pub find_widget_height: f32,
+    /// Screen rect (egui points) where native iOS text interaction should
+    /// live — the editor viewport minus the find widget and toolbar. The
+    /// single source of truth for positioning the `MdView` iOS overlay.
+    pub text_interaction_rect: Option<egui::Rect>,
 }
 
 pub struct MdRender {
@@ -845,6 +847,13 @@ impl Editor {
                     } else {
                         0.
                     };
+
+                    let avail = ui.available_rect_before_wrap();
+                    self.next_resp.text_interaction_rect = Some(egui::Rect::from_min_max(
+                        avail.min,
+                        egui::pos2(avail.max.x, avail.max.y - toolbar_height),
+                    ));
+
                     let editor_shown = ui
                         .allocate_ui(
                             egui::vec2(
@@ -891,6 +900,8 @@ impl Editor {
                         self.show_toolbar(root, ui);
                     }
                     self.show_find_centered(ui);
+
+                    self.next_resp.text_interaction_rect = Some(ui.available_rect_before_wrap());
 
                     // galleys / wrap_lines are cleared and repopulated inside
                     // MdEdit::show — don't clear here or input handling (which
@@ -1356,7 +1367,6 @@ impl Editor {
         let find_output = scope_resp.inner;
         let rendered_rect = scope_resp.response.rect;
         ui.advance_cursor_after_rect(rendered_rect);
-        self.next_resp.find_widget_height = rendered_rect.height();
 
         self.edit.event.internal_events.extend(find_output.events);
         if find_output.scroll_to_match {

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -209,7 +209,7 @@ impl Tab {
                         resp.text_updated = md_resp.text_updated;
                         resp.selection_updated = md_resp.selection_updated;
                         resp.scroll_updated = md_resp.scroll_updated;
-                        resp.find_widget_height = md_resp.find_widget_height;
+                        resp.text_interaction_rect = md_resp.text_interaction_rect;
                     }
                     TabContent::Image(img) => img.show(ui),
                     TabContent::Pdf(pdf) => pdf.show(ui),
@@ -349,7 +349,7 @@ pub struct Response {
     pub selection_updated: bool,
     pub scroll_updated: bool,
     pub open_camera: bool,
-    pub find_widget_height: f32,
+    pub text_interaction_rect: Option<egui::Rect>,
     pub open_file: Option<Uuid>,
 }
 


### PR DESCRIPTION
We started hiding the toolbar when the keyboard is hidden but the area where the toolbar was shown was still not responsive to touches. This PR tugs the quality thread, replacing a handful of bespoke inlays and offsets with: the editor reports a specific screen area that should respond to touches.

fixes https://github.com/lockbook/lockbook/issues/4581