### PR TITLE
md: fold increment

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -49,6 +49,38 @@ pub struct Bounds {
     /// * Inline paragraphs can be empty.
     /// * Inline paragraphs cannot touch.
     pub inline_paragraphs: Paragraphs,
+
+    /// One entry per actively folded section, sorted by tag position.
+    /// * Documents may have no folds.
+    /// * Fold contents can nest (an inner fold within an outer section).
+    pub folds: Vec<FoldBounds>,
+}
+
+/// Tag + hidden-contents ranges of one actively folded section. Both act
+/// as atoms: the cursor never rests strictly inside the tag, navigation
+/// steps past the contents (a cursor right of the `···` chip has cursored
+/// *past* the section), and edits against either resolve whole-fold
+/// (engulf the tag / unfold) rather than touching hidden text.
+#[derive(Clone, Copy, Debug)]
+pub struct FoldBounds {
+    /// The fold tag's range. Never empty.
+    pub tag: (Grapheme, Grapheme),
+    /// The hidden contents: `(start, end]` is invisible while folded.
+    pub contents: (Grapheme, Grapheme),
+}
+
+impl FoldBounds {
+    /// True if `offset` is strictly inside the tag — a cursor position
+    /// that would split the tag's source text.
+    pub fn tag_interior(&self, offset: Grapheme) -> bool {
+        self.tag.start() < offset && offset < self.tag.end()
+    }
+
+    /// True if a cursor at `offset` would sit in the hidden contents.
+    /// `contents.start()` itself is visible (right of the chip).
+    pub fn conceals(&self, offset: Grapheme) -> bool {
+        self.contents.start() < offset && offset <= self.contents.end()
+    }
 }
 
 impl Default for Bounds {
@@ -59,6 +91,7 @@ impl Default for Bounds {
             words: Words::default(),
             wrap_lines: Lines::default(),
             inline_paragraphs: Paragraphs::default(),
+            folds: Vec::default(),
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/fold.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/fold.rs
@@ -1,0 +1,398 @@
+//! Section folding. A fold tag ([`FOLD_TAG`]) at the end of a heading or
+//! list item's first line hides the section's contents and renders as a
+//! `···` chip. The chip *is* the folded text: a cursor right of it has
+//! cursored *past* the section, a selection containing it stands for the
+//! contents it hides, and edits against it resolve whole-fold — grow
+//! over the contents, engulf the tag, or unfold — never touching hidden
+//! text. Find reveals hidden contents without unfolding; everywhere
+//! else, a selection endpoint landing in hidden contents unfolds the
+//! section, keeping every cursor position visible.
+
+use comrak::Arena;
+use comrak::nodes::{AstNode, NodeHeading, NodeValue};
+use lb_rs::model::text::buffer;
+use lb_rs::model::text::offset_types::{Grapheme, IntoRangeExt as _, RangeExt as _};
+use lb_rs::model::text::operation_types::{Operation, Replace};
+
+use crate::tab::markdown_editor::bounds::FoldBounds;
+use crate::tab::markdown_editor::input::{Advance, Bound, Increment, Region};
+use crate::tab::markdown_editor::widget::utils::wrap_layout::{
+    FontFamily, Format, Layout, StyleInfo,
+};
+use crate::tab::markdown_editor::{Event, MdEdit, MdRender};
+use crate::theme::icons::Icon;
+
+pub const FOLD_TAG: &str = "<!-- {\"fold\":true} -->";
+
+/// Visible glyph of the chip a folded section's tag renders as — a
+/// single icon, so the dots are spaced as drawn rather than as three
+/// text glyphs ([`Icon::DOTS_HORIZONTAL`]).
+pub const FOLD_CHIP_TEXT: &str = Icon::DOTS_HORIZONTAL.icon;
+
+/// Click-target id for a fold's chip. Keyed by tag range so layout and
+/// interaction handling derive the same id without the AST node.
+fn fold_chip_id_salt(tag: (Grapheme, Grapheme)) -> egui::Id {
+    egui::Id::new(("md_fold_chip", tag.start().0, tag.end().0))
+}
+
+// ─── fold bounds ─────────────────────────────────────────────────────
+
+impl<'ast> MdRender {
+    /// The hidden contents of a foldable node — [`Self::heading_contents`]
+    /// or [`Self::item_contents`] by node type.
+    pub fn fold_contents(&self, node: &'ast AstNode<'ast>) -> Option<(Grapheme, Grapheme)> {
+        match node.data.borrow().value {
+            NodeValue::Heading(_) => Some(self.heading_contents(node)),
+            NodeValue::Item(_) | NodeValue::TaskItem(_) => Some(self.item_contents(node)),
+            _ => None,
+        }
+    }
+
+    /// Recompute [`super::bounds::Bounds::folds`] — the tag and hidden-
+    /// contents ranges of each actively folded section. Depends on text
+    /// only.
+    pub fn calc_fold_bounds(&mut self, root: &'ast AstNode<'ast>) {
+        let mut folds = Vec::new();
+        for node in root.descendants() {
+            if let Some(fold) = self.fold(node) {
+                if let Some(contents) = self.fold_contents(node) {
+                    folds.push(FoldBounds { tag: self.node_range(fold), contents });
+                }
+            }
+        }
+        folds.sort_unstable_by_key(|f| f.tag);
+        self.bounds.folds = folds;
+    }
+
+    /// The active fold whose tag occupies exactly `tag`, if any. A
+    /// `FOLD_TAG` comment that isn't folding anything (e.g. in a plain
+    /// paragraph) has no entry and renders as regular inline html.
+    pub fn active_fold_at_tag(&self, tag: (Grapheme, Grapheme)) -> Option<FoldBounds> {
+        self.bounds.folds.iter().find(|f| f.tag == tag).copied()
+    }
+}
+
+// ─── find reveal ─────────────────────────────────────────────────────
+
+impl MdRender {
+    /// Ranges that reveal *folded contents* without unfolding: the
+    /// current find match and preview. The selection is deliberately
+    /// excluded — a selection endpoint landing in folded contents
+    /// unfolds for real instead ([`Self::unfold_ops_for_selection`]).
+    pub fn fold_reveal_ranges(&self) -> impl Iterator<Item = (Grapheme, Grapheme)> + '_ {
+        self.find_current_match
+            .into_iter()
+            .chain(self.preview_match)
+    }
+
+    /// Returns true if `range` contains any fold-reveal range.
+    pub fn range_contains_fold_revealed(
+        &self, range: (Grapheme, Grapheme), allow_empty_range: bool, allow_empty_selection: bool,
+    ) -> bool {
+        self.fold_reveal_ranges()
+            .any(|rr| range.contains_range(&rr, allow_empty_range, allow_empty_selection))
+    }
+
+    /// Returns true if a fold-reveal range force-reveals this fold's
+    /// contents.
+    pub fn fold_revealed(&self, fold: &FoldBounds) -> bool {
+        self.range_contains_fold_revealed(fold.contents, false, true)
+    }
+}
+
+// ─── chip rendering + interaction ────────────────────────────────────
+
+impl<'ast> MdRender {
+    /// Lay out an active fold's tag: a `···` chip while the contents are
+    /// hidden, a zero-width anchor while a find match force-reveals them
+    /// (the chip would misread as hidden content). Never tag source.
+    pub fn layout_fold_chip(
+        &self, layout: &mut Layout, parent: &'ast AstNode<'ast>, fold: FoldBounds,
+        node_range: (Grapheme, Grapheme),
+    ) {
+        if self.fold_revealed(&fold) {
+            layout.push_override(node_range, "", self.text_format_html_inline(parent));
+            return;
+        }
+        // Breathing room between the preceding text and the chip,
+        // outside the capsule. Zero-length source: a click here lands
+        // left of the chip.
+        layout.push_override(node_range.start().into_range(), " ", self.text_format(parent));
+        // Interaction outside the style scope so the capsule's side
+        // pads are part of the click target.
+        let format = Format { family: FontFamily::Icons, ..self.text_format_html_inline(parent) };
+        layout.interaction_open(fold_chip_id_salt(fold.tag), egui::Sense::click());
+        layout.style_open(StyleInfo {
+            format: format.clone(),
+            source_range: node_range,
+            chip: true,
+        });
+        layout.push_override(node_range, FOLD_CHIP_TEXT, format);
+        layout.style_close();
+        layout.interaction_close();
+    }
+
+    /// Expand a folded section when its `···` chip is clicked.
+    /// Must run after `interact_fragments`.
+    pub fn handle_fold_interactions(&mut self, ui: &egui::Ui) {
+        if !self.interactive {
+            return;
+        }
+        let parent_base = ui.id();
+        for i in 0..self.bounds.folds.len() {
+            let fold = self.bounds.folds[i];
+            let id = parent_base.with(fold_chip_id_salt(fold.tag));
+            let Some(response) = self.interaction_responses.get(&id).cloned() else {
+                continue;
+            };
+
+            // iOS routes touches through `touch_consuming_rects` —
+            // without this entry a tap on the chip would place the
+            // cursor instead of reaching the expand handler below.
+            self.touch_consuming_rects.push(response.rect);
+
+            if response.hovered() {
+                ui.ctx()
+                    .output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
+            }
+            if response.clicked() {
+                self.render_events.push(Event::Replace {
+                    region: fold.tag.into(),
+                    text: "".into(),
+                    advance_cursor: false,
+                });
+            }
+            response.on_hover_text("Show Contents");
+        }
+    }
+}
+
+// ─── navigation + selection atoms ────────────────────────────────────
+
+impl MdRender {
+    /// Folded regions are atoms for navigation: an advance landing
+    /// inside a fold tag or its hidden contents continues out in the
+    /// travel direction — forward motion past the chip resumes at the
+    /// next visible position after the section. Find-revealed contents
+    /// stay walkable. Loops to a fixpoint so nested folds snap all the
+    /// way out.
+    pub fn snap_offset_out_of_folds(&self, mut offset: Grapheme, backwards: bool) -> Grapheme {
+        let last = self.buffer.current.segs.last_cursor_position();
+        loop {
+            let mut moved = false;
+            for f in &self.bounds.folds {
+                if f.tag_interior(offset) {
+                    offset = if backwards { f.tag.start() } else { f.tag.end() };
+                    moved = true;
+                }
+                if f.conceals(offset) && !self.fold_revealed(f) {
+                    offset = if backwards {
+                        f.contents.start()
+                    } else if f.contents.end() < last {
+                        f.contents.end() + 1
+                    } else {
+                        // hidden through the end of the doc: nothing
+                        // visible forward; rest at the near edge
+                        f.contents.start()
+                    };
+                    moved = true;
+                }
+            }
+            if !moved {
+                return offset;
+            }
+        }
+    }
+
+    /// Fold tags are atoms for selection: an endpoint strictly inside
+    /// one snaps out, so no selection can clip a tag (and an edit over
+    /// the selection can't leave partial tag text behind). A non-empty
+    /// selection grows to cover the tag; a cursor collapses to the
+    /// nearer edge.
+    pub fn snap_selection_out_of_fold_tags(
+        &self, mut range: (Grapheme, Grapheme),
+    ) -> (Grapheme, Grapheme) {
+        for f in &self.bounds.folds {
+            if range.is_empty() {
+                if f.tag_interior(range.0) {
+                    let mid = f.tag.start().0 + (f.tag.end().0 - f.tag.start().0) / 2;
+                    let edge = if range.0.0 < mid { f.tag.start() } else { f.tag.end() };
+                    return (edge, edge);
+                }
+            } else {
+                // Each endpoint moves away from the other (orientation-
+                // agnostic), growing the selection over the atom.
+                if f.tag_interior(range.0) {
+                    range.0 = if range.0 <= range.1 { f.tag.start() } else { f.tag.end() };
+                }
+                if f.tag_interior(range.1) {
+                    range.1 = if range.1 <= range.0 { f.tag.start() } else { f.tag.end() };
+                }
+            }
+        }
+        range
+    }
+}
+
+// ─── capsule semantics for edits ─────────────────────────────────────
+
+impl MdRender {
+    /// The chip stands for the contents it hides: an edit range that
+    /// contains a fold's whole capsule (its tag) grows over that fold's
+    /// hidden contents, so deleting or typing over the selection edits
+    /// what it visibly includes. Find-revealed folds are exempt — their
+    /// contents are on screen and visibly outside the selection.
+    /// Returns an ordered range.
+    pub fn grow_range_over_selected_folds(
+        &self, range: (Grapheme, Grapheme),
+    ) -> (Grapheme, Grapheme) {
+        let mut range = (range.start(), range.end());
+        for f in &self.bounds.folds {
+            if range.0 <= f.tag.start() && range.1 >= f.tag.end() && !self.fold_revealed(f) {
+                range.1 = range.1.max(f.contents.end());
+            }
+        }
+        range
+    }
+
+    /// Fold tags delete atomically: a deletion range clipping one (e.g.
+    /// backspace right of the chip, whose advance snapped over the tag
+    /// atom) widens to consume the whole tag, never leaving partial tag
+    /// text. A deletion covering all the hidden contents takes the tag
+    /// too — a fold with nothing left to hide would orphan into inert
+    /// text. Returns an ordered range.
+    pub fn widen_delete_over_folds(&self, range: (Grapheme, Grapheme)) -> (Grapheme, Grapheme) {
+        let mut range = (range.start(), range.end());
+        for f in &self.bounds.folds {
+            let clips_tag = range.0 < f.tag.end() && range.1 > f.tag.start();
+            let covers_contents = range.0 <= f.tag.end() && range.1 >= f.contents.end();
+            if clips_tag || covers_contents {
+                range.0 = range.0.min(f.tag.start());
+                range.1 = range.1.max(f.tag.end());
+            }
+        }
+        range
+    }
+
+    /// Operations that unfold any folded section a selection endpoint
+    /// landed strictly inside of, so every cursor position is visible.
+    /// Plain navigation steps past folded regions instead; this catches
+    /// the remaining paths (programmatic selects, edits that strand the
+    /// selection in hidden text). A selection that contains the entire
+    /// folded contents (e.g. select-all) spans the fold rather than
+    /// entering it and keeps it folded.
+    pub fn unfold_ops_for_selection(&self) -> Vec<Operation> {
+        let selection = self.buffer.current.selection;
+        let mut ops = Vec::new();
+        for f in &self.bounds.folds {
+            if selection.contains_range(&f.contents, true, true) {
+                continue;
+            }
+            if f.conceals(selection.start()) || f.conceals(selection.end()) {
+                ops.push(Operation::Replace(Replace { range: f.tag, text: "".into() }));
+            }
+        }
+        ops
+    }
+}
+
+// ─── event hooks ─────────────────────────────────────────────────────
+
+impl<'ast> MdEdit {
+    /// Apply [`MdRender::unfold_ops_for_selection`], reparsing on
+    /// change so this frame renders the unfolded state.
+    pub fn unfold_at_selection<'a>(&mut self, arena: &'a Arena<'a>) -> buffer::Response {
+        let ops = self.renderer.unfold_ops_for_selection();
+        if ops.is_empty() {
+            return buffer::Response::default();
+        }
+        self.renderer.buffer.queue(ops);
+        let response = self.renderer.buffer.update();
+        self.renderer.bump_text_seq();
+        self.renderer.reparse(arena);
+        response
+    }
+
+    /// Enter right of a folded node's `···` chip creates the new
+    /// heading / list item *after* the hidden contents instead of
+    /// splitting into them. True if handled (ops + cursor pushed).
+    pub fn fold_newline(&self, root: &'ast AstNode<'ast>, operations: &mut Vec<Operation>) -> bool {
+        // selection must be empty
+        let Some(offset) = self.renderer.selection_offset() else {
+            return false;
+        };
+        for node in root.descendants() {
+            if self.renderer.fold(node).is_none() {
+                continue;
+            }
+            let Some(contents) = self.renderer.fold_contents(node) else {
+                continue;
+            };
+            if offset != contents.start() {
+                continue;
+            }
+            let prefix = match &node.data.borrow().value {
+                NodeValue::Heading(NodeHeading { level, .. }) => "#".repeat(*level as usize) + " ",
+                _ => match self.renderer.insertion_prefix(node) {
+                    Some(prefix) => prefix,
+                    None => return false,
+                },
+            };
+            let insert_at = contents.end().into_range();
+            operations.push(Operation::Replace(Replace {
+                range: insert_at,
+                text: format!("\n{prefix}"),
+            }));
+            // at the insertion point, so advances past the inserted text
+            operations.push(Operation::Select(insert_at));
+            return true;
+        }
+        false
+    }
+
+    /// Deleting against a folded region unfolds it instead of editing
+    /// hidden text: backspace at the first position after the section
+    /// (which would join visible text into it) or forward-delete right
+    /// of the chip removes the fold tag and nothing else. True if
+    /// handled (ops + cursor pushed).
+    pub fn fold_delete(&self, region: Region, operations: &mut Vec<Operation>) -> bool {
+        let Region::SelectionOrAdvance {
+            advance: Advance::Next(Bound::Word) | Advance::By(Increment::Char),
+            backwards,
+        } = region
+        else {
+            return false;
+        };
+        // selection must be empty
+        let Some(offset) = self.renderer.selection_offset() else {
+            return false;
+        };
+        for f in &self.renderer.bounds.folds {
+            let against = if backwards {
+                offset == f.contents.end() + 1
+            } else {
+                offset == f.contents.start()
+            };
+            if !against {
+                continue;
+            }
+            // Backspace on an *empty* line after the folded region
+            // deletes the line: nothing visible joins into hidden text,
+            // and the cursor comes to rest right of the chip.
+            if backwards && self.renderer.line_at_offset(offset).is_empty() {
+                operations.push(Operation::Replace(Replace {
+                    range: (f.contents.end(), f.contents.end() + 1),
+                    text: "".into(),
+                }));
+                operations.push(Operation::Select(f.contents.start().into_range()));
+                return true;
+            }
+            // Otherwise the deletion would edit hidden text (join into
+            // it / erase from it): unfold instead.
+            operations.push(Operation::Replace(Replace { range: f.tag, text: "".into() }));
+            operations.push(Operation::Select(offset.into_range()));
+            return true;
+        }
+        false
+    }
+}

--- a/libs/content/workspace/src/tab/markdown_editor/fold.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/fold.rs
@@ -1,12 +1,14 @@
 //! Section folding. A fold tag ([`FOLD_TAG`]) at the end of a heading or
 //! list item's first line hides the section's contents and renders as a
-//! `···` chip. The chip *is* the folded text: a cursor right of it has
-//! cursored *past* the section, a selection containing it stands for the
-//! contents it hides, and edits against it resolve whole-fold — grow
-//! over the contents, engulf the tag, or unfold — never touching hidden
-//! text. Find reveals hidden contents without unfolding; everywhere
-//! else, a selection endpoint landing in hidden contents unfolds the
-//! section, keeping every cursor position visible.
+//! `···` chip.
+//!
+//! The chip represents the fold *tag* in that, when you place your cursor to
+//! the right of the chip, you are between the fold tag and the folded content.
+//! This is why newline in a folded list item inserts a new list item.
+//!
+//! The chip represents the fold *content* in that, when you replace/delete/copy
+//! it, you replace/delete/copy the content. This is accomplished in the logic
+//! that handles those operations.
 
 use comrak::Arena;
 use comrak::nodes::{AstNode, NodeHeading, NodeValue};
@@ -105,7 +107,7 @@ impl MdRender {
 impl<'ast> MdRender {
     /// Lay out an active fold's tag: a `···` chip while the contents are
     /// hidden, a zero-width anchor while a find match force-reveals them
-    /// (the chip would misread as hidden content). Never tag source.
+    /// (the chip would misread as hidden content). Never show tag source.
     pub fn layout_fold_chip(
         &self, layout: &mut Layout, parent: &'ast AstNode<'ast>, fold: FoldBounds,
         node_range: (Grapheme, Grapheme),

--- a/libs/content/workspace/src/tab/markdown_editor/fold.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/fold.rs
@@ -243,7 +243,7 @@ impl MdRender {
     /// what it visibly includes. Find-revealed folds are exempt — their
     /// contents are on screen and visibly outside the selection.
     /// Returns an ordered range.
-    pub fn grow_range_over_selected_folds(
+    pub fn grow_range_over_fold_contents(
         &self, range: (Grapheme, Grapheme),
     ) -> (Grapheme, Grapheme) {
         let mut range = (range.start(), range.end());
@@ -257,11 +257,11 @@ impl MdRender {
 
     /// Fold tags delete atomically: a deletion range clipping one (e.g.
     /// backspace right of the chip, whose advance snapped over the tag
-    /// atom) widens to consume the whole tag, never leaving partial tag
+    /// atom) grows to consume the whole tag, never leaving partial tag
     /// text. A deletion covering all the hidden contents takes the tag
     /// too — a fold with nothing left to hide would orphan into inert
     /// text. Returns an ordered range.
-    pub fn widen_delete_over_folds(&self, range: (Grapheme, Grapheme)) -> (Grapheme, Grapheme) {
+    pub fn grow_delete_over_fold_tags(&self, range: (Grapheme, Grapheme)) -> (Grapheme, Grapheme) {
         let mut range = (range.start(), range.end());
         for f in &self.bounds.folds {
             let clips_tag = range.0 < f.tag.end() && range.1 > f.tag.start();
@@ -316,7 +316,9 @@ impl<'ast> MdEdit {
     /// Enter right of a folded node's `···` chip creates the new
     /// heading / list item *after* the hidden contents instead of
     /// splitting into them. True if handled (ops + cursor pushed).
-    pub fn fold_newline(&self, root: &'ast AstNode<'ast>, operations: &mut Vec<Operation>) -> bool {
+    pub fn newline_at_fold(
+        &self, root: &'ast AstNode<'ast>, operations: &mut Vec<Operation>,
+    ) -> bool {
         // selection must be empty
         let Some(offset) = self.renderer.selection_offset() else {
             return false;
@@ -355,7 +357,7 @@ impl<'ast> MdEdit {
     /// (which would join visible text into it) or forward-delete right
     /// of the chip removes the fold tag and nothing else. True if
     /// handled (ops + cursor pushed).
-    pub fn fold_delete(&self, region: Region, operations: &mut Vec<Operation>) -> bool {
+    pub fn delete_at_fold(&self, region: Region, operations: &mut Vec<Operation>) -> bool {
         let Region::SelectionOrAdvance {
             advance: Advance::Next(Bound::Word) | Advance::By(Increment::Char),
             backwards,

--- a/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/advance.rs
@@ -8,7 +8,7 @@ use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 impl MdEdit {
     pub fn advance(&mut self, offset: Grapheme, advance: Advance, backwards: bool) -> Grapheme {
         let maybe_x_target_value = mem::take(&mut self.cursor.x_target);
-        match advance {
+        let result = match advance {
             Advance::To(bound) => offset.advance_to_bound(bound, backwards, &self.renderer.bounds),
             Advance::Next(bound) => {
                 offset.advance_to_next_bound(bound, backwards, &self.renderer.bounds)
@@ -41,7 +41,8 @@ impl MdEdit {
                 }
                 result
             }
-        }
+        };
+        self.renderer.snap_offset_out_of_folds(result, backwards)
     }
 
     fn advance_by_line(&self, offset: Grapheme, x_target: f32, backwards: bool) -> Grapheme {

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -34,10 +34,17 @@ impl<'ast> MdEdit {
         let mut response = buffer::Response::default();
         match event {
             Event::Select { region } => {
-                operations.push(Operation::Select(self.region_to_range(region)));
+                let range = self.region_to_range(region);
+                let range = self.renderer.snap_selection_out_of_fold_tags(range);
+                operations.push(Operation::Select(range));
             }
             Event::Replace { region, text, advance_cursor } => {
-                let range = self.region_to_range(region);
+                let mut range = self.region_to_range(region);
+                // Typing/pasting over a selection edits what the selection
+                // stands for, hidden fold contents included.
+                if matches!(region, Region::Selection) {
+                    range = self.renderer.grow_range_over_selected_folds(range);
+                }
                 operations.push(Operation::Replace(Replace { range, text }));
                 if advance_cursor {
                     operations.push(Operation::Select(range.start().to_range()));
@@ -54,6 +61,13 @@ impl<'ast> MdEdit {
                 response.open_camera = true;
             }
             Event::Newline { shift } => {
+                // Enter right of a folded node's `···` chip creates the new
+                // heading / list item *after* the hidden contents instead of
+                // splitting into them; the handler places its own cursor.
+                if !shift && self.fold_newline(root, operations) {
+                    return response;
+                }
+
                 // insert/extend/terminate container blocks
                 let mut handled = || {
                     // selection must be empty
@@ -146,6 +160,12 @@ impl<'ast> MdEdit {
                 operations.push(Operation::Select(current_selection.start().to_range()));
             }
             Event::Delete { region } => {
+                // Deleting against a folded region unfolds it rather than
+                // editing hidden text; the handler places its own cursor.
+                if self.fold_delete(region, operations) {
+                    return response;
+                }
+
                 // delete container block prefix
                 let mut handled = || {
                     // must be mostly vanilla backspace
@@ -188,7 +208,15 @@ impl<'ast> MdEdit {
                 };
                 if !handled() {
                     // default -> delete region
-                    let range = self.region_to_range(region);
+                    let mut range = self.region_to_range(region);
+                    // Deleting a selection deletes what it stands for,
+                    // hidden fold contents included. Gated on a real
+                    // selection: a bare backspace covers the whole tag too
+                    // (atom snap) but must unfold, not destroy.
+                    if !current_selection.is_empty() {
+                        range = self.renderer.grow_range_over_selected_folds(range);
+                    }
+                    let range = self.renderer.widen_delete_over_folds(range);
                     operations.push(Operation::Replace(Replace { range, text: "".into() }));
                 }
 
@@ -385,6 +413,9 @@ impl<'ast> MdEdit {
                 } else {
                     self.clipboard_current_line()
                 };
+                // capsules carry their hidden contents to the clipboard,
+                // so a cut+paste moves the folded section intact
+                let range = self.renderer.grow_range_over_selected_folds(range);
 
                 ctx.copy_text(self.renderer.buffer[range].into());
                 operations.push(Operation::Replace(Replace { range, text: "".into() }));
@@ -395,6 +426,7 @@ impl<'ast> MdEdit {
                 } else {
                     self.clipboard_current_line()
                 };
+                let range = self.renderer.grow_range_over_selected_folds(range);
 
                 ctx.copy_text(self.renderer.buffer[range].into());
             }

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -40,10 +40,10 @@ impl<'ast> MdEdit {
             }
             Event::Replace { region, text, advance_cursor } => {
                 let mut range = self.region_to_range(region);
-                // Typing/pasting over a selection edits what the selection
-                // stands for, hidden fold contents included.
                 if matches!(region, Region::Selection) {
-                    range = self.renderer.grow_range_over_selected_folds(range);
+                    // selecting a fold chip is just selecting a fold tag, but
+                    // replacing it should delete folded content
+                    range = self.renderer.grow_range_over_fold_contents(range);
                 }
                 operations.push(Operation::Replace(Replace { range, text }));
                 if advance_cursor {
@@ -61,10 +61,10 @@ impl<'ast> MdEdit {
                 response.open_camera = true;
             }
             Event::Newline { shift } => {
-                // Enter right of a folded node's `···` chip creates the new
-                // heading / list item *after* the hidden contents instead of
-                // splitting into them; the handler places its own cursor.
-                if !shift && self.fold_newline(root, operations) {
+                // Enter after a `···` fold chip creates the new heading / list
+                // item after the hidden contents
+                let handled = !shift && self.newline_at_fold(root, operations);
+                if handled {
                     return response;
                 }
 
@@ -161,8 +161,10 @@ impl<'ast> MdEdit {
             }
             Event::Delete { region } => {
                 // Deleting against a folded region unfolds it rather than
-                // editing hidden text; the handler places its own cursor.
-                if self.fold_delete(region, operations) {
+                // editing hidden text; delete_at_fold pushes its own ops,
+                // cursor placement included.
+                let handled = self.delete_at_fold(region, operations);
+                if handled {
                     return response;
                 }
 
@@ -209,14 +211,14 @@ impl<'ast> MdEdit {
                 if !handled() {
                     // default -> delete region
                     let mut range = self.region_to_range(region);
-                    // Deleting a selection deletes what it stands for,
-                    // hidden fold contents included. Gated on a real
-                    // selection: a bare backspace covers the whole tag too
-                    // (atom snap) but must unfold, not destroy.
+
+                    // selecting a fold chip is just selecting a fold tag, but
+                    // deleting it should delete folded content
                     if !current_selection.is_empty() {
-                        range = self.renderer.grow_range_over_selected_folds(range);
+                        range = self.renderer.grow_range_over_fold_contents(range);
                     }
-                    let range = self.renderer.widen_delete_over_folds(range);
+
+                    let range = self.renderer.grow_delete_over_fold_tags(range);
                     operations.push(Operation::Replace(Replace { range, text: "".into() }));
                 }
 
@@ -413,9 +415,9 @@ impl<'ast> MdEdit {
                 } else {
                     self.clipboard_current_line()
                 };
-                // capsules carry their hidden contents to the clipboard,
-                // so a cut+paste moves the folded section intact
-                let range = self.renderer.grow_range_over_selected_folds(range);
+                // selecting a fold chip is just selecting a fold tag, but
+                // copying it should copy folded content
+                let range = self.renderer.grow_range_over_fold_contents(range);
 
                 ctx.copy_text(self.renderer.buffer[range].into());
                 operations.push(Operation::Replace(Replace { range, text: "".into() }));
@@ -426,7 +428,7 @@ impl<'ast> MdEdit {
                 } else {
                     self.clipboard_current_line()
                 };
-                let range = self.renderer.grow_range_over_selected_folds(range);
+                let range = self.renderer.grow_range_over_fold_contents(range);
 
                 ctx.copy_text(self.renderer.buffer[range].into());
             }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -57,6 +57,7 @@ pub fn syntax_theme() -> &'static Theme {
 }
 
 pub mod bounds;
+pub mod fold;
 pub mod input;
 pub mod md_label;
 pub mod output;
@@ -515,6 +516,7 @@ impl MdRender {
         if self.bounds.text_seq != self.text_seq {
             self.bounds.inline_paragraphs.clear();
             self.calc_source_lines();
+            self.calc_fold_bounds(root);
             // Populate before compute_bounds: pre_spacing_lines (called
             // from compute_bounds_block_pre_spacing) queries
             // hidden_by_fold, which now expects every node already

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -126,20 +126,12 @@ impl MdEdit {
 
         if buf_resp.text_updated {
             self.renderer.bump_text_seq();
-            // reparse to refresh bounds (the fold check below reads them);
-            // the new root isn't needed here — `show` re-parses for
-            // rendering. `reparse` also wipes the layout cache via
-            // `ensure_text_consistent`.
             self.renderer.reparse(&arena);
         }
 
-        // All cursor positions visible: a selection endpoint that landed in
-        // fold-hidden contents unfolds the section (removes the fold tag)
-        // rather than leaving the cursor in hidden text. Plain navigation
-        // steps past folded regions before this; pointer-driven selection
-        // changes resolve through rendered fragments, which only cover
-        // visible content. This catches the rest (programmatic selects,
-        // edits that strand the selection in hidden text).
+        // selections are automatically snapped out of fold sections but
+        // sometimes you can still end up in them e.g. by indenting an item into
+        // a folded item
         if (buf_resp.text_updated || buf_resp.selection_user_moved)
             && !undo_redo
             && !self.renderer.readonly

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -93,8 +93,14 @@ impl MdEdit {
         // must be merged with the queued-op response so reparse & cache
         // invalidation fire when undo changes the text.
         let mut direct_resp = buffer::Response::default();
+        // Undo/redo restore the selection exactly, possibly into folded
+        // contents (undoing an auto-unfold restores both the tag and the
+        // triggering selection); the fold check below stands down for the
+        // frame so undo isn't immediately re-undone.
+        let mut undo_redo = false;
 
         for event in std::mem::take(&mut self.event.internal_events) {
+            undo_redo |= matches!(event, Event::Undo | Event::Redo);
             direct_resp |= self.calc_operations(ctx, root, event, &mut ops);
         }
 
@@ -108,6 +114,7 @@ impl MdEdit {
             let key_events: Vec<egui::Event> = ctx.input(|r| r.filtered_events(&filter));
             for e in key_events {
                 if let Some(edit_event) = self.translate_egui_keyboard_event(e, root) {
+                    undo_redo |= matches!(edit_event, Event::Undo | Event::Redo);
                     direct_resp |= self.calc_operations(ctx, root, edit_event, &mut ops);
                 }
             }
@@ -119,10 +126,26 @@ impl MdEdit {
 
         if buf_resp.text_updated {
             self.renderer.bump_text_seq();
-            // reparse to refresh bounds; the new root isn't needed here —
-            // `show` re-parses for rendering. `reparse` also wipes the
-            // layout cache via `ensure_text_consistent`.
+            // reparse to refresh bounds (the fold check below reads them);
+            // the new root isn't needed here — `show` re-parses for
+            // rendering. `reparse` also wipes the layout cache via
+            // `ensure_text_consistent`.
             self.renderer.reparse(&arena);
+        }
+
+        // All cursor positions visible: a selection endpoint that landed in
+        // fold-hidden contents unfolds the section (removes the fold tag)
+        // rather than leaving the cursor in hidden text. Plain navigation
+        // steps past folded regions before this; pointer-driven selection
+        // changes resolve through rendered fragments, which only cover
+        // visible content. This catches the rest (programmatic selects,
+        // edits that strand the selection in hidden text).
+        if (buf_resp.text_updated || buf_resp.selection_user_moved)
+            && !undo_redo
+            && !self.renderer.readonly
+            && !self.renderer.plaintext
+        {
+            buf_resp |= self.unfold_at_selection(&arena);
         }
 
         let new_reveal_selection = (!self.renderer.readonly && ctx.memory(|m| m.has_focus(id)))
@@ -198,6 +221,7 @@ impl MdEdit {
         self.renderer.interact_fragments(ui);
         self.renderer.handle_link_interactions(root, ui);
         self.renderer.handle_spoiler_interactions(root, ui);
+        self.renderer.handle_fold_interactions(ui);
 
         let mut ops = Vec::new();
 

--- a/libs/content/workspace/src/tab/markdown_editor/tests/folding.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/folding.rs
@@ -1,0 +1,721 @@
+//! Exact-behavior tests for section folding: the `···` chip, fold tags
+//! never rendering as source, newline-after-fold, navigation treating the
+//! folded region as cursored-past, and edits against it unfolding it.
+
+use lb_rs::model::text::offset_types::Grapheme;
+
+use super::super::fold::FOLD_TAG;
+use super::super::input::{Advance, Bound, Event, Increment, Location, Region};
+use super::harness::TestEditor;
+use super::render_props::{render_frame, test_renderer};
+
+fn select_at(offset: usize) -> Event {
+    Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(Grapheme(offset)),
+            end: Location::Grapheme(Grapheme(offset)),
+        },
+    }
+}
+
+fn char_arrow(backwards: bool) -> Event {
+    Event::Select {
+        region: Region::ToAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards,
+            extend_selection: false,
+        },
+    }
+}
+
+/// `(doc, tag_start, tag_end)` for a folded H1 with a one-line body.
+fn folded_heading_doc() -> (String, usize, usize) {
+    let doc = format!("# a{FOLD_TAG}\nbody");
+    let tag_start = doc.find("<!--").unwrap();
+    let tag_end = tag_start + FOLD_TAG.len();
+    (doc, tag_start, tag_end)
+}
+
+/// The fold tag renders as an atomic chip — never as its source text —
+/// even when the cursor reveals the heading line's syntax.
+#[test]
+fn fold_tag_never_renders_as_source() {
+    let (doc, tag_start, tag_end) = folded_heading_doc();
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    for offset in [0, 3, tag_end] {
+        ws.push(select_at(offset));
+        ws.enter_frame();
+
+        let fragments = &ws.editor.edit.renderer.fragments;
+        let chip = fragments
+            .iter()
+            .find(|f| f.source_range == (Grapheme(tag_start), Grapheme(tag_end)))
+            .unwrap_or_else(|| panic!("no chip fragment with cursor at {offset}"));
+        assert!(chip.atomic, "chip not atomic with cursor at {offset}");
+        assert!(chip.interaction.is_some(), "chip not clickable with cursor at {offset}");
+        assert!(chip.rect.width() > 0.0, "chip has no visible extent with cursor at {offset}");
+        for f in fragments {
+            let (s, e) = f.source_range;
+            let strictly_inside = s.0 >= tag_start && e.0 <= tag_end && e > s;
+            if strictly_inside && !f.atomic {
+                panic!("tag rendered as source text with cursor at {offset}: {:?}", f.source_range);
+            }
+        }
+    }
+    assert!(ws.get_text().contains(FOLD_TAG), "cursor on the heading line must not unfold");
+}
+
+/// Folded contents produce no fragments; a find match within them
+/// reveals them without removing the fold tag.
+#[test]
+fn find_match_reveals_folded_contents_without_unfolding() {
+    let (doc, _, _) = folded_heading_doc();
+    let body = doc.find("body").unwrap();
+    let covers_body = |r: &crate::tab::markdown_editor::MdRender| {
+        r.fragments.iter().any(|f| {
+            f.source_range.0.0 >= body
+                && f.source_range.1.0 <= body + 4
+                && f.source_range.1 > f.source_range.0
+        })
+    };
+
+    let mut r = test_renderer(&doc);
+    assert!(!render_frame(&mut r, 800.0, None, |r| covers_body(r)), "folded body rendered");
+
+    let mut r = test_renderer(&doc);
+    r.find_current_match = Some((Grapheme(body), Grapheme(body + 4)));
+    assert!(render_frame(&mut r, 800.0, None, |r| covers_body(r)), "find match didn't reveal");
+    assert!(r.buffer.current.text.contains(FOLD_TAG), "find reveal must not unfold");
+}
+
+/// Enter with the cursor right of the chip creates a new heading of the
+/// same level *after* the folded contents, with the cursor on it.
+#[test]
+fn newline_right_of_chip_creates_heading_after_folded_content() {
+    let doc = format!("## a{FOLD_TAG}\nbody one\nbody two\n## b");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    ws.push(Event::Newline { shift: false });
+    ws.enter_frame();
+
+    let expected = format!("## a{FOLD_TAG}\nbody one\nbody two\n## \n## b");
+    assert_eq!(ws.get_text(), expected);
+    let cursor = expected.find("## \n").unwrap() + 3;
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(cursor), Grapheme(cursor)),
+    );
+    assert!(ws.get_text().contains(FOLD_TAG), "newline-after must not unfold");
+}
+
+/// Enter with the cursor right of a folded item's chip creates a new
+/// item *after* the folded subtree.
+#[test]
+fn newline_right_of_chip_creates_item_after_folded_subtree() {
+    let doc = format!("* a{FOLD_TAG}\n  * b\n* c");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    ws.push(Event::Newline { shift: false });
+    ws.enter_frame();
+
+    let expected = format!("* a{FOLD_TAG}\n  * b\n* \n* c");
+    assert_eq!(ws.get_text(), expected);
+    let cursor = expected.find("* \n").unwrap() + 2;
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(cursor), Grapheme(cursor)),
+    );
+}
+
+/// The chip stands for the folded text: right-arrow at the end of the
+/// heading text first skips the tag atom, then steps *past* the hidden
+/// contents to the next visible position — never into them.
+#[test]
+fn arrow_right_skips_chip_then_skips_section() {
+    let doc = format!("# a{FOLD_TAG}\nbody\n# b");
+    let tag_start = doc.find("<!--").unwrap();
+    let tag_end = tag_start + FOLD_TAG.len();
+    let next_section = doc.find("\n# b").unwrap() + 1;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_start));
+    ws.enter_frame();
+    ws.push(char_arrow(false));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_end), Grapheme(tag_end)),
+        "right-arrow should skip the chip atom"
+    );
+
+    ws.push(char_arrow(false));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(next_section), Grapheme(next_section)),
+        "right-arrow right of the chip should step past the folded contents"
+    );
+    assert!(ws.get_text().contains(FOLD_TAG), "arrowing past must not unfold");
+}
+
+/// A section folded through the end of the doc has no visible position
+/// after it; right-arrow right of the chip stays put.
+#[test]
+fn arrow_right_at_doc_end_section_stays_put() {
+    let (doc, _, tag_end) = folded_heading_doc();
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    ws.push(char_arrow(false));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_end), Grapheme(tag_end)),
+    );
+    assert!(ws.get_text().contains(FOLD_TAG));
+}
+
+/// Left-arrow mirrors the skips: from the line after the section it lands
+/// right of the chip, and from there left of the chip.
+#[test]
+fn arrow_left_skips_section_then_chip() {
+    let doc = format!("# a{FOLD_TAG}\nbody\n# b");
+    let tag_start = doc.find("<!--").unwrap();
+    let tag_end = tag_start + FOLD_TAG.len();
+    let next_section = doc.find("\n# b").unwrap() + 1;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(next_section));
+    ws.enter_frame();
+    ws.push(char_arrow(true));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_end), Grapheme(tag_end)),
+        "left-arrow should land right of the chip, past the hidden contents"
+    );
+
+    ws.push(char_arrow(true));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_start), Grapheme(tag_start)),
+    );
+    assert!(ws.get_text().contains(FOLD_TAG), "left-arrow must not unfold");
+}
+
+/// Blank lines between a folded section and the next block are boundary,
+/// not contents: they render as visible spacing rows, so arrows rest on
+/// them — in both directions — and a cursor there leaves the fold alone.
+#[test]
+fn blank_line_after_folded_section_is_walkable() {
+    let doc = format!("# h{FOLD_TAG}\np\n\n#");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let blank = doc.rfind("\n\n").unwrap() + 1;
+    let next_section = blank + 1;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(next_section));
+    ws.enter_frame();
+    ws.push(char_arrow(true));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(blank), Grapheme(blank)),
+        "left-arrow should rest on the blank line, not skip to the chip"
+    );
+    assert!(
+        ws.editor.edit.cursor_line(Grapheme(blank)).is_some(),
+        "blank line should render a row for the cursor"
+    );
+    assert!(ws.get_text().contains(FOLD_TAG), "cursor on the blank line must not unfold");
+
+    ws.push(char_arrow(true));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_end), Grapheme(tag_end)),
+        "second left-arrow should skip the hidden contents to the chip"
+    );
+
+    ws.push(char_arrow(false));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(blank), Grapheme(blank)),
+        "right-arrow should step past the hidden contents to the blank line"
+    );
+    assert!(ws.get_text().contains(FOLD_TAG));
+}
+
+/// Same boundary rule for items: the blank line after a folded item's
+/// subtree is walkable.
+#[test]
+fn blank_line_after_folded_item_is_walkable() {
+    let doc = format!("* a{FOLD_TAG}\n  * b\n\n* c");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let blank = doc.rfind("\n\n").unwrap() + 1;
+    let next_item = blank + 1;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(next_item));
+    ws.enter_frame();
+    ws.push(char_arrow(true));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(blank), Grapheme(blank)),
+        "left-arrow should rest on the blank line, not skip to the chip"
+    );
+
+    ws.push(char_arrow(true));
+    ws.enter_frame();
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_end), Grapheme(tag_end)),
+        "second left-arrow should skip the hidden subtree to the chip"
+    );
+    assert!(ws.get_text().contains(FOLD_TAG));
+}
+
+/// A trailing blank line after a section folded through doc end stays
+/// reachable: right-arrow from the chip lands on it.
+#[test]
+fn trailing_blank_line_after_doc_end_fold_is_reachable() {
+    let doc = format!("# a{FOLD_TAG}\nbody\n");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let last = doc.chars().count();
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    ws.push(char_arrow(false));
+    ws.enter_frame();
+    assert_eq!(ws.editor.edit.renderer.buffer.current.selection, (Grapheme(last), Grapheme(last)),);
+    assert!(ws.get_text().contains(FOLD_TAG));
+}
+
+/// Backspace at the first position after a folded section would join
+/// visible text into hidden text; it unfolds instead and deletes nothing.
+#[test]
+fn backspace_after_folded_section_unfolds_instead_of_joining() {
+    let doc = format!("# a{FOLD_TAG}\nbody\n# b");
+    let next_section = doc.find("\n# b").unwrap() + 1;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(next_section));
+    ws.enter_frame();
+    ws.push(Event::Delete {
+        region: Region::SelectionOrAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards: true,
+        },
+    });
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), "# a\nbody\n# b");
+    let cursor = Grapheme(next_section - FOLD_TAG.len());
+    assert_eq!(ws.editor.edit.renderer.buffer.current.selection, (cursor, cursor));
+}
+
+/// A selection that contains capsules stands for their hidden contents:
+/// deleting it deletes the folded subtrees too — nothing left behind to
+/// pop into view.
+#[test]
+fn deleting_selection_of_folded_items_deletes_their_contents() {
+    let doc = format!("* a{FOLD_TAG}\n  * a1\n* b{FOLD_TAG}\n  * b1\n* c");
+    let tag_b_end = doc.rfind("-->").unwrap() + 3;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(Grapheme(0)),
+            end: Location::Grapheme(Grapheme(tag_b_end)),
+        },
+    });
+    ws.enter_frame();
+    ws.push(Event::Delete {
+        region: Region::SelectionOrAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards: true,
+        },
+    });
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), "\n* c");
+    assert_eq!(ws.editor.edit.renderer.buffer.current.selection, (Grapheme(0), Grapheme(0)),);
+}
+
+/// Cut carries a capsule's hidden contents to the clipboard with it, so
+/// cut+paste moves the folded section intact.
+#[test]
+fn cut_selection_with_capsule_takes_contents() {
+    let doc = format!("# a{FOLD_TAG}\nbody\n# b");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(Grapheme(0)),
+            end: Location::Grapheme(Grapheme(tag_end)),
+        },
+    });
+    ws.enter_frame();
+    ws.push(Event::Cut);
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), "\n# b");
+}
+
+/// Typing over a selection that contains a capsule replaces the hidden
+/// contents along with it.
+#[test]
+fn typing_over_selection_replaces_folded_contents() {
+    let doc = format!("# a{FOLD_TAG}\nbody\n# b");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(Grapheme(0)),
+            end: Location::Grapheme(Grapheme(tag_end)),
+        },
+    });
+    ws.enter_frame();
+    ws.push(Event::Replace { region: Region::Selection, text: "x".into(), advance_cursor: true });
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), "x\n# b");
+}
+
+/// Shift+right from right of the chip selects past the hidden contents;
+/// deleting that selection removes the tag along with the contents it
+/// hid, instead of orphaning an inert tag.
+#[test]
+fn deleting_selection_covering_contents_takes_tag_too() {
+    let doc = format!("# a{FOLD_TAG}\nbody\n# b");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    ws.push(Event::Select {
+        region: Region::ToAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards: false,
+            extend_selection: true,
+        },
+    });
+    ws.enter_frame();
+    let next_section = doc.find("\n# b").unwrap() + 1;
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_end), Grapheme(next_section)),
+        "extending right should select past the folded contents"
+    );
+
+    ws.push(Event::Delete {
+        region: Region::SelectionOrAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards: true,
+        },
+    });
+    ws.enter_frame();
+    assert_eq!(ws.get_text(), "# a# b");
+}
+
+/// Backspace on an *empty* line after a folded section has nothing to
+/// join into hidden text: it deletes the line and rests the cursor right
+/// of the chip — no unfold.
+#[test]
+fn backspace_empty_line_after_folded_section_deletes_line() {
+    let doc = format!("* a{FOLD_TAG}\n  * b\n");
+    let tag_end = doc.find("-->").unwrap() + 3;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    let doc_end = doc.chars().count();
+    ws.push(select_at(doc_end));
+    ws.enter_frame();
+    ws.push(Event::Delete {
+        region: Region::SelectionOrAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards: true,
+        },
+    });
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), format!("* a{FOLD_TAG}\n  * b"), "newline deleted, fold kept");
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_end), Grapheme(tag_end)),
+        "cursor should rest right of the chip"
+    );
+}
+
+/// Forward-delete right of the chip would erase hidden text invisibly;
+/// it unfolds instead and deletes nothing.
+#[test]
+fn forward_delete_right_of_chip_unfolds_instead_of_deleting() {
+    let (doc, _, tag_end) = folded_heading_doc();
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    ws.push(Event::Delete {
+        region: Region::SelectionOrAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards: false,
+        },
+    });
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), "# a\nbody");
+}
+
+/// Backspace right of the chip deletes the whole tag (unfolding), never
+/// leaving partial tag text behind.
+#[test]
+fn backspace_right_of_chip_removes_whole_tag() {
+    let (doc, tag_start, tag_end) = folded_heading_doc();
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    ws.push(Event::Delete {
+        region: Region::SelectionOrAdvance {
+            advance: Advance::By(Increment::Char),
+            backwards: true,
+        },
+    });
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), "# a\nbody");
+    assert_eq!(
+        ws.editor.edit.renderer.buffer.current.selection,
+        (Grapheme(tag_start), Grapheme(tag_start)),
+    );
+}
+
+/// Clicking the chip expands the section (removes the fold tag).
+#[test]
+fn click_chip_unfolds() {
+    let (doc, tag_start, tag_end) = folded_heading_doc();
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    let chip_rect = ws
+        .editor
+        .edit
+        .renderer
+        .fragments
+        .iter()
+        .find(|f| {
+            f.source_range == (Grapheme(tag_start), Grapheme(tag_end)) && f.interaction.is_some()
+        })
+        .expect("chip fragment")
+        .rect;
+    let pos = chip_rect.center();
+    ws.enter_frame_with_input(vec![
+        egui::Event::PointerMoved(pos),
+        egui::Event::PointerButton {
+            pos,
+            button: egui::PointerButton::Primary,
+            pressed: true,
+            modifiers: Default::default(),
+        },
+        egui::Event::PointerButton {
+            pos,
+            button: egui::PointerButton::Primary,
+            pressed: false,
+            modifiers: Default::default(),
+        },
+    ]);
+    ws.enter_frame(); // apply the queued unfold
+    ws.enter_frame();
+
+    assert_eq!(ws.get_text(), "# a\nbody");
+}
+
+/// Selecting a region into the folded contents (e.g. shift+arrows past
+/// the chip) unfolds; selecting *across* the entire fold (select-all)
+/// keeps it folded.
+#[test]
+fn selection_into_contents_unfolds_but_select_all_does_not() {
+    let (doc, _, _) = folded_heading_doc();
+
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+    ws.push(Event::Select { region: Region::Bound { bound: Bound::Doc, backwards: false } });
+    ws.enter_frame();
+    assert!(ws.get_text().contains(FOLD_TAG), "select-all must keep the fold");
+
+    let body_mid = doc.find("body").unwrap() + 2;
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+    ws.push(select_at(body_mid));
+    ws.enter_frame();
+    assert_eq!(ws.get_text(), "# a\nbody", "selection endpoint in contents must unfold");
+}
+
+/// Nested folds: a cursor landing in contents hidden by both an outer
+/// and an inner fold unfolds both — every cursor position is visible.
+#[test]
+fn cursor_into_nested_folds_unfolds_all() {
+    let doc = format!("# a{FOLD_TAG}\n## b{FOLD_TAG}\nbody\n");
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    let body_mid = doc.find("body").unwrap() + 2;
+    ws.push(select_at(body_mid));
+    ws.enter_frame();
+    assert_eq!(ws.get_text(), "# a\n## b\nbody\n");
+}
+
+/// The caret beside the chip renders beside the capsule — outside its
+/// side padding — not against the icon glyph like inline-code editing.
+#[test]
+fn cursor_beside_chip_renders_outside_capsule() {
+    let (doc, tag_start, tag_end) = folded_heading_doc();
+    let chip_rect = |ws: &TestEditor| {
+        ws.editor
+            .edit
+            .renderer
+            .fragments
+            .iter()
+            .find(|f| {
+                f.source_range == (Grapheme(tag_start), Grapheme(tag_end))
+                    && f.interaction.is_some()
+            })
+            .expect("chip fragment")
+            .rect
+    };
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(select_at(tag_end));
+    ws.enter_frame();
+    let glyph_right = chip_rect(&ws).max.x;
+    let caret_x = ws
+        .editor
+        .edit
+        .cursor_line(Grapheme(tag_end))
+        .expect("caret")[0]
+        .x;
+    assert!(
+        caret_x > glyph_right + 1.0,
+        "caret right of chip at x={caret_x} should clear the capsule padding (glyph right edge {glyph_right})"
+    );
+
+    ws.push(select_at(tag_start));
+    ws.enter_frame();
+    let glyph_left = chip_rect(&ws).min.x;
+    let caret_x = ws
+        .editor
+        .edit
+        .cursor_line(Grapheme(tag_start))
+        .expect("caret")[0]
+        .x;
+    assert!(
+        caret_x < glyph_left - 1.0,
+        "caret left of chip at x={caret_x} should clear the capsule padding (glyph left edge {glyph_left})"
+    );
+}
+
+/// ToggleFold with the cursor on the heading folds and unfolds without
+/// the cursor's own position immediately undoing the fold.
+#[test]
+fn toggle_fold_round_trip() {
+    let doc = "# a\nbody";
+    let mut ws = TestEditor::new(doc);
+    ws.enter_frame();
+
+    ws.push(select_at(1));
+    ws.enter_frame();
+    ws.push(Event::ToggleFold);
+    ws.enter_frame();
+    ws.enter_frame(); // apply_fold's events apply next frame
+    assert_eq!(ws.get_text(), format!("# a{FOLD_TAG}\nbody"));
+
+    ws.push(Event::ToggleFold);
+    ws.enter_frame();
+    ws.enter_frame();
+    assert_eq!(ws.get_text(), "# a\nbody");
+}
+
+/// Folding while the selection reaches into the contents clips the
+/// selection to the visible region so the section folds and stays folded.
+#[test]
+fn fold_with_selection_into_contents_stays_folded() {
+    let doc = "# a\nbody";
+    let body_mid = doc.find("body").unwrap() + 2;
+    let mut ws = TestEditor::new(doc);
+    ws.enter_frame();
+
+    ws.push(Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(Grapheme(1)),
+            end: Location::Grapheme(Grapheme(body_mid)),
+        },
+    });
+    ws.enter_frame();
+    ws.push(Event::ToggleFold);
+    ws.enter_frame();
+    ws.enter_frame();
+    ws.enter_frame(); // settle: fold replace + clipped selection
+    assert_eq!(ws.get_text(), format!("# a{FOLD_TAG}\nbody"));
+}
+
+/// A word selection that lands inside the tag (e.g. a double-click near
+/// the chip) grows to cover the whole capsule — partial tag text can
+/// never survive as source — and an edit over it replaces the contents
+/// the capsule stands for.
+#[test]
+fn word_select_inside_tag_snaps_to_whole_tag() {
+    let (doc, tag_start, tag_end) = folded_heading_doc();
+    let mut ws = TestEditor::new(&doc);
+    ws.enter_frame();
+
+    ws.push(Event::Select {
+        region: Region::BoundAt {
+            bound: Bound::Word,
+            location: Location::Grapheme(Grapheme(tag_end - 1)),
+            backwards: true,
+        },
+    });
+    ws.enter_frame();
+    let selection = ws.editor.edit.renderer.buffer.current.selection;
+    assert_eq!(
+        (selection.0.0.min(selection.1.0), selection.0.0.max(selection.1.0)),
+        (tag_start, tag_end),
+        "in-tag word selection should cover the whole tag"
+    );
+
+    ws.push(Event::Replace { region: Region::Selection, text: "x".into(), advance_cursor: true });
+    ws.enter_frame();
+    assert_eq!(ws.get_text(), "# ax");
+}

--- a/libs/content/workspace/src/tab/markdown_editor/tests/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/mod.rs
@@ -23,5 +23,6 @@ mod harness;
 
 mod benches;
 mod edit_props;
+mod folding;
 mod regressions;
 mod render_props;

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -277,12 +277,13 @@ fn icon_glyphs_skip_emoji_font() {
 /// Regression for #4662: arrowing up off a folded heading must walk the
 /// cursor to the lines above it, not freeze.
 ///
-/// The fold tag (`<!-- {"fold":true} -->`) renders zero-width until the
-/// cursor lands on the heading line, then reveals to its ~22-char source.
-/// On a narrow viewport that expansion wraps the heading across rows, and
-/// up-arrowing then sticks inside the wrapped tag. The narrow width is
-/// load-bearing: the property suite runs at the fixed 800px `SCREEN_SIZE`,
-/// where the heading never wraps and the bug stays hidden.
+/// Originally the fold tag revealed to its ~22-char source when the cursor
+/// landed on the heading line; on a narrow viewport that expansion wrapped
+/// the heading across rows and up-arrowing stuck inside the wrapped tag.
+/// The tag renders as a compact chip now, but the narrow width keeps the
+/// heading wrapping across rows, preserving the walk this test guards.
+/// (The property suite runs at the fixed 800px `SCREEN_SIZE`, where the
+/// heading never wraps and the original bug stayed hidden.)
 #[test]
 fn up_arrow_through_fold_tag() {
     use super::super::input::Increment;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -275,7 +275,7 @@ impl<'ast> MdRender {
 
         // Contents end at the last child's last line — the end of the
         // hidden subtree. Blank lines past that render as visible
-        // spacing rows, so they're boundary, not contents.
+        // spacing rows.
         if let Some(last_child) = node.children().last() {
             contents.1 = contents.1.max(self.node_last_line(last_child).end());
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -267,28 +267,25 @@ impl<'ast> MdRender {
     pub fn item_contents(&self, node: &'ast AstNode<'ast>) -> (Grapheme, Grapheme) {
         // contents start at the end of the first child, which acts as a sort of section title
         // if no children, start at end of node first line
-        let mut contents = if let Some(first_child) = node.children().next() {
+        let mut contents: (Grapheme, Grapheme) = if let Some(first_child) = node.children().next() {
             self.node_range(first_child).end().into_range()
         } else {
             self.node_first_line(node).end().into_range()
         };
 
-        if let Some(sibling) = node.next_sibling() {
-            let sibling_first_line = self.node_first_line_idx(sibling);
-            let last_line = sibling_first_line - 1;
-            contents.1 = self.bounds.source_lines[last_line].end();
-        } else {
-            // absent a next sibling, we contain the remaining content of the
-            // parent
-            contents.1 = self.node_range(node.parent().unwrap()).end();
+        // Contents end at the last child's last line — the end of the
+        // hidden subtree. Blank lines past that render as visible
+        // spacing rows, so they're boundary, not contents.
+        if let Some(last_child) = node.children().last() {
+            contents.1 = contents.1.max(self.node_last_line(last_child).end());
         }
 
         contents
     }
 
-    /// Returns true if the item contents should be revealed whether the heading is folded or not
+    /// Returns true if the item contents should be revealed whether the item is folded or not
     pub fn item_fold_reveal(&self, node: &'ast AstNode<'ast>) -> bool {
-        self.range_contains_revealed(self.item_contents(node), false, true)
+        self.range_contains_fold_revealed(self.item_contents(node), false, true)
     }
 
     /// Returns true if the item is selected for folding; specialized adaptation of self.selected_block()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -394,7 +394,7 @@ impl<'ast> MdRender {
 
     /// Contents end at the last contained sibling's last line: blank
     /// lines past that — before the next section or at doc end — render
-    /// as visible spacing rows, so they're boundary, not contents.
+    /// as visible spacing rows.
     pub fn heading_contents(&self, node: &'ast AstNode<'ast>) -> (Grapheme, Grapheme) {
         let NodeValue::Heading(heading) = &node.data.borrow().value else {
             panic!("heading_contents() invoked for non-heading")

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -392,6 +392,9 @@ impl<'ast> MdRender {
         height_sum
     }
 
+    /// Contents end at the last contained sibling's last line: blank
+    /// lines past that — before the next section or at doc end — render
+    /// as visible spacing rows, so they're boundary, not contents.
     pub fn heading_contents(&self, node: &'ast AstNode<'ast>) -> (Grapheme, Grapheme) {
         let NodeValue::Heading(heading) = &node.data.borrow().value else {
             panic!("heading_contents() invoked for non-heading")
@@ -402,16 +405,12 @@ impl<'ast> MdRender {
         while let Some(s) = sibling {
             if let NodeValue::Heading(sib_h) = &s.data.borrow().value {
                 if sib_h.level <= heading.level {
-                    let sibling_first_line = self.node_first_line_idx(s);
-                    let last_line = sibling_first_line - 1;
-                    contents.1 = self.bounds.source_lines[last_line].end();
-                    return contents;
+                    break;
                 }
             }
+            contents.1 = self.node_last_line(s).end();
             sibling = s.next_sibling();
         }
-        // No concluding heading: contain the rest of the parent.
-        contents.1 = self.node_range(node.parent().unwrap()).end();
         contents
     }
 
@@ -470,6 +469,6 @@ impl<'ast> MdRender {
 
     /// Returns true if the heading contents should be revealed whether the heading is folded or not
     pub fn heading_fold_reveal(&self, node: &'ast AstNode<'ast>) -> bool {
-        self.range_contains_revealed(self.heading_contents(node), false, true)
+        self.range_contains_fold_revealed(self.heading_contents(node), false, true)
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -11,7 +11,7 @@ use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{Grapheme, Graphemes, IntoRangeExt as _, RangeExt as _};
 
 use crate::tab::markdown_editor::bounds::RangesExt as _;
-use crate::tab::markdown_editor::widget::inline::html_inline::FOLD_TAG;
+use crate::tab::markdown_editor::fold::FOLD_TAG;
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::{Event, MdRender};
 
@@ -547,24 +547,6 @@ impl<'ast> MdRender {
                 }
             }
         }
-    }
-
-    /// Returns the node that this node is folding, if there is one
-    pub fn foldee(&self, node: &'ast AstNode<'ast>) -> Option<&'ast AstNode<'ast>> {
-        let mut root = node;
-        while let Some(parent) = root.parent() {
-            root = parent;
-        }
-
-        for descendant in root.descendants() {
-            if let Some(fold) = self.fold(descendant) {
-                if fold.same_node(node) {
-                    return Some(fold);
-                }
-            }
-        }
-
-        None
     }
 
     pub fn hidden_by_fold(&self, node: &'ast AstNode<'ast>) -> bool {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/find.rs
@@ -5,7 +5,8 @@
 //! - **Decoupled from cursor**: Find highlights and navigates matches without
 //!   moving the document selection. This required a parallel reveal system
 //!   (`reveal_ranges()` in `inline/mod.rs`) so that the current match triggers
-//!   syntax reveal and fold reveal just like the cursor does.
+//!   syntax reveal just like the cursor does, plus fold reveal (a cursor in
+//!   folded contents instead unfolds for real).
 //!
 //! - **Galley culling**: The editor only renders blocks that are visible or
 //!   overlap the selection. To scroll to an off-screen match, we extended

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/code.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/code.rs
@@ -45,10 +45,8 @@ impl<'ast> MdRender {
         let postfix = (node_range.end() - 1, node_range.end()).trim(&range);
         let reveal = self.node_revealed(node);
 
-        layout.style_open(StyleInfo {
-            format: self.text_format_code(node.parent().unwrap()),
-            source_range: node_range,
-        });
+        layout
+            .style_open(StyleInfo::new(self.text_format_code(node.parent().unwrap()), node_range));
         if !prefix.is_empty() {
             if reveal {
                 layout.push_source(prefix, &self.buffer[prefix], self.text_format_syntax());

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/html_inline.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/html_inline.rs
@@ -5,8 +5,6 @@ use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Layout};
 use crate::theme::palette_v2::ThemeExt as _;
 
-pub const FOLD_TAG: &str = "<!-- {\"fold\":true} -->";
-
 impl<'ast> MdRender {
     pub fn text_format_html_inline(&self, parent: &AstNode<'_>) -> Format {
         Format {
@@ -23,10 +21,15 @@ impl<'ast> MdRender {
         if node_range.is_empty() {
             return;
         }
-        // Reveal when cursor is on the range OR when the html-inline
-        // is not a fold marker (regular `<sup>` etc. always show source).
-        let reveal = self.range_revealed(node_range, true) || self.foldee(node).is_none();
-        if reveal {
+        // A tag that's actively folding a section renders as a `···`
+        // chip, never as source.
+        if let Some(fold) = self.active_fold_at_tag(self.node_range(node)) {
+            self.layout_fold_chip(layout, node.parent().unwrap(), fold, node_range);
+            return;
+        }
+        // Regular html inline (`<sup>` etc.): reveal source when the
+        // cursor is on the range, collapse to an anchor otherwise.
+        if self.range_revealed(node_range, true) {
             layout.push_source(node_range, &self.buffer[node_range], self.text_format_syntax());
         } else {
             layout.push_override(

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -93,7 +93,7 @@ impl<'ast> MdRender {
         };
         match title {
             Some(t) => {
-                layout.style_open(StyleInfo { format: link_fmt.clone(), source_range: node_range });
+                layout.style_open(StyleInfo::new(link_fmt.clone(), node_range));
                 layout.push_override(trimmed, &t, link_fmt.clone());
                 layout.style_close();
             }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
@@ -250,7 +250,7 @@ impl<'ast> MdRender {
             }
             return;
         }
-        layout.style_open(StyleInfo { format, source_range: node_range });
+        layout.style_open(StyleInfo::new(format, node_range));
         let reveal = self.node_revealed(node);
         if let Some(prefix_range) = self.prefix_range(node) {
             let trimmed = prefix_range.trim(&range);

--- a/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
@@ -1108,6 +1108,7 @@ impl<'ast> Editor {
 
         // pre-render work
         self.edit.renderer.calc_source_lines();
+        self.edit.renderer.calc_fold_bounds(root);
         self.edit.renderer.populate_hidden_by_fold(root);
         self.edit.renderer.compute_bounds(root);
         self.edit.renderer.bounds.inline_paragraphs.sort();
@@ -1143,6 +1144,7 @@ impl<'ast> Editor {
 
         // pre-render work
         self.edit.renderer.calc_source_lines();
+        self.edit.renderer.calc_fold_bounds(root);
         self.edit.renderer.populate_hidden_by_fold(root);
         self.edit.renderer.compute_bounds(root);
         self.edit.renderer.bounds.inline_paragraphs.sort();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -161,6 +161,15 @@ pub struct StyleInfo {
     /// whole `0..8` range). Identifies the AST node at click time
     /// without storing a pointer.
     pub source_range: (Grapheme, Grapheme),
+    /// Paint the background as a compact capsule hugging the text
+    /// middle (the fold `···` chip) instead of filling the row.
+    pub chip: bool,
+}
+
+impl StyleInfo {
+    pub fn new(format: Format, source_range: (Grapheme, Grapheme)) -> Self {
+        Self { format, source_range, chip: false }
+    }
 }
 
 /// A strike/underline rule, painted on top of text (see `deco_lines`).
@@ -524,6 +533,12 @@ impl MdRender {
 
 // ─── shape (Layout → Vec<InlineItem>) ────────────────────────────────
 
+/// Side padding inside a chip capsule, as a fraction of row height.
+/// Shared by the walker (which lays the pads between the glyph and
+/// the capsule edges) and by cursor math (which backs them out so the
+/// caret beside the atom renders beside the capsule).
+const CHIP_SIDE_PAD: f32 = 0.3;
+
 /// Tab pixel-stop interval. Walker resolves tab advance from running
 /// x within the wrap unit (`ceil(x/stop) * stop - x`). Matches the
 /// monospace 4-character convention pixel-for-pixel in code blocks
@@ -556,14 +571,14 @@ fn shape_to_items(
 ) -> Option<Vec<InlineItem>> {
     use std::sync::{Arc, Mutex};
 
-    // Track open bg-scopes' source ranges, so the matching close can
-    // emit the trailing `Pad` with the scope's end as its source
-    // position. `None` entries hold place for non-bg scopes (Pad not
-    // emitted, but stack depth must mirror StyleOpen/Close). AST
-    // guarantees LIFO nesting.
-    let mut bg_scope_stack: Vec<Option<(Grapheme, Grapheme)>> = Vec::new();
+    // Track open bg-scopes' source ranges + side-pad widths, so the
+    // matching close can emit the trailing `Pad` with the scope's end
+    // as its source position. `None` entries hold place for non-bg
+    // scopes (Pad not emitted, but stack depth must mirror
+    // StyleOpen/Close). AST guarantees LIFO nesting.
+    let mut bg_scope_stack: Vec<Option<((Grapheme, Grapheme), f32)>> = Vec::new();
     let emit_event = |items: &mut Vec<InlineItem>,
-                      bg_scope_stack: &mut Vec<Option<(Grapheme, Grapheme)>>,
+                      bg_scope_stack: &mut Vec<Option<((Grapheme, Grapheme), f32)>>,
                       pos: usize,
                       ev: &FlowEvent| {
         let p = pos as u32;
@@ -572,21 +587,19 @@ fn shape_to_items(
                 let bg = s.format.background != egui::Color32::TRANSPARENT;
                 items.push(InlineItem::StyleOpen(s.clone()));
                 if bg {
-                    items.push(InlineItem::Pad {
-                        advance: inline_pad,
-                        source_pos: s.source_range.start(),
-                    });
-                    bg_scope_stack.push(Some(s.source_range));
+                    // Chips pad wide enough for the glyphs to clear the
+                    // capsule's curved ends.
+                    let pad = if s.chip { row_height * CHIP_SIDE_PAD } else { inline_pad };
+                    items
+                        .push(InlineItem::Pad { advance: pad, source_pos: s.source_range.start() });
+                    bg_scope_stack.push(Some((s.source_range, pad)));
                 } else {
                     bg_scope_stack.push(None);
                 }
             }
             FlowEvent::Close => {
-                if let Some(Some(scope_range)) = bg_scope_stack.pop() {
-                    items.push(InlineItem::Pad {
-                        advance: inline_pad,
-                        source_pos: scope_range.end(),
-                    });
+                if let Some(Some((scope_range, pad))) = bg_scope_stack.pop() {
+                    items.push(InlineItem::Pad { advance: pad, source_pos: scope_range.end() });
                 }
                 items.push(InlineItem::StyleClose);
             }
@@ -1626,6 +1639,7 @@ impl MdRender {
                     .map(|s| s.format.background)
                     .filter(|c| *c != egui::Color32::TRANSPARENT)
             };
+            let chip_of = |f: &Fragment| -> bool { f.style_stack.last().is_some_and(|s| s.chip) };
 
             // Pass 1: coalesce same-bg chains into one pill (single
             // fill, single stroke — no seams at fragment boundaries).
@@ -1637,6 +1651,7 @@ impl MdRender {
                     i += 1;
                     continue;
                 };
+                let chip = chip_of(&row.fragments[i]);
                 let border = row.fragments[i]
                     .style_stack
                     .last()
@@ -1646,6 +1661,7 @@ impl MdRender {
                 let mut chain_end = i + 1;
                 while chain_end < row.fragments.len()
                     && bg_of(&row.fragments[chain_end]) == Some(bg)
+                    && chip_of(&row.fragments[chain_end]) == chip
                 {
                     chain_end += 1;
                 }
@@ -1653,12 +1669,23 @@ impl MdRender {
                 let chain_right = row.fragments[chain_end - 1].rect.right() + paint_top_left.x;
                 let row_top = row.fragments[chain_start].rect.top() + paint_top_left.y;
                 let row_bottom = row.fragments[chain_start].rect.bottom() + paint_top_left.y;
-                let bg_rect = Rect::from_min_max(
+                let mut bg_rect = Rect::from_min_max(
                     egui::Pos2::new(chain_left, row_top - inline_pad),
                     egui::Pos2::new(chain_right, row_bottom + inline_pad),
                 );
+                let mut radius = 2.0;
+                if chip {
+                    // Capsule spanning exactly the row box — no inline_pad
+                    // extension, so it stays inside the line where full-row
+                    // pills like inline code bleed past it.
+                    bg_rect = Rect::from_min_max(
+                        egui::Pos2::new(chain_left, row_top),
+                        egui::Pos2::new(chain_right, row_bottom),
+                    );
+                    radius = (row_bottom - row_top) / 2.0;
+                }
                 if ui.clip_rect().intersects(bg_rect) {
-                    let rounding = corner_rounding(true, true, 2.0);
+                    let rounding = corner_rounding(true, true, radius);
                     ui.painter().rect_filled(bg_rect, rounding, bg);
                     if border != egui::Color32::TRANSPARENT {
                         ui.painter().rect_stroke(
@@ -1868,7 +1895,17 @@ impl MdRender {
     /// the offset's position within the range (midpoint rule). For
     /// non-atomic, sum cluster advances from `source_range.start`.
     pub fn fragment_x(&self, fragment: &Fragment, offset: Grapheme) -> f32 {
+        let chip_scope = fragment
+            .style_stack
+            .last()
+            .filter(|s| s.chip)
+            .map(|s| s.source_range);
         if fragment.atomic {
+            // The caret beside a chip atom sits beside the capsule: back
+            // out the side pad between this fragment's glyph rect and the
+            // capsule edge (pads span the row, so height ≈ row height).
+            let pad =
+                if chip_scope.is_some() { fragment.rect.height() * CHIP_SIDE_PAD } else { 0.0 };
             // Absolute midpoint offset of the range; offsets in the first
             // half snap to the left edge, the rest to the right edge.
             let mid = fragment.source_range.start().0
@@ -1879,11 +1916,26 @@ impl MdRender {
                     .saturating_sub(fragment.source_range.start().0))
                     / 2;
             if offset.0 < mid {
-                fragment.rect.min.x + fragment.content_inset.left
+                fragment.rect.min.x + fragment.content_inset.left - pad
             } else {
-                fragment.rect.max.x - fragment.content_inset.right
+                fragment.rect.max.x - fragment.content_inset.right + pad
             }
         } else {
+            // A chip's scope pads are the capsule's side padding; the
+            // caret at their source position renders at the capsule's
+            // outer edge — left edge for the leading pad, right for the
+            // trailing.
+            if let Some(scope) = chip_scope {
+                if fragment.source_range.is_empty()
+                    && matches!(fragment.content, FragmentContent::Spacer)
+                {
+                    return if fragment.source_range.start() == scope.start() {
+                        fragment.rect.min.x
+                    } else {
+                        fragment.rect.max.x
+                    };
+                }
+            }
             let into = offset.0.saturating_sub(fragment.source_range.start().0);
             if let FragmentContent::Glyphs { cluster_advances, .. } = &fragment.content {
                 if !cluster_advances.is_empty() {

--- a/libs/content/workspace/src/theme/icons.rs
+++ b/libs/content/workspace/src/theme/icons.rs
@@ -45,6 +45,7 @@ impl Icon {
     pub const DOC_MD: Self = ic("\u{f48a}"); // 
     pub const DOC_PDF: Self = ic("\u{e67d}"); // 
     pub const DONE: Self = ic("\u{f012c}"); // 󰄬
+    pub const DOTS_HORIZONTAL: Self = ic("\u{f01d8}"); // 󰇘
     pub const DRAW: Self = Self::BRUSH;
     pub const EMPTY_INBOX: Self = ic("\u{f06ee}"); // 󰛮
     pub const ERASER: Self = ic("\u{f01fe}"); // 󰙂


### PR DESCRIPTION
* folded content represented by `···` chip; click to expand; never see a fold tag
* chip represents what's folded; a cursor after a chip is after that content, so text is inserted after the folded content not inside at the beginning
* if your cursor ends up inside folded content we unfold it

https://github.com/user-attachments/assets/3f7cb4e0-48d2-4eab-91b5-172a48fc1338

fixes https://github.com/lockbook/lockbook/issues/4353