### PR TITLE
md: ios long press drag reorder

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -174,9 +174,13 @@
                 // and begins over an interactive markdown element, bail before
                 // cancelling the editor touch — otherwise the in-flight tap is
                 // dropped and the element (checkbox, fold, link, spoiler) neither
-                // toggles nor places a cursor.
+                // toggles nor places a cursor. Likewise yield to a list-item
+                // drag-reorder, which owns the long-press while the keyboard is
+                // down.
                 let location = recognizer.location(in: mtkView)
-                if touches_interactive_element(wsHandle, Float(location.x), Float(location.y)) {
+                if touches_interactive_element(wsHandle, Float(location.x), Float(location.y))
+                    || is_reordering(wsHandle)
+                {
                     recognizer.state = .failed
                     return
                 }
@@ -203,7 +207,9 @@
                 return
             case .began:
                 let location = recognizer.location(in: mtkView)
-                if touches_interactive_element(wsHandle, Float(location.x), Float(location.y)) {
+                if touches_interactive_element(wsHandle, Float(location.x), Float(location.y))
+                    || is_reordering(wsHandle)
+                {
                     recognizer.state = .failed
                     return
                 }
@@ -850,6 +856,17 @@
 
         override public var canBecomeFirstResponder: Bool {
             true
+        }
+
+        override public func becomeFirstResponder() -> Bool {
+            // A committed drag-reorder owns the gesture; focusing the editor
+            // here would summon the keyboard and place a cursor. Refuse while
+            // armed (a still-pending hold may resolve to a tap, which must
+            // focus). Focus returns to normal once the drag ends.
+            if is_reorder_armed(wsHandle) {
+                return false
+            }
+            return super.becomeFirstResponder()
         }
 
         override public var keyCommands: [UIKeyCommand]? {

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -437,6 +437,48 @@ pub unsafe extern "C" fn will_consume_touch(obj: *mut c_void, x: f32, y: f32) ->
     }
 }
 
+/// Whether a list-item drag-reorder is arming or running. The native
+/// long-press (loupe) and tap gestures fail when this is true so the
+/// reorder owns the touch. See [`Editor::reorder_in_progress`].
+///
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
+pub unsafe extern "C" fn is_reordering(obj: *mut c_void) -> bool {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    if let Some(tab) = obj.workspace.current_tab() {
+        if let ContentState::Open(TabContent::Markdown(md)) = &tab.content {
+            md.reorder_in_progress()
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+/// Whether a reorder is committed and dragging (not the pending hold). iOS
+/// refuses first-responder on this so a reorder doesn't summon the keyboard,
+/// while a tap still focuses. See [`Editor::reorder_armed`].
+///
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
+pub unsafe extern "C" fn is_reorder_armed(obj: *mut c_void) -> bool {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+
+    if let Some(tab) = obj.workspace.current_tab() {
+        if let ContentState::Open(TabContent::Markdown(md)) = &tab.content {
+            md.reorder_armed()
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
 /// Region-only variant of [`will_consume_touch`]: interactive-element
 /// rects without the transient terms (momentum, open menu).
 ///

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -28,29 +28,32 @@ impl MdEdit {
     /// [`MdRender::plan_block_move`]. The post-move selection is
     /// applied in a separate batch so it isn't transformed against the
     /// edit and lands on the moved item.
-    pub fn move_block(&mut self, section_range: (Grapheme, Grapheme), insert_offset: Grapheme) {
+    pub fn move_block(
+        &mut self, section_range: (Grapheme, Grapheme), insert_offset: Grapheme,
+    ) -> buffer::Response {
         let arena = comrak::Arena::new();
         let root = self.renderer.reparse(&arena);
         let Some(plan) = self
             .renderer
             .plan_block_move(root, section_range, insert_offset)
         else {
-            return;
+            return Default::default();
         };
 
         self.renderer
             .buffer
             .queue(vec![Operation::Replace(Replace { range: plan.run_range, text: plan.new_run })]);
-        let resp = self.renderer.buffer.update();
+        let mut resp = self.renderer.buffer.update();
         if !resp.text_updated {
-            return;
+            return resp;
         }
         self.renderer.bump_text_seq();
 
         self.renderer
             .buffer
             .queue(vec![Operation::Select(plan.moved_range)]);
-        self.renderer.buffer.update();
+        resp |= self.renderer.buffer.update();
+        resp
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -213,6 +213,12 @@ pub struct MdEdit {
     /// the marker handle directly). See [`MdEdit::detect_touch_reorder`].
     pub touch_reorder: widget::block::drag::TouchReorder,
 
+    /// A committed reorder `(section_range, insert_offset)`, applied at the
+    /// start of the next `handle_input` so the move lands pre-render — the
+    /// new layout is then current before the platform refetches selection
+    /// geometry. Set on drag release (which runs post-render).
+    pub pending_block_move: Option<((Grapheme, Grapheme), Grapheme)>,
+
     /// Frame-scoped single-target scroll intent, consumed at the end of the
     /// scroll area callback.
     pub pending_scroll: Option<ScrollTarget>,
@@ -254,6 +260,7 @@ impl MdEdit {
             in_progress_selection: None,
             in_progress_block_drag: None,
             touch_reorder: Default::default(),
+            pending_block_move: None,
             pending_scroll: None,
             scroll_area_velocity: Default::default(),
             file_id,
@@ -689,6 +696,7 @@ impl Editor {
                 in_progress_selection: None,
                 in_progress_block_drag: None,
                 touch_reorder: Default::default(),
+                pending_block_move: None,
                 pending_scroll: None,
                 scroll_area_velocity: Default::default(),
                 file_id,

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1199,7 +1199,26 @@ impl Editor {
         self.touches_interactive_element(pos)
             || self.edit.scroll_area_velocity.abs().max_elem() > 0. // velocity zeroed at touch down
             || self.edit.scroll_area.momentum_cancel_press() // platform can check at touch up
+            || self.reorder_armed() // a committed reorder isn't a tap
             || self.toolbar.menu_open
+    }
+
+    /// Whether a touch long-press is arming (`Pending`) or running (`Armed`)
+    /// a list-item drag-reorder. iOS reads this at its native long-press's
+    /// `.began` so the loupe yields *before* our threshold fires; only ever
+    /// true keyboard-down on a reorderable item (see
+    /// [`MdEdit::detect_touch_reorder`]).
+    pub fn reorder_in_progress(&self) -> bool {
+        use widget::block::drag::TouchReorder;
+        matches!(self.edit.touch_reorder, TouchReorder::Pending { .. } | TouchReorder::Armed { .. })
+    }
+
+    /// Whether a reorder is committed and dragging (`Armed`, not the
+    /// still-`Pending` hold). Gates keyboard/cursor suppression — a `Pending`
+    /// hold may still resolve to a tap, which must focus normally.
+    pub fn reorder_armed(&self) -> bool {
+        use widget::block::drag::TouchReorder;
+        matches!(self.edit.touch_reorder, TouchReorder::Armed { .. })
     }
 
     /// Whether `pos` is over an interactive element (checkbox, fold button,

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -55,6 +55,12 @@ impl MdEdit {
     pub fn handle_input(&mut self, ctx: &Context, id: Id) -> buffer::Response {
         let focused = ctx.memory(|m| m.has_focus(id));
 
+        // Deferred block reorder
+        let move_resp = match self.pending_block_move.take() {
+            Some((section_range, insert_offset)) => self.move_block(section_range, insert_offset),
+            None => buffer::Response::default(),
+        };
+
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
 
@@ -124,6 +130,7 @@ impl MdEdit {
         self.renderer.buffer.queue(ops);
         let mut buf_resp = direct_resp;
         buf_resp |= self.renderer.buffer.update();
+        buf_resp |= move_resp; // a deferred reorder reports its text/selection edit
 
         if buf_resp.text_updated {
             self.renderer.bump_text_seq();
@@ -218,7 +225,9 @@ impl MdEdit {
             Some(BlockDragAction::Released(pointer)) => {
                 if let Some(drag) = self.in_progress_block_drag.take() {
                     if let Some(gap) = self.renderer.drop_gap_for(&drag, pointer) {
-                        self.move_block(drag.section_range, gap.insert_offset);
+                        // deferred move
+                        self.pending_block_move = Some((drag.section_range, gap.insert_offset));
+                        ui.ctx().request_repaint();
                     }
                 }
             }

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -191,22 +191,28 @@ impl MdEdit {
         match self.renderer.block_drag_action.take() {
             Some(BlockDragAction::Started(drag)) => {
                 self.in_progress_block_drag = Some(drag);
-                // Select what's being dragged so the selection follows
-                // the move. Shift extends the existing selection — works
-                // through a click-that-becomes-a-tiny-drag, so a bare
-                // shift+click respects the modifier too.
-                let shift = ui.input(|i| i.modifiers.shift);
-                let region = if shift {
-                    let sel = self.renderer.buffer.current.selection;
-                    let lo = sel.start().min(drag.section_range.start());
-                    let hi = sel.end().max(drag.section_range.end());
-                    (lo, hi)
-                } else {
-                    drag.section_range
-                };
-                self.renderer
-                    .render_events
-                    .push(Event::Select { region: region.into() });
+                // Highlight the dragged section during a desktop drag. Skipped
+                // on touch: the highlight sits under the float's cutout (so
+                // it's invisible anyway), and on iOS UIKit would draw it
+                // natively *over* the cutout — messy rects at the source. The
+                // post-move selection comes from `move_block` regardless.
+                // Shift extends the existing selection — works through a
+                // click-that-becomes-a-tiny-drag, so a bare shift+click
+                // respects the modifier too.
+                if !self.renderer.touch_mode {
+                    let shift = ui.input(|i| i.modifiers.shift);
+                    let region = if shift {
+                        let sel = self.renderer.buffer.current.selection;
+                        let lo = sel.start().min(drag.section_range.start());
+                        let hi = sel.end().max(drag.section_range.end());
+                        (lo, hi)
+                    } else {
+                        drag.section_range
+                    };
+                    self.renderer
+                        .render_events
+                        .push(Event::Select { region: region.into() });
+                }
             }
             Some(BlockDragAction::Dragged(_)) => {}
             Some(BlockDragAction::Released(pointer)) => {


### PR DESCRIPTION
ios part of https://github.com/lockbook/lockbook/pull/4765

On mobile, long press anywhere on a list item to drag-reorder it. This only works while the keyboard is down because long press is expected to do other things while editing, like triggering a loupe.


https://github.com/user-attachments/assets/20f243de-58d5-4ded-aa74-d3cd08aae1be

