### PR TITLE
ws & lb-rs: scoped search

### DIFF
--- a/clients/egui/src/account/mod.rs
+++ b/clients/egui/src/account/mod.rs
@@ -417,6 +417,10 @@ impl AccountScreen {
                 .start_space_inspector(self.core.clone(), resp.space_inspector_root);
         }
 
+        if let Some(id) = resp.search_here {
+            self.workspace.search_in_folder(id);
+        }
+
         if let Some(file) = resp.new_folder_modal {
             self.update_tx
                 .send(OpenModal::NewFolder(Some(file)).into())

--- a/clients/egui/src/account/tree.rs
+++ b/clients/egui/src/account/tree.rs
@@ -1493,6 +1493,14 @@ impl FileTree {
                 ui.close();
             }
 
+            if file.is_folder() {
+                ui.separator();
+                if ui.button("Search Here").clicked() {
+                    resp.search_here = Some(file.id);
+                    ui.close();
+                }
+            }
+
             if self.descends_from_root(file.id) && file.is_folder() {
                 ui.separator();
                 if ui.button("Space Inspector").clicked() {
@@ -1868,6 +1876,7 @@ pub struct Response {
     pub delete_requests: HashSet<Uuid>,
     pub dropped_on: Option<Uuid>,
     pub space_inspector_root: Option<File>,
+    pub search_here: Option<Uuid>,
     pub clear_suggested: bool,
     pub clear_suggested_id: Option<Uuid>,
     pub accepted_share: Option<File>,
@@ -1905,6 +1914,7 @@ impl Response {
         this.delete_requests.extend(other.delete_requests);
         this.dropped_on = this.dropped_on.or(other.dropped_on);
         this.space_inspector_root = this.space_inspector_root.or(other.space_inspector_root);
+        this.search_here = this.search_here.or(other.search_here);
         this.clear_suggested = this.clear_suggested || other.clear_suggested;
         this.clear_suggested_id = this.clear_suggested_id.or(other.clear_suggested_id);
         this.accepted_share = this.accepted_share.or(other.accepted_share);

--- a/libs/content/egui_wgpu_renderer/src/lib.rs
+++ b/libs/content/egui_wgpu_renderer/src/lib.rs
@@ -17,7 +17,7 @@ pub use wgpu;
 
 mod shame;
 
-const NOOB_FACTOR: u64 = 80;
+const NOOB_FACTOR: u64 = 8;
 const FRAME_BUDGET: Duration = Duration::from_micros((16_667 / 2) * NOOB_FACTOR);
 
 pub struct RendererState<'w> {

--- a/libs/content/egui_wgpu_renderer/src/lib.rs
+++ b/libs/content/egui_wgpu_renderer/src/lib.rs
@@ -17,7 +17,7 @@ pub use wgpu;
 
 mod shame;
 
-const NOOB_FACTOR: u64 = 8;
+const NOOB_FACTOR: u64 = 80;
 const FRAME_BUDGET: Duration = Duration::from_micros((16_667 / 2) * NOOB_FACTOR);
 
 pub struct RendererState<'w> {

--- a/libs/content/workspace/src/search/content.rs
+++ b/libs/content/workspace/src/search/content.rs
@@ -125,6 +125,12 @@ impl SearchExecutor for ContentSearch {
         self.focused_file = None;
     }
 
+    fn update_filter(&mut self, filter: Option<lb_rs::search::SearchFilter>) {
+        self.searcher.update_filter(filter);
+        self.selected = 0;
+        self.focused_file = None;
+    }
+
     fn set_kb_mode(&mut self, kb_mode: bool) {
         self.kb_mode = kb_mode;
     }

--- a/libs/content/workspace/src/search/content.rs
+++ b/libs/content/workspace/src/search/content.rs
@@ -135,7 +135,9 @@ impl SearchExecutor for ContentSearch {
         self.kb_mode = kb_mode;
     }
 
-    fn show_result_picker(&mut self, ui: &mut egui::Ui, allow_kb_nav: bool) -> super::PickerResponse {
+    fn show_result_picker(
+        &mut self, ui: &mut egui::Ui, allow_kb_nav: bool,
+    ) -> super::PickerResponse {
         self.process_keys(ui.ctx(), allow_kb_nav);
 
         let results = self.searcher.results();
@@ -430,7 +432,8 @@ impl ContentSearch {
                 if i.consume_key_exact(Modifiers::NONE, Key::Enter) {
                     self.activate = true;
                 }
-                if self.focused_file.is_some() && i.consume_key_exact(Modifiers::NONE, Key::Escape) {
+                if self.focused_file.is_some() && i.consume_key_exact(Modifiers::NONE, Key::Escape)
+                {
                     self.focused_file = None;
                     self.selected = 0;
                     self.kb_mode = true;

--- a/libs/content/workspace/src/search/content.rs
+++ b/libs/content/workspace/src/search/content.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use egui::{Context, CornerRadius, Frame, Key, Margin, Modifiers, Ui};
 use lb_rs::Uuid;
 use lb_rs::blocking::Lb;
-use lb_rs::search::{ContentMatch, ContentSearcher, SearchResult};
+use lb_rs::search::{ContentMatch, ContentSearcher, SearchFilter, SearchResult};
 
 use crate::{
     search::{SearchExecutor, SearchType},
@@ -125,7 +125,7 @@ impl SearchExecutor for ContentSearch {
         self.focused_file = None;
     }
 
-    fn update_filter(&mut self, filter: Option<lb_rs::search::SearchFilter>) {
+    fn update_filter(&mut self, filter: Option<SearchFilter>) {
         self.searcher.update_filter(filter);
         self.selected = 0;
         self.focused_file = None;

--- a/libs/content/workspace/src/search/content.rs
+++ b/libs/content/workspace/src/search/content.rs
@@ -129,8 +129,8 @@ impl SearchExecutor for ContentSearch {
         self.kb_mode = kb_mode;
     }
 
-    fn show_result_picker(&mut self, ui: &mut egui::Ui) -> super::PickerResponse {
-        self.process_keys(ui.ctx());
+    fn show_result_picker(&mut self, ui: &mut egui::Ui, allow_kb_nav: bool) -> super::PickerResponse {
+        self.process_keys(ui.ctx(), allow_kb_nav);
 
         let results = self.searcher.results();
 
@@ -398,7 +398,7 @@ impl SearchExecutor for ContentSearch {
 }
 
 impl ContentSearch {
-    fn process_keys(&mut self, ctx: &Context) {
+    fn process_keys(&mut self, ctx: &Context, allow_kb_nav: bool) {
         const NUM_KEYS: [Key; 9] = [
             Key::Num1,
             Key::Num2,
@@ -411,30 +411,32 @@ impl ContentSearch {
             Key::Num9,
         ];
 
-        ctx.input_mut(|i| {
-            if i.consume_key_exact(Modifiers::NONE, Key::ArrowDown) {
-                self.selected = self.selected.saturating_add(1);
-                self.kb_mode = true;
-            }
-            if i.consume_key_exact(Modifiers::NONE, Key::ArrowUp) {
-                self.selected = self.selected.saturating_sub(1);
-                self.kb_mode = true;
-            }
-            if i.consume_key_exact(Modifiers::NONE, Key::Enter) {
-                self.activate = true;
-            }
-            if self.focused_file.is_some() && i.consume_key_exact(Modifiers::NONE, Key::Escape) {
-                self.focused_file = None;
-                self.selected = 0;
-                self.kb_mode = true;
-            }
-            for (idx, &k) in NUM_KEYS.iter().enumerate() {
-                if i.consume_key_exact(Modifiers::COMMAND, k) {
-                    self.activate_nth = Some(idx);
+        if allow_kb_nav {
+            ctx.input_mut(|i| {
+                if i.consume_key_exact(Modifiers::NONE, Key::ArrowDown) {
+                    self.selected = self.selected.saturating_add(1);
                     self.kb_mode = true;
                 }
-            }
-        });
+                if i.consume_key_exact(Modifiers::NONE, Key::ArrowUp) {
+                    self.selected = self.selected.saturating_sub(1);
+                    self.kb_mode = true;
+                }
+                if i.consume_key_exact(Modifiers::NONE, Key::Enter) {
+                    self.activate = true;
+                }
+                if self.focused_file.is_some() && i.consume_key_exact(Modifiers::NONE, Key::Escape) {
+                    self.focused_file = None;
+                    self.selected = 0;
+                    self.kb_mode = true;
+                }
+                for (idx, &k) in NUM_KEYS.iter().enumerate() {
+                    if i.consume_key_exact(Modifiers::COMMAND, k) {
+                        self.activate_nth = Some(idx);
+                        self.kb_mode = true;
+                    }
+                }
+            });
+        }
 
         if ctx.input(|i| i.pointer.delta().length_sq() > 0.0) {
             self.kb_mode = false;

--- a/libs/content/workspace/src/search/mod.rs
+++ b/libs/content/workspace/src/search/mod.rs
@@ -377,7 +377,10 @@ impl Search {
         });
 
         let mut chosen = None;
-        if anchor.ctx.input_mut(|i| i.consume_key_exact(egui::Modifiers::NONE, egui::Key::Enter)) {
+        if anchor
+            .ctx
+            .input_mut(|i| i.consume_key_exact(egui::Modifiers::NONE, egui::Key::Enter))
+        {
             chosen = matches.get(self.scope_selected).cloned();
         }
 
@@ -502,7 +505,9 @@ impl Workspace {
                     egui::Layout::top_down(egui::Align::LEFT),
                     |ui| {
                         let picker = executor.try_write().ok().and_then(|mut guard| {
-                            guard.as_mut().map(|e| e.show_result_picker(ui, allow_kb_nav))
+                            guard
+                                .as_mut()
+                                .map(|e| e.show_result_picker(ui, allow_kb_nav))
                         });
                         match picker {
                             Some(picker) => (picker, true),

--- a/libs/content/workspace/src/search/mod.rs
+++ b/libs/content/workspace/src/search/mod.rs
@@ -13,10 +13,10 @@ pub struct Search {
     scope_was_focused: bool,
     query_focused: bool,
     dispatched_query: String,
+    dispatched_filter: String,
     building: Arc<AtomicBool>,
 
     core: Lb,
-    files: Arc<RwLock<FileCache>>,
 }
 
 #[derive(Default, Eq, PartialEq, Clone, Copy)]
@@ -27,9 +27,9 @@ pub enum SearchType {
 }
 
 impl SearchType {
-    fn create_executor(&self, lb: &Lb, files: &Arc<RwLock<FileCache>>) -> Box<dyn SearchExecutor> {
+    fn create_executor(&self, lb: &Lb) -> Box<dyn SearchExecutor> {
         match self {
-            SearchType::Path => Box::new(PathSearch::new(lb, files.clone())),
+            SearchType::Path => Box::new(PathSearch::new(lb)),
             SearchType::Content => Box::new(ContentSearch::new(lb)),
         }
     }
@@ -58,6 +58,7 @@ pub struct PickerResponse {
 pub trait SearchExecutor: Send + Sync {
     fn search_type(&self) -> SearchType;
     fn handle_query(&mut self, query: &str);
+    fn update_filter(&mut self, filter: Option<SearchFilter>);
     fn set_kb_mode(&mut self, kb_mode: bool);
     /// Render the result list. `activated` is set when the user opens a result
     /// (e.g. Enter or row shortcut); `selected` tracks the highlighted row for
@@ -66,7 +67,7 @@ pub trait SearchExecutor: Send + Sync {
 }
 
 impl Search {
-    pub fn new(lb: &Lb, ctx: &Context, files: Arc<RwLock<FileCache>>) -> Search {
+    pub fn new(lb: &Lb, ctx: &Context) -> Search {
         let mut search = Search {
             search_type: SearchType::Path,
             query: String::new(),
@@ -79,9 +80,9 @@ impl Search {
             scope_was_focused: false,
             query_focused: false,
             dispatched_query: String::new(),
+            dispatched_filter: String::new(),
             building: Arc::new(AtomicBool::new(false)),
             core: lb.clone(),
-            files,
         };
         search.spawn_build(ctx);
         search.spawn_load_folders(ctx);
@@ -104,16 +105,16 @@ impl Search {
     fn spawn_build(&mut self, ctx: &Context) {
         self.building.store(true, Ordering::SeqCst);
         self.dispatched_query.clear();
+        self.dispatched_filter.clear();
 
         let executor = self.executor.clone();
         let building = self.building.clone();
         let core = self.core.clone();
-        let files = self.files.clone();
         let ctx = ctx.clone();
         let search_type = self.search_type;
         thread::spawn(move || {
             let mut guard = executor.write().unwrap();
-            *guard = Some(search_type.create_executor(&core, &files));
+            *guard = Some(search_type.create_executor(&core));
             drop(guard);
             building.store(false, Ordering::SeqCst);
             ctx.request_repaint();
@@ -150,6 +151,25 @@ impl Search {
             thread::spawn(move || {
                 if let Some(executor) = executor.write().unwrap().as_mut() {
                     executor.handle_query(&query);
+                }
+                ctx.request_repaint();
+            });
+        }
+
+        if self.scope_path != self.dispatched_filter {
+            self.dispatched_filter = self.scope_path.clone();
+
+            let filter = if self.scope_path.is_empty() {
+                None
+            } else {
+                Some(SearchFilter::Path(self.scope_path.clone()))
+            };
+
+            let executor = self.executor.clone();
+            let ctx = ctx.clone();
+            thread::spawn(move || {
+                if let Some(executor) = executor.write().unwrap().as_mut() {
+                    executor.update_filter(filter);
                 }
                 ctx.request_repaint();
             });
@@ -259,10 +279,15 @@ impl Search {
             });
         });
 
-        if !self.scope_path.is_empty()
+        if (!self.scope_path.is_empty() || !self.query.is_empty())
             && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
         {
-            self.scope_path.clear();
+            if !self.scope_path.is_empty() {
+                self.scope_path.clear();
+                self.filters_open = false;
+            } else {
+                self.query.clear();
+            }
         }
 
         if focused {
@@ -279,6 +304,7 @@ impl Search {
         let theme = ui.ctx().get_lb_theme();
         ui.horizontal(|ui| {
             ui.spacing_mut().item_spacing.x = 8.0;
+            ui.set_min_height(22.0);
             ui.label(
                 RichText::new("Searching inside")
                     .size(14.0)
@@ -419,7 +445,14 @@ impl Workspace {
                 self.results_and_preview(ui, &executor, search_type, query_focused)
             {
                 if self.is_folder(id) {
-                    self.out.selected_file = Some(id);
+                    let path = self.files.read().unwrap().path(id);
+                    if let Some(tab) = self.tabs.get_mut(&Destination::Search) {
+                        if let ContentState::Open(TabContent::Search(search)) = &mut tab.content {
+                            search.scope_path = path;
+                            search.query.clear();
+                            search.filters_open = true;
+                        }
+                    }
                 } else if in_new_tab {
                     self.open_file(id, false, true);
                 } else {
@@ -532,9 +565,10 @@ use std::thread;
 use egui::{Context, CornerRadius, Frame, Margin, RichText, TextEdit, Ui, Vec2};
 use lb_rs::blocking::Lb;
 use lb_rs::model::path_ops::Filter;
+use lb_rs::search::SearchFilter;
 
 use crate::{
-    file_cache::FileCache,
+    file_cache::FilesExt,
     search::{content::ContentSearch, path::PathSearch},
     show::InputStateExt,
     tab::{ContentState, Destination, TabContent},

--- a/libs/content/workspace/src/search/mod.rs
+++ b/libs/content/workspace/src/search/mod.rs
@@ -311,6 +311,7 @@ impl Search {
                     .color(theme.neutral_fg_secondary()),
             );
             let home = IconButton::new(Icon::HOME.size(16.0))
+                .size(22.0)
                 .tooltip("Home")
                 .colored(self.scope_path.is_empty())
                 .show(ui);
@@ -382,20 +383,36 @@ impl Search {
 
         egui::Popup::from_response(anchor)
             .open(true)
-            .width(anchor.rect.width())
+            .width(400.)
             .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
             .show(|ui| {
+                ui.set_min_width(400.0);
                 ui.spacing_mut().item_spacing.y = 2.0;
                 egui::ScrollArea::vertical()
-                    .max_height(160.0)
+                    .max_height(600.0)
+                    .auto_shrink([false, true])
                     .show(ui, |ui| {
                         for (idx, path) in matches.iter().enumerate() {
-                            let label = RichText::new(path).size(13.0);
-                            let row = ui.selectable_label(idx == self.scope_selected, label);
+                            let selected = idx == self.scope_selected;
+                            let (rect, row) = ui.allocate_at_least(
+                                egui::vec2(ui.available_width(), 22.0),
+                                egui::Sense::click(),
+                            );
+                            let visuals = ui.style().interact_selectable(&row, selected);
+                            if selected || row.hovered() {
+                                ui.painter().rect_filled(rect, 4.0, visuals.bg_fill);
+                            }
+                            ui.painter().text(
+                                egui::pos2(rect.left() + 8.0, rect.center().y),
+                                egui::Align2::LEFT_CENTER,
+                                path,
+                                egui::FontId::proportional(13.0),
+                                visuals.text_color(),
+                            );
                             if row.clicked() {
                                 chosen = Some(path.clone());
                             }
-                            if idx == self.scope_selected {
+                            if selected {
                                 row.scroll_to_me(None);
                             }
                         }

--- a/libs/content/workspace/src/search/mod.rs
+++ b/libs/content/workspace/src/search/mod.rs
@@ -6,6 +6,8 @@ pub struct Search {
     pub query: String,
     pub initialized: bool,
     pub executor: Arc<RwLock<Option<Box<dyn SearchExecutor>>>>,
+    pub filters_open: bool,
+    pub scope: Option<lb_rs::Uuid>,
     dispatched_query: String,
     building: Arc<AtomicBool>,
 
@@ -66,6 +68,8 @@ impl Search {
             query: String::new(),
             initialized: false,
             executor: Arc::new(RwLock::new(None)),
+            filters_open: false,
+            scope: None,
             dispatched_query: String::new(),
             building: Arc::new(AtomicBool::new(false)),
             core: lb.clone(),
@@ -177,26 +181,39 @@ impl Search {
                         .color(theme.neutral_fg_secondary())
                         .show(ui);
 
-                    let resp = TextEdit::singleline(&mut self.query)
-                        .id(text_id)
-                        .frame(false)
-                        .hint_text(
-                            RichText::new(hint)
-                                .size(22.0)
-                                .color(theme.neutral_fg_secondary()),
-                        )
-                        .text_color(theme.neutral_fg())
-                        .font(egui::FontId::proportional(22.0))
-                        .vertical_align(egui::Align::Center)
-                        .desired_width(ui.available_width())
-                        .margin(Margin::ZERO)
-                        .show(ui)
-                        .response;
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let filter = IconButton::new(Icon::FILTER.size(18.0))
+                            .tooltip("Filters")
+                            .colored(self.filters_open)
+                            .show(ui);
+                        if filter.clicked() {
+                            self.filters_open = !self.filters_open;
+                            if !self.filters_open {
+                                self.scope = None;
+                            }
+                        }
 
-                    if !self.initialized || ui.ctx().memory(|m| m.focused().is_none()) {
-                        self.initialized = true;
-                        resp.request_focus();
-                    }
+                        let resp = TextEdit::singleline(&mut self.query)
+                            .id(text_id)
+                            .frame(false)
+                            .hint_text(
+                                RichText::new(hint)
+                                    .size(22.0)
+                                    .color(theme.neutral_fg_secondary()),
+                            )
+                            .text_color(theme.neutral_fg())
+                            .font(egui::FontId::proportional(22.0))
+                            .vertical_align(egui::Align::Center)
+                            .desired_width(ui.available_width())
+                            .margin(Margin::ZERO)
+                            .show(ui)
+                            .response;
+
+                        if !self.initialized || ui.ctx().memory(|m| m.focused().is_none()) {
+                            self.initialized = true;
+                            resp.request_focus();
+                        }
+                    });
                 });
 
                 // Executor selector along the bottom of the box.
@@ -211,8 +228,19 @@ impl Search {
                     ui.radio_value(&mut self.search_type, SearchType::Path, label("Filenames"));
                     ui.radio_value(&mut self.search_type, SearchType::Content, label("Contents"));
                 });
+
+                if self.filters_open {
+                    ui.add_space(8.0);
+                    self.show_filter_bar(ui);
+                }
             });
         });
+
+        if self.scope.is_some()
+            && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
+        {
+            self.scope = None;
+        }
 
         if focused {
             ui.painter().rect_stroke(
@@ -222,6 +250,25 @@ impl Search {
                 egui::epaint::StrokeKind::Inside,
             );
         }
+    }
+
+    fn show_filter_bar(&mut self, ui: &mut Ui) {
+        let theme = ui.ctx().get_lb_theme();
+        ui.horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x = 8.0;
+            ui.label(
+                RichText::new("Searching inside")
+                    .size(14.0)
+                    .color(theme.neutral_fg_secondary()),
+            );
+            let home = IconButton::new(Icon::HOME.size(16.0))
+                .tooltip("Home")
+                .colored(self.scope.is_none())
+                .show(ui);
+            if home.clicked() {
+                self.scope = None;
+            }
+        });
     }
 }
 
@@ -376,5 +423,6 @@ use crate::{
     search::{content::ContentSearch, path::PathSearch},
     tab::{ContentState, Destination, TabContent},
     theme::{icons::Icon, palette_v2::ThemeExt},
+    widgets::IconButton,
     workspace::Workspace,
 };

--- a/libs/content/workspace/src/search/mod.rs
+++ b/libs/content/workspace/src/search/mod.rs
@@ -8,6 +8,10 @@ pub struct Search {
     pub executor: Arc<RwLock<Option<Box<dyn SearchExecutor>>>>,
     pub filters_open: bool,
     pub scope_path: String,
+    folders: Arc<RwLock<Vec<(lb_rs::Uuid, String)>>>,
+    scope_selected: usize,
+    scope_was_focused: bool,
+    query_focused: bool,
     dispatched_query: String,
     building: Arc<AtomicBool>,
 
@@ -58,7 +62,7 @@ pub trait SearchExecutor: Send + Sync {
     /// Render the result list. `activated` is set when the user opens a result
     /// (e.g. Enter or row shortcut); `selected` tracks the highlighted row for
     /// the preview pane.
-    fn show_result_picker(&mut self, ui: &mut Ui) -> PickerResponse;
+    fn show_result_picker(&mut self, ui: &mut Ui, allow_kb_nav: bool) -> PickerResponse;
 }
 
 impl Search {
@@ -70,13 +74,31 @@ impl Search {
             executor: Arc::new(RwLock::new(None)),
             filters_open: false,
             scope_path: String::new(),
+            folders: Arc::new(RwLock::new(Vec::new())),
+            scope_selected: 0,
+            scope_was_focused: false,
+            query_focused: false,
             dispatched_query: String::new(),
             building: Arc::new(AtomicBool::new(false)),
             core: lb.clone(),
             files,
         };
         search.spawn_build(ctx);
+        search.spawn_load_folders(ctx);
         search
+    }
+
+    fn spawn_load_folders(&self, ctx: &Context) {
+        let folders = self.folders.clone();
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        thread::spawn(move || {
+            let loaded = core
+                .list_paths_with_ids(Some(Filter::FoldersOnly))
+                .unwrap_or_default();
+            *folders.write().unwrap() = loaded;
+            ctx.request_repaint();
+        });
     }
 
     fn spawn_build(&mut self, ctx: &Context) {
@@ -162,6 +184,7 @@ impl Search {
 
         let text_id = ui.id().with("search_query_input");
         let focused = ui.memory(|m| m.has_focus(text_id));
+        self.query_focused = focused;
 
         let fill =
             if focused { ui.visuals().extreme_bg_color } else { theme.neutral_bg_secondary() };
@@ -269,20 +292,96 @@ impl Search {
                 self.scope_path.clear();
             }
 
-            TextEdit::singleline(&mut self.scope_path)
+            let resp = TextEdit::singleline(&mut self.scope_path)
                 .frame(false)
-                .hint_text(
-                    RichText::new("/")
-                        .size(14.0)
-                        .color(theme.neutral_fg_secondary()),
-                )
                 .text_color(theme.neutral_fg())
                 .font(egui::FontId::proportional(14.0))
                 .vertical_align(egui::Align::Center)
                 .desired_width(ui.available_width())
                 .margin(Margin::ZERO)
-                .show(ui);
+                .show(ui)
+                .response;
+
+            if resp.changed() {
+                self.scope_selected = 0;
+            }
+            self.show_folder_dropdown(&resp);
         });
+    }
+
+    fn show_folder_dropdown(&mut self, anchor: &egui::Response) {
+        let focused = anchor.has_focus();
+        let open = focused || self.scope_was_focused;
+        self.scope_was_focused = focused;
+        if !open {
+            return;
+        }
+
+        let needle = self.scope_path.to_lowercase();
+        let matches: Vec<String> = {
+            let folders = self.folders.read().unwrap();
+            let mut matches: Vec<String> = folders
+                .iter()
+                .filter(|(_, path)| needle.is_empty() || path.to_lowercase().contains(&needle))
+                .map(|(_, path)| path.clone())
+                .collect();
+            matches.sort_by(|a, b| {
+                let depth = |p: &str| p.matches('/').count();
+                depth(a)
+                    .cmp(&depth(b))
+                    .then_with(|| a.len().cmp(&b.len()))
+                    .then_with(|| a.to_lowercase().cmp(&b.to_lowercase()))
+            });
+            matches.truncate(50);
+            matches
+        };
+        if matches.is_empty() {
+            return;
+        }
+
+        self.scope_selected = self.scope_selected.min(matches.len() - 1);
+        anchor.ctx.input_mut(|i| {
+            if i.consume_key_exact(egui::Modifiers::NONE, egui::Key::ArrowDown) {
+                self.scope_selected = (self.scope_selected + 1).min(matches.len() - 1);
+            }
+            if i.consume_key_exact(egui::Modifiers::NONE, egui::Key::ArrowUp) {
+                self.scope_selected = self.scope_selected.saturating_sub(1);
+            }
+        });
+
+        let mut chosen = None;
+        if anchor.ctx.input_mut(|i| i.consume_key_exact(egui::Modifiers::NONE, egui::Key::Enter)) {
+            chosen = matches.get(self.scope_selected).cloned();
+        }
+
+        egui::Popup::from_response(anchor)
+            .open(true)
+            .width(anchor.rect.width())
+            .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
+            .show(|ui| {
+                ui.spacing_mut().item_spacing.y = 2.0;
+                egui::ScrollArea::vertical()
+                    .max_height(160.0)
+                    .show(ui, |ui| {
+                        for (idx, path) in matches.iter().enumerate() {
+                            let label = RichText::new(path).size(13.0);
+                            let row = ui.selectable_label(idx == self.scope_selected, label);
+                            if row.clicked() {
+                                chosen = Some(path.clone());
+                            }
+                            if idx == self.scope_selected {
+                                row.scroll_to_me(None);
+                            }
+                        }
+                    });
+            });
+
+        if let Some(path) = chosen {
+            self.scope_path = path;
+            self.scope_selected = 0;
+            self.scope_was_focused = false;
+            anchor.surrender_focus();
+        }
     }
 }
 
@@ -308,15 +407,17 @@ impl Workspace {
                 search.manage_executors(ui.ctx());
                 ui.add_space(16.0);
                 search.show_query_box(ui);
-                (search.executor.clone(), search.search_type)
+                (search.executor.clone(), search.search_type, search.query_focused)
             };
-            let (executor, search_type) = extracted;
+            let (executor, search_type, query_focused) = extracted;
 
             ui.add_space(10.0);
             Self::hairline(ui, true);
             ui.add_space(6.0);
 
-            if let Some((id, in_new_tab)) = self.results_and_preview(ui, &executor, search_type) {
+            if let Some((id, in_new_tab)) =
+                self.results_and_preview(ui, &executor, search_type, query_focused)
+            {
                 if self.is_folder(id) {
                     self.out.selected_file = Some(id);
                 } else if in_new_tab {
@@ -330,7 +431,7 @@ impl Workspace {
 
     fn results_and_preview(
         &mut self, ui: &mut Ui, executor: &Arc<RwLock<Option<Box<dyn SearchExecutor>>>>,
-        search_type: SearchType,
+        search_type: SearchType, allow_kb_nav: bool,
     ) -> Option<(lb_rs::Uuid, bool)> {
         const OUTER_PAD: f32 = 24.0;
         const MIN_PREVIEW_WIDTH: f32 = 720.0;
@@ -350,10 +451,9 @@ impl Workspace {
                     Vec2::new(picker_width, ui.available_height()),
                     egui::Layout::top_down(egui::Align::LEFT),
                     |ui| {
-                        let picker = executor
-                            .try_write()
-                            .ok()
-                            .and_then(|mut guard| guard.as_mut().map(|e| e.show_result_picker(ui)));
+                        let picker = executor.try_write().ok().and_then(|mut guard| {
+                            guard.as_mut().map(|e| e.show_result_picker(ui, allow_kb_nav))
+                        });
                         match picker {
                             Some(picker) => (picker, true),
                             None => {
@@ -431,10 +531,12 @@ use std::thread;
 
 use egui::{Context, CornerRadius, Frame, Margin, RichText, TextEdit, Ui, Vec2};
 use lb_rs::blocking::Lb;
+use lb_rs::model::path_ops::Filter;
 
 use crate::{
     file_cache::FileCache,
     search::{content::ContentSearch, path::PathSearch},
+    show::InputStateExt,
     tab::{ContentState, Destination, TabContent},
     theme::{icons::Icon, palette_v2::ThemeExt},
     widgets::IconButton,

--- a/libs/content/workspace/src/search/mod.rs
+++ b/libs/content/workspace/src/search/mod.rs
@@ -279,10 +279,11 @@ impl Search {
             });
         });
 
-        if (!self.scope_path.is_empty() || !self.query.is_empty())
+        let filters_shown = !self.scope_path.is_empty() || self.filters_open;
+        if (filters_shown || !self.query.is_empty())
             && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
         {
-            if !self.scope_path.is_empty() {
+            if filters_shown {
                 self.scope_path.clear();
                 self.filters_open = false;
             } else {
@@ -473,6 +474,7 @@ impl Workspace {
                             search.filters_open = true;
                         }
                     }
+                    self.out.selected_file = Some(id);
                 } else if in_new_tab {
                     self.open_file(id, false, true);
                 } else {

--- a/libs/content/workspace/src/search/mod.rs
+++ b/libs/content/workspace/src/search/mod.rs
@@ -7,7 +7,7 @@ pub struct Search {
     pub initialized: bool,
     pub executor: Arc<RwLock<Option<Box<dyn SearchExecutor>>>>,
     pub filters_open: bool,
-    pub scope: Option<lb_rs::Uuid>,
+    pub scope_path: String,
     dispatched_query: String,
     building: Arc<AtomicBool>,
 
@@ -69,7 +69,7 @@ impl Search {
             initialized: false,
             executor: Arc::new(RwLock::new(None)),
             filters_open: false,
-            scope: None,
+            scope_path: String::new(),
             dispatched_query: String::new(),
             building: Arc::new(AtomicBool::new(false)),
             core: lb.clone(),
@@ -189,7 +189,7 @@ impl Search {
                         if filter.clicked() {
                             self.filters_open = !self.filters_open;
                             if !self.filters_open {
-                                self.scope = None;
+                                self.scope_path.clear();
                             }
                         }
 
@@ -236,10 +236,10 @@ impl Search {
             });
         });
 
-        if self.scope.is_some()
+        if !self.scope_path.is_empty()
             && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
         {
-            self.scope = None;
+            self.scope_path.clear();
         }
 
         if focused {
@@ -263,11 +263,25 @@ impl Search {
             );
             let home = IconButton::new(Icon::HOME.size(16.0))
                 .tooltip("Home")
-                .colored(self.scope.is_none())
+                .colored(self.scope_path.is_empty())
                 .show(ui);
             if home.clicked() {
-                self.scope = None;
+                self.scope_path.clear();
             }
+
+            TextEdit::singleline(&mut self.scope_path)
+                .frame(false)
+                .hint_text(
+                    RichText::new("/")
+                        .size(14.0)
+                        .color(theme.neutral_fg_secondary()),
+                )
+                .text_color(theme.neutral_fg())
+                .font(egui::FontId::proportional(14.0))
+                .vertical_align(egui::Align::Center)
+                .desired_width(ui.available_width())
+                .margin(Margin::ZERO)
+                .show(ui);
         });
     }
 }

--- a/libs/content/workspace/src/search/path.rs
+++ b/libs/content/workspace/src/search/path.rs
@@ -49,7 +49,9 @@ impl SearchExecutor for PathSearch {
         self.kb_mode = kb_mode;
     }
 
-    fn show_result_picker(&mut self, ui: &mut egui::Ui, allow_kb_nav: bool) -> super::PickerResponse {
+    fn show_result_picker(
+        &mut self, ui: &mut egui::Ui, allow_kb_nav: bool,
+    ) -> super::PickerResponse {
         self.process_keys(ui.ctx(), allow_kb_nav);
 
         let rows = self.rows();

--- a/libs/content/workspace/src/search/path.rs
+++ b/libs/content/workspace/src/search/path.rs
@@ -54,8 +54,8 @@ impl SearchExecutor for PathSearch {
         self.kb_mode = kb_mode;
     }
 
-    fn show_result_picker(&mut self, ui: &mut egui::Ui) -> super::PickerResponse {
-        self.process_keys(ui.ctx());
+    fn show_result_picker(&mut self, ui: &mut egui::Ui, allow_kb_nav: bool) -> super::PickerResponse {
+        self.process_keys(ui.ctx(), allow_kb_nav);
 
         // Suggested docs (shown before a query is typed) don't auto-select the
         // first row the way query results do — there's no selection (and so no
@@ -214,7 +214,7 @@ impl PathSearch {
         }
     }
 
-    fn process_keys(&mut self, ctx: &Context) {
+    fn process_keys(&mut self, ctx: &Context, allow_kb_nav: bool) {
         const NUM_KEYS: [Key; 9] = [
             Key::Num1,
             Key::Num2,
@@ -231,28 +231,30 @@ impl PathSearch {
         // first arrow press lands on the first row rather than stepping past it.
         let has_selection = !self.submitted_query.is_empty() || self.interacted;
 
-        ctx.input_mut(|i| {
-            if i.consume_key_exact(Modifiers::NONE, Key::ArrowDown) {
-                self.selected = if has_selection { self.selected.saturating_add(1) } else { 0 };
-                self.interacted = true;
-                self.kb_mode = true;
-            }
-            if i.consume_key_exact(Modifiers::NONE, Key::ArrowUp) {
-                self.selected = if has_selection { self.selected.saturating_sub(1) } else { 0 };
-                self.interacted = true;
-                self.kb_mode = true;
-            }
-            if i.consume_key_exact(Modifiers::NONE, Key::Enter) {
-                self.activate = true;
-            }
-            for (idx, &k) in NUM_KEYS.iter().enumerate() {
-                if i.consume_key_exact(Modifiers::COMMAND, k) {
-                    self.selected = idx;
-                    self.activate = true;
+        if allow_kb_nav {
+            ctx.input_mut(|i| {
+                if i.consume_key_exact(Modifiers::NONE, Key::ArrowDown) {
+                    self.selected = if has_selection { self.selected.saturating_add(1) } else { 0 };
                     self.interacted = true;
+                    self.kb_mode = true;
                 }
-            }
-        });
+                if i.consume_key_exact(Modifiers::NONE, Key::ArrowUp) {
+                    self.selected = if has_selection { self.selected.saturating_sub(1) } else { 0 };
+                    self.interacted = true;
+                    self.kb_mode = true;
+                }
+                if i.consume_key_exact(Modifiers::NONE, Key::Enter) {
+                    self.activate = true;
+                }
+                for (idx, &k) in NUM_KEYS.iter().enumerate() {
+                    if i.consume_key_exact(Modifiers::COMMAND, k) {
+                        self.selected = idx;
+                        self.activate = true;
+                        self.interacted = true;
+                    }
+                }
+            });
+        }
 
         if ctx.input(|i| i.pointer.delta().length_sq() > 0.0) {
             self.kb_mode = false;

--- a/libs/content/workspace/src/search/path.rs
+++ b/libs/content/workspace/src/search/path.rs
@@ -1,5 +1,6 @@
 use egui::{Context, CornerRadius, Frame, Key, Margin, Modifiers, Ui};
 use lb_rs::blocking::Lb;
+use lb_rs::search::SearchFilter;
 
 use crate::{
     search::{SearchExecutor, SearchType},
@@ -40,7 +41,7 @@ impl SearchExecutor for PathSearch {
         self.kb_mode = true;
     }
 
-    fn update_filter(&mut self, filter: Option<lb_rs::search::SearchFilter>) {
+    fn update_filter(&mut self, filter: Option<SearchFilter>) {
         self.searcher.update_filter(filter);
         self.selected = 0;
     }

--- a/libs/content/workspace/src/search/path.rs
+++ b/libs/content/workspace/src/search/path.rs
@@ -1,10 +1,7 @@
-use std::sync::{Arc, RwLock};
-
 use egui::{Context, CornerRadius, Frame, Key, Margin, Modifiers, Ui};
 use lb_rs::blocking::Lb;
 
 use crate::{
-    file_cache::{FileCache, FilesExt},
     search::{SearchExecutor, SearchType},
     show::{DocType, InputStateExt},
     theme::{
@@ -21,19 +18,13 @@ pub struct PathSearch {
     activate: bool,
     kb_mode: bool,
     selected_id: Option<lb_rs::Uuid>,
-    /// Whether the user has engaged the list (hover/arrow) since the last query
-    /// change. Suggested docs start un-engaged so nothing is preselected.
-    interacted: bool,
-    files: Arc<RwLock<FileCache>>,
 }
 
-/// A single row in the picker. Sourced from search results, or from suggested
-/// documents when no query has been typed.
 struct Row {
     id: lb_rs::Uuid,
     filename: String,
     parent_path: String,
-    /// Char indices (into the full path) to bold; empty for suggested docs.
+    is_folder: bool,
     path_indices: Vec<u32>,
 }
 
@@ -47,7 +38,11 @@ impl SearchExecutor for PathSearch {
         self.searcher.query(query);
         self.selected = 0;
         self.kb_mode = true;
-        self.interacted = false;
+    }
+
+    fn update_filter(&mut self, filter: Option<lb_rs::search::SearchFilter>) {
+        self.searcher.update_filter(filter);
+        self.selected = 0;
     }
 
     fn set_kb_mode(&mut self, kb_mode: bool) {
@@ -56,11 +51,6 @@ impl SearchExecutor for PathSearch {
 
     fn show_result_picker(&mut self, ui: &mut egui::Ui, allow_kb_nav: bool) -> super::PickerResponse {
         self.process_keys(ui.ctx(), allow_kb_nav);
-
-        // Suggested docs (shown before a query is typed) don't auto-select the
-        // first row the way query results do — there's no selection (and so no
-        // preview) until the user hovers or arrows into the list.
-        let showing_suggested = self.submitted_query.is_empty();
 
         let rows = self.rows();
         let n = rows.len();
@@ -71,10 +61,7 @@ impl SearchExecutor for PathSearch {
 
         if self.activate {
             self.activate = false;
-            // Enter with no active selection (un-engaged suggestions) opens nothing.
-            let has_selection = !showing_suggested || self.interacted;
-            let activated =
-                if has_selection { rows.get(self.selected).map(|r| r.id) } else { None };
+            let activated = rows.get(self.selected).map(|r| r.id);
             return super::PickerResponse {
                 activated,
                 activated_in_new_tab: false,
@@ -106,9 +93,7 @@ impl SearchExecutor for PathSearch {
         ui.spacing_mut().scroll.floating_width = 12.0;
         ui.spacing_mut().scroll.dormant_handle_opacity = 0.5;
 
-        // Only highlight a row if there's an active selection.
-        let highlight =
-            if !showing_suggested || self.interacted { Some(self.selected) } else { None };
+        let highlight = Some(self.selected);
 
         egui::ScrollArea::vertical()
             .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysVisible)
@@ -137,11 +122,6 @@ impl SearchExecutor for PathSearch {
                 }
             });
 
-        // Hovering or clicking the list counts as engaging it.
-        if hovered.is_some() || clicked.is_some() {
-            self.interacted = true;
-        }
-
         if let Some(i) = clicked {
             self.selected = i;
         } else if !self.kb_mode {
@@ -150,8 +130,7 @@ impl SearchExecutor for PathSearch {
             }
         }
 
-        let has_selection = !showing_suggested || self.interacted;
-        let new_id = if has_selection { rows.get(self.selected).map(|r| r.id) } else { None };
+        let new_id = rows.get(self.selected).map(|r| r.id);
         if new_id != self.selected_id {
             self.selected_id = new_id;
         }
@@ -166,7 +145,7 @@ impl SearchExecutor for PathSearch {
 }
 
 impl PathSearch {
-    pub fn new(lb: &Lb, files: Arc<RwLock<FileCache>>) -> Self {
+    pub fn new(lb: &Lb) -> Self {
         Self {
             searcher: lb.path_searcher(),
             submitted_query: String::new(),
@@ -174,44 +153,21 @@ impl PathSearch {
             activate: false,
             kb_mode: true,
             selected_id: None,
-            interacted: false,
-            files,
         }
     }
 
-    /// The rows to display: live search results, or suggested documents before
-    /// any query is typed.
     fn rows(&self) -> Vec<Row> {
-        if self.submitted_query.is_empty() {
-            let files = self.files.read().unwrap();
-            files
-                .suggested
-                .iter()
-                .filter_map(|id| {
-                    let f = files.get_by_id(*id)?;
-                    if !f.is_document() {
-                        return None;
-                    }
-                    Some(Row {
-                        id: *id,
-                        filename: f.name.clone(),
-                        parent_path: files.path(f.parent),
-                        path_indices: Vec::new(),
-                    })
-                })
-                .collect()
-        } else {
-            self.searcher
-                .results()
-                .iter()
-                .map(|r| Row {
-                    id: r.id,
-                    filename: r.filename.clone(),
-                    parent_path: r.parent_path.clone(),
-                    path_indices: r.path_indices.clone(),
-                })
-                .collect()
-        }
+        self.searcher
+            .results()
+            .iter()
+            .map(|r| Row {
+                id: r.id,
+                filename: r.filename.clone(),
+                parent_path: r.parent_path.clone(),
+                is_folder: r.is_folder,
+                path_indices: r.path_indices.clone(),
+            })
+            .collect()
     }
 
     fn process_keys(&mut self, ctx: &Context, allow_kb_nav: bool) {
@@ -227,20 +183,14 @@ impl PathSearch {
             Key::Num9,
         ];
 
-        // In suggested mode there's no selection until the user engages, so the
-        // first arrow press lands on the first row rather than stepping past it.
-        let has_selection = !self.submitted_query.is_empty() || self.interacted;
-
         if allow_kb_nav {
             ctx.input_mut(|i| {
                 if i.consume_key_exact(Modifiers::NONE, Key::ArrowDown) {
-                    self.selected = if has_selection { self.selected.saturating_add(1) } else { 0 };
-                    self.interacted = true;
+                    self.selected = self.selected.saturating_add(1);
                     self.kb_mode = true;
                 }
                 if i.consume_key_exact(Modifiers::NONE, Key::ArrowUp) {
-                    self.selected = if has_selection { self.selected.saturating_sub(1) } else { 0 };
-                    self.interacted = true;
+                    self.selected = self.selected.saturating_sub(1);
                     self.kb_mode = true;
                 }
                 if i.consume_key_exact(Modifiers::NONE, Key::Enter) {
@@ -250,7 +200,6 @@ impl PathSearch {
                     if i.consume_key_exact(Modifiers::COMMAND, k) {
                         self.selected = idx;
                         self.activate = true;
-                        self.interacted = true;
                     }
                 }
             });
@@ -319,9 +268,8 @@ impl PathSearch {
                 ui.set_min_height(16.0 * 1.3 + 13.0 * 1.3);
 
                 let icon_size = 19.;
-                let is_folder = row.filename.is_empty() || !row.filename.contains('.');
 
-                let (icon, icon_color) = if !is_folder {
+                let (icon, icon_color) = if !row.is_folder {
                     (
                         DocType::from_name(&row.filename).to_icon().size(icon_size),
                         theme.neutral_fg_secondary(),
@@ -343,6 +291,11 @@ impl PathSearch {
                         for glyph in [number.as_str(), modifier] {
                             ui.add(GlyphonLabel::new(glyph, parent_color).font_size(12.0));
                         }
+                    }
+
+                    if row.is_folder {
+                        ui.add_space(6.0);
+                        Icon::FILTER.size(14.0).color(parent_color).show(ui);
                     }
 
                     ui.with_layout(egui::Layout::top_down(egui::Align::LEFT), |ui| {

--- a/libs/content/workspace/src/theme/icons.rs
+++ b/libs/content/workspace/src/theme/icons.rs
@@ -84,7 +84,8 @@ impl Icon {
     pub const SAVE: Self = ic("\u{f0193}"); // 󰆓
     pub const SCHEDULE: Self = ic("\u{f0954}"); // 󰥔
     pub const SEARCH: Self = ic("\u{e644}"); // 
-    pub const FILTER: Self = ic("\u{f0232}"); // 
+    pub const FILTER: Self = ic("\u{f0232}"); // 󰈲
+    pub const HOME: Self = ic("\u{f02dc}"); // 󰋜
     pub const SYNC: Self = ic("\u{f006a}"); // 󰁪
     pub const SHARED_FOLDER: Self = ic("\u{f024c}"); // 󰉌
     pub const SHAPES: Self = ic("\u{f0832}"); // 󰠱

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -216,11 +216,9 @@ impl Workspace {
                     self.ctx.clone(),
                 )))
             }
-            Destination::Search => ContentState::Open(TabContent::Search(Search::new(
-                &self.core,
-                &self.ctx,
-                self.files.clone(),
-            ))),
+            Destination::Search => {
+                ContentState::Open(TabContent::Search(Search::new(&self.core, &self.ctx)))
+            }
         };
         let now = Instant::now();
         self.tabs.insert(

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -1150,6 +1150,18 @@ impl Workspace {
         }
     }
 
+    pub fn search_in_folder(&mut self, folder_id: Uuid) {
+        self.upsert_search(Some(SearchType::Content));
+        let path = self.files.read().unwrap().path(folder_id);
+        if let Some(tab) = self.tabs.get_mut(&Destination::Search) {
+            if let ContentState::Open(TabContent::Search(search)) = &mut tab.content {
+                search.scope_path = path;
+                search.filters_open = true;
+            }
+        }
+        self.out.selected_file = Some(folder_id);
+    }
+
     pub fn start_space_inspector(&mut self, _core: Lb, folder: Option<File>) {
         if let Some(i) = self
             .tab_strip

--- a/libs/lb/lb-rs/src/search/content.rs
+++ b/libs/lb/lb-rs/src/search/content.rs
@@ -108,32 +108,29 @@ impl ContentSearcher {
 
     /// Update the active filter and refresh results for the current query.
     pub fn update_filter(&mut self, filter: Option<SearchFilter>) {
-        self.filter_ids = filter.map(|SearchFilter::Path(path)| {
-            self.path_to_id
-                .get(&path)
-                .and_then(|id| self.descendants.get(id))
-                .map(|ids| ids.iter().copied().collect())
-                .unwrap_or_default()
-        });
-        let query = self.submitted_query.clone();
-        self.submitted_query.clear();
-        self.query(&query);
+        self.filter_ids = super::resolve_filter(filter, &self.path_to_id, &self.descendants);
+        self.rebuild();
     }
 
     /// Update the search query. Results available via `results()`.
     pub fn query(&mut self, input: &str) {
         let query = input.to_lowercase();
-
         if self.submitted_query == query {
             return;
         }
-        self.submitted_query = query.clone();
-        self.results.clear();
+        self.submitted_query = query;
+        self.rebuild();
+    }
 
-        if query.is_empty() {
+    /// Rebuild `results` from the current query and filter. Shared by `query` and
+    /// `update_filter`.
+    fn rebuild(&mut self) {
+        self.results.clear();
+        if self.submitted_query.is_empty() {
             return;
         }
 
+        let query = &self.submitted_query;
         let words: Vec<&str> = query.split_whitespace().collect();
 
         for doc in &self.documents {
@@ -151,9 +148,9 @@ impl ContentSearcher {
             .to_lowercase();
 
             let mut matched_words = vec![false; words.len()];
-            let path_matches = collect_matches(&path, &query, &words, &mut matched_words);
+            let path_matches = collect_matches(&path, query, &words, &mut matched_words);
             let content_matches =
-                collect_matches(&doc.lowercased_content, &query, &words, &mut matched_words);
+                collect_matches(&doc.lowercased_content, query, &words, &mut matched_words);
 
             let all_words_matched = matched_words.iter().all(|&m| m);
             let has_match = !path_matches.is_empty() || !content_matches.is_empty();

--- a/libs/lb/lb-rs/src/search/content.rs
+++ b/libs/lb/lb-rs/src/search/content.rs
@@ -1,8 +1,9 @@
 use super::path::split_path;
-use super::{ContentMatch, SearchResult};
+use super::{ContentMatch, SearchFilter, SearchResult, build_descendants};
 use crate::blocking::Lb;
 use crate::model::file::File;
 use std::cmp::Reverse;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -21,6 +22,9 @@ pub struct ContentSearcher {
     results: Vec<SearchResult>,
     submitted_query: String,
     build_time: Duration,
+    descendants: HashMap<Uuid, Vec<Uuid>>,
+    path_to_id: HashMap<String, Uuid>,
+    filter_ids: Option<HashSet<Uuid>>,
 }
 
 impl ContentSearcher {
@@ -28,6 +32,9 @@ impl ContentSearcher {
         let start = Instant::now();
         let metas = lb.list_metadatas().unwrap_or_default();
         let paths = Arc::new(lb.list_paths_with_ids(None).unwrap_or_default());
+
+        let descendants = build_descendants(&metas);
+        let path_to_id = paths.iter().map(|(id, path)| (path.clone(), *id)).collect();
 
         let md_files: Vec<File> = metas
             .into_iter()
@@ -93,7 +100,24 @@ impl ContentSearcher {
             results: Vec::new(),
             submitted_query: String::new(),
             build_time: start.elapsed(),
+            descendants,
+            path_to_id,
+            filter_ids: None,
         }
+    }
+
+    /// Update the active filter and refresh results for the current query.
+    pub fn update_filter(&mut self, filter: Option<SearchFilter>) {
+        self.filter_ids = filter.map(|SearchFilter::Path(path)| {
+            self.path_to_id
+                .get(&path)
+                .and_then(|id| self.descendants.get(id))
+                .map(|ids| ids.iter().copied().collect())
+                .unwrap_or_default()
+        });
+        let query = self.submitted_query.clone();
+        self.submitted_query.clear();
+        self.query(&query);
     }
 
     /// Update the search query. Results available via `results()`.
@@ -113,6 +137,12 @@ impl ContentSearcher {
         let words: Vec<&str> = query.split_whitespace().collect();
 
         for doc in &self.documents {
+            if let Some(ids) = &self.filter_ids {
+                if !ids.contains(&doc.file.id) {
+                    continue;
+                }
+            }
+
             let path = if doc.parent_path == "/" {
                 format!("/{}", doc.filename)
             } else {
@@ -133,6 +163,7 @@ impl ContentSearcher {
                     id: doc.file.id,
                     filename: doc.filename.clone(),
                     parent_path: doc.parent_path.clone(),
+                    is_folder: false,
                     path_indices: Vec::new(),
                     path_matches,
                     content_matches,

--- a/libs/lb/lb-rs/src/search/mod.rs
+++ b/libs/lb/lb-rs/src/search/mod.rs
@@ -1,11 +1,34 @@
 pub mod content;
 pub mod path;
 
+use std::collections::HashMap;
 use std::ops::Range;
 use uuid::Uuid;
 
+use crate::model::file::File;
+
 pub use content::ContentSearcher;
 pub use path::PathSearcher;
+
+/// Map each file id to all of its descendant ids (children, grandchildren, ...).
+/// Built once when an executor's index is constructed.
+pub(crate) fn build_descendants(files: &[File]) -> HashMap<Uuid, Vec<Uuid>> {
+    let parent_of: HashMap<Uuid, Uuid> = files.iter().map(|f| (f.id, f.parent)).collect();
+
+    let mut descendants: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+    for f in files {
+        let mut node = f.id;
+        while let Some(&parent) = parent_of.get(&node) {
+            if parent == node {
+                break; // root is its own parent
+            }
+            descendants.entry(parent).or_default().push(f.id);
+            node = parent;
+        }
+    }
+
+    descendants
+}
 
 /// Unified search result for both path and content searches.
 #[derive(Debug, Clone, Default)]
@@ -13,11 +36,19 @@ pub struct SearchResult {
     pub id: Uuid,
     pub filename: String,
     pub parent_path: String,
+    pub is_folder: bool,
     /// Character indices in the full path that matched (for path search highlighting).
     pub path_indices: Vec<u32>,
     pub path_matches: Vec<ContentMatch>,
     /// Content matches within the document.
     pub content_matches: Vec<ContentMatch>,
+}
+
+/// Scopes a search to a subset of the working set.
+#[derive(Debug, Clone)]
+pub enum SearchFilter {
+    /// Restrict results to a folder path.
+    Path(String),
 }
 
 /// A match highlight within document content.

--- a/libs/lb/lb-rs/src/search/mod.rs
+++ b/libs/lb/lb-rs/src/search/mod.rs
@@ -1,7 +1,7 @@
 pub mod content;
 pub mod path;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use uuid::Uuid;
 
@@ -28,6 +28,21 @@ pub(crate) fn build_descendants(files: &[File]) -> HashMap<Uuid, Vec<Uuid>> {
     }
 
     descendants
+}
+
+/// Resolve a filter to the set of file ids it admits (the scoped folder's
+/// descendants), or `None` when there is no filter.
+pub(crate) fn resolve_filter(
+    filter: Option<SearchFilter>, path_to_id: &HashMap<String, Uuid>,
+    descendants: &HashMap<Uuid, Vec<Uuid>>,
+) -> Option<HashSet<Uuid>> {
+    filter.map(|SearchFilter::Path(path)| {
+        path_to_id
+            .get(&path)
+            .and_then(|id| descendants.get(id))
+            .map(|ids| ids.iter().copied().collect())
+            .unwrap_or_default()
+    })
 }
 
 /// Unified search result for both path and content searches.

--- a/libs/lb/lb-rs/src/search/mod.rs
+++ b/libs/lb/lb-rs/src/search/mod.rs
@@ -10,41 +10,6 @@ use crate::model::file::File;
 pub use content::ContentSearcher;
 pub use path::PathSearcher;
 
-/// Map each file id to all of its descendant ids (children, grandchildren, ...).
-/// Built once when an executor's index is constructed.
-pub(crate) fn build_descendants(files: &[File]) -> HashMap<Uuid, Vec<Uuid>> {
-    let parent_of: HashMap<Uuid, Uuid> = files.iter().map(|f| (f.id, f.parent)).collect();
-
-    let mut descendants: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
-    for f in files {
-        let mut node = f.id;
-        while let Some(&parent) = parent_of.get(&node) {
-            if parent == node {
-                break; // root is its own parent
-            }
-            descendants.entry(parent).or_default().push(f.id);
-            node = parent;
-        }
-    }
-
-    descendants
-}
-
-/// Resolve a filter to the set of file ids it admits (the scoped folder's
-/// descendants), or `None` when there is no filter.
-pub(crate) fn resolve_filter(
-    filter: Option<SearchFilter>, path_to_id: &HashMap<String, Uuid>,
-    descendants: &HashMap<Uuid, Vec<Uuid>>,
-) -> Option<HashSet<Uuid>> {
-    filter.map(|SearchFilter::Path(path)| {
-        path_to_id
-            .get(&path)
-            .and_then(|id| descendants.get(id))
-            .map(|ids| ids.iter().copied().collect())
-            .unwrap_or_default()
-    })
-}
-
 /// Unified search result for both path and content searches.
 #[derive(Debug, Clone, Default)]
 pub struct SearchResult {
@@ -81,4 +46,39 @@ impl Lb {
     pub async fn path_searcher(&self) -> PathSearcher {
         PathSearcher::new(self).await
     }
+}
+
+/// Map each file id to all of its descendant ids (children, grandchildren, ...).
+/// Built once when an executor's index is constructed.
+pub(crate) fn build_descendants(files: &[File]) -> HashMap<Uuid, Vec<Uuid>> {
+    let parent_of: HashMap<Uuid, Uuid> = files.iter().map(|f| (f.id, f.parent)).collect();
+
+    let mut descendants: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+    for f in files {
+        let mut node = f.id;
+        while let Some(&parent) = parent_of.get(&node) {
+            if parent == node {
+                break; // root is its own parent
+            }
+            descendants.entry(parent).or_default().push(f.id);
+            node = parent;
+        }
+    }
+
+    descendants
+}
+
+/// Resolve a filter to the set of file ids it admits (the scoped folder's
+/// descendants), or `None` when there is no filter.
+pub(crate) fn resolve_filter(
+    filter: Option<SearchFilter>, path_to_id: &HashMap<String, Uuid>,
+    descendants: &HashMap<Uuid, Vec<Uuid>>,
+) -> Option<HashSet<Uuid>> {
+    filter.map(|SearchFilter::Path(path)| {
+        path_to_id
+            .get(&path)
+            .and_then(|id| descendants.get(id))
+            .map(|ids| ids.iter().copied().collect())
+            .unwrap_or_default()
+    })
 }

--- a/libs/lb/lb-rs/src/search/path.rs
+++ b/libs/lb/lb-rs/src/search/path.rs
@@ -1,11 +1,14 @@
-use super::SearchResult;
+use super::{SearchFilter, SearchResult, build_descendants};
 use crate::Lb;
 use crate::model::file::File;
 use nucleo::{
     Matcher, Nucleo,
     pattern::{CaseMatching, Normalization},
 };
+use std::cmp::Reverse;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use uuid::Uuid;
 
 /// Split a path into (parent_path, filename).
 pub(crate) fn split_path(path: &str) -> (&str, &str) {
@@ -30,6 +33,9 @@ pub struct PathSearcher {
     nucleo: Nucleo<PathEntry>,
     results: Vec<SearchResult>,
     submitted_query: String,
+    descendants: HashMap<Uuid, Vec<Uuid>>,
+    path_to_id: HashMap<String, Uuid>,
+    filter_ids: Option<HashSet<Uuid>>,
 }
 
 impl PathSearcher {
@@ -59,7 +65,32 @@ impl PathSearcher {
             }
         }
 
-        Self { nucleo, results: Vec::new(), submitted_query: String::new() }
+        let descendants = build_descendants(&files);
+        let path_to_id = paths.iter().map(|(id, path)| (path.clone(), *id)).collect();
+
+        let mut searcher = Self {
+            nucleo,
+            results: Vec::new(),
+            submitted_query: String::new(),
+            descendants,
+            path_to_id,
+            filter_ids: None,
+        };
+        searcher.query("");
+        searcher
+    }
+
+    /// Update the active filter and refresh results for the current query.
+    pub fn update_filter(&mut self, filter: Option<SearchFilter>) {
+        self.filter_ids = filter.map(|SearchFilter::Path(path)| {
+            self.path_to_id
+                .get(&path)
+                .and_then(|id| self.descendants.get(id))
+                .map(|ids| ids.iter().copied().collect())
+                .unwrap_or_default()
+        });
+        let query = self.submitted_query.clone();
+        self.query(&query);
     }
 
     /// Update the search query. Results available via `results()`.
@@ -78,11 +109,39 @@ impl PathSearcher {
         // Build results
         self.results.clear();
         let snapshot = self.nucleo.snapshot();
-        let count = snapshot.matched_item_count().min(100);
+
+        if input.is_empty() {
+            let mut entries: Vec<&PathEntry> = (0..snapshot.matched_item_count())
+                .filter_map(|i| snapshot.get_matched_item(i).map(|item| item.data))
+                .filter(|e| self.filter_ids.as_ref().map_or(true, |ids| ids.contains(&e.file.id)))
+                .collect();
+            entries.sort_by_key(|e| Reverse(e.file.last_modified));
+            self.results
+                .extend(entries.into_iter().take(100).map(|e| SearchResult {
+                    id: e.file.id,
+                    filename: e.filename.clone(),
+                    parent_path: e.parent_path.clone(),
+                    is_folder: e.file.is_folder(),
+                    path_indices: Vec::new(),
+                    path_matches: Vec::new(),
+                    content_matches: Vec::new(),
+                }));
+            return;
+        }
+
         let mut matcher = Matcher::new(nucleo::Config::DEFAULT);
 
-        for i in 0..count {
+        for i in 0..snapshot.matched_item_count() {
+            if self.results.len() >= 100 {
+                break;
+            }
             if let Some(item) = snapshot.get_matched_item(i) {
+                if let Some(ids) = &self.filter_ids {
+                    if !ids.contains(&item.data.file.id) {
+                        continue;
+                    }
+                }
+
                 let mut indices = Vec::new();
                 self.nucleo.pattern.column_pattern(0).indices(
                     item.matcher_columns[0].slice(..),
@@ -94,6 +153,7 @@ impl PathSearcher {
                     id: item.data.file.id,
                     filename: item.data.filename.clone(),
                     parent_path: item.data.parent_path.clone(),
+                    is_folder: item.data.file.is_folder(),
                     path_indices: indices,
                     path_matches: Vec::new(),
                     content_matches: Vec::new(),

--- a/libs/lb/lb-rs/src/search/path.rs
+++ b/libs/lb/lb-rs/src/search/path.rs
@@ -123,11 +123,19 @@ impl PathSearcher {
         if self.submitted_query.is_empty() {
             let mut entries: Vec<&PathEntry> = (0..snapshot.matched_item_count())
                 .filter_map(|i| snapshot.get_matched_item(i).map(|item| item.data))
-                .filter(|e| self.filter_ids.as_ref().map_or(true, |ids| ids.contains(&e.file.id)))
+                .filter(|e| {
+                    self.filter_ids
+                        .as_ref()
+                        .map_or(true, |ids| ids.contains(&e.file.id))
+                })
                 .collect();
             entries.sort_by_key(|e| Reverse(e.file.last_modified));
-            self.results
-                .extend(entries.into_iter().take(100).map(|e| path_result(e, Vec::new())));
+            self.results.extend(
+                entries
+                    .into_iter()
+                    .take(100)
+                    .map(|e| path_result(e, Vec::new())),
+            );
             return;
         }
 

--- a/libs/lb/lb-rs/src/search/path.rs
+++ b/libs/lb/lb-rs/src/search/path.rs
@@ -29,6 +29,18 @@ struct PathEntry {
     parent_path: String,
 }
 
+fn path_result(entry: &PathEntry, path_indices: Vec<u32>) -> SearchResult {
+    SearchResult {
+        id: entry.file.id,
+        filename: entry.filename.clone(),
+        parent_path: entry.parent_path.clone(),
+        is_folder: entry.file.is_folder(),
+        path_indices,
+        path_matches: Vec::new(),
+        content_matches: Vec::new(),
+    }
+}
+
 pub struct PathSearcher {
     nucleo: Nucleo<PathEntry>,
     results: Vec<SearchResult>,
@@ -82,15 +94,8 @@ impl PathSearcher {
 
     /// Update the active filter and refresh results for the current query.
     pub fn update_filter(&mut self, filter: Option<SearchFilter>) {
-        self.filter_ids = filter.map(|SearchFilter::Path(path)| {
-            self.path_to_id
-                .get(&path)
-                .and_then(|id| self.descendants.get(id))
-                .map(|ids| ids.iter().copied().collect())
-                .unwrap_or_default()
-        });
-        let query = self.submitted_query.clone();
-        self.query(&query);
+        self.filter_ids = super::resolve_filter(filter, &self.path_to_id, &self.descendants);
+        self.rebuild();
     }
 
     /// Update the search query. Results available via `results()`.
@@ -106,26 +111,23 @@ impl PathSearcher {
 
         while self.nucleo.tick(10).running {}
 
-        // Build results
+        self.rebuild();
+    }
+
+    /// Rebuild `results` from the current query and filter without re-running the
+    /// matcher. Shared by `query` (after a reparse) and `update_filter`.
+    fn rebuild(&mut self) {
         self.results.clear();
         let snapshot = self.nucleo.snapshot();
 
-        if input.is_empty() {
+        if self.submitted_query.is_empty() {
             let mut entries: Vec<&PathEntry> = (0..snapshot.matched_item_count())
                 .filter_map(|i| snapshot.get_matched_item(i).map(|item| item.data))
                 .filter(|e| self.filter_ids.as_ref().map_or(true, |ids| ids.contains(&e.file.id)))
                 .collect();
             entries.sort_by_key(|e| Reverse(e.file.last_modified));
             self.results
-                .extend(entries.into_iter().take(100).map(|e| SearchResult {
-                    id: e.file.id,
-                    filename: e.filename.clone(),
-                    parent_path: e.parent_path.clone(),
-                    is_folder: e.file.is_folder(),
-                    path_indices: Vec::new(),
-                    path_matches: Vec::new(),
-                    content_matches: Vec::new(),
-                }));
+                .extend(entries.into_iter().take(100).map(|e| path_result(e, Vec::new())));
             return;
         }
 
@@ -149,15 +151,7 @@ impl PathSearcher {
                     &mut indices,
                 );
 
-                self.results.push(SearchResult {
-                    id: item.data.file.id,
-                    filename: item.data.filename.clone(),
-                    parent_path: item.data.parent_path.clone(),
-                    is_folder: item.data.file.is_folder(),
-                    path_indices: indices,
-                    path_matches: Vec::new(),
-                    content_matches: Vec::new(),
-                });
+                self.results.push(path_result(item.data, indices));
             }
         }
     }

--- a/libs/lb/lb-rs/src/search/path.rs
+++ b/libs/lb/lb-rs/src/search/path.rs
@@ -126,7 +126,7 @@ impl PathSearcher {
                 .filter(|e| {
                     self.filter_ids
                         .as_ref()
-                        .map_or(true, |ids| ids.contains(&e.file.id))
+                        .is_none_or(|ids| ids.contains(&e.file.id))
                 })
                 .collect();
             entries.sort_by_key(|e| Reverse(e.file.last_modified));


### PR DESCRIPTION
while searching there is now a filter button:

<img width="1412" height="944" alt="image" src="https://github.com/user-attachments/assets/386fcd07-24b2-4dce-8974-5163ad6ddc07" />

you can use it to scope search to a particular directory: 

<img width="1412" height="944" alt="image" src="https://github.com/user-attachments/assets/89023910-d1b7-4b6d-82f7-ec43c8b30ded" />

<img width="1412" height="944" alt="image" src="https://github.com/user-attachments/assets/39159cc2-7441-437e-935e-8a8eedfd7afe" />

hitting escape will clear the filters and then the next escape will clear the query.

you can also get here quickly / iteratively by searching for a folder directly:

<img width="1412" height="944" alt="image" src="https://github.com/user-attachments/assets/aabaf230-23ef-4856-9334-f0c4023fc25a" />

you can see the folders have a lil filter icon to communicate what would happen

<img width="1412" height="944" alt="image" src="https://github.com/user-attachments/assets/0a9dc334-558f-4ee2-a690-aaab39ede67a" />

there is also a "search here" in the file tree context menu

<img width="1412" height="944" alt="image" src="https://github.com/user-attachments/assets/297145c1-9816-4a9b-b819-85f9cb1f5c3f" />

this does fixes #4781

this does not address #4791 
this does not address #4747 

thinking about whipping up a quick video