### PR TITLE
canvas: pan & pinch fixes

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -987,6 +987,7 @@
         var panRecognizer: UIPanGestureRecognizer?
         var pinchRecognizer: UIPinchGestureRecognizer?
         var pinchStartTouches = [(Float, Float)]()
+        var pinchCumulativeScale: CGFloat = 1.0
 
         // menu
         var menuDelegate: SvgMenuDelegate?
@@ -1131,25 +1132,23 @@
                 mtkView.kineticTimer?.invalidate()
                 mtkView.kineticTimer = nil
             }
-            
-            if event.state == .began{
+
+            if event.state == .began {
                 pinchStartTouches.removeAll()
-                for i in 0..<(sender?.numberOfTouches ?? 0){
+                for i in 0..<(sender?.numberOfTouches ?? 0) {
                     let point = sender?.location(ofTouch: i, in: self)
                     if let p = point {
                         pinchStartTouches.append((Float(p.x), Float(p.y)))
                     }
                 }
-                event.scale = 1.0
+                pinchCumulativeScale = event.scale
             }
 
-            let scale = event.scale
             let pinchCenter = event.location(in: mtkView)
 
             if event.state == .changed {
-                let zoomDelta = Float(scale)
-
-                let viewCenter = CGPoint(x: mtkView.bounds.midX, y: mtkView.bounds.midY)
+                let zoomDelta = Float(event.scale / pinchCumulativeScale)
+                pinchCumulativeScale = event.scale
 
                 multi_touch(
                     wsHandle,
@@ -1162,8 +1161,7 @@
                     pinchStartTouches.map{$0.1},
                     UInt(pinchStartTouches.count)
                 )
-                
-                event.scale = 1.0
+                mtkView.setNeedsDisplay()
             }
         }
 

--- a/libs/content/workspace/src/tab/svg_editor/input_controller.rs
+++ b/libs/content/workspace/src/tab/svg_editor/input_controller.rs
@@ -44,18 +44,26 @@ impl InputControllerConfig {
     }
 }
 
-// Multipliers for converting `MouseWheelUnit::Line`/`::Page` deltas into points.
-// Sampled per frame from egui — without this, Windows precision trackpads (which
-// report scroll in line units, unlike macOS/iPad) pan the canvas at ~1/40th speed.
+// Per-frame snapshot of egui's scroll/zoom calibration. Used to convert raw
+// `MouseWheelUnit::Line`/`::Page` deltas to points (Windows precision trackpads
+// scroll in line units, unlike macOS/iPad) and to translate ctrl+wheel pinch on
+// Windows into the same zoom factor egui would compute internally.
 #[derive(Clone, Copy, Debug)]
 struct ScrollUnits {
     points_per_line: f32,
     points_per_page: f32,
+    zoom_modifier: egui::Modifiers,
+    scroll_zoom_speed: f32,
 }
 
 impl Default for ScrollUnits {
     fn default() -> Self {
-        Self { points_per_line: 40.0, points_per_page: 800.0 }
+        Self {
+            points_per_line: 40.0,
+            points_per_page: 800.0,
+            zoom_modifier: egui::Modifiers::COMMAND,
+            scroll_zoom_speed: 1.0 / 200.0,
+        }
     }
 }
 
@@ -212,10 +220,13 @@ impl InputController {
     pub fn process(
         &mut self, ui: &mut egui::Ui, layout: &LayoutContext,
     ) -> Vec<InputControllerEvent> {
-        let scroll_units = ScrollUnits {
-            points_per_line: ui.ctx().options(|o| o.input_options.line_scroll_speed),
-            points_per_page: ui.input(|r| r.screen_rect().height()),
-        };
+        let points_per_page = ui.input(|r| r.screen_rect().height());
+        let scroll_units = ui.ctx().options(|o| ScrollUnits {
+            points_per_line: o.input_options.line_scroll_speed,
+            points_per_page,
+            zoom_modifier: o.input_options.zoom_modifier,
+            scroll_zoom_speed: o.input_options.scroll_zoom_speed,
+        });
         let mut controller_events =
             ui.input(|r| self.process_events(r.events.iter(), layout, scroll_units));
         let extended_controller_events =
@@ -299,7 +310,7 @@ impl InputController {
         }
     }
 
-    pub fn process_events(
+    fn process_events(
         &mut self, events: Iter<egui::Event>, layout: &LayoutContext, scroll_units: ScrollUnits,
     ) -> Vec<InputControllerEvent> {
         self.is_touch_frame = false;
@@ -409,7 +420,7 @@ impl InputController {
                 None
             }
             egui::Event::PointerGone => None,
-            egui::Event::MouseWheel { unit, delta, modifiers: _ } => {
+            egui::Event::MouseWheel { unit, delta, modifiers } => {
                 if self.tool_running.is_some() {
                     return None;
                 }
@@ -423,6 +434,11 @@ impl InputController {
                     egui::MouseWheelUnit::Page => scroll_units.points_per_page * delta,
                 };
                 self.viewport_changing = Some(Instant::now());
+                // Mirror egui's own formula in `zoom_delta()`
+                if modifiers.matches_any(scroll_units.zoom_modifier) {
+                    let factor = (scroll_units.scroll_zoom_speed * (delta.x + delta.y)).exp();
+                    return Some(ViewportChange::new(self, &egui::Event::Zoom(factor), false));
+                }
                 Some(InputControllerEvent::ViewportChange(
                     Transform::identity().post_translate(delta.x, delta.y),
                 ))

--- a/libs/content/workspace/src/tab/svg_editor/input_controller.rs
+++ b/libs/content/workspace/src/tab/svg_editor/input_controller.rs
@@ -44,6 +44,21 @@ impl InputControllerConfig {
     }
 }
 
+// Multipliers for converting `MouseWheelUnit::Line`/`::Page` deltas into points.
+// Sampled per frame from egui — without this, Windows precision trackpads (which
+// report scroll in line units, unlike macOS/iPad) pan the canvas at ~1/40th speed.
+#[derive(Clone, Copy, Debug)]
+struct ScrollUnits {
+    points_per_line: f32,
+    points_per_page: f32,
+}
+
+impl Default for ScrollUnits {
+    fn default() -> Self {
+        Self { points_per_line: 40.0, points_per_page: 800.0 }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct TouchInfo {
     id: egui::TouchId,
@@ -126,9 +141,6 @@ impl ViewportChange {
                 transform
                     .post_translate((1.0 - factor) * origin_pos.x, (1.0 - factor) * origin_pos.y)
             }
-            egui::Event::MouseWheel { unit: _, delta, modifiers: _ } => {
-                Transform::identity().post_translate(delta.x, delta.y)
-            }
             _ => Transform::identity(),
         };
         InputControllerEvent::ViewportChange(transform)
@@ -200,7 +212,12 @@ impl InputController {
     pub fn process(
         &mut self, ui: &mut egui::Ui, layout: &LayoutContext,
     ) -> Vec<InputControllerEvent> {
-        let mut controller_events = ui.input(|r| self.process_events(r.events.iter(), layout));
+        let scroll_units = ScrollUnits {
+            points_per_line: ui.ctx().options(|o| o.input_options.line_scroll_speed),
+            points_per_page: ui.input(|r| r.screen_rect().height()),
+        };
+        let mut controller_events =
+            ui.input(|r| self.process_events(r.events.iter(), layout, scroll_units));
         let extended_controller_events =
             self.process_extended_events(ui.ctx().read_events(), layout);
 
@@ -283,12 +300,12 @@ impl InputController {
     }
 
     pub fn process_events(
-        &mut self, events: Iter<egui::Event>, layout: &LayoutContext,
+        &mut self, events: Iter<egui::Event>, layout: &LayoutContext, scroll_units: ScrollUnits,
     ) -> Vec<InputControllerEvent> {
         self.is_touch_frame = false;
         let result: Vec<InputControllerEvent> = events
             .filter_map(|event| {
-                let controller_event = self.ui_to_controller_event(event, layout);
+                let controller_event = self.ui_to_controller_event(event, layout, scroll_units);
 
                 if self.config.is_read_only
                     && !matches!(controller_event, Some(InputControllerEvent::ViewportChange(_)))
@@ -334,7 +351,7 @@ impl InputController {
     }
 
     fn ui_to_controller_event(
-        &mut self, event: &egui::Event, ctx: &LayoutContext,
+        &mut self, event: &egui::Event, ctx: &LayoutContext, scroll_units: ScrollUnits,
     ) -> Option<InputControllerEvent> {
         let run_button =
             &MouseProps { button: ButtonType::Primary, modifiers: egui::Modifiers::NONE };
@@ -392,13 +409,23 @@ impl InputController {
                 None
             }
             egui::Event::PointerGone => None,
-            egui::Event::MouseWheel { .. } => {
-                if self.tool_running.is_none() {
-                    self.viewport_changing = Some(Instant::now());
-                    return Some(ViewportChange::new(self, event, false));
+            egui::Event::MouseWheel { unit, delta, modifiers: _ } => {
+                if self.tool_running.is_some() {
+                    return None;
                 }
-
-                None
+                // Convert the platform-reported delta into points. Windows precision
+                // trackpads (and discrete mouse wheels) report `Line`/`Page`; macOS
+                // and iPad report `Point`. Without this the canvas pans at ~1/40th
+                // the expected speed on Windows.
+                let delta = match unit {
+                    egui::MouseWheelUnit::Point => delta,
+                    egui::MouseWheelUnit::Line => scroll_units.points_per_line * delta,
+                    egui::MouseWheelUnit::Page => scroll_units.points_per_page * delta,
+                };
+                self.viewport_changing = Some(Instant::now());
+                Some(InputControllerEvent::ViewportChange(
+                    Transform::identity().post_translate(delta.x, delta.y),
+                ))
             }
             egui::Event::Touch { device_id, id, phase, pos, force } => {
                 self.is_touch_frame = true;
@@ -682,7 +709,7 @@ mod tests {
         fn process(
             &self, controller: &mut InputController, layout: &LayoutContext,
         ) -> Vec<InputControllerEvent> {
-            controller.process_events(self.iter(), layout)
+            controller.process_events(self.iter(), layout, ScrollUnits::default())
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4637 (scroll sensitivity on windows)
* canvas was ignoring scroll 'unit' which on windows is lines of text instead of points/pixels

fixes pinch scrolling instead of zooming on windows
* canvas was ignoring scroll modifiers which on windows is used to represent zoom as ctrl+scroll

fixes https://github.com/lockbook/lockbook/issues/3957 (trackpad / universal control (sidecar) zoom rapidly zooming in on iPad)
* previous reset-based mechanism to compute scroll deltas was flaky under trackpad input