### PR TITLE
md: android tap to stop scroll no longer places cursor or opens keyboard

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1174,7 +1174,8 @@ impl Editor {
 
     pub fn will_consume_touch(&self, pos: Pos2) -> bool {
         self.touches_interactive_element(pos)
-            || self.edit.scroll_area_velocity.abs().max_elem() > 0.
+            || self.edit.scroll_area_velocity.abs().max_elem() > 0. // velocity zeroed at touch down
+            || self.edit.scroll_area.momentum_cancel_press() // platform can check at touch up
             || self.toolbar.menu_open
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -548,6 +548,8 @@ impl MdEdit {
                     }
                 } else if response.clicked() && modifiers.shift && !cfg!(target_os = "android") {
                     Some(Region::ToLocation(location))
+                } else if response.clicked() && self.scroll_area.momentum_cancel_press() {
+                    None
                 } else if response.clicked() {
                     if cfg!(target_os = "android") && self.selection_tap(pos) {
                         let selection = self.renderer.buffer.current.selection;

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -32,10 +32,12 @@
 //! - Touch fling momentum: after release, content coasts with
 //!   exponential decay; cancelled by tap, drag-start on body or
 //!   scrollbar, programmatic scroll, or hitting a scroll boundary.
-//! - A tap that cancels momentum is consumed by the scroll area; it
-//!   doesn't also place the cursor or toggle interactive elements
-//!   (fold buttons, task-list checkboxes). Embedders gate other touch
-//!   handlers on [`AffineScrollArea::velocity`].
+//! - A tap that cancels momentum is a stop gesture, not a content tap.
+//!   The scroll area latches it (see
+//!   [`AffineScrollArea::momentum_cancel_press`]); embedders gate cursor
+//!   placement and keyboard summon on that latch, since
+//!   [`AffineScrollArea::velocity`] is already zero by the time the tap's
+//!   click resolves.
 //! - Scrollbar thumb drag: 1 px of mouse-pointer motion ≈ 1 px of
 //!   thumb motion. The drag rate is in approx units, so it drifts
 //!   gracefully when per-row `approx`/`precise` is off.
@@ -1045,17 +1047,33 @@ pub struct AffineScrollArea<Id: Clone + Eq + std::fmt::Debug> {
     /// Salt for the scrollbar's interact rect — must be stable across
     /// frames and unique among visible scroll areas.
     id_salt: egui::Id,
+    /// Latched while a momentum-cancelling stop-tap is in progress (press
+    /// to release). See [`momentum_cancel_press`](Self::momentum_cancel_press).
+    momentum_cancel_press: bool,
 }
 
 impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
     pub fn new(id_salt: impl Hash) -> Self {
-        Self { state: ScrollArea::default(), touch_scroll: false, id_salt: egui::Id::new(id_salt) }
+        Self {
+            state: ScrollArea::default(),
+            touch_scroll: false,
+            id_salt: egui::Id::new(id_salt),
+            momentum_cancel_press: false,
+        }
     }
 
     /// Touch-scroll velocity (precise px/sec). y is vertical; x is
     /// always 0. Non-zero while momentum is in flight.
     pub fn velocity(&self) -> Vec2 {
         self.state.velocity()
+    }
+
+    /// Whether the live touch gesture began as a tap that cancelled scroll
+    /// momentum. Held from press to release so the click it resolves to can
+    /// be suppressed (cursor placement, keyboard) — [`velocity`](Self::velocity)
+    /// is already zero by then, so it can't be gated on instead.
+    pub fn momentum_cancel_press(&self) -> bool {
+        self.momentum_cancel_press
     }
 
     /// Raw persisted offset for change-detection (no row projection).
@@ -1151,6 +1169,9 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
 
         // Touch body drag → scroll + velocity tracking.
         let dt = ui.input(|i| i.stable_dt).max(0.0001);
+        // Read before the kills below: a press on the drag-only body fires
+        // `drag_started`, which zeroes velocity in `kill_momentum`.
+        let momentum_in_flight = self.state.velocity_precise.abs() > 1.0;
         if scrollable && self.touch_scroll && response.drag_started() {
             self.state.kill_momentum();
         }
@@ -1186,12 +1207,22 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         } else {
             self.state.velocity_precise = 0.0;
         }
-        // Tap kills momentum without claiming the click.
+        // Tap kills momentum without claiming the click; if it cancelled a
+        // fling, latch that so the embedder can suppress the click (see
+        // `momentum_cancel_press`).
         let pressed_in_rect = ui.input(|i| {
             i.pointer.any_pressed() && i.pointer.press_origin().is_some_and(|p| rect.contains(p))
         });
         if self.touch_scroll && pressed_in_rect {
+            if momentum_in_flight {
+                self.momentum_cancel_press = true;
+            }
             self.state.velocity_precise = 0.0;
+        }
+        // Clear the latch once the gesture ends, after the embedder has read
+        // it this frame (pre_render runs before finish).
+        if ui.input(|i| i.pointer.any_released() || !i.pointer.any_down()) {
+            self.momentum_cancel_press = false;
         }
 
         // Scrollbar drag/click. Drag deltas use the pre-input geometry


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4659

On iOS, cursor placement and keyboard summoning are controlled on the native side. The native side checks the scroll momentum on touch down via `will_consume_touch()`. On Android, cursor placement (workspace) and keyboard summoning (native) each check on touch up, by which point the scroll momentum has already been cancelled. The fix introduces a flag that remembers this touch is momentum-cancelling and uses it to address both needs.