### PR TITLE
md: snap scroll thumb to drags in addition to clicks

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1207,7 +1207,7 @@ impl Editor {
                         // entries. The immutable `DocScrollContent`
                         // borrow is released here before phase 2's
                         // mutable renderer paint.
-                        let (visible, neighbors, scrollbar_track) = {
+                        let (visible, neighbors, scrollbar_track, scrollbar_grab) = {
                             use crate::widgets::affine_scroll::{Rows as _, VisibleRow};
 
                             let content = scroll_content::DocScrollContent::for_frame(
@@ -1246,15 +1246,19 @@ impl Editor {
                                     id = next_id;
                                 }
                             }
-                            (resp.visible, neighbors, resp.scrollbar_track)
+                            (resp.visible, neighbors, resp.scrollbar_track, resp.scrollbar_grab)
                         };
-                        // Register the scrollbar's track so iOS taps
-                        // on it don't fall through to cursor-placement
+                        // Register the scrollbar's track and grab area so iOS
+                        // taps on them don't fall through to cursor-placement
                         // / keyboard-summon handlers.
                         self.edit
                             .renderer
                             .touch_consuming_rects
                             .push(scrollbar_track);
+                        self.edit
+                            .renderer
+                            .touch_consuming_rects
+                            .push(scrollbar_grab);
 
                         // Phase 2: paint each visible row with a mutable
                         // renderer borrow. Block list re-collected

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1207,7 +1207,7 @@ impl Editor {
                         // entries. The immutable `DocScrollContent`
                         // borrow is released here before phase 2's
                         // mutable renderer paint.
-                        let (visible, neighbors, scrollbar_track, scrollbar_grab) = {
+                        let (visible, neighbors, scrollbar_grab) = {
                             use crate::widgets::affine_scroll::{Rows as _, VisibleRow};
 
                             let content = scroll_content::DocScrollContent::for_frame(
@@ -1246,19 +1246,15 @@ impl Editor {
                                     id = next_id;
                                 }
                             }
-                            (resp.visible, neighbors, resp.scrollbar_track, resp.scrollbar_grab)
+                            (resp.visible, neighbors, resp.scrollbar_grab)
                         };
-                        // Register the scrollbar's track and grab area so iOS
-                        // taps on them don't fall through to cursor-placement
-                        // / keyboard-summon handlers.
+                        // Register the scrollbar's grab area so iOS taps on it
+                        // don't fall through to cursor-placement / keyboard-
+                        // summon handlers.
                         self.edit
                             .renderer
                             .touch_consuming_rects
-                            .push(scrollbar_track);
-                        self.edit
-                            .renderer
-                            .touch_consuming_rects
-                            .push(scrollbar_grab);
+                            .extend(scrollbar_grab);
 
                         // Phase 2: paint each visible row with a mutable
                         // renderer borrow. Block list re-collected

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1125,9 +1125,11 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         let bar_geom = self.state.scrollbar(rows, bar_track);
         let scrollable = bar_geom.scrollable_approx > 0.0;
 
-        // interacting with the scrollbar opens the keyboard on mobile and places the cursor
-        // mitgate this by triggering a scroll only when you interact with the thumb
-        let bar_interact_rect = if self.touch_scroll { bar_geom.thumb } else { bar_track };
+        // On touch, widen the track's hit area — the bar is far narrower than
+        // a fingertip, and an interaction that misses it becomes a body drag
+        // (which scrolls the opposite direction).
+        let bar_interact_rect =
+            if self.touch_scroll { bar_track.expand2(Vec2::new(15.0, 0.0)) } else { bar_track };
         let bar_response = ui.interact(bar_interact_rect, bar_id, Sense::click_and_drag());
 
         // Wheel: precise pixels. egui convention: positive y = scroll up
@@ -1183,8 +1185,9 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         // command, so reading the live thumb position would double-apply
         // any scroll that already happened this frame.
         if scrollable && (bar_response.dragged() || bar_response.clicked()) {
-            // A drag that starts on the track outside the thumb jumps to the
-            // pointer like a click, then continues as a relative thumb drag.
+            // A drag that grabs the thumb moves it relatively; any other
+            // click or drag on the bar jumps the thumb to the pointer
+            // (and the jumped drag continues relatively from there).
             let drag_jump = bar_response.drag_started()
                 && bar_response
                     .interact_pointer_pos()
@@ -1214,7 +1217,12 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         let bar_after = self.state.scrollbar(rows, bar_track);
         draw_scrollbar(ui, bar_after);
 
-        ShowResponse { response, visible, scrollbar_track: bar_track }
+        ShowResponse {
+            response,
+            visible,
+            scrollbar_track: bar_track,
+            scrollbar_grab: bar_interact_rect,
+        }
     }
 }
 
@@ -1232,6 +1240,10 @@ pub struct ShowResponse<Id> {
     /// taps on the scrollbar don't fall through to other touch handlers
     /// (cursor placement, virtual keyboard).
     pub scrollbar_track: Rect,
+    /// Rect that grabs scrollbar clicks and drags — on touch, the track plus
+    /// its widened hit area, which extends past the visual. Register with the
+    /// touch-consuming surface alongside `scrollbar_track`.
+    pub scrollbar_grab: Rect,
 }
 
 /// Returned by [`AffineScrollArea::begin`]; pass to `finish` after

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -68,9 +68,10 @@
 //!
 //! ## Scrollbar
 //!
+//! - Hidden — no paint, no hit area — when the document fits the
+//!   viewport and there's nothing to scroll.
 //! - Thumb size proportional to the visible fraction; floored at
-//!   [`MIN_THUMB_PX`] for grabability; fills the track when the doc
-//!   fits the viewport.
+//!   [`MIN_THUMB_PX`] for grabability.
 //! - Thumb position proportional to scroll progress in approx
 //!   coordinate.
 //! - Track + thumb expressed in window-local pixels; embedder chooses
@@ -1127,10 +1128,13 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
 
         // On touch, widen the track's hit area — the bar is far narrower than
         // a fingertip, and an interaction that misses it becomes a body drag
-        // (which scrolls the opposite direction).
+        // (which scrolls the opposite direction). When the document fits the
+        // viewport the bar is absent entirely — no hit area, no paint — and
+        // pointer input falls through to the content beneath.
         let bar_interact_rect =
             if self.touch_scroll { bar_track.expand2(Vec2::new(15.0, 0.0)) } else { bar_track };
-        let bar_response = ui.interact(bar_interact_rect, bar_id, Sense::click_and_drag());
+        let bar_response =
+            scrollable.then(|| ui.interact(bar_interact_rect, bar_id, Sense::click_and_drag()));
 
         // Wheel: precise pixels. egui convention: positive y = scroll up
         // (content moves down). We want offset to grow when user scrolls
@@ -1184,7 +1188,7 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         // — the user's drag is a pixel-velocity gesture, not a position
         // command, so reading the live thumb position would double-apply
         // any scroll that already happened this frame.
-        if scrollable && (bar_response.dragged() || bar_response.clicked()) {
+        if let Some(bar_response) = bar_response.as_ref().filter(|r| r.dragged() || r.clicked()) {
             // A drag that grabs the thumb moves it relatively; any other
             // click or drag on the bar jumps the thumb to the pointer
             // (and the jumped drag continues relatively from there).
@@ -1214,15 +1218,11 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         let visible = self.state.visible(rows);
         warm_around_visible(rows, &visible, rect.height());
 
-        let bar_after = self.state.scrollbar(rows, bar_track);
-        draw_scrollbar(ui, bar_after);
-
-        ShowResponse {
-            response,
-            visible,
-            scrollbar_track: bar_track,
-            scrollbar_grab: bar_interact_rect,
+        if scrollable {
+            draw_scrollbar(ui, self.state.scrollbar(rows, bar_track));
         }
+
+        ShowResponse { response, visible, scrollbar_grab: scrollable.then_some(bar_interact_rect) }
     }
 }
 
@@ -1235,15 +1235,13 @@ pub struct ShowResponse<Id> {
     /// Visible rows top-down. `top` is viewport-local; add `viewport.min.y`
     /// for screen coordinates.
     pub visible: Vec<VisibleRow<Id>>,
-    /// Track rect of the rendered scrollbar (window-local pixels).
-    /// Embedders register this with their touch-consuming surface so
-    /// taps on the scrollbar don't fall through to other touch handlers
-    /// (cursor placement, virtual keyboard).
-    pub scrollbar_track: Rect,
-    /// Rect that grabs scrollbar clicks and drags — on touch, the track plus
-    /// its widened hit area, which extends past the visual. Register with the
-    /// touch-consuming surface alongside `scrollbar_track`.
-    pub scrollbar_grab: Rect,
+    /// Rect that grabs scrollbar clicks and drags (window-local pixels) —
+    /// the track plus, on touch, its widened hit area. Embedders register
+    /// it with their touch-consuming surface so taps on the scrollbar
+    /// don't fall through to other touch handlers (cursor placement,
+    /// virtual keyboard). `None` when the document fits the viewport and
+    /// the scrollbar is hidden.
+    pub scrollbar_grab: Option<Rect>,
 }
 
 /// Returned by [`AffineScrollArea::begin`]; pass to `finish` after

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1183,7 +1183,13 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         // command, so reading the live thumb position would double-apply
         // any scroll that already happened this frame.
         if scrollable && (bar_response.dragged() || bar_response.clicked()) {
-            if bar_response.dragged() {
+            // A drag that starts on the track outside the thumb jumps to the
+            // pointer like a click, then continues as a relative thumb drag.
+            let drag_jump = bar_response.drag_started()
+                && bar_response
+                    .interact_pointer_pos()
+                    .is_some_and(|pos| !bar_geom.thumb.contains(pos));
+            if bar_response.dragged() && !drag_jump {
                 let drag_y = ui.input(|i| i.pointer.delta().y);
                 let approx_delta = bar_geom.pixel_to_approx(drag_y);
                 self.state.handle(rows, Action::ScrollByThumb(approx_delta));


### PR DESCRIPTION
* fixes https://github.com/lockbook/lockbook/issues/4616
* fixes difficulties grabbing scrollbar on mobile
* hides scrollbar when not enough content to scroll