### PR TITLE
android: material you theme translation updates

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceThemeHelper.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceThemeHelper.kt
@@ -49,16 +49,31 @@ object WorkspaceThemeHelper {
     ): WorkspaceTheme {
         val defaultTheme = Workspace.defaultTheme(darkMode) as WorkspaceTheme
         val materialPrimary =
-            context.getMaterialColorOrFallback(com.google.android.material.R.attr.colorPrimaryFixed, R.color.md_theme_primary)
+            context.getMaterialColorOrFallback(androidx.appcompat.R.attr.colorPrimary, R.color.md_theme_primary)
         val materialSecondary =
             context.getMaterialColorOrFallback(com.google.android.material.R.attr.colorSecondary, R.color.md_theme_secondary)
         val materialTertiary =
             context.getMaterialColorOrFallback(com.google.android.material.R.attr.colorTertiary, R.color.md_theme_tertiary)
+        val materialPrimaryContainer =
+            context.getMaterialColorOrFallback(
+                com.google.android.material.R.attr.colorPrimaryContainer,
+                R.color.md_theme_primaryContainer,
+            )
+        val materialSecondaryContainer =
+            context.getMaterialColorOrFallback(
+                com.google.android.material.R.attr.colorSecondaryContainer,
+                R.color.md_theme_secondaryContainer,
+            )
+        val materialTertiaryContainer =
+            context.getMaterialColorOrFallback(
+                com.google.android.material.R.attr.colorTertiaryContainer,
+                R.color.md_theme_tertiaryContainer,
+            )
         val materialSurface =
             context.getMaterialColorOrFallback(com.google.android.material.R.attr.colorSurface, R.color.md_theme_surface)
-        val materialSurfaceVariant =
+        val materialSurfaceContainerHigh =
             context.getMaterialColorOrFallback(
-                com.google.android.material.R.attr.colorSurfaceVariant,
+                com.google.android.material.R.attr.colorSurfaceContainerHigh,
                 R.color.md_theme_surfaceVariant,
             )
         val materialOnSurface =
@@ -91,28 +106,34 @@ object WorkspaceThemeHelper {
                 intArrayOf(materialPrimary, materialSecondary, materialTertiary),
                 renderedAccentSlots,
             )
-        val materialRoleColors =
+        val fgAccentColors =
             mapOf(
                 prefs.primary to materialPrimary,
                 prefs.secondary to materialSecondary,
                 prefs.tertiary to materialTertiary,
+            )
+        val bgAccentColors =
+            mapOf(
+                prefs.primary to materialPrimaryContainer,
+                prefs.secondary to materialSecondaryContainer,
+                prefs.tertiary to materialTertiaryContainer,
             )
 
         val dim =
             harmonizedDim
                 .copy(
                     black = if (darkMode) materialSurface else materialOnSurface,
-                    grey = materialOnSurfaceVariant,
+                    grey = if (darkMode) materialSurfaceContainerHigh else materialOnSurfaceVariant,
                     white = if (darkMode) materialOnSurface else materialSurface,
-                ).withPaletteColors(materialRoleColors)
+                ).withPaletteColors(if (darkMode) bgAccentColors else fgAccentColors)
 
         val bright =
             harmonizedBright
                 .copy(
                     black = materialOnSurface,
-                    grey = if (darkMode) materialOnSurfaceVariant else materialSurfaceVariant,
+                    grey = if (darkMode) materialOnSurfaceVariant else materialSurfaceContainerHigh,
                     white = materialSurface,
-                ).withPaletteColors(materialRoleColors)
+                ).withPaletteColors(if (darkMode) fgAccentColors else bgAccentColors)
 
         return WorkspaceTheme(
             isDark = darkMode,


### PR DESCRIPTION
The standing logic to translate Material You themes to workspace themes uses foreground tones in place of background tones for one neutral and all accent colors. Material You defines foreground and background colors deliberately much like workspace, suggesting a straightforward translation.

Before:
<img width="252" height="566" alt="image" src="https://github.com/user-attachments/assets/e3995558-50e3-438d-91f5-061feaa767e4" /> <img width="252" height="566" alt="image" src="https://github.com/user-attachments/assets/2c200782-1764-4105-a63f-d278ffc23aec" />

After:
<img width="252" height="566" alt="image" src="https://github.com/user-attachments/assets/571b8df3-acd6-4e8f-a358-9017bff4528f" /> <img width="252" height="566" alt="image" src="https://github.com/user-attachments/assets/961ecb90-e609-4031-a66f-7713d3e7b84e" />

Example result trying to maintain another experience without these changes:
<img width="252" height="566" alt="image" src="https://github.com/user-attachments/assets/2933c17e-9850-4a0a-b4d4-c56998360ded" />
