### PR TITLE
md: improve image selection & interaction

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -387,7 +387,7 @@ class WorkspaceView(
 
                 if (response.hasEditMenu && contextMenu == null) {
                     val actionModeCallback =
-                        TextEditorContextMenu(textInputWrapper)
+                        TextEditorContextMenu(textInputWrapper, response.editMenuForAtom)
 
                     contextMenu =
                         this@WorkspaceView.startActionMode(
@@ -559,6 +559,8 @@ class WorkspaceView(
         const val SPEN_ACTION_DOWN = 211
         const val SPEN_ACTION_MOVE = 213
         const val SPEN_ACTION_UP = 212
+
+        const val EDIT_ATOM_MENU_ID = 0x00E0170A // arbitrary; distinct from android.R.id.*
     }
 
     inner class FloatingTextEditorContextMenu(
@@ -606,6 +608,7 @@ class WorkspaceView(
 
     inner class TextEditorContextMenu(
         private val textInputWrapper: WorkspaceTextInputWrapper,
+        private val forAtom: Boolean = false,
     ) : ActionMode.Callback {
         override fun onCreateActionMode(
             mode: ActionMode?,
@@ -625,6 +628,14 @@ class WorkspaceView(
         }
 
         private fun populateMenuWithItems(menu: Menu) {
+            if (forAtom) {
+                // select the URL inside the image atom, revealing its source —
+                // the only touch path in, since mobile has no arrow keys
+                menu
+                    .add(Menu.NONE, EDIT_ATOM_MENU_ID, 0, "Edit")
+                    .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+            }
+
             if (!textInputWrapper.wsInputConnection.wsEditable
                     .getSelection()
                     .isEmpty()
@@ -660,7 +671,14 @@ class WorkspaceView(
             item: MenuItem?,
         ): Boolean {
             if (item != null) {
-                textInputWrapper.wsInputConnection.performContextMenuAction(item.itemId)
+                if (item.itemId == EDIT_ATOM_MENU_ID) {
+                    Workspace.enterSelectedAtom(wgpuObj)
+                    // schedule the frame that processes the event, whose selection
+                    // update then flows back via `response.selectionUpdated`
+                    invalidate()
+                } else {
+                    textInputWrapper.wsInputConnection.performContextMenuAction(item.itemId)
+                }
             }
 
             if (contextMenu != null) {

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -26,6 +26,7 @@ data class AndroidResponse(
     val hasEditMenu: Boolean,
     val editMenuX: Float,
     val editMenuY: Float,
+    val editMenuForAtom: Boolean,
     val selectionUpdated: Boolean,
     val textUpdated: Boolean
 )
@@ -99,6 +100,7 @@ object Workspace {
     external fun clipboardSendImage(rustObj: Long, content: ByteArray, isPaste: Boolean)
     external fun isPenOnlyDraw(rustObj: Long) : Boolean
     external fun insertTextAtCursor(rustObj: Long, text: String)
+    external fun enterSelectedAtom(rustObj: Long)
 }
 
 data class NativeWorkspaceTab(

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -62,6 +62,9 @@
         /// edit menu (copy/paste); presented from Rust via `output.has_context_menu`.
         var menuInteraction: UIEditMenuInteraction?
         var menuDelegate: UIEditMenuInteractionDelegate?
+        /// menu is over a selected image atom — offer "Edit" (set per-present
+        /// from `output.context_menu_for_atom`)
+        var editMenuForAtom = false
 
         init(mtkView: iOSMTK, headerSize: Double) {
             self.mtkView = mtkView
@@ -77,7 +80,8 @@
             addInteraction(textInteraction)
 
             // edit menu, presented from Rust (see `output.has_context_menu`)
-            let menuDelegate = SvgMenuDelegate()
+            let menuDelegate = MdMenuDelegate()
+            menuDelegate.view = self
             let menuInteraction = UIEditMenuInteraction(delegate: menuDelegate)
             addInteraction(menuInteraction)
             self.menuDelegate = menuDelegate
@@ -1317,6 +1321,29 @@
 
     public class SvgMenuDelegate: NSObject, UIEditMenuInteractionDelegate {}
 
+    // MARK: - MdMenuDelegate
+
+    /// Prepends "Edit" to the edit menu when it's over a selected image atom —
+    /// select the URL inside the atom, revealing its source, since mobile has no arrow keys.
+    public class MdMenuDelegate: NSObject, UIEditMenuInteractionDelegate {
+        weak var view: MdView?
+
+        public func editMenuInteraction(
+            _ interaction: UIEditMenuInteraction, menuFor configuration: UIEditMenuConfiguration,
+            suggestedActions: [UIMenuElement]
+        ) -> UIMenu? {
+            guard let view, view.editMenuForAtom else { return nil } // nil → default menu
+            let edit = UIAction(title: "Edit") { [weak view] _ in
+                guard let view else { return }
+                enter_selected_atom(view.wsHandle)
+                // schedule the frame that processes the event, whose selection
+                // update then flows back via `output.selection_updated`
+                view.mtkView.setNeedsDisplay(view.mtkView.frame)
+            }
+            return UIMenu(children: [edit] + suggestedActions)
+        }
+    }
+
     // MARK: - iOSMTKViewDelegate
 
     public class iOSMTKViewDelegate: NSObject, MTKViewDelegate {
@@ -1435,6 +1462,7 @@
                 // Edit menu requested by Rust (e.g. tapping a selected image);
                 // point is egui screen space → convert to this view's local space.
                 if output.has_context_menu, let menuInteraction = currentWrapper.menuInteraction {
+                    currentWrapper.editMenuForAtom = output.context_menu_for_atom
                     let point = CGPoint(
                         x: CGFloat(output.context_menu_x) - currentWrapper.interactionRect.minX,
                         y: CGFloat(output.context_menu_y) - currentWrapper.interactionRect.minY

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -59,6 +59,10 @@
         /// range adjustment (selection handles)
         var rangeAdjustmentInProgress = false
 
+        /// edit menu (copy/paste); presented from Rust via `output.has_context_menu`.
+        var menuInteraction: UIEditMenuInteraction?
+        var menuDelegate: UIEditMenuInteractionDelegate?
+
         init(mtkView: iOSMTK, headerSize: Double) {
             self.mtkView = mtkView
             currentHeaderSize = headerSize
@@ -71,6 +75,13 @@
             // text input
             textInteraction.textInput = self
             addInteraction(textInteraction)
+
+            // edit menu, presented from Rust (see `output.has_context_menu`)
+            let menuDelegate = SvgMenuDelegate()
+            let menuInteraction = UIEditMenuInteraction(delegate: menuDelegate)
+            addInteraction(menuInteraction)
+            self.menuDelegate = menuDelegate
+            self.menuInteraction = menuInteraction
 
             for gestureRecognizer in gestureRecognizers ?? [] {
                 // receive touch events immediately even if they are part of any recognized gestures
@@ -1419,6 +1430,17 @@
 
                 if output.selection_updated, !mtkView.ignoreSelectionUpdate {
                     mtkView.onSelectionChanged?()
+                }
+
+                // Edit menu requested by Rust (e.g. tapping a selected image);
+                // point is egui screen space → convert to this view's local space.
+                if output.has_context_menu, let menuInteraction = currentWrapper.menuInteraction {
+                    let point = CGPoint(
+                        x: CGFloat(output.context_menu_x) - currentWrapper.interactionRect.minX,
+                        y: CGFloat(output.context_menu_y) - currentWrapper.interactionRect.minY
+                    )
+                    let config = UIEditMenuConfiguration(identifier: nil, sourcePoint: point)
+                    menuInteraction.presentEditMenu(with: config)
                 }
 
                 // Position the interaction overlay to the rect Rust reports

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -98,7 +98,7 @@ fn android_response_to_java<'local>(
 
     env.new_object(
         cls,
-        "(JLjava/lang/String;ZLjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ZZFFZZ)V",
+        "(JLjava/lang/String;ZLjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ZZFFZZZ)V",
         &[
             JValue::Long(redraw_in),
             JValue::Object(&JObject::from(copied_text)),
@@ -111,6 +111,7 @@ fn android_response_to_java<'local>(
             JValue::Bool(if response.has_edit_menu { 1 } else { 0 }),
             JValue::Float(response.edit_menu_x),
             JValue::Float(response.edit_menu_y),
+            JValue::Bool(if response.edit_menu_for_atom { 1 } else { 0 }),
             JValue::Bool(if response.selection_updated { 1 } else { 0 }),
             JValue::Bool(if response.text_updated { 1 } else { 0 }),
         ],
@@ -169,6 +170,16 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_insertTextAtCursor(
             .events
             .push(egui::Event::Text(text.into()));
     }
+}
+
+/// Edit-menu "Edit" over a selected image: select the URL inside the atom, revealing its
+/// source (mobile has no arrow keys to get inside).
+#[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_enterSelectedAtom(
+    _env: JNIEnv, _: JClass, obj: jlong,
+) {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+    obj.renderer.context.push_markdown_event(Event::EnterAtom);
 }
 
 /// Push real IME visibility (from the Android inset listener) into the

--- a/libs/content/workspace-ffi/src/android/response.rs
+++ b/libs/content/workspace-ffi/src/android/response.rs
@@ -21,6 +21,9 @@ pub struct AndroidResponse {
     pub has_edit_menu: bool,
     pub edit_menu_x: f32,
     pub edit_menu_y: f32,
+    /// The menu is over a selected atom (image, link card/capsule) — offer "Edit"
+    /// (`enterSelectedAtom`) alongside the standard actions.
+    pub edit_menu_for_atom: bool,
 
     pub selection_updated: bool,
     pub text_updated: bool,
@@ -73,8 +76,12 @@ impl From<crate::Response> for AndroidResponse {
             text_updated: markdown_editor_text_updated,
             selection_updated: markdown_editor_selection_updated,
             has_edit_menu: context_menu.is_some(),
-            edit_menu_x: context_menu.unwrap_or_default().x,
-            edit_menu_y: context_menu.unwrap_or_default().y,
+            edit_menu_x: context_menu.unwrap_or_default().0.x,
+            edit_menu_y: context_menu.unwrap_or_default().0.y,
+            edit_menu_for_atom: matches!(
+                context_menu,
+                Some((_, workspace_rs::tab::ContextMenuTarget::Atom))
+            ),
             virtual_keyboard_shown,
         }
     }

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -9,6 +9,18 @@ use workspace_rs::theme::palette_v2::{Mode, ThemeExt};
 
 use super::response::*;
 
+/// Edit-menu "Edit" over a selected image: select the URL inside the atom, revealing its
+/// source (mobile has no arrow keys to get inside).
+///
+/// # Safety
+#[no_mangle]
+pub unsafe extern "C" fn enter_selected_atom(obj: *mut c_void) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+    obj.renderer
+        .context
+        .push_markdown_event(workspace_rs::tab::markdown_editor::input::Event::EnterAtom);
+}
+
 #[no_mangle]
 pub extern "C" fn folder_selected(obj: *mut c_void, id: CUuid) {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };

--- a/libs/content/workspace-ffi/src/apple/ios/response.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/response.rs
@@ -31,6 +31,12 @@ pub struct IOSResponse {
     /// should occupy — the editor viewport minus the find widget and toolbar.
     pub has_text_interaction_rect: bool,
     pub text_interaction_rect: CRect,
+
+    /// Present the edit menu (copy/paste) at this point — set on tapping a
+    /// selected image. Egui screen points; `MdView` converts to local space.
+    pub has_context_menu: bool,
+    pub context_menu_x: f64,
+    pub context_menu_y: f64,
 }
 
 impl From<crate::Response> for IOSResponse {
@@ -62,7 +68,7 @@ impl From<crate::Response> for IOSResponse {
             virtual_keyboard_shown,
             window_title: _,
             request_paste: _,
-            context_menu: _,
+            context_menu,
         } = value;
 
         let doc_created = match file_created {
@@ -101,6 +107,9 @@ impl From<crate::Response> for IOSResponse {
                     max_y: r.max.y as f64,
                 })
                 .unwrap_or_default(),
+            has_context_menu: context_menu.is_some(),
+            context_menu_x: context_menu.map(|p| p.x as f64).unwrap_or_default(),
+            context_menu_y: context_menu.map(|p| p.y as f64).unwrap_or_default(),
         }
     }
 }

--- a/libs/content/workspace-ffi/src/apple/ios/response.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/response.rs
@@ -37,6 +37,9 @@ pub struct IOSResponse {
     pub has_context_menu: bool,
     pub context_menu_x: f64,
     pub context_menu_y: f64,
+    /// The menu is over a selected atom (image, link card/capsule) — offer "Edit"
+    /// (`enter_selected_atom`) alongside the standard actions.
+    pub context_menu_for_atom: bool,
 }
 
 impl From<crate::Response> for IOSResponse {
@@ -108,8 +111,12 @@ impl From<crate::Response> for IOSResponse {
                 })
                 .unwrap_or_default(),
             has_context_menu: context_menu.is_some(),
-            context_menu_x: context_menu.map(|p| p.x as f64).unwrap_or_default(),
-            context_menu_y: context_menu.map(|p| p.y as f64).unwrap_or_default(),
+            context_menu_x: context_menu.map(|(p, _)| p.x as f64).unwrap_or_default(),
+            context_menu_y: context_menu.map(|(p, _)| p.y as f64).unwrap_or_default(),
+            context_menu_for_atom: matches!(
+                context_menu,
+                Some((_, workspace_rs::tab::ContextMenuTarget::Atom))
+            ),
         }
     }
 }

--- a/libs/content/workspace-ffi/src/response.rs
+++ b/libs/content/workspace-ffi/src/response.rs
@@ -2,7 +2,7 @@ use egui::{
     Context, CursorIcon, OutputCommand, PlatformOutput, ViewportCommand, ViewportIdMap,
     ViewportOutput,
 };
-use workspace_rs::tab::ExtendedOutput;
+use workspace_rs::tab::{ContextMenuTarget, ExtendedOutput};
 
 // This general purpose workspace-ffi response captures the workspace widget response and platform response, but each
 // platform translates the workspace response into its own platform-specific response with just those fields that make
@@ -20,7 +20,7 @@ pub struct Response {
     pub virtual_keyboard_shown: Option<bool>,
     pub window_title: Option<String>,
     pub request_paste: bool,
-    pub context_menu: Option<egui::Pos2>,
+    pub context_menu: Option<(egui::Pos2, ContextMenuTarget)>,
 }
 
 impl Response {

--- a/libs/content/workspace/src/resolvers/image_embed.rs
+++ b/libs/content/workspace/src/resolvers/image_embed.rs
@@ -1,9 +1,6 @@
 use std::ops::Deref as _;
 
-use egui::{
-    Align2, Color32, CursorIcon, FontId, Id, OpenUrl, Pos2, Rect, Sense, Stroke, Ui, UiBuilder,
-    Vec2,
-};
+use egui::{Align2, Color32, FontId, Pos2, Rect, Stroke, Ui, UiBuilder, Vec2};
 use epaint::RectShape;
 use lb_rs::Uuid;
 
@@ -36,15 +33,8 @@ impl EmbedResolver for ImageEmbedResolver {
                 show_placeholder(ui, rect, Icon::IMAGE, "Loading image...");
             }
             ImageState::Loaded(texture_id) => {
-                let resp = ui.interact(rect, Id::new(texture_id), Sense::click());
-                if resp.hovered() {
-                    ui.output_mut(|o| o.cursor_icon = CursorIcon::PointingHand);
-                }
-                if resp.clicked() {
-                    ui.ctx()
-                        .open_url(OpenUrl { url: url.into(), new_tab: true });
-                }
-
+                // Paint only — interaction (open vs. select) is driven by the
+                // fragment's `Sense::click` scope via `handle_image_interactions`.
                 ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
                     ui.painter().add(
                         RectShape::filled(rect, 2.0_f32, Color32::WHITE).with_texture(

--- a/libs/content/workspace/src/tab/markdown_editor/bounds.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/bounds.rs
@@ -54,6 +54,11 @@ pub struct Bounds {
     /// * Documents may have no folds.
     /// * Fold contents can nest (an inner fold within an outer section).
     pub folds: Vec<FoldBounds>,
+
+    /// Source range of each collapsed inline image, sorted. Atoms for
+    /// navigation: the cursor steps past a whole image rather than into its
+    /// `![alt](url)` source, and a backspace against one selects it.
+    pub images: Vec<(Grapheme, Grapheme)>,
 }
 
 /// Tag + hidden-contents ranges of one actively folded section. Both act
@@ -92,6 +97,7 @@ impl Default for Bounds {
             wrap_lines: Lines::default(),
             inline_paragraphs: Paragraphs::default(),
             folds: Vec::default(),
+            images: Vec::default(),
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -135,13 +135,31 @@ impl MdEdit {
             }
         }
 
-        result.sort_by(|a, b| {
-            a.top()
-                .total_cmp(&b.top())
-                .then(a.left().total_cmp(&b.left()))
-        });
-
-        result
+        // Reading order: group vertically-overlapping rects into rows, then by
+        // x — so the last rect is the selection's geometric end, where iOS reads
+        // the end handle. A raw top-sort would put a low inter-image space rect
+        // last, dropping the handle on the next image's left edge.
+        let mut by_top: Vec<usize> = (0..result.len()).collect();
+        by_top.sort_by(|&a, &b| result[a].top().total_cmp(&result[b].top()));
+        let mut row_of = vec![0usize; result.len()];
+        let mut row = 0;
+        let mut row_bottom = f32::NEG_INFINITY;
+        for (i, &k) in by_top.iter().enumerate() {
+            if i != 0 && result[k].top() > row_bottom + 0.5 {
+                row += 1;
+                row_bottom = result[k].bottom();
+            } else {
+                row_bottom = row_bottom.max(result[k].bottom());
+            }
+            row_of[k] = row;
+        }
+        let mut ordered: Vec<(usize, Rect)> = result
+            .iter()
+            .enumerate()
+            .map(|(i, r)| (row_of[i], *r))
+            .collect();
+        ordered.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.left().total_cmp(&b.1.left())));
+        ordered.into_iter().map(|(_, r)| r).collect()
     }
 
     /// Draws a cursor at the provided offset with the provided accent color.
@@ -298,15 +316,23 @@ impl MdEdit {
         use crate::tab::markdown_editor::widget::utils::wrap_layout::FragmentContent;
         let frag = self.renderer.fragment_at_offset(offset)?;
         let x = self.renderer.fragment_x(frag, offset);
-        // Image fragments span the image band; `rect.bottom()` is the
-        // row's text baseline. Caret stays text-height around it.
-        let y_range = match &frag.content {
-            FragmentContent::Image { .. } => {
+        let row_h = self.renderer.layout.row_height;
+        // A caret bordering a collapsed image (just before or just after it)
+        // spans the image's height.
+        let border_image = self.renderer.fragments.iter().find(|f| {
+            matches!(f.content, FragmentContent::Image { .. })
+                && (f.source_range.start() == offset || f.source_range.end() == offset)
+        });
+        let y_range = match (border_image, &frag.content) {
+            (Some(image), _) => {
+                egui::Rangef::new(image.rect.top(), image.rect.bottom() + row_h * 0.2)
+            }
+            // interior of an image
+            (None, FragmentContent::Image { .. }) => {
                 let baseline = frag.rect.bottom();
-                let row_h = self.renderer.layout.row_height;
                 egui::Rangef::new(baseline - row_h * 0.8, baseline + row_h * 0.2)
             }
-            _ => frag.rect.y_range(),
+            (None, _) => frag.rect.y_range(),
         };
         let y_range = y_range.expand(self.renderer.layout.row_spacing / 2.);
         Some([Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }])

--- a/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mod.rs
@@ -108,6 +108,7 @@ pub enum Event {
     DecrementBaseFontSize,
     Camera, // launch camera on platform
     ToggleFold,
+    EnterAtom, // select the URL inside the selected atom (e.g. image), revealing its source; the touch path in, since mobile has no arrow keys
 }
 
 impl From<(Grapheme, Grapheme)> for Region {

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -202,6 +202,12 @@ impl<'ast> MdEdit {
                     return response;
                 }
 
+                // Deleting against a collapsed image selects it (a second
+                // press deletes) rather than erasing a char of its source.
+                if self.delete_at_image(region, operations) {
+                    return response;
+                }
+
                 // delete container block prefix
                 let mut handled = || {
                     // must be mostly vanilla backspace

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -1132,11 +1132,16 @@ impl<'ast> MdEdit {
             // Anchor / empty-range fragment: every position maps to
             // its source point.
             frag.source_range.start().into_range()
-        } else if frag.atomic {
-            // Override / atomic fragment: hit-test snaps to the
-            // nearest edge of its source range, returning the full
-            // range so callers that want "select the whole thing"
-            // get that semantics.
+        } else if frag.atomic
+            && !matches!(
+                frag.content,
+                crate::tab::markdown_editor::widget::utils::wrap_layout::FragmentContent::Image { .. }
+            )
+        {
+            // Atomic fragment (marker, indentation): a click selects the whole
+            // range. Images are excluded — clicking *near* one (resolved as the
+            // nearest fragment) places a cursor at its edge; selecting the image
+            // is reserved for a click on it via `handle_image_interactions`.
             frag.source_range
         } else {
             self.renderer.fragment_offset(frag, pos.x).into_range()

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -506,6 +506,9 @@ impl<'ast> MdEdit {
                     }
                 }
             }
+            Event::EnterAtom => {
+                self.enter_at_image(root, operations);
+            }
         }
 
         response

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -570,6 +570,7 @@ impl MdRender {
             self.bounds.inline_paragraphs.clear();
             self.calc_source_lines();
             self.calc_fold_bounds(root);
+            self.calc_image_bounds(root);
             // Populate before compute_bounds: pre_spacing_lines (called
             // from compute_bounds_block_pre_spacing) queries
             // hidden_by_fold, which now expects every node already
@@ -1303,7 +1304,13 @@ impl Editor {
                         // the scrollbar (so taps on the bar don't).
                         let begun = self.edit.scroll_area.begin(ui);
 
-                        let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
+                        let pre = self.edit.pre_render(
+                            ui,
+                            canvas_rect,
+                            scroll_id,
+                            root,
+                            self.keyboard_visible,
+                        );
 
                         self.edit.renderer.fragments.clear();
                         self.edit.renderer.block_boxes.clear();

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -18,9 +18,9 @@ use egui::{Context, EventFilter, Id, Pos2, Rect, Sense, Stroke, Ui, UiBuilder, V
 use lb_rs::model::text::buffer::{self, Buffer};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _, RangeIterExt as _};
 
-use crate::tab::ExtendedOutput as _;
 use crate::tab::markdown_editor::ScrollTarget;
 use crate::tab::markdown_editor::bounds::{BoundExt as _, RangesExt as _};
+use crate::tab::{ContextMenuTarget, ExtendedOutput as _};
 use crate::theme::icons::Icon;
 use crate::theme::palette_v2::ThemeExt as _;
 use crate::widgets::IconButton;
@@ -561,6 +561,7 @@ impl MdEdit {
                         ctx.set_context_menu(
                             self.context_menu_pos(range, rect.intersect(ui.clip_rect()))
                                 .unwrap_or(pos),
+                            ContextMenuTarget::Text,
                         );
                         Some(Region::BoundAt { bound: Bound::Word, location, backwards: true })
                     } else if self.renderer.buffer.current.selection.is_empty() {
@@ -584,13 +585,14 @@ impl MdEdit {
                         ctx.set_context_menu(
                             self.context_menu_pos(selection, rect.intersect(ui.clip_rect()))
                                 .unwrap_or(pos),
+                            ContextMenuTarget::Text,
                         );
                         None
                     } else {
                         Some(Region::Location(location))
                     }
                 } else if response.secondary_clicked() {
-                    ctx.set_context_menu(pos);
+                    ctx.set_context_menu(pos, ContextMenuTarget::Text);
                     None
                 } else if response.drag_stopped() {
                     std::mem::take(&mut self.in_progress_selection).map(Region::from)

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -172,7 +172,9 @@ impl MdEdit {
     pub fn show(&mut self, ui: &mut Ui, rect: Rect, id: Id) {
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
-        let pre = self.pre_render(ui, rect, id, root);
+        // Composer entry point (chat); no keyboard-state plumbing — image
+        // taps there fall back to desktop/cmd gating via `touch_mode`.
+        let pre = self.pre_render(ui, rect, id, root, false);
 
         self.renderer.fragments.clear();
         self.renderer.block_boxes.clear();
@@ -444,6 +446,7 @@ impl MdEdit {
     /// selection. Returns the focus state for [`MdEdit::post_render`].
     pub fn pre_render<'a>(
         &mut self, ui: &mut Ui, rect: Rect, id: Id, root: &'a comrak::nodes::AstNode<'a>,
+        keyboard_visible: bool,
     ) -> PreRenderState {
         self.renderer.dark_mode = ui.style().visuals.dark_mode;
         self.renderer.viewport_height = ui.clip_rect().height();
@@ -475,6 +478,9 @@ impl MdEdit {
         self.renderer.handle_fold_interactions(ui);
 
         let mut ops = Vec::new();
+
+        // image taps → open (cmd / keyboard-hidden) or select
+        self.handle_image_interactions(root, ui, id, keyboard_visible, &mut ops);
 
         // --- context menu (desktop only) -------------------------------------
         ui.ctx()

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -114,6 +114,35 @@ fn image_link_no_break_opportunities_wraps() {
     }
 }
 
+/// Mobile edit-menu "Edit": with the selection exactly covering a collapsed
+/// image atom, `Event::EnterAtom` selects the image's URL — endpoints inside
+/// the syntax reveal the raw markdown, and the likeliest edit becomes
+/// type-to-replace. The only touch path in, since mobile has no arrow keys.
+/// A selection that isn't an image is a no-op.
+#[test]
+fn enter_atom_selects_image_url() {
+    let url = "https://example.com/i.png";
+    let mut ws = TestEditor::new(&format!("![alt]({url})\n"));
+    ws.enter_frame();
+    let img = ws.editor.edit.renderer.bounds.images[0];
+
+    // non-image selection: no-op
+    ws.push(Event::EnterAtom);
+    ws.enter_frame();
+    assert!(!ws.editor.edit.renderer.range_revealed_interior(img));
+
+    // tap-select the atom, then enter it
+    ws.push(Event::Select { region: img.into() });
+    ws.enter_frame();
+    assert!(!ws.editor.edit.renderer.range_revealed_interior(img), "selected, not revealed");
+    ws.push(Event::EnterAtom);
+    ws.enter_frame();
+
+    let sel = ws.editor.edit.renderer.buffer.current.selection;
+    assert_eq!(&ws.editor.edit.renderer.buffer[sel], url, "url selected: {sel:?}");
+    assert!(ws.editor.edit.renderer.range_revealed_interior(img), "source revealed");
+}
+
 #[test]
 fn long_link_stays_inside_render_area() {
     // Long links should wrap at UAX#14 break opportunities (`/`,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/container/mod.rs
@@ -737,6 +737,10 @@ impl<'ast> MdRender {
             .collect();
         levels.reverse();
         let base_x = content_top_left.x - indent * levels.len() as f32;
+
+        let line_inflated = self.row_height_inflated_at_line(node, line);
+        let line_row_height = line_inflated.unwrap_or(row_height);
+
         for (k, level) in levels.iter().enumerate() {
             let range = self.line_own_prefix(level, line);
             if range.is_empty() {
@@ -758,7 +762,11 @@ impl<'ast> MdRender {
                     afs,
                     self.text_format_syntax(),
                 );
-                let baseline_shift = (row_height - afs) * 0.8;
+                let baseline_shift = if line_inflated.is_some() {
+                    (line_row_height - afs) / 2.0
+                } else {
+                    (row_height - afs) * 0.8
+                };
                 // `result.width` is the available width, not the laid-out
                 // marker width; measure the rightmost glyph edge instead.
                 let marker_width = result
@@ -775,14 +783,14 @@ impl<'ast> MdRender {
                 // (vertical nav round-trips).
                 for frag in &mut self.fragments[first..] {
                     frag.rect.min.y = content_top_left.y;
-                    frag.rect.max.y = content_top_left.y + row_height;
+                    frag.rect.max.y = content_top_left.y + line_row_height;
                 }
                 continue;
             }
 
             let rect = Rect::from_min_max(
                 Pos2::new(left, content_top_left.y),
-                Pos2::new(left + indent, content_top_left.y + row_height),
+                Pos2::new(left + indent, content_top_left.y + line_row_height),
             );
             self.fragments.push(Fragment {
                 rect,
@@ -892,8 +900,19 @@ impl<'ast> MdRender {
         while !leaf.data.borrow().value.contains_inlines() {
             leaf = leaf.children().next()?;
         }
-        let leaf_first_line = self.node_first_line(leaf);
-        let leaf_node_line = self.node_line(leaf, leaf_first_line);
+        self.row_height_inflated_at_line(leaf, self.node_first_line(leaf))
+    }
+
+    /// Visual height of `node`'s row at `line` when an inline image inflates
+    /// it; `None` otherwise.
+    pub fn row_height_inflated_at_line(
+        &self, node: &'ast AstNode<'ast>, line: (Grapheme, Grapheme),
+    ) -> Option<f32> {
+        let mut leaf = node;
+        while !leaf.data.borrow().value.contains_inlines() {
+            leaf = leaf.children().next()?;
+        }
+        let leaf_node_line = self.node_line(leaf, line);
         if leaf_node_line.is_empty() || self.disable_images {
             return None;
         }
@@ -901,7 +920,9 @@ impl<'ast> MdRender {
             .descendants()
             .filter(|d| matches!(d.data.borrow().value, NodeValue::Image(_)))
             .filter(|d| leaf_node_line.contains_range(&self.node_range(d), true, true))
-            .filter(|d| !self.node_revealed(d))
+            // Same collapse predicate as `layout_image`, else a selected image
+            // stays tall but the row doesn't inflate, shifting the marker.
+            .filter(|d| !self.range_revealed_interior(self.node_range(d)))
             .filter_map(|d| self.image_logical_size(d).map(|s| s.y))
             .fold(0.0_f32, f32::max);
         let leaf_row_height = self.row_height(leaf);

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -5,6 +5,7 @@ use egui::{self, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 use lb_rs::model::text::operation_types::Operation;
 
+use crate::tab::ExtendedOutput as _;
 use crate::tab::markdown_editor::input::{Advance, Bound, Event, Increment, Location, Region};
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{ImageSpec, Layout};
@@ -191,6 +192,10 @@ impl<'ast> MdEdit {
                         end: Location::Grapheme(node_range.end()),
                     };
                     self.calc_operations(ui.ctx(), root, Event::Select { region }, ops);
+                    // Touch: pop the edit menu (copy/paste) above the image.
+                    if self.renderer.touch_mode {
+                        ui.ctx().set_context_menu(response.rect.center_top());
+                    }
                 }
             }
         }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -5,11 +5,11 @@ use egui::{self, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 use lb_rs::model::text::operation_types::Operation;
 
-use crate::tab::ExtendedOutput as _;
 use crate::tab::markdown_editor::input::{Advance, Bound, Event, Increment, Location, Region};
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{ImageSpec, Layout};
 use crate::tab::markdown_editor::{MdEdit, MdRender};
+use crate::tab::{ContextMenuTarget, ExtendedOutput as _};
 
 impl MdRender {
     pub fn warm_images<'a>(&self, node: &'a comrak::nodes::AstNode<'a>) {
@@ -192,13 +192,49 @@ impl<'ast> MdEdit {
                         end: Location::Grapheme(node_range.end()),
                     };
                     self.calc_operations(ui.ctx(), root, Event::Select { region }, ops);
-                    // Touch: pop the edit menu (copy/paste) above the image.
+                    // Touch: pop the edit menu (copy/edit/paste) above the image.
                     if self.renderer.touch_mode {
-                        ui.ctx().set_context_menu(response.rect.center_top());
+                        ui.ctx()
+                            .set_context_menu(response.rect.center_top(), ContextMenuTarget::Atom);
                     }
                 }
             }
         }
+    }
+
+    /// If the selection exactly covers a collapsed image (i.e. a tap-selected
+    /// atom), select its URL — the selection endpoints inside the syntax
+    /// reveal the source, and the likeliest edit becomes type-to-replace.
+    /// Touch platforms trigger this from the edit menu's "Edit" action — with
+    /// no arrow keys, there's otherwise no way to move the cursor into the
+    /// syntax. True if handled (op pushed).
+    pub fn enter_at_image(
+        &self, root: &'ast AstNode<'ast>, operations: &mut Vec<Operation>,
+    ) -> bool {
+        let selection = self.renderer.buffer.current.selection;
+        for node in root.descendants() {
+            if !matches!(node.data.borrow().value, NodeValue::Image(_)) {
+                continue;
+            }
+            let img = self.renderer.node_range(node);
+            if selection != img || self.renderer.range_revealed_interior(img) {
+                continue;
+            }
+            // `![alt](url)` — the postfix is `](url)`; without an alt there
+            // are no children (no postfix) and the url starts after `![](`.
+            let url_range = match self.renderer.postfix_range(node) {
+                Some(postfix) => (postfix.start() + 2, postfix.end() - 1),
+                None => (img.start() + 4, img.end() - 1),
+            };
+            let url_range = if url_range.0 <= url_range.1 {
+                url_range
+            } else {
+                (img.start() + 2, img.start() + 2) // degenerate: interior caret
+            };
+            operations.push(Operation::Select(url_range));
+            return true;
+        }
+        false
     }
 
     /// Backspace/forward-delete against a collapsed image selects it rather

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -1,12 +1,14 @@
 use std::f32;
 
-use comrak::nodes::AstNode;
+use comrak::nodes::{AstNode, NodeValue};
 use egui::{self, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
+use lb_rs::model::text::operation_types::Operation;
 
-use crate::tab::markdown_editor::MdRender;
+use crate::tab::markdown_editor::input::{Advance, Bound, Event, Increment, Location, Region};
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{ImageSpec, Layout};
+use crate::tab::markdown_editor::{MdEdit, MdRender};
 
 impl MdRender {
     pub fn warm_images<'a>(&self, node: &'a comrak::nodes::AstNode<'a>) {
@@ -100,7 +102,8 @@ impl<'ast> MdRender {
     ) {
         let node_range = self.node_range(node);
         let single_line = range.contains_range(&node_range, true, true);
-        let collapsed_size = (!self.disable_images && !self.node_revealed(node) && single_line)
+        let revealed = self.range_revealed_interior(node_range);
+        let collapsed_size = (!self.disable_images && !revealed && single_line)
             .then(|| self.image_logical_size(node))
             .flatten();
         let Some(size) = collapsed_size else {
@@ -111,6 +114,8 @@ impl<'ast> MdRender {
             comrak::nodes::NodeValue::Image(link) => link.url.clone(),
             _ => return,
         };
+        // Always interactive: a plain tap selects, a cmd/keyboard-hidden tap opens.
+        layout.interaction_open(Self::image_interaction_id_salt(node_range), egui::Sense::click());
         layout.push_image(ImageSpec {
             advance: size.x,
             ascent: size.y,
@@ -118,6 +123,106 @@ impl<'ast> MdRender {
             source_range: node_range,
             url,
         });
+        layout.interaction_close();
+    }
+
+    /// Interaction-response salt for a rendered image; distinct from
+    /// [`Self::link_interaction_id_salt`] so the collapsed-image and
+    /// revealed-link handlers don't collide.
+    pub fn image_interaction_id_salt(node_range: (Grapheme, Grapheme)) -> egui::Id {
+        egui::Id::new(("md_image", node_range))
+    }
+
+    /// Recompute [`super::super::super::bounds::Bounds::images`] — the source
+    /// range of every inline image. Empty when images render raw (disabled),
+    /// since then the source is plain editable text. Depends on text only.
+    pub fn calc_image_bounds<'a>(&mut self, root: &'a AstNode<'a>) {
+        let mut images = Vec::new();
+        if !self.disable_images {
+            for node in root.descendants() {
+                if matches!(node.data.borrow().value, NodeValue::Image(_)) {
+                    images.push(self.node_range(node));
+                }
+            }
+        }
+        images.sort_unstable();
+        self.bounds.images = images;
+    }
+}
+
+impl<'ast> MdEdit {
+    /// Open or select an image clicked this frame: a cmd-click (desktop) or
+    /// keyboard-hidden tap (mobile) opens its target, a plain tap selects it.
+    /// Adds the rect to `touch_consuming_rects` so iOS routes the tap here.
+    pub fn handle_image_interactions(
+        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, keyboard_visible: bool,
+        ops: &mut Vec<Operation>,
+    ) {
+        let open_image = if self.renderer.touch_mode {
+            !keyboard_visible
+        } else {
+            ui.ctx().input(|i| i.modifiers.command)
+        };
+        for node in root.descendants() {
+            let url = match &node.data.borrow().value {
+                NodeValue::Image(link) => link.url.clone(),
+                _ => continue,
+            };
+            let node_range = self.renderer.node_range(node);
+            let salt = MdRender::image_interaction_id_salt(node_range);
+            let response = match self.renderer.interaction_responses.get(&ui.id().with(salt)) {
+                Some(r) => r.clone(), // clone to release the `renderer` borrow
+                None => continue,
+            };
+
+            self.renderer.touch_consuming_rects.push(response.rect);
+
+            if open_image && response.hovered() {
+                ui.ctx()
+                    .output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
+            }
+            if response.clicked() {
+                if open_image {
+                    self.renderer.open_resolved_link(&url, ui.ctx());
+                } else {
+                    ui.memory_mut(|m| m.request_focus(id));
+                    let region = Region::BetweenLocations {
+                        start: Location::Grapheme(node_range.start()),
+                        end: Location::Grapheme(node_range.end()),
+                    };
+                    self.calc_operations(ui.ctx(), root, Event::Select { region }, ops);
+                }
+            }
+        }
+    }
+
+    /// Backspace/forward-delete against a collapsed image selects it rather
+    /// than erasing a character of its source; a second press then deletes the
+    /// selection. Mirrors [`Self::delete_at_fold`]'s non-destructive edit. True
+    /// if handled (ops pushed).
+    pub fn delete_at_image(&self, region: Region, operations: &mut Vec<Operation>) -> bool {
+        let Region::SelectionOrAdvance {
+            advance: Advance::Next(Bound::Word) | Advance::By(Increment::Char),
+            backwards,
+        } = region
+        else {
+            return false;
+        };
+        // selection must be empty
+        let Some(offset) = self.renderer.selection_offset() else {
+            return false;
+        };
+        for &img in &self.renderer.bounds.images {
+            if self.renderer.range_revealed_interior(img) {
+                continue;
+            }
+            let against = if backwards { offset == img.end() } else { offset == img.start() };
+            if against {
+                operations.push(Operation::Select(img));
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link.rs
@@ -127,6 +127,18 @@ impl<'ast> MdRender {
         self.link_resolver.resolve_link(url)
     }
 
+    /// Open `url` in a new tab, navigating in-app for internal file links and
+    /// to the browser otherwise. Shared by link and image interaction handlers.
+    pub fn open_resolved_link(&self, url: &str, ctx: &egui::Context) {
+        match self.resolve_link(url) {
+            Some(ResolvedLink::File(file_id)) => ctx.open_file(file_id, true),
+            Some(ResolvedLink::External(target)) => {
+                ctx.open_url(egui::OpenUrl { url: target, new_tab: true })
+            }
+            None => ctx.open_url(egui::OpenUrl { url: url.into(), new_tab: true }),
+        }
+    }
+
     pub fn link_state_for_url(&self, url: &str) -> LinkState {
         self.link_resolver.link_state(url)
     }
@@ -240,15 +252,7 @@ impl<'ast> MdRender {
                         ui.ctx().open_file(file_id, true);
                     }
                 } else {
-                    match self.resolve_link(&url) {
-                        Some(ResolvedLink::File(file_id)) => ui.ctx().open_file(file_id, true),
-                        Some(ResolvedLink::External(target)) => ui
-                            .ctx()
-                            .open_url(egui::OpenUrl { url: target, new_tab: true }),
-                        None => ui
-                            .ctx()
-                            .open_url(egui::OpenUrl { url: url.clone(), new_tab: true }),
-                    }
+                    self.open_resolved_link(&url, ui.ctx());
                 }
                 return;
             }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/mod.rs
@@ -120,6 +120,15 @@ impl<'ast> MdRender {
             .any(|rr| range.intersects(&rr, allow_empty))
     }
 
+    /// True if any reveal range has an endpoint *strictly inside* `range`.
+    /// Unlike [`Self::range_revealed`], bordering or wholly enclosing it
+    /// (tap-select, select-all) doesn't count — only a cursor/end in the interior.
+    pub fn range_revealed_interior(&self, range: (Grapheme, Grapheme)) -> bool {
+        self.reveal_ranges().any(|rr| {
+            range.contains(rr.start(), false, false) || range.contains(rr.end(), false, false)
+        })
+    }
+
     /// Returns true if `range` contains any reveal range.
     pub fn range_contains_revealed(
         &self, range: (Grapheme, Grapheme), allow_empty_range: bool, allow_empty_selection: bool,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/toolbar.rs
@@ -1109,6 +1109,7 @@ impl<'ast> Editor {
         // pre-render work
         self.edit.renderer.calc_source_lines();
         self.edit.renderer.calc_fold_bounds(root);
+        self.edit.renderer.calc_image_bounds(root);
         self.edit.renderer.populate_hidden_by_fold(root);
         self.edit.renderer.compute_bounds(root);
         self.edit.renderer.bounds.inline_paragraphs.sort();
@@ -1145,6 +1146,7 @@ impl<'ast> Editor {
         // pre-render work
         self.edit.renderer.calc_source_lines();
         self.edit.renderer.calc_fold_bounds(root);
+        self.edit.renderer.calc_image_bounds(root);
         self.edit.renderer.populate_hidden_by_fold(root);
         self.edit.renderer.compute_bounds(root);
         self.edit.renderer.bounds.inline_paragraphs.sort();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1791,6 +1791,28 @@ impl MdRender {
 
                 if let FragmentContent::Image { url } = &frag.content {
                     self.embeds.show(ui, url, screen_rect);
+
+                    // The image's opaque fill hides the selection slot behind it,
+                    // so tint it when the selection covers it (a partial overlap
+                    // reveals it to raw text instead). iOS draws this natively.
+                    if ui.ctx().os() != egui::os::OperatingSystem::IOS {
+                        use crate::theme::palette_v2::ThemeExt as _;
+                        let sel = self
+                            .in_progress_selection
+                            .unwrap_or(self.buffer.current.selection);
+                        let sr = frag.source_range;
+                        if !sel.is_empty() && sel.contains_range(&sr, true, true) {
+                            let theme = self.ctx.get_lb_theme();
+                            let accent = theme.bg().get_color(theme.prefs().primary);
+                            let tint = egui::Color32::from_rgba_unmultiplied(
+                                accent.r(),
+                                accent.g(),
+                                accent.b(),
+                                90,
+                            );
+                            ui.painter().rect_filled(screen_rect, 2.0, tint);
+                        }
+                    }
                 }
 
                 // Collected here, painted after the text callback (#4617).
@@ -1921,18 +1943,26 @@ impl MdRender {
     /// `pos_to_range`'s atomic branch). Returns `None` only when
     /// `self.fragments` is empty.
     pub fn closest_fragment_at_pos(&self, pos: Pos2) -> Option<usize> {
+        if self.fragments.is_empty() {
+            return None;
+        }
+
+        // y-distance is to the fragment's *row*, not the fragment: else a tall
+        // image captures clicks across its full height, above its line's short
+        // baseline text. `fragment_row_spans` groups each line into one row.
+        let row_span = self.fragment_row_spans();
+
         let mut closest: Option<usize> = None;
         let mut closest_dist = (f32::INFINITY, f32::INFINITY);
         for (i, f) in self.fragments.iter().enumerate() {
             if f.rect.contains(pos) {
                 return Some(i);
             }
-            let y_dist = if f.rect.y_range().contains(pos.y) {
+            let (rtop, rbottom) = row_span[i];
+            let y_dist = if rtop <= pos.y && pos.y <= rbottom {
                 0.0
             } else {
-                (pos.y - f.rect.top())
-                    .abs()
-                    .min((pos.y - f.rect.bottom()).abs())
+                (pos.y - rtop).abs().min((pos.y - rbottom).abs())
             };
             let x_dist = if f.rect.x_range().contains(pos.x) {
                 0.0
@@ -1951,6 +1981,35 @@ impl MdRender {
             }
         }
         closest
+    }
+
+    /// Each fragment's visual-row `(top, bottom)`: maximal runs of vertically-
+    /// overlapping fragments, so a tall image bridges its row's marker and
+    /// baseline text. Rows never overlap, so an interval-merge over tops finds them.
+    fn fragment_row_spans(&self) -> Vec<(f32, f32)> {
+        let mut order: Vec<usize> = (0..self.fragments.len()).collect();
+        order.sort_by(|&a, &b| {
+            self.fragments[a]
+                .rect
+                .top()
+                .total_cmp(&self.fragments[b].rect.top())
+        });
+        let mut spans = vec![(0.0f32, 0.0f32); self.fragments.len()];
+        let mut i = 0;
+        while i < order.len() {
+            let top = self.fragments[order[i]].rect.top();
+            let mut bottom = self.fragments[order[i]].rect.bottom();
+            let start = i;
+            i += 1;
+            while i < order.len() && self.fragments[order[i]].rect.top() <= bottom {
+                bottom = bottom.max(self.fragments[order[i]].rect.bottom());
+                i += 1;
+            }
+            for &idx in &order[start..i] {
+                spans[idx] = (top, bottom);
+            }
+        }
+        spans
     }
 
     /// Cursor screen x for `offset` within `fragment`. For atomic

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -494,12 +494,22 @@ impl Workspace {
     }
 }
 
+/// What the mobile context menu was popped over, so the platform can offer
+/// target-specific actions (e.g. "Edit" over an atom — an image or link
+/// preview whose source is only reachable via `EnterAtom` on touch).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ContextMenuTarget {
+    #[default]
+    Text,
+    Atom,
+}
+
 // todo: find a better place for the code that attaches additional things to egui::Context
 pub trait ExtendedOutput {
     fn set_virtual_keyboard_shown(&self, enabled: bool);
     fn pop_virtual_keyboard_shown(&self) -> Option<bool>;
-    fn set_context_menu(&self, pos: egui::Pos2);
-    fn pop_context_menu(&self) -> Option<egui::Pos2>;
+    fn set_context_menu(&self, pos: egui::Pos2, target: ContextMenuTarget);
+    fn pop_context_menu(&self) -> Option<(egui::Pos2, ContextMenuTarget)>;
     fn open_file(&self, id: Uuid, new_tab: bool);
     fn pop_open_files(&self) -> Vec<(Uuid, bool)>;
 }
@@ -516,13 +526,13 @@ impl ExtendedOutput for egui::Context {
         self.memory_mut(|m| m.data.remove_temp(Id::new("virtual_keyboard_shown")))
     }
 
-    fn set_context_menu(&self, pos: egui::Pos2) {
+    fn set_context_menu(&self, pos: egui::Pos2, target: ContextMenuTarget) {
         self.memory_mut(|m| {
-            m.data.insert_temp(Id::new("context_menu"), pos);
+            m.data.insert_temp(Id::new("context_menu"), (pos, target));
         })
     }
 
-    fn pop_context_menu(&self) -> Option<egui::Pos2> {
+    fn pop_context_menu(&self) -> Option<(egui::Pos2, ContextMenuTarget)> {
         self.memory_mut(|m| m.data.remove_temp(Id::new("context_menu")))
     }
 


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4847

Makes inline images behave as first class atomic objects in the markdown editor and fixes hit-test bugs due to mixed height content.
* images can be selected copied & deleted as a unit
* syntax only revealed when cursored into with right/left arrow
* on desktop: click an image to select it or cmd+click it to open it 
* on mobile: tap an image to select it with the keyboard showing or tap to open it with the keyboard hidden

<img width="800" height="502" alt="CleanShot 2026-06-29 at 22 50 53" src="https://github.com/user-attachments/assets/d383bea1-2de9-476f-b0f0-74f3974714a2" />

