### PR TITLE
md: android long press drag reorder

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
+++ b/clients/android/app/src/main/java/app/lockbook/screen/WorkspaceFragment.kt
@@ -104,6 +104,12 @@ class WorkspaceFragment : Fragment() {
             activityModel.updateMainScreenUI(UpdateMainScreenUI.OpenWorkspacePane)
         }
 
+        // Forward real IME visibility into the editor so touch long-press
+        // can pick drag-reorder (keyboard down) vs text selection (up).
+        model.keyboardVisible.observe(viewLifecycleOwner) { visible ->
+            workspaceWrapper.workspaceView.setKeyboardShown(visible)
+        }
+
         model.createDocAt.observe(viewLifecycleOwner) { it ->
             workspaceWrapper.workspaceView.createDocAt(it)
         }

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -443,6 +443,14 @@ class WorkspaceView(
         return Workspace.willConsumeTouches(wgpuObj, x, y)
     }
 
+    fun setKeyboardShown(shown: Boolean) {
+        if (wgpuObj == Long.MAX_VALUE || surface == null) {
+            return
+        }
+
+        Workspace.setKeyboardShown(wgpuObj, shown)
+    }
+
     override fun surfaceRedrawNeeded(holder: SurfaceHolder) {
         drawImmediately()
     }

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -50,6 +50,7 @@ object Workspace {
 
     external fun unfocusTitle(rustObj: Long)
     external fun willConsumeTouches(rustObj: Long, x: Float, y: Float): Boolean
+    external fun setKeyboardShown(rustObj: Long, shown: Boolean)
     external fun touchesBegin(rustObj: Long, id: Int, x: Float, y: Float, pressure: Float)
     external fun touchesMoved(rustObj: Long, id: Int, x: Float, y: Float, pressure: Float)
     external fun touchesPredicted(rustObj: Long, id: Int, x: Float, y: Float, pressure: Float)

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -171,6 +171,18 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_insertTextAtCursor(
     }
 }
 
+/// Push real IME visibility (from the Android inset listener) into the
+/// editor so touch long-press can pick drag-reorder vs text selection.
+#[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_setKeyboardShown(
+    _env: JNIEnv, _: JClass, obj: jlong, shown: jboolean,
+) {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+    if let Some(md) = obj.workspace.current_tab_markdown_mut() {
+        md.keyboard_visible = shown == 1;
+    }
+}
+
 #[no_mangle]
 pub extern "system" fn Java_app_lockbook_workspace_Workspace_willConsumeTouches(
     _env: JNIEnv, _: JClass, obj: jlong, x: jfloat, y: jfloat,

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -805,6 +805,7 @@ pub unsafe extern "C" fn update_virtual_keyboard(obj: *mut c_void, showing: bool
     };
 
     markdown.virtual_keyboard_shown = showing;
+    markdown.keyboard_visible = showing;
 }
 
 /// # Safety

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -281,6 +281,12 @@ pub struct Editor {
 
     // misc
     pub virtual_keyboard_shown: bool,
+    /// Real platform IME visibility, pushed by the client (Android inset
+    /// listener, iOS keyboard callbacks). Unlike `virtual_keyboard_shown`
+    /// — the editor's *request* — this is whether the keyboard is actually
+    /// on screen. Touch long-press uses it: keyboard down → drag-reorder,
+    /// keyboard up → text selection.
+    pub keyboard_visible: bool,
 
     // outputs from drawing a frame need an additional frame to process before reporting
     next_resp: Response,
@@ -692,6 +698,7 @@ impl Editor {
 
             // this is used to toggle the mobile toolbar
             virtual_keyboard_shown: cfg!(target_os = "android"),
+            keyboard_visible: false,
             unprocessed_scroll: Default::default(),
 
             prev_dimensions: None,

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -206,6 +206,10 @@ pub struct MdEdit {
     /// Mirrored onto the renderer each frame for the dim/indicator paint.
     pub in_progress_block_drag: Option<widget::block::drag::BlockDrag>,
 
+    /// Touch long-press → reorder gesture state (touch only; desktop drags
+    /// the marker handle directly). See [`MdEdit::detect_touch_reorder`].
+    pub touch_reorder: widget::block::drag::TouchReorder,
+
     /// Frame-scoped single-target scroll intent, consumed at the end of the
     /// scroll area callback.
     pub pending_scroll: Option<ScrollTarget>,
@@ -246,6 +250,7 @@ impl MdEdit {
             phone_mode: false,
             in_progress_selection: None,
             in_progress_block_drag: None,
+            touch_reorder: Default::default(),
             pending_scroll: None,
             scroll_area_velocity: Default::default(),
             file_id,
@@ -677,6 +682,7 @@ impl Editor {
                 event: Default::default(),
                 in_progress_selection: None,
                 in_progress_block_drag: None,
+                touch_reorder: Default::default(),
                 pending_scroll: None,
                 scroll_area_velocity: Default::default(),
                 file_id,
@@ -1240,6 +1246,12 @@ impl Editor {
                     .scope_builder(UiBuilder::new().max_rect(canvas_rect), |ui| {
                         ui.set_clip_rect(canvas_rect);
                         self.edit.scroll_area.touch_scroll = touch_scroll;
+                        // An armed touch reorder owns the gesture — don't
+                        // scroll the body under the dragged item.
+                        self.edit.scroll_area.suppress_body_drag = matches!(
+                            self.edit.touch_reorder,
+                            widget::block::drag::TouchReorder::Armed { .. }
+                        );
 
                         // Body alloc → pre_render → scrollbar/content
                         // ordering puts pre_render's click rect above
@@ -1362,9 +1374,11 @@ impl Editor {
                             self.edit.show_range(ui, range, color);
                         }
 
-                        // List-item drag-to-reorder: consume the handle
-                        // action, commit on release (visuals are drawn
-                        // after post_render so they composite on top).
+                        // List-item drag-to-reorder: detect the touch
+                        // long-press, then consume the handle action and
+                        // commit on release (visuals are drawn after
+                        // post_render so they composite on top).
+                        self.edit.detect_touch_reorder(ui, self.keyboard_visible);
                         self.edit.handle_block_drag(ui);
                         pre
                     })

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -102,6 +102,9 @@ pub struct MdRender {
     pub dark_mode: bool,
     pub ext: String,
     pub touch_mode: bool,
+    /// Set only while painting the floating drag-reorder card, so chrome
+    /// that shouldn't travel with it (the fold button) can opt out.
+    pub painting_drag_float: bool,
 
     // document
     pub buffer: Buffer,
@@ -409,6 +412,7 @@ impl MdRender {
             dark_mode,
             ext: "md".into(),
             touch_mode,
+            painting_drag_float: false,
             buffer: "".into(),
             bounds: Default::default(),
             bounds_seq: 0,
@@ -479,6 +483,7 @@ impl MdRender {
             dark_mode: false,
             ext: "md".into(),
             touch_mode: false,
+            painting_drag_float: false,
             bounds: Default::default(),
             buffer: md.into(),
             fragments: Vec::new(),
@@ -628,6 +633,7 @@ impl Editor {
             dark_mode,
             ext,
             touch_mode,
+            painting_drag_float: false,
 
             bounds: Default::default(),
             buffer: md.into(),

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -841,7 +841,11 @@ impl Editor {
 
         let all_selected = self.edit.renderer.buffer.current.selection
             == (0.into(), self.edit.renderer.last_cursor_position());
-        if self.initialized && buf_resp.selection_user_moved && !all_selected {
+        if self.initialized
+            && buf_resp.selection_user_moved
+            && !all_selected
+            && self.edit.in_progress_block_drag.is_none()
+        {
             self.edit.pending_scroll = Some(ScrollTarget::Cursor);
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -395,6 +395,7 @@ impl MdEdit {
             })
             .map(|b| (b.rect, b.node_range))
             .collect();
+        self.renderer.painting_drag_float = true;
         ui.push_id("md_block_drag_float", |ui| {
             for (rect, nr) in &constituents {
                 if let Some(node) = root
@@ -405,6 +406,7 @@ impl MdEdit {
                 }
             }
         });
+        self.renderer.painting_drag_float = false;
         let floating_text = std::mem::take(&mut self.renderer.text_areas);
         let floating_deco = std::mem::take(&mut self.renderer.deco_lines);
         self.renderer.fragments.truncate(frag_len);

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -706,8 +706,11 @@ impl MdEdit {
                 .hline(deco.x, deco.y, Stroke::new(1.0, deco.color));
         }
 
-        let has_selection_handles = !self.renderer.buffer.current.selection.is_empty()
-            || self.in_progress_selection.is_some();
+        // A reorder selects the dragged section; its handles would clutter
+        // the floating card, so suppress them while a drag is in flight.
+        let has_selection_handles = (!self.renderer.buffer.current.selection.is_empty()
+            || self.in_progress_selection.is_some())
+            && self.in_progress_block_drag.is_none();
         if ui.ctx().os() == OperatingSystem::Android && has_selection_handles {
             self.show_selection_handles(ui);
         }

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -28,6 +28,7 @@ use crate::widgets::IconButton;
 use super::MdEdit;
 use super::input::cursor::SELECTION_HANDLE_HEIGHT;
 use super::input::{Bound, Event, Location, Region};
+use super::widget::block::drag::{BlockBox, BlockDragAction, TouchReorder};
 
 /// Hand-off between [`MdEdit::pre_render`] and [`MdEdit::post_render`].
 pub struct PreRenderState {
@@ -187,8 +188,6 @@ impl MdEdit {
     /// Consume the marker's [`BlockDragAction`] for the frame and, on
     /// release, commit the reorder via [`MdEdit::move_block`].
     pub(crate) fn handle_block_drag(&mut self, ui: &mut Ui) {
-        use crate::tab::markdown_editor::widget::block::drag::BlockDragAction;
-
         match self.renderer.block_drag_action.take() {
             Some(BlockDragAction::Started(drag)) => {
                 self.in_progress_block_drag = Some(drag);
@@ -376,7 +375,7 @@ impl MdEdit {
         let box_len = self.renderer.block_boxes.len();
         let section = drag.section_range;
         // Top-most items in the span; descendants paint via `show_block`.
-        let in_span: Vec<crate::tab::markdown_editor::widget::block::drag::BlockBox> = self
+        let in_span: Vec<BlockBox> = self
             .renderer
             .block_boxes
             .iter()
@@ -549,6 +548,12 @@ impl MdEdit {
                 } else if response.clicked() && modifiers.shift && !cfg!(target_os = "android") {
                     Some(Region::ToLocation(location))
                 } else if response.clicked() && self.scroll_area.momentum_cancel_press() {
+                    None
+                } else if response.clicked()
+                    && matches!(self.touch_reorder, TouchReorder::Armed { .. })
+                {
+                    // Long-press that armed a reorder also lands as a click on
+                    // release — consume it so it doesn't place the cursor.
                     None
                 } else if response.clicked() {
                     if cfg!(target_os = "android") && self.selection_tap(pos) {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -152,6 +152,7 @@ impl<'ast> MdRender {
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
         let show_fold_button = self.interactive
+            && !self.painting_drag_float // chrome shouldn't travel with the drag card
             && !self.reveal_line(node, first_line) // the revealed marker occupies the gutter
             && (self.touch_mode
                 || hovered

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/item.rs
@@ -49,9 +49,12 @@ impl<'ast> MdRender {
         let annotation_size = Vec2 { x: self.layout.indent, y: annotation_row_height };
         let annotation_space = Rect::from_min_size(top_left, annotation_size);
 
-        // Marker doubles as drag handle (bullet/number is non-interactive).
+        // Desktop drag handle (bullet/number is non-interactive). On touch
+        // the body must own the press instead, so a pan scrolls and a hold
+        // arms a reorder (see `MdEdit::detect_touch_reorder`).
         let drag_id = ui.id().with(("item_drag", self.node_range(node)));
-        let drag_resp = ui.interact(annotation_space, drag_id, egui::Sense::drag());
+        let sense = if self.touch_mode { egui::Sense::hover() } else { egui::Sense::drag() };
+        let drag_resp = ui.interact(annotation_space, drag_id, sense);
         self.handle_item_drag_resp(ui, node, &drag_resp);
 
         let annotation_color = self.ctx.get_lb_theme().neutral_fg_secondary();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -160,6 +160,7 @@ impl<'ast> MdRender {
         let (fold_button_size, fold_button_icon_size, fold_button_space) =
             Self::fold_button_size_icon_size_space(top_left, row_height, self.layout.indent);
         let show_fold_button = self.interactive
+            && !self.painting_drag_float // chrome shouldn't travel with the drag card
             && !self.reveal_line(node, first_line) // the revealed marker occupies the gutter
             && (self.touch_mode
                 || hovered

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/task_item.rs
@@ -46,7 +46,15 @@ impl<'ast> MdRender {
             let extra_height = self.layout.row_spacing / 2.;
             let clickable_space = checkbox_space.expand(extra_width.min(extra_height));
 
-            let sense = if self.readonly { Sense::hover() } else { Sense::click_and_drag() };
+            // On touch the checkbox still toggles (click) but doesn't drag —
+            // reorder is the body's long-press (see `detect_touch_reorder`).
+            let sense = if self.readonly {
+                Sense::hover()
+            } else if self.touch_mode {
+                Sense::click()
+            } else {
+                Sense::click_and_drag()
+            };
             let checkbox_response =
             // ui.id().with() instead of Id::new() so two views of the same document
             // get distinct checkbox IDs

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/drag.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/drag.rs
@@ -8,13 +8,29 @@ use comrak::nodes::{AstNode, NodeValue};
 use egui::{CursorIcon, Pos2, Rect, Ui, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, Graphemes, RangeExt as _};
 
-use crate::tab::markdown_editor::MdRender;
+use crate::tab::markdown_editor::{MdEdit, MdRender};
 
 #[derive(Clone, Copy, Debug)]
 pub enum BlockDragAction {
     Started(BlockDrag),
     Dragged(Pos2),
     Released(Pos2),
+}
+
+/// Touch long-press → drag-reorder gesture state. Desktop reorders
+/// immediately from the marker handle; touch requires a stationary hold
+/// so a pan still scrolls. Driven by `MdEdit::detect_touch_reorder`.
+#[derive(Clone, Copy, Debug, Default)]
+pub enum TouchReorder {
+    #[default]
+    Idle,
+    /// Finger down on a reorderable item, disambiguating long-press
+    /// (arm) from pan (cancel).
+    Pending { origin: Pos2, started: f64 },
+    /// Long-press fired; the reorder runs via `in_progress_block_drag`.
+    /// `last` is the most recent live pointer — used on release, since
+    /// touch-up nulls `latest_pos` (Android `PointerGone`).
+    Armed { last: Pos2 },
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -141,6 +157,32 @@ impl<'ast> MdRender {
                 self.block_drag_action = Some(BlockDragAction::Dragged(p));
             }
         }
+    }
+
+    /// Single-item drag for the reorderable list item under `pos` — the
+    /// touch long-press path. `None` if `pos` isn't over an item that has
+    /// a reorder sibling. The innermost (smallest) box wins, so a press on
+    /// a nested item reorders it among its own siblings. Multi-select drag
+    /// stays desktop-only.
+    pub fn touch_reorder_target(&self, pos: Pos2) -> Option<BlockDrag> {
+        let area = |b: &BlockBox| b.rect.width() * b.rect.height();
+        let b = self
+            .block_boxes
+            .iter()
+            .filter(|b| b.rect.contains(pos))
+            .min_by(|a, c| area(a).total_cmp(&area(c)))?;
+        let has_sibling = self
+            .block_boxes
+            .iter()
+            .filter(|x| x.parent_start == b.parent_start)
+            .nth(1)
+            .is_some();
+        has_sibling.then(|| BlockDrag {
+            section_range: b.node_range,
+            grabbed: b.node_range,
+            parent_start: b.parent_start,
+            grab_offset: pos - b.rect.left_top(),
+        })
     }
 
     /// Union of indexed item rects within `span`.
@@ -348,5 +390,78 @@ impl<'ast> MdRender {
             }
         }
         self.line_idx_for_offset(end)
+    }
+}
+
+impl MdEdit {
+    /// Touch long-press → drag-reorder. Pre-arm the body owns the gesture
+    /// so a pan still scrolls; a stationary hold past `LONG_PRESS` arms the
+    /// reorder. Release is read from raw input (with the last live pointer),
+    /// so it fires even when touch-up nulls `latest_pos`. No-op unless touch,
+    /// editable, and the keyboard is down (keyboard up → text selection).
+    /// Emits into `block_drag_action`, consumed by `handle_block_drag`.
+    pub(crate) fn detect_touch_reorder(&mut self, ui: &mut Ui, keyboard_visible: bool) {
+        // Structural conditions don't change mid-gesture; a non-touch /
+        // read-only / non-interactive editor never reorders.
+        if !self.renderer.touch_mode || self.renderer.readonly || !self.renderer.interactive {
+            self.touch_reorder = TouchReorder::Idle;
+            return;
+        }
+
+        const LONG_PRESS: f64 = 0.4;
+        const SLOP: f32 = 12.0;
+
+        let (any_down, any_pressed, any_released, origin, latest, time, t0) = ui.input(|i| {
+            (
+                i.pointer.any_down(),
+                i.pointer.any_pressed(),
+                i.pointer.any_released(),
+                i.pointer.press_origin(),
+                i.pointer.latest_pos(),
+                i.time,
+                i.pointer.press_start_time(),
+            )
+        });
+
+        match self.touch_reorder {
+            TouchReorder::Idle => {
+                // Keyboard up → long-press is text selection, not reorder.
+                if let (true, false, Some(origin), Some(started)) =
+                    (any_pressed, keyboard_visible, origin, t0)
+                {
+                    if self.renderer.touch_reorder_target(origin).is_some() {
+                        self.touch_reorder = TouchReorder::Pending { origin, started };
+                    }
+                }
+            }
+            TouchReorder::Pending { origin, started } => {
+                let moved = latest.map(|p| (p - origin).length()).unwrap_or(0.0);
+                if keyboard_visible || !any_down {
+                    self.touch_reorder = TouchReorder::Idle; // keyboard rose, or tapped
+                } else if moved > SLOP {
+                    self.touch_reorder = TouchReorder::Idle; // pan → leave it to scroll
+                } else if time - started >= LONG_PRESS {
+                    match self.renderer.touch_reorder_target(origin) {
+                        Some(drag) => {
+                            self.renderer.block_drag_action = Some(BlockDragAction::Started(drag));
+                            self.touch_reorder =
+                                TouchReorder::Armed { last: latest.unwrap_or(origin) };
+                        }
+                        None => self.touch_reorder = TouchReorder::Idle,
+                    }
+                } else {
+                    ui.ctx().request_repaint(); // tick toward the threshold
+                }
+            }
+            TouchReorder::Armed { last } => {
+                let last = latest.unwrap_or(last);
+                if any_released || !any_down {
+                    self.renderer.block_drag_action = Some(BlockDragAction::Released(last));
+                    self.touch_reorder = TouchReorder::Idle;
+                } else {
+                    self.touch_reorder = TouchReorder::Armed { last };
+                }
+            }
+        }
     }
 }

--- a/libs/content/workspace/src/widgets/affine_scroll.rs
+++ b/libs/content/workspace/src/widgets/affine_scroll.rs
@@ -1044,6 +1044,10 @@ pub struct AffineScrollArea<Id: Clone + Eq + std::fmt::Debug> {
     /// When true, drag on the body (not just the scrollbar) scrolls
     /// the content with momentum. Intended for touch input.
     pub touch_scroll: bool,
+    /// When true, body-drag scrolling is suppressed for the frame — the
+    /// embedder has claimed the touch for something else (e.g. an armed
+    /// list-item drag-reorder). Momentum and the scrollbar are unaffected.
+    pub suppress_body_drag: bool,
     /// Salt for the scrollbar's interact rect — must be stable across
     /// frames and unique among visible scroll areas.
     id_salt: egui::Id,
@@ -1057,6 +1061,7 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         Self {
             state: ScrollArea::default(),
             touch_scroll: false,
+            suppress_body_drag: false,
             id_salt: egui::Id::new(id_salt),
             momentum_cancel_press: false,
         }
@@ -1185,7 +1190,7 @@ impl<Id: Clone + Eq + std::fmt::Debug> AffineScrollArea<Id> {
         if self.touch_scroll && touch_cancelled {
             self.state.kill_momentum();
         }
-        if scrollable && self.touch_scroll && response.dragged() {
+        if scrollable && self.touch_scroll && !self.suppress_body_drag && response.dragged() {
             let drag_y = ui.input(|i| i.pointer.delta().y);
             let precise_delta = -drag_y;
             self.state


### PR DESCRIPTION
android part of #4765 

On mobile, long press anywhere on a list item to drag-reorder it. This only works while the keyboard is down because long press is expected to do other things while editing, like triggering a loupe.


https://github.com/user-attachments/assets/47b515af-8935-4d88-8109-d903517ccd05

