### PR TITLE
md: render images inline

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -294,12 +294,20 @@ impl MdEdit {
     }
 
     pub fn cursor_line(&self, offset: Grapheme) -> Option<[Pos2; 2]> {
+        use crate::tab::markdown_editor::widget::utils::wrap_layout::FragmentContent;
         let frag = self.renderer.fragment_at_offset(offset)?;
         let x = self.renderer.fragment_x(frag, offset);
-        let y_range = frag
-            .rect
-            .y_range()
-            .expand(self.renderer.layout.row_spacing / 2.);
+        // Image fragments span the image band; `rect.bottom()` is the
+        // row's text baseline. Caret stays text-height around it.
+        let y_range = match &frag.content {
+            FragmentContent::Image { .. } => {
+                let baseline = frag.rect.bottom();
+                let row_h = self.renderer.layout.row_height;
+                egui::Rangef::new(baseline - row_h * 0.8, baseline + row_h * 0.2)
+            }
+            _ => frag.rect.y_range(),
+        };
+        let y_range = y_range.expand(self.renderer.layout.row_spacing / 2.);
         Some([Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }])
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -17,6 +17,82 @@ use super::render_props::{
 
 // ── renderer ──
 
+/// Image fragments allocate exactly the image's logical size — no
+/// doubled advance or padding.
+#[test]
+fn inline_image_advance_matches_rendered_width() {
+    use crate::file_cache::FileCache;
+    use crate::resolvers::image_embed::ImageEmbedResolver;
+    use crate::widgets::image_cache::ImageCache;
+    use crate::workspace::WsPersistentStore;
+    use egui::{Color32, ColorImage, ImageData, TextureOptions};
+    use lb_rs::Uuid;
+    use std::sync::Arc;
+    use std::sync::RwLock;
+
+    let lb = super::harness::build_lb();
+    let ctx = egui::Context::default();
+    ctx.set_pixels_per_point(2.0);
+    let client = super::super::HttpClient::default();
+    let files = Arc::new(RwLock::new(FileCache::empty()));
+    let persistence = WsPersistentStore::new(false, format!("/tmp/{}", Uuid::new_v4()).into());
+    let image_cache =
+        ImageCache::new(ctx.clone(), client, lb.clone(), files.clone(), persistence.clone());
+    let image_cache_handle = image_cache.clone();
+    let file_id = Uuid::new_v4();
+    let embed = Box::new(ImageEmbedResolver::new(image_cache, file_id));
+    let url = "https://placehold.co/180x120";
+    let editor = super::super::Editor::new(
+        &format!("![]({url}) ![]({url})\n\nfollow\n"),
+        file_id,
+        None,
+        super::super::MdResources {
+            ctx: ctx.clone(),
+            core: lb,
+            persistence,
+            link_resolver: Box::new(()),
+            embeds: embed,
+            files,
+        },
+        super::super::MdConfig { readonly: false, ext: "md".to_string(), tablet_or_desktop: true },
+    );
+    let mut ws = super::harness::TestEditor::from_editor(editor);
+
+    // 180×120 SVG rasterized at ppi=2 → 360×240 px texture.
+    let texture_id = {
+        let pixels = vec![Color32::WHITE; 360 * 240];
+        let image = ImageData::Color(Arc::new(ColorImage::new([360, 240], pixels)));
+        ctx.tex_manager()
+            .write()
+            .alloc("placehold_test".into(), image, TextureOptions::default())
+    };
+    image_cache_handle.complete_load(url, Ok(texture_id));
+
+    // Cursor off both images so they collapse rather than revealing.
+    ws.push(Event::Select {
+        region: Region::BetweenLocations {
+            start: Location::Grapheme(Grapheme(80)),
+            end: Location::Grapheme(Grapheme(80)),
+        },
+    });
+    ws.enter_frame();
+    ws.enter_frame();
+
+    let images: Vec<_> = ws
+        .editor
+        .edit
+        .renderer
+        .fragments
+        .iter()
+        .filter(|f| matches!(f.content, FragmentContent::Image { .. }))
+        .collect();
+    assert_eq!(images.len(), 2);
+    for f in &images {
+        assert!((f.rect.width() - 180.0).abs() < 1.0, "width: {}", f.rect.width());
+        assert!((f.rect.height() - 120.0).abs() < 1.0, "height: {}", f.rect.height());
+    }
+}
+
 #[test]
 fn image_link_no_break_opportunities_wraps() {
     // Real-world content from a user file (cb650r.md): a line

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -35,6 +35,10 @@ impl<'ast> MdRender {
     pub fn show_item(&mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2) {
         let first_line = self.node_first_line(node);
         let row_height = self.node_line_row_height(node, first_line);
+        // `Some` when an image inflates the first content row — marker
+        // centers on the inflated row instead of the text row's top.
+        let inflated = self.first_content_row_height_inflated(node);
+        let annotation_row_height = inflated.unwrap_or(row_height);
 
         let parent = node.parent().unwrap();
         let NodeValue::List(node_list) = parent.data.borrow().value else {
@@ -42,7 +46,7 @@ impl<'ast> MdRender {
         };
         let NodeList { list_type, start, .. } = node_list;
 
-        let annotation_size = Vec2 { x: self.layout.indent, y: row_height };
+        let annotation_size = Vec2 { x: self.layout.indent, y: annotation_row_height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 
         let annotation_color = self.ctx.get_lb_theme().neutral_fg_secondary();
@@ -79,11 +83,16 @@ impl<'ast> MdRender {
                     let buffer = self.upsert_glyphon_buffer(&text, afs, afs, f32::MAX, &format);
                     let size = buffer.read().unwrap().shaped_size(ppi);
 
-                    // Right-align to the content edge, baseline-shifted into the
-                    // row, identically to the revealed marker (overflow left) so
-                    // revealing the item doesn't shift the number.
+                    // Right-align to the content edge; baseline-shift y
+                    // so toggling reveal doesn't jump the number. On an
+                    // image-inflated row, baseline-alignment would park
+                    // it at the bottom corner — center vertically.
                     let x = annotation_space.right() - size.x;
-                    let y = annotation_space.top() + (row_height - afs) * 0.8;
+                    let y = if inflated.is_some() {
+                        annotation_space.top() + (annotation_row_height - afs) / 2.0
+                    } else {
+                        annotation_space.top() + (row_height - afs) * 0.8
+                    };
                     let rect = Rect::from_min_size(Pos2::new(x, y), size);
                     self.text_areas.push(TextBufferArea::new(
                         buffer,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -871,6 +871,33 @@ impl<'ast> MdRender {
         self.row_height(node)
     }
 
+    /// Visual height of `node`'s first content row when an inline image
+    /// inflates it; `None` otherwise. Mirrors the wrap-layout row
+    /// metric (`max(default_ascent, max_image_height) + default_descent`)
+    /// so sibling markers can center on the actual row.
+    pub fn first_content_row_height_inflated(&self, node: &'ast AstNode<'ast>) -> Option<f32> {
+        let mut leaf = node;
+        while !leaf.data.borrow().value.contains_inlines() {
+            leaf = leaf.children().next()?;
+        }
+        let leaf_first_line = self.node_first_line(leaf);
+        let leaf_node_line = self.node_line(leaf, leaf_first_line);
+        if leaf_node_line.is_empty() || self.disable_images {
+            return None;
+        }
+        let max_image_height = leaf
+            .descendants()
+            .filter(|d| matches!(d.data.borrow().value, NodeValue::Image(_)))
+            .filter(|d| leaf_node_line.contains_range(&self.node_range(d), true, true))
+            .filter(|d| !self.node_revealed(d))
+            .filter_map(|d| self.image_logical_size(d).map(|s| s.y))
+            .fold(0.0_f32, f32::max);
+        let leaf_row_height = self.row_height(leaf);
+        let leaf_ascent = leaf_row_height * 0.8;
+        let leaf_descent = leaf_row_height * 0.2;
+        (max_image_height > leaf_ascent).then_some(max_image_height + leaf_descent)
+    }
+
     // compute bounds for blocks stacked vertically
     pub fn compute_bounds_block_children(&mut self, node: &'ast AstNode<'ast>) {
         for child in node.children() {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -21,8 +21,13 @@ impl<'ast> MdRender {
 
         let first_line = self.node_first_line(node);
         let row_height = self.node_line_row_height(node, first_line);
+        // Inflated when an image sits on the first row, so the
+        // checkbox centers on the visual row.
+        let annotation_row_height = self
+            .first_content_row_height_inflated(node)
+            .unwrap_or(row_height);
 
-        let annotation_size = Vec2 { x: self.layout.indent, y: row_height };
+        let annotation_size = Vec2 { x: self.layout.indent, y: annotation_row_height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
         // when revealed, the raw `- [ ]` marker occupies this column instead
         if !self.reveal_line(node, first_line) {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/paragraph.rs
@@ -1,4 +1,4 @@
-use comrak::nodes::{AstNode, NodeLink, NodeValue};
+use comrak::nodes::AstNode;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt, RangeIterExt as _};
 
@@ -8,16 +8,6 @@ use crate::tab::markdown_editor::widget::utils::wrap_layout::Layout;
 impl<'ast> MdRender {
     pub fn height_paragraph(&self, node: &'ast AstNode<'ast>) -> f32 {
         let mut result = 0.;
-        if !self.disable_images {
-            for descendant in node.descendants() {
-                if let NodeValue::Image(node_link) = &descendant.data.borrow().value {
-                    let NodeLink { url, .. } = &**node_link;
-                    result += self.height_image(node, url, self.image_dims(descendant));
-                    result += self.layout.block_spacing;
-                }
-            }
-        }
-
         let last_line_idx = self.node_last_line_idx(node);
         for line_idx in self.node_lines(node).iter() {
             let line = self.bounds.source_lines[line_idx];
@@ -80,20 +70,6 @@ impl<'ast> MdRender {
         for line in self.node_lines(node).iter() {
             let line = self.bounds.source_lines[line];
             let node_line = self.node_line(node, line);
-
-            if !self.disable_images {
-                for descendant in node.descendants() {
-                    if let NodeValue::Image(node_link) = &descendant.data.borrow().value {
-                        let NodeLink { url, .. } = &**node_link;
-                        if node_line.contains_inclusive(self.node_range(descendant).start()) {
-                            let dims = self.image_dims(descendant);
-                            self.show_image_block(ui, node, top_left, url, dims);
-                            top_left.y += self.height_image(node, url, dims);
-                            top_left.y += self.layout.block_spacing;
-                        }
-                    }
-                }
-            }
 
             let line_height = self.height_paragraph_line(node, node_line);
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/table_cell.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/table_cell.rs
@@ -1,4 +1,4 @@
-use comrak::nodes::{AstNode, NodeLink, NodeValue};
+use comrak::nodes::AstNode;
 use egui::{Pos2, Ui, Vec2};
 
 use crate::tab::markdown_editor::MdRender;
@@ -14,17 +14,9 @@ impl<'ast> MdRender {
 
     pub fn height_table_cell(&self, node: &'ast AstNode<'ast>) -> f32 {
         let width = self.width(node) - 2.0 * self.layout.block_padding;
-        let mut images_height = 0.;
-        for descendant in node.descendants() {
-            if let NodeValue::Image(node_link) = &descendant.data.borrow().value {
-                let NodeLink { url, .. } = &**node_link;
-                images_height += self.height_image(node, url, self.image_dims(descendant));
-                images_height += self.layout.block_spacing;
-            }
-        }
         let content =
             self.compute_layout_from(self.layout_table_cell(node), width, self.layout.row_height);
-        self.layout.block_padding + images_height + content.height + self.layout.block_padding
+        self.layout.block_padding + content.height + self.layout.block_padding
     }
 
     pub fn width_table_cell(&self, node: &'ast AstNode<'ast>) -> f32 {
@@ -36,15 +28,6 @@ impl<'ast> MdRender {
         top_left += Vec2::splat(self.layout.block_padding);
         let width = self.width(node) - 2.0 * self.layout.block_padding;
 
-        for descendant in node.descendants() {
-            if let NodeValue::Image(node_link) = &descendant.data.borrow().value {
-                let NodeLink { url, .. } = &**node_link;
-                let dims = self.image_dims(descendant);
-                self.show_image_block(ui, node, top_left, url, dims);
-                top_left.y += self.height_image(node, url, dims);
-                top_left.y += self.layout.block_spacing;
-            }
-        }
         let result =
             self.compute_layout_from(self.layout_table_cell(node), width, self.layout.row_height);
         self.show_wrap_layout(ui, top_left, &result);

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/mod.rs
@@ -5,7 +5,7 @@ use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{FontFamily, Format};
 
-use comrak::nodes::{AstNode, NodeHeading, NodeLink, NodeValue};
+use comrak::nodes::{AstNode, NodeHeading, NodeValue};
 use egui::ahash::HashMap;
 use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::{Grapheme, Graphemes, IntoRangeExt as _, RangeExt as _};
@@ -127,10 +127,6 @@ impl<'ast> MdRender {
             NodeValue::TaskItem(_) => self.height_task_item(node),
 
             // inline
-            NodeValue::Image(node_link) => {
-                let NodeLink { url, .. } = &**node_link;
-                self.height_image(node, url, self.image_dims(node)) // rendering the image itself
-            }
             NodeValue::Subtext
             | NodeValue::Code(_)
             | NodeValue::Emph
@@ -139,6 +135,7 @@ impl<'ast> MdRender {
             | NodeValue::FootnoteReference(_)
             | NodeValue::Highlight
             | NodeValue::HtmlInline(_)
+            | NodeValue::Image(_)
             | NodeValue::LineBreak
             | NodeValue::Link(_)
             | NodeValue::Math(_)
@@ -210,6 +207,8 @@ impl<'ast> MdRender {
                 let row_height = self.row_height(node);
                 let width = self.width(node).max(row_height);
                 let mut chars = 0usize;
+                // Approx doesn't shape inline content, so track image
+                // height separately and `max` it in at the end.
                 let mut image_height = 0.0f32;
                 for d in node.descendants() {
                     match &d.data.borrow().value {
@@ -218,15 +217,10 @@ impl<'ast> MdRender {
                         NodeValue::HtmlInline(s) => chars += s.chars().count(),
                         NodeValue::Math(m) => chars += m.literal.chars().count(),
                         NodeValue::SoftBreak | NodeValue::LineBreak => chars += 1,
-                        // `embeds.size` is a HashMap lookup — returns
-                        // a placeholder before the image loads, the
-                        // actual dimensions after. The layout cache
-                        // invalidates on `embeds_updated`, so this
-                        // value picks up loaded dimensions on the
-                        // next read.
                         NodeValue::Image(link) => {
                             let dims = self.embeds.size(&link.url);
-                            image_height += self.image_size(dims, width, self.image_dims(d)).y;
+                            image_height = image_height
+                                .max(self.image_size(dims, width, self.image_dims(d)).y);
                         }
                         _ => {}
                     }
@@ -234,7 +228,9 @@ impl<'ast> MdRender {
                 let char_width = row_height * 0.5;
                 let chars_per_row = (width / char_width).floor().max(1.0) as usize;
                 let rows = ((chars as f32) / chars_per_row as f32).ceil().max(1.0);
-                rows * row_height + (rows - 1.0).max(0.0) * self.layout.row_spacing + image_height
+                let text_height =
+                    rows * row_height + (rows - 1.0).max(0.0) * self.layout.row_spacing;
+                text_height.max(image_height)
             }
             NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_) => {
                 let row_height = self.row_height(node);
@@ -317,10 +313,6 @@ impl<'ast> MdRender {
             }
 
             // inline
-            NodeValue::Image(node_link) => {
-                let NodeLink { url, .. } = &**node_link;
-                self.show_image_block(ui, node, top_left, url, self.image_dims(node))
-            }
             NodeValue::Subtext
             | NodeValue::Code(_)
             | NodeValue::Emph
@@ -329,6 +321,7 @@ impl<'ast> MdRender {
             | NodeValue::FootnoteReference(_)
             | NodeValue::Highlight
             | NodeValue::HtmlInline(_)
+            | NodeValue::Image(_)
             | NodeValue::LineBreak
             | NodeValue::Link(_)
             | NodeValue::Math(_)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -1,11 +1,12 @@
 use std::f32;
 
 use comrak::nodes::AstNode;
-use egui::{self, Pos2, Rect, Ui, Vec2};
-use lb_rs::model::text::offset_types::Grapheme;
+use egui::{self, Vec2};
+use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 
 use crate::tab::markdown_editor::MdRender;
-use crate::tab::markdown_editor::widget::utils::wrap_layout::Layout;
+use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
+use crate::tab::markdown_editor::widget::utils::wrap_layout::{ImageSpec, Layout};
 
 impl MdRender {
     pub fn warm_images<'a>(&self, node: &'a comrak::nodes::AstNode<'a>) {
@@ -20,26 +21,6 @@ impl MdRender {
 }
 
 impl<'ast> MdRender {
-    pub fn height_image(&self, node: &'ast AstNode<'ast>, url: &str, requested: ImageDims) -> f32 {
-        let width = self.width(node);
-        let dims = self.embeds.size(url);
-        self.image_size(dims, width, requested).y
-    }
-
-    pub fn show_image_block(
-        &mut self, ui: &mut Ui, node: &'ast AstNode<'ast>, top_left: Pos2, url: &str,
-        requested: ImageDims,
-    ) {
-        let width = self.width(node);
-        let dims = self.embeds.size(url);
-        let size = self.image_size(dims, width, requested);
-        let padding = (width - size.x) / 2.0;
-        let image_top_left = top_left + Vec2::new(padding, 0.);
-        let rect = Rect::from_min_size(image_top_left, size);
-
-        self.embeds.show(ui, url, rect);
-    }
-
     pub fn image_size(&self, texture_size: Vec2, width: f32, requested: ImageDims) -> Vec2 {
         // Constrain the image to fit the renderer with a margin of breathing
         // room. Clamp to non-negative — when the renderer is too small to
@@ -92,14 +73,51 @@ impl<'ast> MdRender {
         }
     }
 
-    /// Inline image. Block-positioned image rendering (the actual
-    /// image-rect) lives in `show_image_block` and runs above the
-    /// paragraph line; this just contributes the inline syntax bytes
-    /// (`![alt](url)`) to the wrap layout — same logic as `layout_link`.
+    /// Logical-point size an `Image` node will render at, constrained
+    /// by its block's width and any Obsidian `|WxH` hint. `None` if
+    /// `node` isn't an `Image`, has no leaf-block ancestor, or
+    /// collapses to zero on the first frame.
+    pub fn image_logical_size(&self, node: &'ast AstNode<'ast>) -> Option<Vec2> {
+        let url = match &node.data.borrow().value {
+            comrak::nodes::NodeValue::Image(link) => link.url.clone(),
+            _ => return None,
+        };
+        let block_ancestor = node
+            .ancestors()
+            .skip(1)
+            .find(|a| a.data.borrow().value.is_leaf_block())?;
+        let width = self.width(block_ancestor);
+        let texture_size = self.embeds.size(&url);
+        let size = self.image_size(texture_size, width, self.image_dims(node));
+        (size.x > 0.0 && size.y > 0.0).then_some(size)
+    }
+
+    /// Collapsed → emit one `InlineItem::Image` covering the syntax.
+    /// Revealed / `disable_images` / multi-line / unsizable → fall
+    /// through to `layout_link` so the source bytes render for editing.
     pub fn layout_image(
         &self, layout: &mut Layout, node: &'ast AstNode<'ast>, range: (Grapheme, Grapheme),
     ) {
-        self.layout_link(layout, node, range);
+        let node_range = self.node_range(node);
+        let single_line = range.contains_range(&node_range, true, true);
+        let collapsed_size = (!self.disable_images && !self.node_revealed(node) && single_line)
+            .then(|| self.image_logical_size(node))
+            .flatten();
+        let Some(size) = collapsed_size else {
+            self.layout_link(layout, node, range);
+            return;
+        };
+        let url = match &node.data.borrow().value {
+            comrak::nodes::NodeValue::Image(link) => link.url.clone(),
+            _ => return,
+        };
+        layout.push_image(ImageSpec {
+            advance: size.x,
+            ascent: size.y,
+            descent: 0.0,
+            source_range: node_range,
+            url,
+        });
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -142,6 +142,9 @@ pub enum InlineItem {
         source_range: (Grapheme, Grapheme),
         visible_byte_range: std::ops::Range<u32>,
     },
+    /// Inline embedded content (currently images). Atomic; breaker
+    /// treats it like a `Box`.
+    Image(ImageSpec),
     /// Open an inline-box style scope.
     StyleOpen(StyleInfo),
     /// Close the most recent open. AST nesting guarantees LIFO.
@@ -149,6 +152,18 @@ pub enum InlineItem {
     /// Tags subsequent fragments until `InteractionClose`.
     InteractionOpen(egui::Id, egui::Sense),
     InteractionClose,
+}
+
+/// Inline image's painted box and source span. `advance` is the box
+/// width; the box sits `ascent` above and `descent` below the row's
+/// text baseline. `source_range` covers the full `![alt](url)` syntax.
+#[derive(Clone, Debug)]
+pub struct ImageSpec {
+    pub advance: f32,
+    pub ascent: f32,
+    pub descent: f32,
+    pub source_range: (Grapheme, Grapheme),
+    pub url: String,
 }
 
 /// Style record for one inline-box instance. Snapshotted into each
@@ -279,6 +294,8 @@ pub enum FragmentContent {
     /// No glyphs; the rect just paints bg from `style_stack`.
     /// Standalone Pad / wrap-break-glue / Break / Anchor fragments.
     Spacer,
+    /// Embedded image; paint via `MdRender::embeds.show(ui, &url, rect)`.
+    Image { url: String },
 }
 
 /// Zero-width cursor position for source bytes with no painted
@@ -337,6 +354,8 @@ enum FlowEvent {
     /// Translates to an `InlineItem::Break` at this point in the
     /// shaped stream.
     Break((Grapheme, Grapheme)),
+    /// Embedded image; translates 1:1 to `InlineItem::Image`.
+    Image(ImageSpec),
     InteractionOpen(egui::Id, egui::Sense),
     InteractionClose,
 }
@@ -412,6 +431,12 @@ impl Layout {
     pub fn push_break(&mut self, source_range: (Grapheme, Grapheme)) {
         self.events
             .push((self.visible.len(), FlowEvent::Break(source_range)));
+    }
+
+    /// Emit a pre-sized inline image at the current position.
+    pub fn push_image(&mut self, spec: ImageSpec) {
+        self.events
+            .push((self.visible.len(), FlowEvent::Image(spec)));
     }
 
     /// Open an interaction scope; fragments emitted before the matching
@@ -602,6 +627,9 @@ fn shape_to_items(
                     items.push(InlineItem::Pad { advance: pad, source_pos: scope_range.end() });
                 }
                 items.push(InlineItem::StyleClose);
+            }
+            FlowEvent::Image(spec) => {
+                items.push(InlineItem::Image(spec.clone()));
             }
             FlowEvent::Break(r) => {
                 items.push(InlineItem::Break { source_range: *r, visible_byte_range: p..p });
@@ -1191,7 +1219,7 @@ pub fn greedy_break(items: &[InlineItem], width: f32, inline_pad: f32) -> Vec<us
         let effective_width =
             if bg_open(&scope_bg_stack) { width - 2.0 * inline_pad } else { width };
         match &items[i] {
-            InlineItem::Box { advance, .. } => {
+            InlineItem::Box { advance, .. } | InlineItem::Image(ImageSpec { advance, .. }) => {
                 let lg = if cur_width + advance > effective_width {
                     pick_wrap_point(last_whitespace_glue, last_any_glue, i, effective_width)
                 } else {
@@ -1273,11 +1301,21 @@ fn item_advance(item: &InlineItem) -> f32 {
         InlineItem::Box { advance, .. } => *advance,
         InlineItem::Glue { natural, .. } => *natural,
         InlineItem::Pad { advance, .. } => *advance,
+        InlineItem::Image(spec) => spec.advance,
         InlineItem::Break { .. }
         | InlineItem::StyleOpen(_)
         | InlineItem::StyleClose
         | InlineItem::InteractionOpen(..)
         | InlineItem::InteractionClose => 0.0,
+    }
+}
+
+/// `Some(ascent, descent)` for items that override row metrics; row
+/// `ascent`/`descent` are the max of these and the text default.
+fn item_metrics(item: &InlineItem) -> Option<(f32, f32)> {
+    match item {
+        InlineItem::Image(spec) => Some((spec.ascent, spec.descent)),
+        _ => None,
     }
 }
 
@@ -1294,14 +1332,24 @@ pub fn build_rows(
     inline_pad: f32,
 ) -> Vec<Row> {
     let mut rows: Vec<Row> = Vec::with_capacity(breaks.len().saturating_sub(1));
-    let ascent = row_height * 0.8;
-    let descent = row_height * 0.2;
+    let default_ascent = row_height * 0.8;
+    let default_descent = row_height * 0.2;
     let mut style_stack: Vec<StyleInfo> = Vec::new();
     let mut interaction_stack: Vec<(egui::Id, egui::Sense)> = Vec::new();
     let mut y_top = 0.0f32;
 
     for win in breaks.windows(2) {
         let (start, end) = (win[0], win[1]);
+        // Row baseline = `y_top + ascent`. Text fragments span the
+        // text band (`baseline ± default_*`); image fragments hang
+        // above the baseline so `image_bottom == baseline`.
+        let (ascent, descent) = items[start..end]
+            .iter()
+            .filter_map(item_metrics)
+            .fold((default_ascent, default_descent), |(a, d), (ia, id)| (a.max(ia), d.max(id)));
+        let baseline = y_top + ascent;
+        let text_top = baseline - default_ascent;
+        let text_bottom = baseline + default_descent;
         // Last item is the row's "wrap break" — its advance is
         // suppressed and its source range is excluded from
         // `row.source_range`. Exactly one item per row plays this
@@ -1340,10 +1388,8 @@ pub fn build_rows(
             .is_some_and(|s| s.format.background != egui::Color32::TRANSPARENT)
         {
             let info = style_stack.last().unwrap();
-            let rect = Rect::from_min_max(
-                Pos2::new(x, y_top),
-                Pos2::new(x + inline_pad, y_top + ascent + descent),
-            );
+            let rect =
+                Rect::from_min_max(Pos2::new(x, text_top), Pos2::new(x + inline_pad, text_bottom));
             left_pad_idx = Some(row_fragments.len());
             row_fragments.push(Fragment {
                 rect,
@@ -1360,19 +1406,16 @@ pub fn build_rows(
         for (rel_idx, it) in items[start..end].iter().enumerate() {
             let abs_idx = start + rel_idx;
             let is_wrap_break = wrap_break_idx == Some(abs_idx);
-            // Super/sub shrink glyphs to 75% of the row metric; shift
-            // the fragment rect vertically so the smaller glyph sits at
-            // the top of the row (super) or the bottom (sub). Glue/Box
-            // only — Pads and Breaks inherit full row height so
-            // surrounding pills/decorations stay aligned with siblings.
+            // Super/sub stick to text-band edges, not `ascent` extremes —
+            // an image-inflated row would otherwise drag them outward.
             let (item_y_min, item_y_max) = {
                 let f = style_stack.last().map(|s| &s.format);
-                let full = ascent + descent;
-                let small = full * 0.75;
+                let text_height = default_ascent + default_descent;
+                let small = text_height * 0.75;
                 match f {
-                    Some(f) if f.superscript => (y_top, y_top + small),
-                    Some(f) if f.subscript => (y_top + (full - small), y_top + full),
-                    _ => (y_top, y_top + full),
+                    Some(f) if f.superscript => (text_top, text_top + small),
+                    Some(f) if f.subscript => (text_bottom - small, text_bottom),
+                    _ => (text_top, text_bottom),
                 }
             };
             match it {
@@ -1475,8 +1518,8 @@ pub fn build_rows(
                 }
                 InlineItem::Pad { advance, source_pos } => {
                     let rect = Rect::from_min_max(
-                        Pos2::new(x, y_top),
-                        Pos2::new(x + advance, y_top + ascent + descent),
+                        Pos2::new(x, text_top),
+                        Pos2::new(x + advance, text_bottom),
                     );
                     row_fragments.push(Fragment {
                         rect,
@@ -1489,11 +1532,29 @@ pub fn build_rows(
                     });
                     x += advance;
                 }
-                InlineItem::Break { source_range, visible_byte_range } => {
+                InlineItem::Image(spec) => {
+                    let img_top = baseline - spec.ascent;
+                    let img_bottom = baseline + spec.descent;
                     let rect = Rect::from_min_max(
-                        Pos2::new(x, y_top),
-                        Pos2::new(x, y_top + ascent + descent),
+                        Pos2::new(x, img_top),
+                        Pos2::new(x + spec.advance, img_bottom),
                     );
+                    src_lo = src_lo.min(spec.source_range.start());
+                    src_hi = src_hi.max(spec.source_range.end());
+                    row_fragments.push(Fragment {
+                        rect,
+                        content_inset: FragmentInset::default(),
+                        source_range: spec.source_range,
+                        style_stack: style_stack.clone(),
+                        content: FragmentContent::Image { url: spec.url.clone() },
+                        atomic: true,
+                        interaction: interaction_stack.last().copied(),
+                    });
+                    x += spec.advance;
+                }
+                InlineItem::Break { source_range, visible_byte_range } => {
+                    let rect =
+                        Rect::from_min_max(Pos2::new(x, text_top), Pos2::new(x, text_bottom));
                     byte_x.push((visible_byte_range.start, x));
                     byte_x.push((visible_byte_range.end, x));
                     row_visible_lo = Some(
@@ -1550,10 +1611,8 @@ pub fn build_rows(
         {
             let info = style_stack.last().unwrap();
             let source_pos = if src_lo <= src_hi { src_hi } else { info.source_range.start() };
-            let rect = Rect::from_min_max(
-                Pos2::new(x, y_top),
-                Pos2::new(x + inline_pad, y_top + ascent + descent),
-            );
+            let rect =
+                Rect::from_min_max(Pos2::new(x, text_top), Pos2::new(x + inline_pad, text_bottom));
             row_fragments.push(Fragment {
                 rect,
                 content_inset: FragmentInset::default(),
@@ -1587,8 +1646,8 @@ pub fn build_rows(
                 anchors.push(Anchor {
                     source_range: seg.source,
                     x: anchor_x,
-                    y_top,
-                    height: ascent + descent,
+                    y_top: text_top,
+                    height: text_bottom - text_top,
                 });
             }
         }
@@ -1728,6 +1787,10 @@ impl MdRender {
                         ui.ctx(),
                         ui.clip_rect(),
                     ));
+                }
+
+                if let FragmentContent::Image { url } = &frag.content {
+                    self.embeds.show(ui, url, screen_rect);
                 }
 
                 // Collected here, painted after the text callback (#4617).

--- a/libs/content/workspace/src/widgets/image_cache.rs
+++ b/libs/content/workspace/src/widgets/image_cache.rs
@@ -225,7 +225,9 @@ impl ImageCache {
                     let file = core.get_file_by_id(id).map_err(|e| e.to_string())?;
                     file.name.ends_with(".svg")
                 } else {
-                    url.ends_with(".svg")
+                    // Servers can return SVG without a `.svg` suffix
+                    // (placehold.co's default); sniff the bytes too.
+                    url.ends_with(".svg") || bytes_look_like_svg(&image_bytes)
                 };
 
                 let image_bytes = if is_svg {
@@ -274,6 +276,23 @@ impl ImageCache {
     }
 }
 
+/// Sniff for SVG bytes — `<?xml` or `<svg` after optional BOM and
+/// leading whitespace.
+fn bytes_look_like_svg(bytes: &[u8]) -> bool {
+    let mut s = bytes;
+    if let [0xEF, 0xBB, 0xBF, rest @ ..] = s {
+        s = rest;
+    }
+    while let [first, rest @ ..] = s {
+        if first.is_ascii_whitespace() {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    s.starts_with(b"<?xml") || s.starts_with(b"<svg")
+}
+
 fn rasterize_svg(
     bytes: &[u8], is_lockbook_svg: bool, viewport_width: f32, pixels_per_point: f32,
 ) -> Result<Vec<u8>, String> {
@@ -292,8 +311,9 @@ fn rasterize_svg(
     let scale = (viewport_width / w).min(1.0) * pixels_per_point;
     let pix_w = (w * scale) as u32;
     let pix_h = (h * scale) as u32;
-    let transform =
-        if scale < 1.0 { base_transform.post_scale(scale, scale) } else { base_transform };
+    // Pixmap is `w * scale` wide; the transform must match or the SVG
+    // draws at natural size into a too-big pixmap's top-left.
+    let transform = base_transform.post_scale(scale, scale);
 
     let mut pix_map = Pixmap::new(pix_w, pix_h)
         .ok_or("failed to create pixmap")
@@ -346,4 +366,53 @@ async fn download_image(client: &HttpClient, url: &str) -> Result<Vec<u8>, Strin
         return Err(format!("{} {}", status.as_u16(), status.canonical_reason().unwrap_or("")));
     }
     Ok(response.bytes().await.map_err(|e| e.to_string())?.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bytes_look_like_svg, rasterize_svg};
+
+    /// At ppi>1 the SVG fills the whole upscaled pixmap, not just a
+    /// top-left `1/ppi × 1/ppi` quadrant.
+    #[test]
+    fn svg_rasterization_fills_pixmap_at_hidpi() {
+        let svg_str = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"180\" height=\"120\" viewBox=\"0 0 180 120\"><rect width=\"100%\" height=\"100%\" fill=\"#DDDDDD\"/></svg>";
+        let png = rasterize_svg(svg_str.as_bytes(), false, 1920.0, 2.0).unwrap();
+        let img = image::ImageReader::new(std::io::Cursor::new(&png))
+            .with_guessed_format()
+            .unwrap()
+            .decode()
+            .unwrap()
+            .to_rgba8();
+        assert_eq!(img.dimensions(), (360, 240));
+        assert!(img.get_pixel(350, 120)[3] > 0, "far-right pixel transparent");
+    }
+
+    /// Synthetic stand-in for the placehold.co/180x120 response —
+    /// rasterized at ppi=2 should yield a 360×240 PNG.
+    #[test]
+    fn placehold_co_svg_dims() {
+        let svg_str = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"180\" height=\"120\" viewBox=\"0 0 180 120\"><rect width=\"100%\" height=\"100%\" fill=\"#DDDDDD\"/></svg>";
+        let png_bytes = rasterize_svg(svg_str.as_bytes(), false, 1920.0, 2.0).unwrap();
+        let img = image::ImageReader::new(std::io::Cursor::new(&png_bytes))
+            .with_guessed_format()
+            .unwrap()
+            .decode()
+            .unwrap();
+        assert_eq!((img.width(), img.height()), (360, 240));
+    }
+
+    #[test]
+    fn svg_byte_sniff() {
+        assert!(bytes_look_like_svg(b"<svg xmlns=\"...\"></svg>"));
+        assert!(bytes_look_like_svg(b"<?xml version=\"1.0\"?><svg/>"));
+        assert!(bytes_look_like_svg(b"   <svg/>"));
+        assert!(bytes_look_like_svg(b"\xEF\xBB\xBF<svg/>"));
+        assert!(bytes_look_like_svg(b"\xEF\xBB\xBF\n<?xml ?><svg/>"));
+        assert!(!bytes_look_like_svg(b"\x89PNG\r\n\x1a\n"));
+        assert!(!bytes_look_like_svg(b"GIF89a"));
+        assert!(!bytes_look_like_svg(b"\xFF\xD8\xFF"));
+        assert!(!bytes_look_like_svg(b""));
+        assert!(!bytes_look_like_svg(b"<html><svg/></html>"));
+    }
 }


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4590

<img width="800" height="502" alt="CleanShot 2026-06-16 at 23 12 58" src="https://github.com/user-attachments/assets/1e204567-4924-4a07-bed8-2575f71eb7f2" />
