### PR TITLE
android: scroll while dragging selection handles

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -7,7 +7,7 @@ use crate::tab::ExtendedInput as _;
 use crate::tab::markdown_editor::MdEdit;
 use crate::theme::palette_v2::ThemeExt as _;
 
-use super::{Event, Location, Region};
+use super::{Event, Region};
 
 const SELECTION_HANDLE_RADIUS: f32 = 12.0;
 pub(in crate::tab::markdown_editor) const SELECTION_HANDLE_HEIGHT: f32 =
@@ -225,6 +225,7 @@ impl MdEdit {
         let response = ui.interact(hit_rect, id, Sense::drag());
 
         if response.drag_stopped() {
+            self.in_progress_handle = None;
             if let Some(in_progress_selection) = mem::take(&mut self.in_progress_selection) {
                 let region = Region::from(in_progress_selection);
                 ui.ctx().push_markdown_event(Event::Select { region });
@@ -238,19 +239,17 @@ impl MdEdit {
             if let Some(last) = self.renderer.fragments.last() {
                 new_pos.y = new_pos.y.min(last.rect.max.y - 1.0);
             }
+            // The fixed handle anchors at the committed selection (the buffer
+            // selection doesn't change until drag release); handles paint at
+            // raw .0/.1. Clamp the dragged handle so the two never cross and
+            // the selection keeps ≥1 grapheme — matching Google Keep.
             let selection = self.renderer.buffer.current.selection;
-            let region = if is_start {
-                Region::BetweenLocations {
-                    start: Location::Pos(new_pos),
-                    end: Location::Grapheme(selection.1),
-                }
-            } else {
-                Region::BetweenLocations {
-                    start: Location::Grapheme(selection.0),
-                    end: Location::Pos(new_pos),
-                }
-            };
-            self.in_progress_selection = Some(self.region_to_range(region));
+            let dragged = self.pos_to_char_offset(new_pos);
+            let moving =
+                if is_start { dragged.min(selection.1 - 1) } else { dragged.max(selection.0 + 1) };
+            self.in_progress_selection =
+                Some(if is_start { (moving, selection.1) } else { (selection.0, moving) });
+            self.in_progress_handle = Some(moving);
             self.pending_scroll = Some(crate::tab::markdown_editor::ScrollTarget::Cursor);
         }
     }
@@ -260,13 +259,15 @@ impl MdEdit {
         use crate::tab::markdown_editor::scroll_content::DocScrollContent;
         use crate::widgets::affine_scroll::Align;
 
-        // Make the moving end of the selection visible. Passed as a
-        // zero-length range — `build_target_reveal` handles single-point
-        // and multi-line ranges identically.
-        let cursor = self
-            .in_progress_selection
-            .unwrap_or(self.renderer.buffer.current.selection)
-            .1;
+        // Make the moving end of the selection visible. During a handle drag
+        // that's the dragged handle (either end); otherwise the selection end.
+        // Passed as a zero-length range — `build_target_reveal` handles
+        // single-point and multi-line ranges identically.
+        let cursor = self.in_progress_handle.unwrap_or_else(|| {
+            self.in_progress_selection
+                .unwrap_or(self.renderer.buffer.current.selection)
+                .1
+        });
 
         // expand cursor rect by one row to scroll while drag selecting
         let pad = if self.in_progress_selection.is_some() {

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1641,7 +1641,6 @@ fn endpoint_offset(
     if let Some(frag) = renderer.fragment_at_offset(target) {
         let y_range = frag.rect.y_range().expand(pad);
         let y = match side {
-
             EndpointSide::Top => y_range.min - android_top_overlay(content),
             EndpointSide::Bottom => y_range.max,
         };

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -205,6 +205,11 @@ pub struct MdEdit {
     /// when `None`.
     pub in_progress_selection: Option<(Grapheme, Grapheme)>,
 
+    /// Offset of the selection handle being dragged (Android), so auto-scroll
+    /// follows the moving handle rather than always the selection end. `None`
+    /// outside a handle drag — scroll then falls back to the selection end.
+    pub in_progress_handle: Option<Grapheme>,
+
     /// Active list-item drag-to-reorder — `Some` from grab until release.
     /// Mirrored onto the renderer each frame for the dim/indicator paint.
     pub in_progress_block_drag: Option<widget::block::drag::BlockDrag>,
@@ -258,6 +263,7 @@ impl MdEdit {
             event: Default::default(),
             phone_mode: false,
             in_progress_selection: None,
+            in_progress_handle: None,
             in_progress_block_drag: None,
             touch_reorder: Default::default(),
             pending_block_move: None,
@@ -506,6 +512,7 @@ impl MdRender {
             search_range: None,
             disable_images: false,
             in_progress_selection: None,
+            in_progress_handle: None,
             in_progress_block_drag: None,
             find_current_match: None,
             preview_match: None,
@@ -694,6 +701,7 @@ impl Editor {
                 cursor: Default::default(),
                 event: Default::default(),
                 in_progress_selection: None,
+                in_progress_handle: None,
                 in_progress_block_drag: None,
                 touch_reorder: Default::default(),
                 pending_block_move: None,
@@ -1617,6 +1625,13 @@ enum EndpointSide {
     Bottom,
 }
 
+/// Height of the fixed overlay covering the top of the editor (Android
+/// status-bar safe area); zero elsewhere. Equals the leading pad, which
+/// exists to hold content clear of that overlay.
+fn android_top_overlay(content: &scroll_content::DocScrollContent<'_, '_>) -> f32 {
+    if cfg!(target_os = "android") { content.leading_precise } else { 0.0 }
+}
+
 fn endpoint_offset(
     renderer: &MdRender, content: &scroll_content::DocScrollContent<'_, '_>,
     state: &crate::widgets::affine_scroll::ScrollArea<DocRowId>, target: Grapheme,
@@ -1626,7 +1641,8 @@ fn endpoint_offset(
     if let Some(frag) = renderer.fragment_at_offset(target) {
         let y_range = frag.rect.y_range().expand(pad);
         let y = match side {
-            EndpointSide::Top => y_range.min,
+
+            EndpointSide::Top => y_range.min - android_top_overlay(content),
             EndpointSide::Bottom => y_range.max,
         };
         return state.offset_at_viewport_y(content, y - canvas_rect.min.y);

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -770,6 +770,7 @@ impl MdEdit {
         self.renderer.buffer = Buffer::from("");
         self.renderer.bump_text_seq();
         self.in_progress_selection = None;
+        self.in_progress_handle = None;
         self.event.internal_events.clear();
     }
 


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4654
fixes an issue where selection handles could cross / appear backwards


https://github.com/user-attachments/assets/c4f939c2-d186-432c-a4c2-4e2411fbeb99

