### PR TITLE
chat: agent tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9564,6 +9564,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "similar",
  "syntect",
  "syntect-assets",
  "time",

--- a/libs/content/workspace/Cargo.toml
+++ b/libs/content/workspace/Cargo.toml
@@ -41,6 +41,7 @@ resvg = "0.41.0"
 scraper = "0.14"
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.82"
+similar = "2.6.0"
 content_inspector = "0.2"
 syntect-assets = { default-features = false, version = "0.23", features = [
     "regex-fancy",

--- a/libs/content/workspace/src/tab/chat/anthropic.rs
+++ b/libs/content/workspace/src/tab/chat/anthropic.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::backend::{ChatMsg, CompletionReq, ModelInfo};
+use super::backend::{ChatMsg, Completion, CompletionReq, ModelInfo, ToolCall, parse_tool_args};
 use super::settings::Provider;
 
 /// Total request attempts (initial + backoff retries on 429/5xx).
@@ -47,6 +47,11 @@ struct Event {
     kind: String,
     #[serde(default)]
     message: Option<MessageStart>,
+    /// Which content block a `content_block_*` event belongs to.
+    #[serde(default)]
+    index: Option<usize>,
+    #[serde(default)]
+    content_block: Option<ContentBlockStart>,
     #[serde(default)]
     delta: Option<Delta>,
     #[serde(default)]
@@ -61,10 +66,25 @@ struct MessageStart {
     usage: Option<WireUsage>,
 }
 
+/// A new content block opening. Tool-use blocks carry the call's id and
+/// name here; their arguments follow as `input_json_delta` fragments.
+#[derive(Deserialize)]
+struct ContentBlockStart {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
 #[derive(Deserialize)]
 struct Delta {
     #[serde(default)]
     text: Option<String>,
+    /// A fragment of a tool-use block's argument JSON.
+    #[serde(default)]
+    partial_json: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -88,13 +108,39 @@ struct WireError {
 impl AnthropicBackend {
     pub(super) async fn complete(
         &self, req: CompletionReq, deltas: UnboundedSender<String>,
-    ) -> Result<Usage, String> {
+    ) -> Result<Completion, String> {
         let messages: Vec<_> = req
             .messages
             .iter()
             .map(|msg| match msg {
                 ChatMsg::User(text) => json!({ "role": "user", "content": text }),
-                ChatMsg::Assistant(text) => json!({ "role": "assistant", "content": text }),
+                ChatMsg::Assistant { text, tool_calls } if !tool_calls.is_empty() => {
+                    // A call turn is a content-block array; an empty text
+                    // block is invalid on this wire, so it's included only
+                    // when the model actually said something.
+                    let mut blocks = Vec::new();
+                    if !text.is_empty() {
+                        blocks.push(json!({ "type": "text", "text": text }));
+                    }
+                    for c in tool_calls {
+                        blocks.push(json!({
+                            "type": "tool_use", "id": c.id, "name": c.name, "input": c.args,
+                        }));
+                    }
+                    json!({ "role": "assistant", "content": blocks })
+                }
+                ChatMsg::Assistant { text, .. } => {
+                    json!({ "role": "assistant", "content": text })
+                }
+                ChatMsg::ToolResult { id, content, is_error } => {
+                    let mut block = json!({
+                        "type": "tool_result", "tool_use_id": id, "content": content,
+                    });
+                    if *is_error {
+                        block["is_error"] = json!(true);
+                    }
+                    json!({ "role": "user", "content": [block] })
+                }
             })
             .collect();
 
@@ -111,6 +157,24 @@ impl AnthropicBackend {
         if !req.system.is_empty() {
             body["system"] = json!(req.system);
         }
+        if !req.tools.is_empty() {
+            body["tools"] = req
+                .tools
+                .iter()
+                .map(|t| {
+                    json!({
+                        "name": t.name,
+                        "description": t.description,
+                        "input_schema": t.parameters,
+                        "strict": true,
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into();
+            // One call at a time — matches the harness's single-decision
+            // approval channel.
+            body["tool_choice"] = json!({ "type": "auto", "disable_parallel_tool_use": true });
+        }
         // Anthropic controls reasoning depth through effort on adaptive
         // thinking (Opus 4.6+), not `reasoning_effort`. Values: low / medium
         // / high / xhigh / max.
@@ -123,6 +187,11 @@ impl AnthropicBackend {
         // retry a couple of times before surfacing. Always pre-stream, so a
         // retry can't duplicate delivered text.
         let mut attempts: u32 = 0;
+        // `strict: true` needs a model that supports it (and a conforming
+        // schema). A model that rejects the key 400s naming it — strip it
+        // from every tool and re-send once, the way the OpenAI adapter falls
+        // back to `plain_tools`.
+        let mut strict_stripped = false;
         let resp = loop {
             attempts += 1;
             let resp = self
@@ -150,16 +219,44 @@ impl AnthropicBackend {
                 tokio::time::sleep(std::time::Duration::from_secs(wait)).await;
                 continue;
             }
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("{status}: {}", body.chars().take(500).collect::<String>()));
+            let error_body = resp.text().await.unwrap_or_default();
+            if !strict_stripped
+                && !req.tools.is_empty()
+                && status.as_u16() == 400
+                && error_body.contains("strict")
+            {
+                strict_stripped = true;
+                if let Some(tools) = body["tools"].as_array_mut() {
+                    for tool in tools {
+                        if let Some(obj) = tool.as_object_mut() {
+                            obj.remove("strict");
+                        }
+                    }
+                }
+                continue;
+            }
+            return Err(format!("{status}: {}", error_body.chars().take(500).collect::<String>()));
         };
 
         // SSE: `message_start` carries input/cache usage, `content_block_delta`
         // the text, `message_delta` the output count, `message_stop` the end.
-        // The buffer stays raw bytes, decoded per complete line — network
-        // chunks split mid-character, and decoding a chunk at a time would
-        // corrupt multi-byte glyphs into � (and persist them).
+        // Tool calls open as `content_block_start` (id + name) and accumulate
+        // argument JSON through `input_json_delta` fragments keyed by block
+        // index. The buffer stays raw bytes, decoded per complete line —
+        // network chunks split mid-character, and decoding a chunk at a time
+        // would corrupt multi-byte glyphs into � (and persist them).
         let mut usage = Usage::default();
+        // Tool-use blocks in progress, keyed by block index: (id, name, args).
+        let mut blocks: std::collections::BTreeMap<usize, (String, String, String)> =
+            Default::default();
+        let finish = |blocks: std::collections::BTreeMap<usize, (String, String, String)>,
+                      usage: Usage| {
+            let tool_calls = blocks
+                .into_values()
+                .map(|(id, name, args)| ToolCall { id, name, args: parse_tool_args(&args) })
+                .collect();
+            Completion { tool_calls, usage }
+        };
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();
         loop {
@@ -185,10 +282,33 @@ impl AnthropicBackend {
                             usage.cache_write = u.cache_creation_input_tokens.unwrap_or(0);
                         }
                     }
+                    "content_block_start" => {
+                        if let Some(block) = event.content_block {
+                            if block.kind == "tool_use" {
+                                blocks.insert(
+                                    event.index.unwrap_or(0),
+                                    (
+                                        block.id.unwrap_or_default(),
+                                        block.name.unwrap_or_default(),
+                                        String::new(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
                     "content_block_delta" => {
-                        if let Some(text) = event.delta.and_then(|d| d.text) {
-                            if !text.is_empty() {
-                                let _ = deltas.send(text);
+                        if let Some(delta) = event.delta {
+                            if let Some(text) = delta.text {
+                                if !text.is_empty() {
+                                    let _ = deltas.send(text);
+                                }
+                            }
+                            if let Some(fragment) = delta.partial_json {
+                                if let Some((_, _, args)) =
+                                    event.index.and_then(|i| blocks.get_mut(&i))
+                                {
+                                    args.push_str(&fragment);
+                                }
                             }
                         }
                     }
@@ -197,7 +317,7 @@ impl AnthropicBackend {
                             usage.output = u.output_tokens.unwrap_or(usage.output);
                         }
                     }
-                    "message_stop" => return Ok(usage),
+                    "message_stop" => return Ok(finish(blocks, usage)),
                     "error" => {
                         let message = event.error.map(|e| e.message).unwrap_or_default();
                         return Err(format!("provider error: {message}"));
@@ -206,7 +326,7 @@ impl AnthropicBackend {
                 }
             }
         }
-        Ok(usage)
+        Ok(finish(blocks, usage))
     }
 }
 
@@ -287,7 +407,19 @@ mod tests {
          data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n\
          data: {\"type\":\"message_stop\"}\n\n";
 
-    fn complete(base_url: &str) -> (Result<Usage, String>, Vec<String>) {
+    fn complete(base_url: &str) -> (Result<Completion, String>, Vec<String>) {
+        let req = CompletionReq {
+            system: "system".into(),
+            messages: vec![ChatMsg::User("hi".into())],
+            max_tokens: 100,
+            tools: vec![],
+        };
+        complete_req(base_url, req)
+    }
+
+    fn complete_req(
+        base_url: &str, req: CompletionReq,
+    ) -> (Result<Completion, String>, Vec<String>) {
         let backend = anthropic(&Provider {
             name: "anthropic".into(),
             display_name: None,
@@ -297,11 +429,6 @@ mod tests {
             api_key: Some("test-key".into()),
             effort: None,
         });
-        let req = CompletionReq {
-            system: "system".into(),
-            messages: vec![ChatMsg::User("hi".into())],
-            max_tokens: 100,
-        };
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -358,6 +485,7 @@ mod tests {
             system: "s".into(),
             messages: vec![ChatMsg::User("hi".into())],
             max_tokens: 100,
+            tools: vec![],
         };
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         tokio::runtime::Builder::new_current_thread()
@@ -375,9 +503,103 @@ mod tests {
     fn streams_deltas_and_usage() {
         let base = serve_once(SSE_ANTHROPIC);
         let (result, deltas) = complete(&base);
-        let usage = result.unwrap();
+        let completion = result.unwrap();
         assert_eq!(deltas.join(""), "Hello");
+        assert!(completion.tool_calls.is_empty());
+        let usage = completion.usage;
         assert_eq!((usage.input, usage.output, usage.cache_read, usage.cache_write), (10, 2, 6, 4));
+    }
+
+    /// Tools ride the wire in the native shape (`input_schema`, `strict`)
+    /// with parallel calls disabled; call turns re-serialize as content-block
+    /// arrays and results as `tool_result` user turns, with `is_error` only
+    /// when set.
+    #[test]
+    fn tools_and_call_turns_ride_the_wire() {
+        let (base, body_rx) = super::super::openai::mock::serve_capturing(SSE_ANTHROPIC);
+        let req = CompletionReq {
+            system: "s".into(),
+            messages: vec![
+                ChatMsg::User("add milk".into()),
+                ChatMsg::Assistant {
+                    text: String::new(),
+                    tool_calls: vec![ToolCall {
+                        id: "toolu_1".into(),
+                        name: "read_note".into(),
+                        args: json!({ "path": "/todo.md" }),
+                    }],
+                },
+                ChatMsg::ToolResult {
+                    id: "toolu_1".into(),
+                    content: "error: not found".into(),
+                    is_error: true,
+                },
+            ],
+            max_tokens: 100,
+            tools: vec![super::super::backend::ToolSchema {
+                name: "read_note",
+                description: "Read a note.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } },
+                    "required": ["path"],
+                    "additionalProperties": false,
+                }),
+            }],
+        };
+        let (result, _) = complete_req(&base, req);
+        assert!(result.is_ok(), "{result:?}");
+        let body: serde_json::Value = serde_json::from_str(&body_rx.recv().unwrap()).unwrap();
+        assert_eq!(body["tools"][0]["name"], "read_note");
+        assert!(body["tools"][0].get("input_schema").is_some());
+        assert_eq!(body["tools"][0]["strict"], true);
+        assert_eq!(body["tool_choice"]["type"], "auto");
+        assert_eq!(body["tool_choice"]["disable_parallel_tool_use"], true);
+        // Call turn: no empty text block, one tool_use block with the parsed
+        // input object (not a string).
+        let call_turn = &body["messages"][1]["content"];
+        assert_eq!(call_turn.as_array().unwrap().len(), 1);
+        assert_eq!(call_turn[0]["type"], "tool_use");
+        assert_eq!(call_turn[0]["id"], "toolu_1");
+        assert_eq!(call_turn[0]["input"]["path"], "/todo.md");
+        // Result turn: a user message wrapping one tool_result block.
+        let result_turn = &body["messages"][2];
+        assert_eq!(result_turn["role"], "user");
+        assert_eq!(result_turn["content"][0]["type"], "tool_result");
+        assert_eq!(result_turn["content"][0]["tool_use_id"], "toolu_1");
+        assert_eq!(result_turn["content"][0]["is_error"], true);
+    }
+
+    /// A tool-use block opens with id + name, accumulates argument JSON
+    /// through `input_json_delta` fragments, and lands as a parsed call at
+    /// message_stop — while text deltas keep streaming.
+    #[test]
+    fn tool_use_accumulates_across_fragments() {
+        const SSE_TOOL: &str = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n\
+             data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n\n\
+             data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+             data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Checking.\"}}\n\n\
+             data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_9\",\"name\":\"read_note\",\"input\":{}}}\n\n\
+             data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\"}}\n\n\
+             data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"/todo.md\\\"}\"}}\n\n\
+             data: {\"type\":\"content_block_stop\",\"index\":1}\n\n\
+             data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":7}}\n\n\
+             data: {\"type\":\"message_stop\"}\n\n";
+        // Split inside the second argument fragment.
+        let split_at = SSE_TOOL.find("/todo.md").unwrap() + 3;
+        let base = super::super::openai::mock::serve_split(SSE_TOOL, split_at);
+        let (result, deltas) = complete(&base);
+        let completion = result.unwrap();
+        assert_eq!(deltas.join(""), "Checking.");
+        assert_eq!(
+            completion.tool_calls,
+            vec![ToolCall {
+                id: "toolu_9".into(),
+                name: "read_note".into(),
+                args: json!({ "path": "/todo.md" }),
+            }]
+        );
+        assert_eq!(completion.usage.output, 7);
     }
 
     /// Same guarantee as the OpenAI backend: a chunk boundary mid-character

--- a/libs/content/workspace/src/tab/chat/backend.rs
+++ b/libs/content/workspace/src/tab/chat/backend.rs
@@ -1,8 +1,7 @@
 //! Provider-neutral completion backend for the chat agent. Streaming-first:
 //! a backend delivers text deltas as they arrive and returns the turn's
-//! usage when the stream ends. Tool calls will extend [`CompletionReq`] and
-//! the delta channel in a later increment; on-device inference slots in as
-//! another [`Backend`] variant.
+//! outcome — any tool calls the model requested, plus usage — when the
+//! stream ends. On-device inference slots in as another [`Backend`] variant.
 
 use lb_rs::model::chat::Usage;
 use tokio::sync::mpsc::UnboundedSender;
@@ -15,13 +14,68 @@ pub struct CompletionReq {
     pub system: String,
     pub messages: Vec<ChatMsg>,
     pub max_tokens: u32,
+    /// Tools advertised to the model. Keep the set and order stable across a
+    /// conversation — tools render ahead of everything else in the provider's
+    /// prompt, so any change invalidates its cache.
+    pub tools: Vec<ToolSchema>,
 }
 
 /// A transcript message in model context.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ChatMsg {
     User(String),
-    Assistant(String),
+    /// A model turn: streamed text plus any tool calls it requested.
+    Assistant {
+        text: String,
+        tool_calls: Vec<ToolCall>,
+    },
+    /// One tool call's outcome, echoed back under the provider's call id.
+    ToolResult {
+        id: String,
+        content: String,
+        is_error: bool,
+    },
+}
+
+/// A tool the model may call: name, guidance, and a JSON Schema for its
+/// arguments (flat object, `additionalProperties: false` — strict-compatible
+/// on both wire dialects).
+pub struct ToolSchema {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub parameters: serde_json::Value,
+}
+
+/// One tool invocation requested by the model.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ToolCall {
+    /// Provider-assigned call id; the matching [`ChatMsg::ToolResult`] echoes
+    /// it.
+    pub id: String,
+    pub name: String,
+    /// Parsed arguments. When the model streams malformed argument JSON the
+    /// text arrives as `{"raw": <text>}`, so dispatch can answer with a
+    /// steering error instead of the turn dying.
+    pub args: serde_json::Value,
+}
+
+/// Parse a tool call's accumulated argument string into [`ToolCall::args`],
+/// the same way on both wire dialects: empty text is no arguments (`{}`),
+/// and malformed JSON is wrapped raw (`{"raw": <text>}`) so dispatch answers
+/// with a steering error instead of the turn dying.
+pub fn parse_tool_args(args: &str) -> serde_json::Value {
+    if args.trim().is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_str(args).unwrap_or_else(|_| serde_json::json!({ "raw": args }))
+    }
+}
+
+/// A finished (unstopped) completion.
+#[derive(Debug)]
+pub struct Completion {
+    pub tool_calls: Vec<ToolCall>,
+    pub usage: Usage,
 }
 
 /// One entry from a provider's `/models` listing. `id` is what goes on the
@@ -52,12 +106,12 @@ pub enum Backend {
 
 impl Backend {
     /// Run one completion, sending each text delta on `deltas` as it arrives.
-    /// Returns the turn's token usage once the stream completes. The caller
-    /// accumulates deltas itself, so cancelling (dropping) this future keeps
-    /// the text streamed so far.
+    /// Returns the turn's tool calls and token usage once the stream
+    /// completes. The caller accumulates deltas itself, so cancelling
+    /// (dropping) this future keeps the text streamed so far.
     pub async fn complete(
         &self, req: CompletionReq, deltas: UnboundedSender<String>,
-    ) -> Result<Usage, String> {
+    ) -> Result<Completion, String> {
         match self {
             Backend::Anthropic(b) => b.complete(req, deltas).await,
             Backend::OpenAi(b) => b.complete(req, deltas).await,

--- a/libs/content/workspace/src/tab/chat/config.rs
+++ b/libs/content/workspace/src/tab/chat/config.rs
@@ -8,12 +8,22 @@ use super::*;
 
 impl Chat {
     /// The provider the next turn runs with: this user's per-chat selection
-    /// (latest config entry) resolved against the *cached* provider list.
-    /// Pure — no file I/O, so it's safe on the UI thread every time config
-    /// changes. The list is refreshed by the background loader.
+    /// (latest config entry), or — for a chat with none — the sticky last-used
+    /// default, resolved against the *cached* provider list. Pure — no file
+    /// I/O (both the list and the default are cached by the background loader),
+    /// so it's safe on the UI thread every time config changes.
     pub(super) fn resolve_provider(&self) -> Option<settings::Provider> {
         let selection = latest_selection(&self.entries, &self.account.username);
-        let mut provider = settings::resolve(self.providers.clone(), selection.as_ref())?;
+        let mut provider = match &selection {
+            // An explicit per-chat pick resolves strictly — a selection naming
+            // a missing provider yields None rather than silently rerouting.
+            Some(sel) => settings::resolve(self.providers.clone(), Some(sel))?,
+            // A new chat inherits the sticky last-used default; if that names a
+            // provider that's since gone, degrade to the alphabetically-first
+            // one rather than leaving the fresh chat with nothing.
+            None => settings::resolve(self.providers.clone(), self.default_selection.as_ref())
+                .or_else(|| settings::resolve(self.providers.clone(), None))?,
+        };
         // Per-chat effort overrides the file default, but only where effort
         // applies — a stored pick shouldn't leak onto a non-reasoning model
         // the chat later switched to. `EFFORT_AUTO` clears it.
@@ -71,6 +81,7 @@ impl Chat {
             let loaded = LoadedConfig {
                 providers: settings::load(&core),
                 system_prompt: settings::system_prompt(&core),
+                default_selection: settings::load_default(&core),
             };
             let _ = tx.send(loaded);
             ctx.request_repaint();
@@ -90,6 +101,7 @@ impl Chat {
                 let before = self.provider.clone();
                 self.providers = loaded.providers;
                 self.system_prompt = loaded.system_prompt;
+                self.default_selection = loaded.default_selection;
                 self.config_loaded = true;
                 self.provider = self.resolve_provider();
                 if self.provider != before {
@@ -105,8 +117,14 @@ impl Chat {
     /// selection syncs across this user's devices; credentials never do. An
     /// empty `model` means the provider's file default.
     pub(super) fn write_selection(&mut self, provider: String, model: String) {
+        let selection = lb_rs::model::chat::ModelSelection { provider, model };
+        // Sticky last-used: mirror the pick to the synced global default so the
+        // next new chat starts here. Also updated in memory so a new chat
+        // opened before the next config reload already sees it.
+        settings::write_default(&self.core, &selection);
+        self.default_selection = Some(selection.clone());
         self.write_config(lb_rs::model::chat::ChatConfig {
-            model: Some(lb_rs::model::chat::ModelSelection { provider, model }),
+            model: Some(selection),
             ..Default::default()
         });
     }

--- a/libs/content/workspace/src/tab/chat/config.rs
+++ b/libs/content/workspace/src/tab/chat/config.rs
@@ -30,15 +30,21 @@ impl Chat {
     /// signal): a listing means reachable and authenticated.
     pub(super) fn onboard_stage(&self) -> Option<Onboard> {
         let Some(p) = &self.provider else { return Some(Onboard::Choose) };
-        // A provider still carrying the template placeholder was never set up:
-        // treat it as unconfigured and offer the chooser, not a dead-end status.
-        if p.api_key.as_deref() == Some(KEY_PLACEHOLDER) {
-            return Some(Onboard::Choose);
-        }
         let key = (p.name.clone(), p.base_url.clone());
-        if let Some((_, e)) = self.models_err.as_ref().filter(|(k, _)| *k == key) {
+        let err = self
+            .models_err
+            .as_ref()
+            .filter(|(k, _)| *k == key)
+            .map(|(_, e)| e);
+        // A real key the server rejected — the composer's "fix key" button.
+        // (An unconfigured provider never resolves here: it's filtered at
+        // load, so it shows the roster, exactly like a missing file.)
+        if err.is_some_and(|e| is_auth_error(e)) {
+            return Some(Onboard::NeedKey { name: p.name.clone(), label: p.label() });
+        }
+        if err.is_some() {
             let local = p.base_url.contains("localhost") || p.base_url.contains("127.0.0.1");
-            return Some(Onboard::Unreachable { label: p.label(), auth: is_auth_error(e), local });
+            return Some(Onboard::Unreachable { label: p.label(), local });
         }
         if self.models.as_ref().is_none_or(|(k, _)| *k != key) {
             return Some(Onboard::Connecting(p.label()));
@@ -226,9 +232,8 @@ impl Chat {
         match name {
             "ollama" => {}
             "custom" => {
-                // Suppress the placeholder auto-prompt (as the form's "edit
-                // the file" link does) — hand-editing is the flow here.
-                self.key_prompt_dismissed = Some(name.to_string());
+                // Hand-editing is the flow for a blank custom file; the
+                // "add key" button still reaches the masked field otherwise.
                 self.open_provider_file(file_id);
             }
             _ if self.file_has_real_key(file_id) => {}
@@ -332,9 +337,6 @@ impl Chat {
         {
             p.api_key = Some(key);
         }
-        // Keep the auto-prompt suppressed while we validate — the entry is
-        // already open, so an auth error must not open a second one.
-        self.key_prompt_dismissed = name;
         // Drop the stale pre-submit validation so `poll_key_connection` waits
         // for the fresh fetch rather than reading the old error as a rejection.
         self.models = None;
@@ -420,48 +422,6 @@ impl Chat {
         match range {
             Some(r) => self.ctx.open_file_at_range(file_id, r, true),
             None => self.ctx.open_file(file_id, true),
-        }
-    }
-
-    /// Open the key form on its own when the resolved provider can't run a
-    /// turn without one. Fires once per provider until dismissed, so it
-    /// doesn't nag after Cancel.
-    ///
-    /// - Placeholder key (unconfigured): established chats only — no chooser
-    ///   can show there and every send is blocked, so the connect step is the
-    ///   only fix. (Recovers a pick whose connect step never finished; a tab
-    ///   rebuild also clears the dismissal.) Empty chats have the chooser.
-    /// - Auth error on a real key: empty chats only — an established chat
-    ///   surfaces this as error rows and the toolbar picker.
-    pub(super) fn maybe_prompt_key(&mut self) {
-        if self.key_entry.is_some() {
-            return;
-        }
-        let Some(p) = &self.provider else { return };
-        let empty = self.visible().is_empty();
-        let fire = if p.api_key.as_deref() == Some(KEY_PLACEHOLDER) {
-            !empty
-        } else {
-            let key = (p.name.clone(), p.base_url.clone());
-            empty
-                && self
-                    .models_err
-                    .as_ref()
-                    .is_some_and(|(k, e)| *k == key && is_auth_error(e))
-        };
-        if !fire || self.key_prompt_dismissed.as_deref() == Some(p.name.as_str()) {
-            return;
-        }
-        let (name, label) = (p.name.clone(), p.label());
-        // Mark handled before the lookup so it runs at most once per
-        // provider — never every frame, even if the path lookup fails.
-        // Saving a key re-arms it (clears this) so a rejected key re-prompts.
-        self.key_prompt_dismissed = Some(name.clone());
-        if let Ok(file) = self
-            .core
-            .get_by_path(&format!("/.agent/providers/{name}.json"))
-        {
-            self.open_key_entry(&name, label, file.id);
         }
     }
 

--- a/libs/content/workspace/src/tab/chat/diff.rs
+++ b/libs/content/workspace/src/tab/chat/diff.rs
@@ -1,0 +1,161 @@
+//! Rendered diffs as *segments*: each run of changed blocks becomes its own
+//! independently-parsed markdown snippet (old blocks, then new blocks), so
+//! the viewer stacks and tints them separately. Splicing whole blocks (by
+//! the renderer's own parse) keeps every segment complete and valid — and
+//! parsing segments separately means a deleted list and its replacement can
+//! never merge into one loose list the way a combined document's would.
+
+use comrak::Arena;
+
+use crate::tab::markdown_editor::MdRender;
+
+/// One stacked piece of a rendered diff: consecutive same-kind blocks,
+/// joined as one markdown snippet.
+#[derive(Clone)]
+pub struct Segment {
+    pub text: String,
+    pub kind: SegKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SegKind {
+    /// Unchanged surroundings (the approval card keeps one block of them;
+    /// row bodies keep none).
+    Context,
+    Del,
+    Add,
+}
+
+/// Diff `old` → `new` at block granularity into stacked segments, keeping
+/// `context` unchanged blocks around each changed run. Elision is implicit —
+/// dropped blocks simply don't appear.
+pub fn segments(old: &str, new: &str, context: usize) -> Vec<Segment> {
+    use similar::{ChangeTag, TextDiff};
+    let old_blocks = blocks(old);
+    let new_blocks = blocks(new);
+    let old_refs: Vec<&str> = old_blocks.iter().map(String::as_str).collect();
+    let new_refs: Vec<&str> = new_blocks.iter().map(String::as_str).collect();
+    let diff = TextDiff::from_slices(&old_refs, &new_refs);
+    let tagged: Vec<(&str, ChangeTag)> = diff
+        .iter_all_changes()
+        .map(|c| (c.value(), c.tag()))
+        .collect();
+
+    let keep = |i: usize| {
+        let lo = i.saturating_sub(context);
+        let hi = (i + context).min(tagged.len().saturating_sub(1));
+        tagged[lo..=hi].iter().any(|(_, t)| *t != ChangeTag::Equal)
+    };
+
+    let mut out: Vec<Segment> = Vec::new();
+    for (i, (block, tag)) in tagged.iter().enumerate() {
+        if !keep(i) {
+            continue;
+        }
+        let kind = match tag {
+            ChangeTag::Insert => SegKind::Add,
+            ChangeTag::Delete => SegKind::Del,
+            ChangeTag::Equal => SegKind::Context,
+        };
+        match out.last_mut() {
+            // Consecutive same-kind kept blocks join into one snippet.
+            Some(last) if last.kind == kind && keep(i.saturating_sub(1)) && i > 0 => {
+                last.text.push_str("\n\n");
+                last.text.push_str(block);
+            }
+            _ => out.push(Segment { text: (*block).to_string(), kind }),
+        }
+    }
+    out
+}
+
+/// Top-level markdown blocks of `text`, segmented by the renderer's own
+/// parse (same comrak options), so the diff's units are exactly the blocks
+/// the segments will render.
+fn blocks(text: &str) -> Vec<String> {
+    let arena = Arena::new();
+    // The renderer parses with a trailing newline; match it.
+    let source = format!("{text}\n");
+    let root = comrak::parse_document(&arena, &source, &MdRender::comrak_options());
+    let lines: Vec<&str> = source.lines().collect();
+    root.children()
+        .filter_map(|node| {
+            let sp = node.data.borrow().sourcepos;
+            let start = sp.start.line.checked_sub(1)?;
+            let end = sp.end.line.min(lines.len());
+            let block = lines.get(start..end)?.join("\n");
+            (!block.trim().is_empty()).then_some(block)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flat(segs: &[Segment]) -> Vec<(&str, SegKind)> {
+        segs.iter().map(|s| (s.text.as_str(), s.kind)).collect()
+    }
+
+    /// Zero context (row bodies): nothing but the changed blocks, old then
+    /// new, each its own segment.
+    #[test]
+    fn zero_context_is_just_the_change() {
+        let old = "# Title\n\nkeep this.\n\ndrop this one.\n";
+        let new = "# Title\n\nkeep this.\n\na new one.\n\nand a tail.\n";
+        let segs = segments(old, new, 0);
+        assert_eq!(
+            flat(&segs),
+            [("drop this one.", SegKind::Del), ("a new one.\n\nand a tail.", SegKind::Add)]
+        );
+    }
+
+    /// One block of context (the approval card): the nearest unchanged
+    /// blocks bracket the change; farther blocks are simply absent.
+    #[test]
+    fn card_context_brackets_the_change() {
+        let old = "# Title\n\nkeep this.\n\ndrop this one.\n";
+        let new = "# Title\n\nkeep this.\n\na new one.\n";
+        let segs = segments(old, new, 1);
+        assert_eq!(
+            flat(&segs),
+            [
+                ("keep this.", SegKind::Context),
+                ("drop this one.", SegKind::Del),
+                ("a new one.", SegKind::Add),
+            ]
+        );
+    }
+
+    /// A replaced list arrives as two separate segments — parsed apart, they
+    /// can't merge into one loose list.
+    #[test]
+    fn lists_stay_separate_segments() {
+        let old = "### calls\n\n- [ ] dad\n- [ ] mom\n";
+        let new = "### calls\n\n- [x] dad\n- [ ] mom\n";
+        let segs = segments(old, new, 0);
+        assert_eq!(
+            flat(&segs),
+            [("- [ ] dad\n- [ ] mom", SegKind::Del), ("- [x] dad\n- [ ] mom", SegKind::Add)]
+        );
+    }
+
+    /// Identical documents produce no segments.
+    #[test]
+    fn equal_docs_are_empty() {
+        assert!(segments("a\n\nb\n", "a\n\nb\n", 1).is_empty());
+    }
+
+    /// Distant changes produce independent runs — no marker blocks between,
+    /// elision is the absence itself.
+    #[test]
+    fn distant_changes_are_separate_runs() {
+        let old = "a\n\nb\n\nc\n\nd\n\ne\n";
+        let new = "A\n\nb\n\nc\n\nd\n\nE\n";
+        let segs = segments(old, new, 0);
+        assert_eq!(
+            flat(&segs),
+            [("a", SegKind::Del), ("A", SegKind::Add), ("e", SegKind::Del), ("E", SegKind::Add),]
+        );
+    }
+}

--- a/libs/content/workspace/src/tab/chat/harness.rs
+++ b/libs/content/workspace/src/tab/chat/harness.rs
@@ -14,15 +14,19 @@
 //! partial and yields an error row the UI offers to retry.
 
 use lb_rs::model::chat::Usage;
+use serde_json::Value;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
-use super::anthropic;
 use super::backend::{Backend, ChatMsg, CompletionReq};
-use super::openai;
+use super::diff;
 use super::settings::Provider;
+use super::tools::{self, Buffers};
+use super::{anthropic, openai};
 
 /// Per-request output cap. Comfortably under Cerebras' free-tier 32k.
 const MAX_TOKENS: u32 = 16_000;
+/// Completions per user turn before we stop (a runaway tool loop backstop).
+const MAX_TOOL_TURNS: u32 = 30;
 
 /// UI → driver. Turn-running commands carry the provider resolved at send
 /// time, so a config edit between turns just takes effect — nothing watches
@@ -39,8 +43,13 @@ enum Cmd {
     Retry { provider: Provider, system: Option<String> },
     /// Replace model context wholesale — the UI's transcript mutations
     /// (delete, and later edit/regenerate) recompute the seed and hand the
-    /// driver its new truth. Sent only while idle.
-    Reseed(Vec<ChatMsg>),
+    /// driver its new truth. Sent only while idle. Buffers are session state
+    /// and survive a reseed.
+    Reseed(Vec<ChatMsg>, Buffers),
+    /// Approve the pending edit — it runs and then applies to the real note.
+    Approve,
+    /// Deny the pending edit; the model is told and steers.
+    Deny,
 }
 
 /// Driver → UI.
@@ -53,9 +62,40 @@ enum AgentEvent {
         text: String,
         usage: Option<Usage>,
     },
+    /// An edit wants to run; the UI shows the approval card (with the
+    /// proposed diff) and the turn blocks until approve/deny. Reads and
+    /// listings run without a gate.
+    ToolRequest {
+        name: String,
+        /// The call's raw arguments, for the card's adapted permission prose.
+        args: Value,
+        /// For edits: the proposed change as diff segments, or the steering
+        /// error approval would hit. `None` for gated reads.
+        preview: Option<Result<Vec<diff::Segment>, String>>,
+    },
+    /// A tool call resolved (ran, or was denied) — persist it.
+    ToolDone(ToolOutcome),
     /// The turn failed; any partial text was discarded. Retryable.
     Error(String),
     TurnEnded,
+}
+
+/// A finished tool call, as the transcript should record it.
+pub struct ToolOutcome {
+    pub name: String,
+    pub args: Value,
+    /// The result the model saw (truncated on persist).
+    pub result: String,
+    /// A steering failure — the call had no successful buffer effect, so
+    /// replay suppresses its mutation.
+    pub is_error: bool,
+    /// A harness-authored consequence of the user's approval (the automatic
+    /// write-back after an approved edit), not a model call — the record
+    /// persists and folds but stays out of model context.
+    pub user_action: bool,
+    /// Raw content to persist as this record's replay attachment (full, out of
+    /// model context): a read/auto-open capture, or a merge-sync's merged text.
+    pub capture: Option<String>,
 }
 
 /// UI-side handle to the driver thread. Dropping it closes the channels and
@@ -65,15 +105,29 @@ pub struct Harness {
     pub busy: bool,
     /// Text streamed so far this turn.
     pub streaming: String,
+    /// The edit awaiting the user's decision; `Some` drives the approval
+    /// card.
+    pub pending_tool: Option<PendingTool>,
 
     cmd_tx: UnboundedSender<Cmd>,
     events_rx: UnboundedReceiver<AgentEvent>,
+}
+
+/// An edit shown to the user for approval.
+pub struct PendingTool {
+    pub name: String,
+    pub args: Value,
+    /// For edits: the proposed change as diff segments, or the steering
+    /// error approval would hit. `None` for gated reads.
+    pub preview: Option<Result<Vec<diff::Segment>, String>>,
 }
 
 /// Transcript-bound output of [`Harness::pump`].
 pub enum HarnessUpdate {
     /// Append as an agent message stamped with the turn's usage.
     Reply { text: String, usage: Option<Usage> },
+    /// Append a tool record.
+    Tool(ToolOutcome),
     /// Append as an error row.
     Error(String),
 }
@@ -84,19 +138,26 @@ impl Harness {
     /// the one its command carries, and a misconfigured provider isn't
     /// pre-screened: the turn fails and surfaces as a retryable error row,
     /// which beats a silently dormant agent.
-    pub fn new(ctx: egui::Context, history: Vec<ChatMsg>) -> Self {
+    pub fn new(
+        ctx: egui::Context, core: lb_rs::blocking::Lb, history: Vec<ChatMsg>, buffers: Buffers,
+    ) -> Self {
         let (cmd_tx, cmd_rx) = unbounded_channel();
         let (events_tx, events_rx) = unbounded_channel();
 
+        // The async core, for tool dispatch on the driver's own runtime.
+        let lb = core.async_lb().clone();
         std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
+            // Multi-threaded so tool dispatch's `spawn_blocking` (pdf, content
+            // search) doesn't stall the driver.
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
                 .enable_all()
                 .build()
                 .expect("tokio runtime");
-            rt.block_on(run(history, ctx, cmd_rx, events_tx));
+            rt.block_on(run(history, buffers, lb, ctx, cmd_rx, events_tx));
         });
 
-        Self { busy: false, streaming: String::new(), cmd_tx, events_rx }
+        Self { busy: false, streaming: String::new(), pending_tool: None, cmd_tx, events_rx }
     }
 
     /// Send a user message to the agent. The caller has already appended it
@@ -118,10 +179,25 @@ impl Harness {
         let _ = self.cmd_tx.send(Cmd::Retry { provider, system });
     }
 
-    /// Replace model context after a transcript mutation. Call only while
-    /// idle — a reseed during a turn would race the in-flight reply.
-    pub fn reseed(&mut self, history: Vec<ChatMsg>) {
-        let _ = self.cmd_tx.send(Cmd::Reseed(history));
+    /// Approve the pending edit. No-op if nothing is pending.
+    pub fn approve(&mut self) {
+        if self.pending_tool.take().is_some() {
+            let _ = self.cmd_tx.send(Cmd::Approve);
+        }
+    }
+
+    /// Deny the pending edit.
+    pub fn deny(&mut self) {
+        if self.pending_tool.take().is_some() {
+            let _ = self.cmd_tx.send(Cmd::Deny);
+        }
+    }
+
+    /// Replace model context and rebuild the variable buffers after a
+    /// transcript mutation. Call only while idle — a reseed during a turn
+    /// would race the in-flight reply.
+    pub fn reseed(&mut self, history: Vec<ChatMsg>, buffers: Buffers) {
+        let _ = self.cmd_tx.send(Cmd::Reseed(history, buffers));
     }
 
     /// Drain driver events into transcript-bound updates. Cheap when nothing
@@ -137,11 +213,23 @@ impl Harness {
                         updates.push(HarnessUpdate::Reply { text, usage });
                     }
                 }
+                AgentEvent::ToolRequest { name, args, preview } => {
+                    self.pending_tool = Some(PendingTool { name, args, preview });
+                }
+                AgentEvent::ToolDone(outcome) => {
+                    self.pending_tool = None;
+                    updates.push(HarnessUpdate::Tool(outcome));
+                }
                 AgentEvent::Error(e) => {
                     self.streaming.clear();
                     updates.push(HarnessUpdate::Error(e));
                 }
-                AgentEvent::TurnEnded => self.busy = false,
+                // A turn can end while an edit is pending (stopped
+                // mid-approval) — clear the card so it doesn't stick.
+                AgentEvent::TurnEnded => {
+                    self.busy = false;
+                    self.pending_tool = None;
+                }
             }
         }
         updates
@@ -149,8 +237,8 @@ impl Harness {
 }
 
 async fn run(
-    mut history: Vec<ChatMsg>, ctx: egui::Context, mut cmd_rx: UnboundedReceiver<Cmd>,
-    events_tx: UnboundedSender<AgentEvent>,
+    mut history: Vec<ChatMsg>, mut buffers: Buffers, lb: lb_rs::Lb, ctx: egui::Context,
+    mut cmd_rx: UnboundedReceiver<Cmd>, events_tx: UnboundedSender<AgentEvent>,
 ) {
     let send = |ev: AgentEvent| {
         let _ = events_tx.send(ev);
@@ -178,15 +266,18 @@ async fn run(
             Cmd::Retry { provider, system } if matches!(history.last(), Some(ChatMsg::User(_))) => {
                 (provider, system)
             }
-            // Not a turn; no busy state to clear.
-            Cmd::Reseed(new_history) => {
+            // Not a turn; no busy state to clear. The rebuilt buffers replace
+            // the branch (a mutation may have removed tool rows).
+            Cmd::Reseed(new_history, new_buffers) => {
                 history = new_history;
+                buffers = new_buffers;
                 continue;
             }
-            // A stale Stop lost the race with natural completion. `stop()`
-            // never set busy, and an unpaired TurnEnded here could clear a
-            // *newer* turn's busy flag mid-stream — say nothing.
-            Cmd::Stop => continue,
+            // A stale Stop lost the race with natural completion; a stray
+            // Approve/Deny arrived with no edit pending. None of these set
+            // busy, and an unpaired TurnEnded could clear a *newer* turn's
+            // busy flag mid-stream — say nothing.
+            Cmd::Stop | Cmd::Approve | Cmd::Deny => continue,
             // An unretryable Retry did set busy; release it.
             Cmd::Retry { .. } => {
                 send(AgentEvent::TurnEnded);
@@ -194,7 +285,12 @@ async fn run(
             }
         };
 
-        // The turn's backend, from the provider resolved at send time.
+        // Reads egress note content to the provider, so they gate on
+        // approval too — except when the model runs on this machine and
+        // nothing leaves it.
+        let local = provider.is_local();
+        // The turn's backend, from the provider resolved at send time; reused
+        // across the turn's completions.
         let backend = match provider.kind.as_str() {
             "openai" => Backend::OpenAi(openai::openai_compat(&provider)),
             "anthropic" => Backend::Anthropic(anthropic::anthropic(&provider)),
@@ -205,54 +301,177 @@ async fn run(
             }
         };
 
-        let req = CompletionReq {
-            system: system.unwrap_or_else(preamble),
-            messages: history.clone(),
-            max_tokens: MAX_TOKENS,
-        };
-        let (delta_tx, mut delta_rx) = unbounded_channel();
-        let fut = backend.complete(req, delta_tx);
-        tokio::pin!(fut);
+        // A user turn spans one or more completions, threaded by tool calls:
+        // complete → (tool call? show for approval, run it, feed the result
+        // back, re-complete) → final text.
+        let mut turns = 0u32;
+        'turn: loop {
+            turns += 1;
+            let req = CompletionReq {
+                system: system.clone().unwrap_or_else(preamble),
+                messages: history.clone(),
+                max_tokens: MAX_TOKENS,
+                tools: tools::schemas(),
+            };
+            let (delta_tx, mut delta_rx) = unbounded_channel();
+            let fut = backend.complete(req, delta_tx);
+            tokio::pin!(fut);
 
-        // Forward deltas as they stream, accumulating the reply locally so a
-        // stop keeps what's arrived. Outcome is the backend result, or None
-        // on stop.
-        let mut text = String::new();
-        let outcome = loop {
-            tokio::select! {
-                Some(delta) = delta_rx.recv() => {
-                    text.push_str(&delta);
-                    send(AgentEvent::Delta(delta));
+            // Forward deltas as they stream, accumulating locally so a stop
+            // keeps what's arrived. Outcome is the backend result, or None on
+            // stop.
+            let mut text = String::new();
+            let outcome = loop {
+                tokio::select! {
+                    Some(delta) = delta_rx.recv() => {
+                        text.push_str(&delta);
+                        send(AgentEvent::Delta(delta));
+                    }
+                    result = &mut fut => break Some(result),
+                    cmd = cmd_rx.recv() => match cmd {
+                        Some(Cmd::Stop) | None => break None,
+                        Some(other) => pending.push_back(other),
+                    },
                 }
-                result = &mut fut => break Some(result),
-                cmd = cmd_rx.recv() => match cmd {
-                    Some(Cmd::Stop) | None => break None,
-                    Some(other) => pending.push_back(other),
-                },
+            };
+            // Deltas sent before finishing but after our last poll.
+            while let Ok(delta) = delta_rx.try_recv() {
+                text.push_str(&delta);
+                send(AgentEvent::Delta(delta));
             }
-        };
-        // Deltas the backend sent before finishing but after our last poll.
-        while let Ok(delta) = delta_rx.try_recv() {
-            text.push_str(&delta);
-            send(AgentEvent::Delta(delta));
+
+            let completion = match outcome {
+                Some(Ok(c)) => c,
+                // Stopped: keep the partial as the reply — the user watched it
+                // stream and chose to cut it there.
+                None => {
+                    if !text.trim().is_empty() {
+                        history.push(ChatMsg::Assistant { text: text.clone(), tool_calls: vec![] });
+                    }
+                    send(AgentEvent::Reply { text, usage: None });
+                    break 'turn;
+                }
+                // Failed: discard the partial so a retry re-runs clean.
+                Some(Err(e)) => {
+                    send(AgentEvent::Error(e));
+                    break 'turn;
+                }
+            };
+
+            let calls = completion.tool_calls.clone();
+            history
+                .push(ChatMsg::Assistant { text: text.clone(), tool_calls: completion.tool_calls });
+            // The agent's words (may be empty when it only called a tool).
+            send(AgentEvent::Reply { text, usage: Some(completion.usage) });
+
+            if calls.is_empty() {
+                break 'turn;
+            }
+            if turns >= MAX_TOOL_TURNS {
+                send(AgentEvent::Error("stopped: too many tool calls this turn".into()));
+                break 'turn;
+            }
+
+            // One call at a time on the wire, but handle a batch defensively —
+            // every tool_use needs a matching result. Edits always block on
+            // the user's approval (and, once approved and successful, apply
+            // straight through to the real note); reads gate only when the
+            // provider is remote.
+            for call in calls {
+                let is_edit = call.name == "edit_note";
+                let gated = is_edit || !local;
+                if gated {
+                    let preview = if is_edit {
+                        Some(tools::preview_edit(&lb, &buffers, &call.args).await)
+                    } else {
+                        None
+                    };
+                    send(AgentEvent::ToolRequest {
+                        name: call.name.clone(),
+                        args: call.args.clone(),
+                        preview,
+                    });
+
+                    // Block on the decision, queuing unrelated commands.
+                    let approved = loop {
+                        match cmd_rx.recv().await {
+                            Some(Cmd::Approve) => break Some(true),
+                            Some(Cmd::Deny) => break Some(false),
+                            Some(Cmd::Stop) | None => break None,
+                            Some(other) => pending.push_back(other),
+                        }
+                    };
+                    match approved {
+                        // Stopped mid-approval: end the turn. The assistant's
+                        // call is left unanswered in the driver's history, but
+                        // the next Say reseeds from the transcript.
+                        None => break 'turn,
+                        // Denied: record the refusal (identical text live and
+                        // persisted); the model adjusts.
+                        Some(false) => {
+                            history.push(ChatMsg::ToolResult {
+                                id: call.id.clone(),
+                                content: tools::DENIED_RESULT.into(),
+                                is_error: false,
+                            });
+                            send(AgentEvent::ToolDone(ToolOutcome {
+                                name: call.name,
+                                args: call.args,
+                                result: tools::DENIED_RESULT.into(),
+                                // No buffer effect — replay skips it.
+                                is_error: true,
+                                capture: None,
+                                user_action: false,
+                            }));
+                            continue;
+                        }
+                        Some(true) => {}
+                    }
+                }
+
+                let out = tools::dispatch(&lb, &mut buffers, &call.name, &call.args).await;
+                let edit_applied = is_edit && !out.is_error;
+                history.push(ChatMsg::ToolResult {
+                    id: call.id.clone(),
+                    content: out.result.clone(),
+                    is_error: out.is_error,
+                });
+                send(AgentEvent::ToolDone(ToolOutcome {
+                    name: call.name,
+                    args: call.args.clone(),
+                    result: out.result,
+                    is_error: out.is_error,
+                    capture: out.capture,
+                    user_action: false,
+                }));
+
+                // The approved edit lands on the real note now. The receipt
+                // record persists and folds (it marks the buffer saved, and
+                // captures a merge's inflow) but stays out of model context —
+                // the model's picture is simply that edits apply.
+                if edit_applied {
+                    let synced = tools::sync_note(&lb, &mut buffers, &call.args).await;
+                    if synced.is_error {
+                        // Receipts don't render, so a failed write-back must
+                        // surface as an error row. No record is right for
+                        // replay too: the disk didn't change, so the buffer
+                        // folding back dirty matches reality.
+                        send(AgentEvent::Error(synced.result));
+                    } else {
+                        send(AgentEvent::ToolDone(ToolOutcome {
+                            name: "sync_note".into(),
+                            args: call.args,
+                            result: synced.result,
+                            is_error: false,
+                            capture: synced.capture,
+                            user_action: true,
+                        }));
+                    }
+                }
+            }
+            // Re-complete with the tool results now in context.
         }
 
-        match outcome {
-            Some(Ok(usage)) => {
-                history.push(ChatMsg::Assistant(text.clone()));
-                send(AgentEvent::Reply { text, usage: Some(usage) });
-            }
-            // Stopped: keep the partial as the reply — the user watched it
-            // stream and chose to cut it there.
-            None => {
-                if !text.trim().is_empty() {
-                    history.push(ChatMsg::Assistant(text.clone()));
-                }
-                send(AgentEvent::Reply { text, usage: None });
-            }
-            // Failed: discard the partial so a retry re-runs the turn clean.
-            Some(Err(e)) => send(AgentEvent::Error(e)),
-        }
         // With a queued command the run continues straight into the next
         // turn; TurnEnded (busy=false) would flicker the stop button.
         if pending.is_empty() {
@@ -261,18 +480,20 @@ async fn run(
     }
 }
 
-/// The prompt's editable substance — also the prompt-file template,
-/// so customizing starts from what's actually sent. Tool guidance joins in
-/// the tools increment. Privacy claims deliberately absent: the transcript
-/// is sent to whatever provider the user configured, and a model told "this
-/// app is E2EE" overclaims privacy in exactly the conversations where the
-/// nuance matters.
+/// The prompt's editable substance — also the prompt-file template, so
+/// customizing starts from what's actually sent. Privacy claims deliberately
+/// absent: the transcript is sent to whatever provider the user configured,
+/// and a model told "this app is E2EE" overclaims privacy in exactly the
+/// conversations where the nuance matters.
 pub const PREAMBLE: &str = "You are the user's personal assistant inside their lockbook: a file \
      tree of mostly-markdown notes, synced across their devices. You are \
      talking with them in a chat tab of the lockbook app. Your replies \
      render as markdown chat bubbles, so keep them short and conversational \
-     — headers and long lists usually read poorly in a bubble. You don't \
-     yet have tools to read or edit their notes; if asked, say so plainly.";
+     — headers and long lists usually read poorly in a bubble. \
+     You have tools to explore and edit their notes. read_note before \
+     editing, and prefer editing over rewriting a whole note. Just use the \
+     tools directly rather than asking permission in prose. Link to notes by \
+     their bare lockbook path, like [todo](/notes/todo.md).";
 
 /// Default system prompt: [`PREAMBLE`] plus the date (day-granular, so the
 /// provider's prompt cache misses at most once a day).
@@ -284,25 +505,57 @@ fn preamble() -> String {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::super::openai::mock::{SSE_HELLO, serve_once};
+    use lb_rs::model::core_config::{ClientType, Config};
+
+    use super::super::openai::mock::{SSE_HELLO, serve_once, serve_seq};
     use super::*;
+
+    /// An offline core — enough to construct the harness. Tool dispatch
+    /// against it (no account) returns steering errors, which is all these
+    /// tests need.
+    fn offline_core() -> lb_rs::blocking::Lb {
+        lb_rs::blocking::Lb::init(Config {
+            writeable_path: format!("/tmp/{}", lb_rs::Uuid::new_v4()),
+            logs: false,
+            stdout_logs: false,
+            colored_logs: false,
+            background_work: false,
+            client_type: ClientType::Unknown,
+        })
+        .unwrap()
+    }
+
+    fn provider(base_url: String) -> Provider {
+        Provider {
+            name: "mock".into(),
+            display_name: None,
+            kind: "openai".into(),
+            base_url,
+            model: "test-model".into(),
+            api_key: Some("test-key".into()),
+            effort: None,
+        }
+    }
+
+    /// Pump until idle (or timeout), collecting updates.
+    fn drain(harness: &mut Harness) -> Vec<HarnessUpdate> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut out = Vec::new();
+        while Instant::now() < deadline && (harness.busy || out.is_empty()) {
+            out.extend(harness.pump());
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        out
+    }
 
     /// End to end through the driver thread: say → streamed deltas → reply
     /// with usage → idle.
     #[test]
     fn say_streams_a_reply() {
-        let provider = Provider {
-            name: "mock".into(),
-            display_name: None,
-            kind: "openai".into(),
-            base_url: serve_once(SSE_HELLO),
-            model: "test-model".into(),
-            api_key: Some("test-key".into()),
-            effort: None,
-        };
-        let mut harness = Harness::new(egui::Context::default(), Vec::new());
+        let mut harness =
+            Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
 
-        harness.say("hi".into(), provider, None);
+        harness.say("hi".into(), provider(serve_once(SSE_HELLO)), None);
         assert!(harness.busy);
 
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -311,6 +564,7 @@ mod tests {
             for update in harness.pump() {
                 match update {
                     HarnessUpdate::Reply { text, usage } => replies.push((text, usage)),
+                    HarnessUpdate::Tool(_) => panic!("unexpected tool"),
                     HarnessUpdate::Error(e) => panic!("unexpected error: {e}"),
                 }
             }
@@ -324,5 +578,117 @@ mod tests {
         assert_eq!(usage.unwrap().input, 7);
         assert!(!harness.busy);
         assert!(harness.streaming.is_empty());
+    }
+
+    /// SSE body for a single-call completion invoking `edit_note`.
+    const SSE_EDIT_CALL: &str = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n\
+         data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"edit_note\",\"arguments\":\"{\\\"path\\\":\\\"/a.md\\\",\\\"old_str\\\":\\\"x\\\",\\\"new_str\\\":\\\"y\\\"}\"}}]}}]}\n\n\
+         data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1}}\n\n\
+         data: [DONE]\n\n";
+
+    /// An edit call raises the approval card; approval runs it (a steering
+    /// error on the offline core, so no write-back receipt) and the turn
+    /// completes.
+    #[test]
+    fn edit_requests_approval_then_runs() {
+        let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
+        let mut harness =
+            Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
+        harness.say("edit my note".into(), provider(base), None);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && harness.pending_tool.is_none() {
+            harness.pump();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let pending = harness.pending_tool.as_ref().expect("approval card");
+        assert_eq!(pending.name, "edit_note");
+        assert_eq!(pending.args["path"], "/a.md");
+        // No account on the offline core → the preview carries the
+        // steering error approval would hit.
+        assert!(matches!(&pending.preview, Some(Err(e)) if e.starts_with("error:")));
+        assert!(harness.busy);
+
+        harness.approve();
+
+        let updates = drain(&mut harness);
+        let tools: Vec<_> = updates
+            .iter()
+            .filter_map(|u| match u {
+                HarnessUpdate::Tool(t) => Some(t),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tools.len(), 1, "steering-errored edit gets no receipt");
+        assert_eq!(tools[0].name, "edit_note");
+        assert!(tools[0].result.starts_with("error:"), "{}", tools[0].result);
+        assert!(!harness.busy);
+        assert!(harness.pending_tool.is_none());
+    }
+
+    /// Denying an edit feeds the denial back without running it; the turn
+    /// still completes.
+    #[test]
+    fn denied_edit_completes_without_running() {
+        let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
+        let mut harness =
+            Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
+        harness.say("do it".into(), provider(base), None);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && harness.pending_tool.is_none() {
+            harness.pump();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(harness.pending_tool.is_some());
+        harness.deny();
+
+        let updates = drain(&mut harness);
+        let tool = updates
+            .iter()
+            .find_map(|u| match u {
+                HarnessUpdate::Tool(t) => Some(t),
+                _ => None,
+            })
+            .expect("a denied tool row");
+        assert_eq!(tool.result, tools::DENIED_RESULT);
+        assert!(tool.is_error);
+        assert!(!harness.busy);
+    }
+
+    /// The full tool round-trip: first completion emits a call → it runs
+    /// ungated and feeds a result back → second completion returns the final
+    /// reply → idle.
+    #[test]
+    fn tool_call_runs_ungated_then_completes() {
+        // First response calls `list`; second (after the result) is the reply.
+        const SSE_LIST_CALL: &str = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n\
+             data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"list\",\"arguments\":\"{}\"}}]}}]}\n\n\
+             data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1}}\n\n\
+             data: [DONE]\n\n";
+        let base = serve_seq(vec![SSE_LIST_CALL, SSE_HELLO]);
+        let mut harness =
+            Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
+        harness.say("what's in my vault?".into(), provider(base), None);
+
+        // Drain to completion: a tool row, then the reply — no decision step.
+        let updates = drain(&mut harness);
+        let mut saw_tool = false;
+        let mut reply = None;
+        for u in updates {
+            match u {
+                HarnessUpdate::Tool(t) => {
+                    assert_eq!(t.name, "list");
+                    // No account on the offline core → a steering error result.
+                    assert!(t.result.starts_with("error:"), "{}", t.result);
+                    saw_tool = true;
+                }
+                HarnessUpdate::Reply { text, .. } => reply = Some(text),
+                HarnessUpdate::Error(e) => panic!("unexpected error: {e}"),
+            }
+        }
+        assert!(saw_tool, "expected a tool row");
+        assert_eq!(reply.as_deref(), Some("Hello"));
+        assert!(!harness.busy);
     }
 }

--- a/libs/content/workspace/src/tab/chat/mod.rs
+++ b/libs/content/workspace/src/tab/chat/mod.rs
@@ -23,8 +23,9 @@ use egui::{
 };
 use lb_rs::Uuid;
 use lb_rs::model::account::Account;
-use lb_rs::model::chat::{Buffer, Message};
+use lb_rs::model::chat::{Buffer, Message, ToolRecord};
 use lb_rs::model::file_metadata::DocumentHmac;
+use serde_json::json;
 
 use crate::GlyphonRendererCallback;
 use crate::file_cache::FileCache;
@@ -36,10 +37,12 @@ use crate::theme::palette_v2::{Palette, ThemeExt, username_color};
 mod anthropic;
 mod backend;
 mod config;
+mod diff;
 mod glyphs;
 mod harness;
 mod openai;
 mod settings;
+mod tools;
 mod view;
 
 const MAX_WIDTH: f32 = 800.0;
@@ -55,17 +58,22 @@ const COMPOSER_MAX_HEIGHT: f32 = 160.0;
 const COMPOSER_BOTTOM_GAP: f32 = 16.0;
 /// Android nav-bar clearance, used while the keyboard is down.
 const COMPOSER_NAV_CLEARANCE: f32 = 60.0;
-/// Horizontal inset on each side of the composer bubble within its column. The
-/// send button lives in the right inset, outside the bubble.
-const SIDE_INSET: f32 = 48.0;
 /// Font size of note rows (errors, agent status).
 const NOTE_FONT: f32 = 12.0;
+/// Font size of tool-call text (summaries, metrics, listings, results) —
+/// matches the rendered message body (the markdown row height).
+const TOOL_FONT: f32 = 16.0;
+/// Extra breathing room above and below each contiguous run of tool rows.
+const TOOL_GROUP_PAD: f32 = 8.0;
 /// Gap under a run's name header.
 const NAME_GAP: f32 = 6.0;
 /// The metadata strip under every message row: timestamp, branch arrows,
 /// and (on hover) action icons — in reserved space below the message, never
 /// overlaid on it.
 const STRIP_H: f32 = 18.0;
+/// Extra gap between an agent reply and its action strip (the copy button) —
+/// more breathing room than the tight `ROW_GAP` a user bubble gets.
+const AGENT_STRIP_GAP: f32 = 8.0;
 /// The toolbar row inside the composer bubble (Zed-style): provider/model
 /// dropdowns on the left, send/stop on the right.
 const TOOLBAR_H: f32 = 32.0;
@@ -240,6 +248,63 @@ enum RowPlan {
         galley: Arc<Galley>,
         pos: Pos2,
     },
+    /// A completed tool call, styled as an expandable container (the
+    /// markdown table's grammar): a filled header bar with the summary +
+    /// right-aligned metric, and — when expanded — a bordered content area
+    /// beneath it holding the call's body. The whole container toggles.
+    Tool {
+        header_rect: Rect,
+        summary: Arc<Galley>,
+        metric: Option<Arc<Galley>>,
+        body: Option<Arc<Galley>>,
+        body_pos: Pos2,
+        /// Markdown-rendered body segments (an edit's del/add hunks, a
+        /// read's note as one context segment), stacked via the entry's own
+        /// label with wash bands behind changed ones.
+        rendered: Option<(Vec<diff::Segment>, Pos2, f32)>,
+        list_rows: Vec<ListRowPlan>,
+        /// The full container rect, bordered when expanded.
+        border: Option<Rect>,
+    },
+}
+
+/// One row of an expanded `list` body: a path, clickable when it names a
+/// document.
+struct ListRowPlan {
+    galley: Arc<Galley>,
+    rect: Rect,
+    /// Set when clicking should open the path (documents only).
+    open_path: Option<String>,
+}
+
+/// The trailing approval card for a call awaiting a decision, styled like a
+/// [`RowPlan::Tool`] container pinned open: a filled header bar carrying the
+/// command summary (no right metric — it hasn't run), over a bordered body
+/// holding the permission prose, the proposed change, and Approve / Deny.
+/// Laid out in pass 1, painted after the rows.
+struct ReviewPlan {
+    header_rect: Rect,
+    /// The command summary ([`tools::detail_for`]), left of the header bar.
+    summary: Arc<Galley>,
+    /// The plain-language permission request, atop the body.
+    prose: Arc<Galley>,
+    prose_pos: Pos2,
+    body: ReviewBody,
+    approve: Arc<Galley>,
+    approve_rect: Rect,
+    deny: Arc<Galley>,
+    deny_rect: Rect,
+    /// The full container, bordered like an expanded tool row.
+    border: Rect,
+}
+
+/// The card body's proposed change, below the permission prose: an edit's
+/// change as stacked markdown segments with changed ones washed, a steering
+/// error as a plain line, or nothing (a gated read is prose-only).
+enum ReviewBody {
+    None,
+    Galley { galley: Arc<Galley>, pos: Pos2 },
+    Rendered { segments: Vec<diff::Segment>, pos: Pos2, width: f32 },
 }
 
 /// The metadata strip under a row, laid out in pass 1 and drawn after the
@@ -266,7 +331,13 @@ impl Entry {
 
     /// Carries no rendered row: a config entry or an otherwise empty message.
     fn hidden(&self) -> bool {
-        self.msg.config.is_some() || self.msg.content.is_empty()
+        self.msg.config.is_some()
+            // Legacy context-excluded capture rows (captures ride their
+            // record's extra now) — persisted for replay, never shown.
+            || self.msg.extra.get("hidden").and_then(|v| v.as_bool()) == Some(true)
+            // Empty rows are placeholders/config — but a tool row is legitimate
+            // with no prose (it renders from its record).
+            || (self.msg.content.is_empty() && self.msg.tool.is_none())
     }
 }
 
@@ -280,9 +351,13 @@ pub struct Chat {
     /// bridge the composer uses — `focused_mdedit_mut` points here while the
     /// connect step is open. Plaintext + `mask` so it renders as `*`.
     pub key_field: MdEdit,
-    /// The key field's rect last frame, surfaced as the text-interaction rect
-    /// so the native text view positions over it.
+    /// The masked field's tight layout rect (one centered row), where the
+    /// `MdEdit` renders and clips.
     key_field_rect: Rect,
+    /// The full visible field box, surfaced as the text-interaction rect: the
+    /// native text view (and its tap-to-focus / double-tap-to-paste gestures)
+    /// spans the whole box, not just the one-row layout strip.
+    key_field_hit_rect: Rect,
     pub account: Account,
     pub seq: usize,
     pub initialized: bool,
@@ -291,15 +366,23 @@ pub struct Chat {
     base: Vec<u8>,
     /// Composer region from the last frame, for `will_consume_touch`.
     composer_rect: Rect,
+    /// The composer buffer's `seq` last frame (bumps on any text OR selection
+    /// change). A mismatch this frame means an app-driven edit the native
+    /// (iOS) text bridge didn't originate — a send-clear, edit-prefill, or
+    /// stash-restore — so we tell it to re-sync its caret.
+    composer_seq: usize,
     /// Sending while scrolled up jumps back to the bottom (which also
     /// re-sticks the scroll). Set on submit, consumed next frame.
     scroll_to_bottom: bool,
     /// Chosen child per fork (parent id → child id), for the ‹ 2/3 › arrows.
     /// View state: per-device, unsynced, defaults to the newest sibling.
     branch_choice: HashMap<Uuid, Uuid>,
-    /// After a branch switch: hold the clicked strip (by visible index) at
-    /// its previous on-screen y, and suspend stick-to-bottom for the frame.
-    branch_anchor: Option<(usize, f32)>,
+    /// After a height-changing click: hold the clicked row (by visible
+    /// index) at its previous on-screen y, and suspend stick-to-bottom for
+    /// the frame. The bool picks the anchor edge: true = the message row's
+    /// top (tool toggles — the header must not move, the growth is below),
+    /// false = the strip's top (branch arrows — the pointer is in the strip).
+    branch_anchor: Option<(usize, f32, bool)>,
     /// While regenerating: hide the superseded reply (children of this
     /// parent) so the transcript ends at the invoking message during the
     /// turn. Cleared when the new reply (or error) lands.
@@ -310,6 +393,9 @@ pub struct Chat {
     harness: Option<harness::Harness>,
     /// Renders the in-flight streaming reply.
     streaming_label: MdLabel,
+    /// Renders the approval card's proposed change (the combined block
+    /// diff) as markdown.
+    review_label: MdLabel,
     /// Unshared at open — eligible for an agent (setup guidance is shown if
     /// none could be built).
     unshared: bool,
@@ -334,10 +420,6 @@ pub struct Chat {
     /// (validation lands in the background), so the closing frame hands focus
     /// back to the composer — no click is involved to do it naturally.
     connect_was_open: bool,
-    /// Provider whose auto key-prompt was dismissed, so it isn't re-shown
-    /// every frame after Cancel. Cleared on a new key so a rejected one
-    /// re-prompts.
-    key_prompt_dismissed: Option<String>,
     /// The provider chooser opened over an existing transcript (toolbar →
     /// "add provider") — same canvas as first-run onboarding, but explicitly
     /// summoned, so it gets a cancel. Cleared by picking or cancelling.
@@ -349,8 +431,9 @@ pub struct Chat {
     /// The composer draft stashed when editing began, restored on cancel or
     /// after the edit is sent.
     draft_stash: Option<String>,
-    /// Parent for the reply of the turn in flight — the message it answers.
-    /// Stamped as `reply_to` on the pushed reply/error row.
+    /// Parent for the next row of the turn in flight: the invoking message at
+    /// send, advanced to each landed tool/reply row so a turn chains instead
+    /// of forking. Stamped as `reply_to` on every pushed agent row.
     pending_parent: Option<Uuid>,
     /// Live `/models` listing for the picker, keyed by (provider name,
     /// base_url) so editing the file's url invalidates it. Runtime data,
@@ -365,6 +448,17 @@ pub struct Chat {
     models_err: Option<(ModelsKey, String)>,
     /// Brand glyph textures for the picker, rasterized on first use.
     glyphs: glyphs::Glyphs,
+    /// Completed tool rows the user has expanded (by message id), to reveal
+    /// the tool's body. Per-device view state, unsynced.
+    expanded_tools: std::collections::HashSet<Uuid>,
+    /// Per-row tool visualization (collapsed metric + expanded body), derived
+    /// by re-folding the visible records. In-memory only, rebuilt when
+    /// `tool_viz_key` misses.
+    tool_viz: HashMap<Uuid, tools::Viz>,
+    /// The final fold — the buffers the next tool call runs against.
+    folded: tools::Buffers,
+    /// Fingerprint of the timeline `tool_viz`/`folded` were built from.
+    tool_viz_key: Option<u64>,
 }
 
 type ModelListing = Vec<backend::ModelInfo>;
@@ -416,15 +510,19 @@ const MODELS_RETRY: std::time::Duration = std::time::Duration::from_secs(15);
 /// advances on its own as the config validates in the background — no
 /// confirmation step: pick a provider, paste a key, and the chat notices.
 enum Onboard {
-    /// No provider file yet — offer the roster to pick from.
+    /// No provider configured — offer the roster to pick from.
     Choose,
-    /// A provider is set; its `/models` listing hasn't come back yet.
+    /// The resolved provider has no working key: an unconfigured placeholder,
+    /// or a real key the server rejected. The composer slot becomes an "add
+    /// key" button (never a secret input); the dedicated masked field the
+    /// button opens is the only place a key is typed.
+    NeedKey { name: String, label: String },
+    /// A provider is set with a key; its `/models` listing hasn't landed yet.
     Connecting(String),
-    /// The listing failed. `auth` is whether it looked like an auth error
-    /// (bad/missing key) versus a connectivity failure, and `local` whether
-    /// the endpoint is this machine — each needs different advice ("check
-    /// your key" / "check your connection" / "is the server running?").
-    Unreachable { label: String, auth: bool, local: bool },
+    /// The listing failed for a non-auth reason — `local` whether the endpoint
+    /// is this machine ("is the server running?") or remote ("check your
+    /// connection"). Auth failures are [`Onboard::NeedKey`] instead.
+    Unreachable { label: String, local: bool },
     /// Reachable, but no model chosen (a local server we can't guess for).
     PickModel(String),
 }
@@ -549,7 +647,12 @@ impl Chat {
         let unshared = !is_shared(&files.read().unwrap(), id);
         let harness = unshared.then(|| {
             let visible = resolve_visible(&entries, &HashMap::new(), None);
-            harness::Harness::new(ctx.clone(), seed_history(&entries, &visible))
+            harness::Harness::new(
+                ctx.clone(),
+                core.clone(),
+                seed_history(&entries, &visible),
+                rebuild_buffers(&entries, &visible),
+            )
         });
         Self {
             id,
@@ -562,13 +665,22 @@ impl Chat {
             base: bytes.to_vec(),
             key_field,
             key_field_rect: Rect::NOTHING,
+            key_field_hit_rect: Rect::NOTHING,
             composer_rect: Rect::NOTHING,
+            composer_seq: 0,
             scroll_to_bottom: false,
             branch_choice: HashMap::new(),
             branch_anchor: None,
             hide_children_of: None,
             harness,
             streaming_label: {
+                let mut label = MdLabel::new(ctx.clone());
+                label.renderer.files = Arc::clone(&files);
+                label.renderer.link_resolver =
+                    Box::new(FileCacheLinkResolver::new(Arc::clone(&files), id));
+                label
+            },
+            review_label: {
                 let mut label = MdLabel::new(ctx.clone());
                 label.renderer.files = Arc::clone(&files);
                 label.renderer.link_resolver = Box::new(FileCacheLinkResolver::new(files, id));
@@ -585,7 +697,6 @@ impl Chat {
             config_rx: None,
             key_entry: None,
             connect_was_open: false,
-            key_prompt_dismissed: None,
             chooser_open: false,
             // Left None so the first frame kicks the initial background load
             // (a cheap thread spawn, not the file read that blew the budget).
@@ -598,6 +709,10 @@ impl Chat {
             models_rx: None,
             models_attempt: None,
             models_err: None,
+            expanded_tools: std::collections::HashSet::new(),
+            tool_viz: HashMap::new(),
+            folded: tools::Buffers::default(),
+            tool_viz_key: None,
             ctx,
         }
     }
@@ -607,9 +722,38 @@ impl Chat {
         resolve_visible(&self.entries, &self.branch_choice, self.hide_children_of)
     }
 
-    /// Model context for the visible timeline.
-    fn visible_seed(&self) -> Vec<backend::ChatMsg> {
-        seed_history(&self.entries, &self.visible())
+    /// The driver's full seed: model context plus the rebuilt variable buffers
+    /// — everything a reseed (or reopen) needs to reconstruct agent state from
+    /// the transcript.
+    fn agent_seed(&self) -> (Vec<backend::ChatMsg>, tools::Buffers) {
+        let visible = self.visible();
+        (seed_history(&self.entries, &visible), rebuild_buffers(&self.entries, &visible))
+    }
+
+    /// Rebuild `tool_viz`/`folded` if the visible timeline changed since the
+    /// last build. Keyed by a fingerprint of everything that shapes the
+    /// timeline: the entry log (`seq`), branch choices, and regenerate-hiding.
+    fn ensure_tool_viz(&mut self) {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        self.seq.hash(&mut h);
+        self.hide_children_of.hash(&mut h);
+        // Order-independent over the choice map.
+        let mut choices = 0u64;
+        for kv in &self.branch_choice {
+            let mut h2 = DefaultHasher::new();
+            kv.hash(&mut h2);
+            choices ^= h2.finish();
+        }
+        choices.hash(&mut h);
+        let key = h.finish();
+        if self.tool_viz_key == Some(key) {
+            return;
+        }
+        let (viz, folded) = build_tool_viz(&self.entries, &self.visible());
+        self.tool_viz = viz;
+        self.folded = folded;
+        self.tool_viz_key = Some(key);
     }
 
     /// Begin editing a message: stash the in-progress draft, prefill the
@@ -649,30 +793,51 @@ impl Chat {
         self.pending_parent = msg_id;
         self.provider = self.resolve_provider();
         let system = self.system_prompt.clone();
-        let mut seed = self.visible_seed();
+        let (mut seed, buffers) = self.agent_seed();
         seed.pop(); // `say` pushes the new message itself
         if let (Some(harness), Some(provider)) = (&mut self.harness, self.provider.clone()) {
-            harness.reseed(seed);
+            harness.reseed(seed, buffers);
             harness.say(content, provider, system);
         }
         self.scroll_to_bottom = true;
     }
 
     /// Re-roll an agent reply: hide it for the duration of the turn and run
-    /// a retry against the timeline ending at its invoking message. The new
-    /// reply lands as the old one's sibling.
+    /// a retry against the timeline ending at its invoking message. The rerun
+    /// supersedes the *whole turn* — a turn's rows chain (tool rows, receipts,
+    /// reply), so the walk goes up to the turn root; anything less would seed
+    /// the driver mid-turn, which the retry guard refuses. Already-applied
+    /// edits stay applied: the rerun re-reads the notes as they now are.
     fn regenerate(&mut self, idx: usize) {
-        let Some(parent) = parent_for_sibling(&self.entries, idx) else { return };
+        let Some(parent) = self.turn_root(idx) else { return };
         self.hide_children_of = Some(parent);
         self.pending_parent = Some(parent);
         self.provider = self.resolve_provider();
         let system = self.system_prompt.clone();
-        let seed = self.visible_seed();
+        let (seed, buffers) = self.agent_seed();
         if let (Some(harness), Some(provider)) = (&mut self.harness, self.provider.clone()) {
-            harness.reseed(seed);
+            harness.reseed(seed, buffers);
             harness.retry(provider, system);
         }
         self.scroll_to_bottom = true;
+    }
+
+    /// The id of the user message whose turn produced `entries[idx]`: walk
+    /// the reply chain upward while rows are agent-authored.
+    fn turn_root(&self, idx: usize) -> Option<Uuid> {
+        let mut i = idx;
+        // Capped: a cyclic reply_to in a hand-mangled file must not hang.
+        for _ in 0..self.entries.len() {
+            if !self.entries[i].msg.agent {
+                return self.entries[i].msg.id;
+            }
+            let parent = parent_for_sibling(&self.entries, i)?;
+            if parent.is_nil() {
+                return None;
+            }
+            i = self.entries.iter().position(|e| e.msg.id == Some(parent))?;
+        }
+        None
     }
 
     /// The editor the native (iOS) text bridge should target: the masked key
@@ -716,9 +881,9 @@ impl Chat {
         // reseed contract forbids it — the send-time reseed in `submit`
         // repairs the divergence at the next turn instead.
         {
-            let seed = self.visible_seed();
+            let (seed, buffers) = self.agent_seed();
             if let Some(harness) = self.harness.as_mut().filter(|h| !h.busy) {
-                harness.reseed(seed);
+                harness.reseed(seed, buffers);
             }
         }
     }
@@ -731,6 +896,63 @@ impl Chat {
     pub fn saved(&mut self, hmac: DocumentHmac, content: Vec<u8>) {
         self.hmac = Some(hmac);
         self.base = content;
+    }
+
+    /// Delete a message and everything downstream — its whole subtree *and*
+    /// its sibling alternatives' subtrees — so no hidden branch pops back
+    /// into view. The parent is upstream and stays; all of the parent's
+    /// descendants go. Config rows (hidden, out of the tree) are untouched.
+    fn delete_cascade(&mut self, idx: usize) {
+        let children = child_map(&self.entries);
+        // The deleted row's parent key. Its whole descendant set — every
+        // sibling branch — is what we remove.
+        let Some(parent_key) = children
+            .iter()
+            .find(|(_, kids)| kids.contains(&idx))
+            .map(|(p, _)| *p)
+        else {
+            // Not in the tree (shouldn't happen from a visible row) — remove
+            // just this entry.
+            self.entries.remove(idx);
+            self.seq += 1;
+            return;
+        };
+
+        let mut remove: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let mut stack = children.get(&parent_key).cloned().unwrap_or_default();
+        while let Some(node) = stack.pop() {
+            if remove.insert(node) {
+                if let Some(kids) = children.get(&Some(node)) {
+                    stack.extend(kids.iter().copied());
+                }
+            }
+        }
+
+        let removed_ids: std::collections::HashSet<Uuid> = remove
+            .iter()
+            .filter_map(|&k| self.entries[k].msg.id)
+            .collect();
+        let mut idxs: Vec<usize> = remove.into_iter().collect();
+        idxs.sort_unstable_by(|a, b| b.cmp(a));
+        for k in idxs {
+            self.entries.remove(k);
+        }
+
+        // Prune view state that referenced the removed rows.
+        self.branch_choice
+            .retain(|k, v| !removed_ids.contains(k) && !removed_ids.contains(v));
+        self.branch_anchor = None;
+        if self.editing.is_some_and(|id| removed_ids.contains(&id)) {
+            self.editing = None;
+            self.draft_stash = None;
+        }
+        if self
+            .hide_children_of
+            .is_some_and(|id| removed_ids.contains(&id))
+        {
+            self.hide_children_of = None;
+        }
+        self.seq += 1;
     }
 
     /// Reset the chat to its at-creation state: every entry goes — messages,
@@ -746,7 +968,7 @@ impl Chat {
         let selection = latest_selection(&self.entries, &self.account.username);
         let effort = latest_effort(&self.entries, &self.account.username);
         if let Some(h) = &mut self.harness {
-            h.reseed(Vec::new());
+            h.reseed(Vec::new(), tools::Buffers::default());
         }
         self.entries.clear();
         self.branch_choice.clear();
@@ -764,14 +986,15 @@ impl Chat {
         // With no re-recorded selection this falls back to the default
         // provider (or none) — same resolution as a brand-new chat.
         self.provider = self.resolve_provider();
-        self.key_prompt_dismissed = None;
         self.seq += 1;
     }
 
     /// Append an agent-authored row: a reply, or (with `error`) a dim red
-    /// note excluded from agent context. Attached to the message the turn
-    /// answered, and the branch choice follows it — a regenerated reply
-    /// supersedes its sibling on screen without deleting it.
+    /// note excluded from agent context. Attached to the previous row of the
+    /// turn (`pending_parent`, which each landed row advances — so a turn's
+    /// tool rows and reply form a chain, not siblings), and the branch choice
+    /// follows it — a regenerated reply supersedes its sibling on screen
+    /// without deleting it.
     fn push_agent_message(
         &mut self, content: String, usage: Option<lb_rs::model::chat::Usage>, error: bool,
     ) {
@@ -784,6 +1007,60 @@ impl Chat {
             self.branch_choice.insert(parent, id);
         }
         self.hide_children_of = None;
+        // Later rows of this turn chain under this one. Error rows don't
+        // advance: a retry's reply should land as the error's sibling.
+        if !error {
+            self.pending_parent = msg.id;
+        }
+        self.entries.push(Entry::new(
+            msg,
+            &self.ctx,
+            Arc::clone(&self.composer.renderer.files),
+            self.id,
+        ));
+        self.seq += 1;
+    }
+
+    /// Append a tool round-trip as one agent row carrying its `tool` record.
+    /// The model-facing result is truncated for the transcript; the raw
+    /// content replay needs (a read's note, an auto-open's pre-edit snapshot, a
+    /// merge's text) rides the row's `capture` extra — stored full, out of
+    /// model context and out of the rendered row.
+    fn push_tool_message(&mut self, outcome: harness::ToolOutcome) {
+        // A one-line summary is the row's content (rendered collapsed); the
+        // full result lives on the tool record, revealed on expand.
+        let summary = tools::detail_for(&outcome.name, &outcome.args);
+        let mut msg = Message::new(self.account.username.clone(), summary, Utc::now().timestamp());
+        msg.agent = true;
+        msg.tool = Some(ToolRecord {
+            name: outcome.name,
+            args: outcome.args,
+            result: truncate_for_persist(outcome.result),
+        });
+        if let Some(content) = outcome.capture {
+            msg.extra.insert("capture".into(), json!(content));
+        }
+        // A steering failure / denial — replay skips its mutation, and the
+        // model-context result is flagged an error.
+        if outcome.is_error {
+            msg.extra.insert("tool_error".into(), json!(true));
+        }
+        // The user's own sync-button action: persisted and folded like any
+        // record, but excluded from model context (see seed_history).
+        if outcome.user_action {
+            msg.extra.insert("user_action".into(), json!(true));
+        }
+        // Chain into the turn like a reply row: parented on the previous row,
+        // branch choice follows (a regenerated turn's first row may be a tool
+        // call — it must supersede the old sibling and unhide the timeline),
+        // and later rows of the turn chain under it. A denied/errored tool row
+        // still advances: the model's follow-up answers it.
+        msg.reply_to = self.pending_parent;
+        if let (Some(parent), Some(id)) = (self.pending_parent, msg.id) {
+            self.branch_choice.insert(parent, id);
+        }
+        self.hide_children_of = None;
+        self.pending_parent = msg.id;
         self.entries.push(Entry::new(
             msg,
             &self.ctx,
@@ -803,6 +1080,7 @@ impl Chat {
                 harness::HarnessUpdate::Reply { text, usage } => {
                     self.push_agent_message(text, usage, false)
                 }
+                harness::HarnessUpdate::Tool(outcome) => self.push_tool_message(outcome),
                 harness::HarnessUpdate::Error(e) => self.push_agent_message(e, None, true),
             }
         }
@@ -869,11 +1147,11 @@ impl Chat {
             // it. The divergence paths are real: messages typed before a
             // provider existed never reached the driver, and sync merges
             // add entries the driver never saw.
-            let mut seed = self.visible_seed();
+            let (mut seed, buffers) = self.agent_seed();
             seed.pop(); // `say` pushes the new message itself
             let system = self.system_prompt.clone();
             if let (Some(harness), Some(provider)) = (&mut self.harness, self.provider.clone()) {
-                harness.reseed(seed);
+                harness.reseed(seed, buffers);
                 harness.say(content, provider, system);
             }
         }
@@ -932,22 +1210,7 @@ fn resolve_visible(
     let msgs: Vec<usize> = (0..entries.len())
         .filter(|&i| !entries[i].hidden())
         .collect();
-    let id_to_idx: HashMap<Uuid, usize> = msgs
-        .iter()
-        .filter_map(|&i| entries[i].msg.id.map(|id| (id, i)))
-        .collect();
-
-    // children[parent entry index (None = root)] = child indices, ts order.
-    let mut children: HashMap<Option<usize>, Vec<usize>> = HashMap::new();
-    for (k, &i) in msgs.iter().enumerate() {
-        let implicit = (k > 0).then(|| msgs[k - 1]);
-        let parent = match entries[i].msg.reply_to {
-            Some(rt) if rt.is_nil() => None,
-            Some(rt) => id_to_idx.get(&rt).copied().or(implicit),
-            None => implicit,
-        };
-        children.entry(parent).or_default().push(i);
-    }
+    let children = child_map(entries);
 
     let mut visible = Vec::new();
     let mut parent: Option<usize> = None;
@@ -983,6 +1246,31 @@ fn resolve_visible(
     visible
 }
 
+/// The tree's `children` map (parent entry index, `None` = root → child
+/// indices in ts order), built the same way [`resolve_visible`] does so
+/// deletion and display agree on parentage. Hidden rows (config) are not in
+/// the tree.
+fn child_map(entries: &[Entry]) -> HashMap<Option<usize>, Vec<usize>> {
+    let msgs: Vec<usize> = (0..entries.len())
+        .filter(|&i| !entries[i].hidden())
+        .collect();
+    let id_to_idx: HashMap<Uuid, usize> = msgs
+        .iter()
+        .filter_map(|&i| entries[i].msg.id.map(|id| (id, i)))
+        .collect();
+    let mut children: HashMap<Option<usize>, Vec<usize>> = HashMap::new();
+    for (k, &i) in msgs.iter().enumerate() {
+        let implicit = (k > 0).then(|| msgs[k - 1]);
+        let parent = match entries[i].msg.reply_to {
+            Some(rt) if rt.is_nil() => None,
+            Some(rt) => id_to_idx.get(&rt).copied().or(implicit),
+            None => implicit,
+        };
+        children.entry(parent).or_default().push(i);
+    }
+    children
+}
+
 /// The parent id a sibling of `entries[idx]` should carry: the row's own
 /// resolved parent (`Uuid::nil()` = root), or `None` when the parent is a
 /// legacy id-less row that can't be referenced.
@@ -1006,7 +1294,6 @@ enum RowAction {
     Delete(usize),
     Edit(usize),
     ResendFrom(usize),
-    Regenerate(usize),
     /// Re-run the turn behind the tail error row.
     RetryLast,
     /// Switch a fork to the sibling at entry index `target`. `vi`/`anchor_y`
@@ -1015,6 +1302,15 @@ enum RowAction {
     Switch {
         parent: Uuid,
         target: usize,
+        vi: usize,
+        anchor_y: f32,
+    },
+    /// Expand or collapse a tool container. `vi`/`anchor_y` pin the row's
+    /// *header* to its on-screen position across the height change (the
+    /// body grows downward), instead of letting stick-to-bottom yank the
+    /// view.
+    ToggleTool {
+        id: Uuid,
         vi: usize,
         anchor_y: f32,
     },
@@ -1029,13 +1325,13 @@ enum RowKind {
 }
 
 /// Right-click menu on a message row — the secondary path to the row's
-/// actions, plus the ones that don't earn an icon (Retry from here, Delete).
-#[allow(clippy::too_many_arguments)]
+/// actions, plus the ones that don't earn an icon (Retry, Delete).
+/// The row response is created *before* the row's content paints (so links
+/// inside the content sit on top); this attaches the menu and actions to it.
 fn row_menu(
-    ui: &mut Ui, rect: Rect, i: usize, content: &str, kind: RowKind, editable: bool, regen: bool,
+    resp: &egui::Response, i: usize, content: &str, kind: RowKind, editable: bool,
     can_delete: bool, action: &mut Option<RowAction>,
 ) {
-    let resp = ui.interact(rect, Id::new(("chat_row", i)), Sense::click());
     resp.context_menu(|ui| {
         ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
         if ui.button("Copy").clicked() {
@@ -1047,14 +1343,10 @@ fn row_menu(
                 *action = Some(RowAction::Edit(i));
                 ui.close();
             }
-            if ui.button("Retry from here").clicked() {
+            if ui.button("Retry").clicked() {
                 *action = Some(RowAction::ResendFrom(i));
                 ui.close();
             }
-        }
-        if regen && ui.button("Regenerate").clicked() {
-            *action = Some(RowAction::Regenerate(i));
-            ui.close();
         }
         if can_delete && ui.button("Delete").clicked() {
             *action = Some(RowAction::Delete(i));
@@ -1063,21 +1355,150 @@ fn row_menu(
     });
 }
 
-/// The visible timeline as model context: agent replies as assistant turns,
-/// everything else as user turns; errors carry nothing the model saw.
+/// Persisted tool-result cap. The model sees the full result live; the
+/// transcript keeps a bounded copy for its model context. The raw content
+/// replay needs (a read's note, a merge's text) rides its record's `capture`
+/// attachment, stored full and separately.
+const TOOL_RESULT_CAP: usize = 32 * 1024;
+
+/// Truncate a tool result to the persist cap on a char boundary, marking the
+/// cut.
+fn truncate_for_persist(mut result: String) -> String {
+    if result.len() > TOOL_RESULT_CAP {
+        let mut cut = TOOL_RESULT_CAP;
+        while !result.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        result.truncate(cut);
+        result.push_str("\n…(truncated)");
+    }
+    result
+}
+
+/// The visible timeline as model context. Human/agent prose become user /
+/// assistant turns; a tool row becomes an assistant `tool_use` turn plus its
+/// `tool_result`, so a reopened chat replays the same tool context the live
+/// driver held. Error rows carry nothing the model saw.
+///
+/// The agent's text preceding a tool call was persisted as its own reply row;
+/// it's folded onto the following tool call's assistant turn (`carry`) so the
+/// sequence alternates user/assistant correctly and the two never land as
+/// consecutive assistant turns.
 fn seed_history(entries: &[Entry], visible: &[VisibleRow]) -> Vec<backend::ChatMsg> {
-    visible
-        .iter()
-        .map(|row| &entries[row.idx])
-        .filter(|e| !e.msg.error)
-        .map(|e| {
-            if e.msg.agent {
-                backend::ChatMsg::Assistant(e.msg.content.clone())
-            } else {
-                backend::ChatMsg::User(e.msg.content.clone())
-            }
-        })
-        .collect()
+    let mut out = Vec::new();
+    let mut carry: Option<String> = None;
+    let flush = |out: &mut Vec<backend::ChatMsg>, carry: &mut Option<String>| {
+        if let Some(text) = carry.take() {
+            out.push(backend::ChatMsg::Assistant { text, tool_calls: vec![] });
+        }
+    };
+    for row in visible {
+        let msg = &entries[row.idx].msg;
+        if msg.error {
+            continue;
+        }
+        // Write-back receipts fold into buffers but never enter model
+        // context — the model has no matching call to pair them with.
+        if user_actioned(msg) {
+            continue;
+        }
+        if let Some(record) = &msg.tool {
+            // The call id only needs to match its result within this reseed;
+            // the message id is stable and unique.
+            let id = msg.id.map(|i| i.to_string()).unwrap_or_default();
+            out.push(backend::ChatMsg::Assistant {
+                text: carry.take().unwrap_or_default(),
+                tool_calls: vec![backend::ToolCall {
+                    id: id.clone(),
+                    name: record.name.clone(),
+                    args: record.args.clone(),
+                }],
+            });
+            out.push(backend::ChatMsg::ToolResult {
+                id,
+                content: record.result.clone(),
+                is_error: tool_errored(msg),
+            });
+        } else if msg.agent {
+            flush(&mut out, &mut carry);
+            carry = Some(msg.content.clone());
+        } else {
+            flush(&mut out, &mut carry);
+            out.push(backend::ChatMsg::User(msg.content.clone()));
+        }
+    }
+    flush(&mut out, &mut carry);
+    out
+}
+
+/// Fold the visible tool records into a fresh buffer store, calling `f` per
+/// record with everything a fold needs (its `capture` attachment and error
+/// flag decoded). The shared spine of [`rebuild_buffers`] and
+/// [`build_tool_viz`] — the inverse of live dispatch, so both agree on how a
+/// reopened chat reconstructs agent state.
+fn fold_visible(
+    entries: &[Entry], visible: &[VisibleRow],
+    mut f: impl FnMut(&mut tools::Buffers, &Message, &ToolRecord, Option<String>, bool),
+) -> tools::Buffers {
+    let mut buffers = tools::Buffers::default();
+    for row in visible {
+        let msg = &entries[row.idx].msg;
+        let Some(record) = &msg.tool else { continue };
+        let capture = msg
+            .extra
+            .get("capture")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        f(&mut buffers, msg, record, capture, tool_errored(msg));
+    }
+    buffers
+}
+
+/// Rebuild the agent's variable buffers by folding the visible tool records —
+/// captures load content, edits transform it, syncs mark it clean. Reopening a
+/// chat reconstructs every open buffer, including unsaved edits. Each record's
+/// raw content rides its `capture` attachment (see [`push_tool_message`]).
+fn rebuild_buffers(entries: &[Entry], visible: &[VisibleRow]) -> tools::Buffers {
+    fold_visible(entries, visible, |buffers, _msg, record, capture, errored| {
+        tools::fold_record(buffers, &record.name, &record.args, capture, errored);
+    })
+}
+
+/// Derive each visible tool row's collapsed metric and expanded body by
+/// re-folding the visible records — the same fold as [`rebuild_buffers`],
+/// snapshotting around each record. Also returns the final fold: the buffers
+/// the next tool call runs against.
+fn build_tool_viz(
+    entries: &[Entry], visible: &[VisibleRow],
+) -> (HashMap<Uuid, tools::Viz>, tools::Buffers) {
+    let mut viz = HashMap::new();
+    let buffers = fold_visible(entries, visible, |buffers, msg, record, capture, errored| {
+        let v = tools::viz_record(
+            buffers,
+            &record.name,
+            &record.args,
+            capture,
+            errored,
+            &record.result,
+        );
+        if let Some(id) = msg.id {
+            viz.insert(id, v);
+        }
+    });
+    (viz, buffers)
+}
+
+/// Whether a row is a harness-authored consequence of the user's approval
+/// (the write-back receipt after an approved edit): persisted and folded,
+/// but neither model context nor a rendered row — sync isn't a tool call.
+fn user_actioned(msg: &Message) -> bool {
+    msg.extra.get("user_action").and_then(|v| v.as_bool()) == Some(true)
+}
+
+/// Whether a tool row recorded a steering failure or denial (no successful
+/// buffer effect).
+fn tool_errored(msg: &Message) -> bool {
+    msg.extra.get("tool_error").and_then(|v| v.as_bool()) == Some(true)
 }
 
 /// Whether a file (or any ancestor) is shared — a shared chat is a group
@@ -1129,6 +1550,213 @@ mod tests {
             .iter()
             .map(|r| entries[r.idx].msg.content.clone())
             .collect()
+    }
+
+    /// A persisted tool row seeds as an assistant `tool_use` turn plus its
+    /// `tool_result`, with the agent's preceding reply text folded onto the
+    /// call's turn — so a reopened chat replays the same tool context and the
+    /// turns alternate correctly.
+    #[test]
+    fn seed_emits_tool_pairs() {
+        let user = msg("read my todo", Some(Uuid::nil()));
+        let mut reply = Message::new("me".into(), "Let me check.".into(), 0);
+        reply.agent = true;
+        let mut tool = Message::new("me".into(), "read_note /todo.md".into(), 0);
+        tool.agent = true;
+        tool.tool = Some(ToolRecord {
+            name: "read_note".into(),
+            args: json!({ "path": "/todo.md" }),
+            result: "[/todo.md — 1 lines]\n- milk".into(),
+        });
+        let entries = vec![user, entry(reply), entry(tool)];
+        let visible = resolve_visible(&entries, &HashMap::new(), None);
+        let seed = seed_history(&entries, &visible);
+
+        // user, assistant{"Let me check." + call}, tool_result — no dangling
+        // consecutive assistant turns.
+        assert_eq!(seed.len(), 3);
+        assert!(matches!(&seed[0], backend::ChatMsg::User(t) if t == "read my todo"));
+        match &seed[1] {
+            backend::ChatMsg::Assistant { text, tool_calls } => {
+                assert_eq!(text, "Let me check.");
+                assert_eq!(tool_calls.len(), 1);
+                assert_eq!(tool_calls[0].name, "read_note");
+            }
+            other => panic!("expected assistant call turn, got {other:?}"),
+        }
+        match &seed[2] {
+            backend::ChatMsg::ToolResult { id, content, .. } => {
+                assert_eq!(*id, tool_calls_id(&seed));
+                assert!(content.contains("milk"));
+            }
+            other => panic!("expected tool result, got {other:?}"),
+        }
+    }
+
+    fn tool_calls_id(seed: &[backend::ChatMsg]) -> String {
+        match &seed[1] {
+            backend::ChatMsg::Assistant { tool_calls, .. } => tool_calls[0].id.clone(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Rows landed during one turn chain — user → tool → reply, each parented
+    /// on the last — rather than forking as siblings of the invoking message.
+    #[test]
+    fn turn_rows_chain_instead_of_forking() {
+        use lb_rs::model::core_config::{ClientType, Config};
+        let core = lb_rs::blocking::Lb::init(Config {
+            writeable_path: format!("/tmp/{}", Uuid::new_v4()),
+            logs: false,
+            stdout_logs: false,
+            colored_logs: false,
+            background_work: false,
+            client_type: ClientType::Unknown,
+        })
+        .unwrap();
+        let files = Arc::new(RwLock::new(FileCache::empty()));
+        let mut chat = Chat::new(
+            b"",
+            Uuid::new_v4(),
+            None,
+            Account::new("me".into(), "url".into()),
+            egui::Context::default(),
+            files,
+            &core,
+        );
+
+        let user = Message::new("me".into(), "list my notes".into(), 0);
+        let user_id = user.id;
+        chat.entries.push(entry(user));
+        chat.pending_parent = user_id;
+
+        chat.push_tool_message(harness::ToolOutcome {
+            name: "list".into(),
+            args: json!({}),
+            result: "/a.md".into(),
+            is_error: false,
+            capture: None,
+            user_action: false,
+        });
+        chat.push_agent_message("Here are your notes.".into(), None, false);
+
+        let visible = chat.visible();
+        assert_eq!(visible.len(), 3);
+        assert!(visible.iter().all(|r| r.fork.is_none()), "turn rows must chain, not fork");
+        let tool = &chat.entries[visible[1].idx].msg;
+        assert!(tool.tool.is_some());
+        assert_eq!(tool.reply_to, user_id);
+        assert_eq!(chat.entries[visible[2].idx].msg.reply_to, tool.id);
+    }
+
+    /// Regenerating any row of a turn reruns from the turn root: the chain
+    /// walks up through agent rows (reply, receipts, tool rows) to the
+    /// invoking user message, so the driver reseeds at a user turn — never
+    /// mid-turn, which the retry guard would refuse.
+    #[test]
+    fn regenerate_reruns_from_turn_root() {
+        use lb_rs::model::core_config::{ClientType, Config};
+        let core = lb_rs::blocking::Lb::init(Config {
+            writeable_path: format!("/tmp/{}", Uuid::new_v4()),
+            logs: false,
+            stdout_logs: false,
+            colored_logs: false,
+            background_work: false,
+            client_type: ClientType::Unknown,
+        })
+        .unwrap();
+        let files = Arc::new(RwLock::new(FileCache::empty()));
+        let mut chat = Chat::new(
+            b"",
+            Uuid::new_v4(),
+            None,
+            Account::new("me".into(), "url".into()),
+            egui::Context::default(),
+            files,
+            &core,
+        );
+
+        let user = Message::new("me".into(), "fix my note".into(), 0);
+        let user_id = user.id;
+        chat.entries.push(entry(user));
+        chat.pending_parent = user_id;
+        chat.push_tool_message(harness::ToolOutcome {
+            name: "edit_note".into(),
+            args: json!({ "path": "/a.md", "old_str": "x", "new_str": "y" }),
+            result: "edited /a.md".into(),
+            is_error: false,
+            capture: None,
+            user_action: false,
+        });
+        chat.push_agent_message("Done.".into(), None, false);
+
+        let reply_idx = chat.entries.len() - 1;
+        chat.regenerate(reply_idx);
+        assert_eq!(chat.hide_children_of, user_id, "whole turn superseded");
+        assert_eq!(chat.pending_parent, user_id, "rerun lands as the turn's sibling");
+        // The truncated seed ends at the user message — what the retry
+        // guard requires.
+        let (seed, _) = chat.agent_seed();
+        assert!(matches!(seed.last(), Some(backend::ChatMsg::User(t)) if t == "fix my note"));
+    }
+
+    /// Deleting a message nukes everything downstream — its subtree and its
+    /// sibling alternatives — so no hidden branch resurfaces. The parent
+    /// stays; config rows are untouched.
+    #[test]
+    fn delete_cascade_nukes_subtree_and_siblings() {
+        use lb_rs::model::core_config::{ClientType, Config};
+        let core = lb_rs::blocking::Lb::init(Config {
+            writeable_path: format!("/tmp/{}", Uuid::new_v4()),
+            logs: false,
+            stdout_logs: false,
+            colored_logs: false,
+            background_work: false,
+            client_type: ClientType::Unknown,
+        })
+        .unwrap();
+        let files = Arc::new(RwLock::new(FileCache::empty()));
+        let mut chat = Chat::new(
+            b"",
+            Uuid::new_v4(),
+            None,
+            Account::new("me".into(), "url".into()),
+            egui::Context::default(),
+            files,
+            &core,
+        );
+
+        // root q → reply A (+ regenerated sibling A2) → follow-up q2 under A.
+        let q = Message::new("me".into(), "q".into(), 0);
+        let q_id = q.id;
+        chat.entries.push(entry(q));
+        let mut a = Message::new("me".into(), "A".into(), 1);
+        a.agent = true;
+        a.reply_to = q_id;
+        let a_id = a.id;
+        chat.entries.push(entry(a));
+        let mut a2 = Message::new("me".into(), "A2".into(), 2);
+        a2.agent = true;
+        a2.reply_to = q_id;
+        chat.entries.push(entry(a2));
+        let mut q2 = Message::new("me".into(), "q2".into(), 3);
+        q2.reply_to = a_id;
+        chat.entries.push(entry(q2));
+
+        let a_idx = chat
+            .entries
+            .iter()
+            .position(|e| e.msg.content == "A")
+            .unwrap();
+        chat.delete_cascade(a_idx);
+
+        // A, its sibling A2, and A's follow-up q2 all gone; the question stays.
+        let left: Vec<&str> = chat
+            .entries
+            .iter()
+            .map(|e| e.msg.content.as_str())
+            .collect();
+        assert_eq!(left, ["q"], "only the upstream question remains");
     }
 
     /// Legacy rows (no ids, no reply_to) resolve as one linear chain.

--- a/libs/content/workspace/src/tab/chat/mod.rs
+++ b/libs/content/workspace/src/tab/chat/mod.rs
@@ -409,6 +409,10 @@ pub struct Chat {
     provider: Option<settings::Provider>,
     providers: Vec<settings::Provider>,
     system_prompt: Option<String>,
+    /// The user's sticky default selection for new chats: the most recent pick
+    /// in any chat, loaded from `/.agent/default.json`. Used only when this
+    /// chat has no per-chat selection of its own.
+    default_selection: Option<lb_rs::model::chat::ModelSelection>,
     /// False until the first background load lands — distinguishes "no
     /// providers yet" (don't flash the setup hint) from "genuinely none".
     config_loaded: bool,
@@ -468,6 +472,7 @@ type ModelListing = Vec<backend::ModelInfo>;
 struct LoadedConfig {
     providers: Vec<settings::Provider>,
     system_prompt: Option<String>,
+    default_selection: Option<lb_rs::model::chat::ModelSelection>,
 }
 
 /// The inline "connect a provider" step — a masked key field in the
@@ -693,6 +698,7 @@ impl Chat {
             provider: None,
             providers: Vec::new(),
             system_prompt: None,
+            default_selection: None,
             config_loaded: false,
             config_rx: None,
             key_entry: None,
@@ -1757,6 +1763,59 @@ mod tests {
             .map(|e| e.msg.content.as_str())
             .collect();
         assert_eq!(left, ["q"], "only the upstream question remains");
+    }
+
+    /// A chat with no per-chat selection resolves to the sticky last-used
+    /// default rather than the alphabetically-first provider; a stale default
+    /// (naming a since-removed provider) degrades to alphabetically-first.
+    #[test]
+    fn new_chat_uses_sticky_default() {
+        use lb_rs::model::chat::ModelSelection;
+        use lb_rs::model::core_config::{ClientType, Config};
+        let core = lb_rs::blocking::Lb::init(Config {
+            writeable_path: format!("/tmp/{}", Uuid::new_v4()),
+            logs: false,
+            stdout_logs: false,
+            colored_logs: false,
+            background_work: false,
+            client_type: ClientType::Unknown,
+        })
+        .unwrap();
+        let files = Arc::new(RwLock::new(FileCache::empty()));
+        let mut chat = Chat::new(
+            b"",
+            Uuid::new_v4(),
+            None,
+            Account::new("me".into(), "url".into()),
+            egui::Context::default(),
+            files,
+            &core,
+        );
+        // `load` sorts by name, so "first in the list" is alphabetical.
+        let prov = |name: &str| settings::Provider {
+            name: name.into(),
+            display_name: None,
+            kind: "openai".into(),
+            base_url: "https://x/v1".into(),
+            model: "m".into(),
+            api_key: Some("k".into()),
+            effort: None,
+        };
+        chat.providers = vec![prov("anthropic"), prov("cerebras")];
+
+        // No default, no per-chat selection → alphabetically-first.
+        chat.default_selection = None;
+        assert_eq!(chat.resolve_provider().unwrap().name, "anthropic");
+
+        // Sticky default wins over the alphabetical fallback.
+        chat.default_selection =
+            Some(ModelSelection { provider: "cerebras".into(), model: String::new() });
+        assert_eq!(chat.resolve_provider().unwrap().name, "cerebras");
+
+        // A default naming a removed provider degrades, doesn't strand the chat.
+        chat.default_selection =
+            Some(ModelSelection { provider: "ghost".into(), model: String::new() });
+        assert_eq!(chat.resolve_provider().unwrap().name, "anthropic");
     }
 
     /// Legacy rows (no ids, no reply_to) resolve as one linear chain.

--- a/libs/content/workspace/src/tab/chat/openai.rs
+++ b/libs/content/workspace/src/tab/chat/openai.rs
@@ -7,7 +7,9 @@ use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::backend::{ChatMsg, CompletionReq, ModelInfo};
+use super::backend::{
+    ChatMsg, Completion, CompletionReq, ModelInfo, ToolCall, ToolSchema, parse_tool_args,
+};
 use super::settings::Provider;
 
 /// Total request attempts (initial + backoff retries on 429/5xx).
@@ -26,6 +28,9 @@ struct HostQuirks {
     /// Output cap that fit the host's per-minute token budget (Groq's free
     /// tier admission-checks prompt + cap against 8k TPM).
     cap: Option<u32>,
+    /// Rejected OpenAI's newer tool fields (`strict`,
+    /// `parallel_tool_calls`) — send the universal core only.
+    plain_tools: bool,
 }
 
 fn quirks(base_url: &str) -> HostQuirks {
@@ -99,6 +104,78 @@ struct Choice {
 struct Delta {
     #[serde(default)]
     content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<ToolCallDelta>,
+}
+
+/// One streamed fragment of a tool call. The id and name arrive on the first
+/// fragment; `arguments` arrives as JSON split across fragments, keyed to its
+/// call by `index`.
+#[derive(Deserialize)]
+struct ToolCallDelta {
+    #[serde(default)]
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<FunctionDelta>,
+}
+
+#[derive(Deserialize)]
+struct FunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+/// A tool call mid-accumulation.
+#[derive(Default)]
+struct PartialCall {
+    id: String,
+    name: String,
+    args: String,
+}
+
+/// Write `tools` (and the one-call-at-a-time preference) into the request
+/// body. `plain` sends only the universal core — no `strict`, no
+/// `parallel_tool_calls` — for hosts that reject the newer fields.
+fn set_tools(body: &mut serde_json::Value, tools: &[ToolSchema], plain: bool) {
+    body["tools"] = tools
+        .iter()
+        .map(|t| {
+            let mut f = json!({
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters,
+            });
+            if !plain {
+                f["strict"] = json!(true);
+            }
+            json!({ "type": "function", "function": f })
+        })
+        .collect();
+    let obj = body.as_object_mut().expect("body is an object");
+    if plain {
+        obj.remove("parallel_tool_calls");
+    } else {
+        obj.insert("parallel_tool_calls".into(), json!(false));
+    }
+}
+
+/// Assemble accumulated fragments into calls: parse each argument string
+/// (empty = no args; malformed = wrapped raw so dispatch can steer), and
+/// synthesize ids for providers that omit them.
+fn finish_calls(parts: Vec<PartialCall>) -> Vec<ToolCall> {
+    parts
+        .into_iter()
+        .enumerate()
+        .filter(|(_, p)| !p.name.is_empty())
+        .map(|(i, p)| {
+            let id = if p.id.is_empty() { format!("call_{i}") } else { p.id };
+            ToolCall { id, name: p.name, args: parse_tool_args(&p.args) }
+        })
+        .collect()
 }
 
 #[derive(Deserialize)]
@@ -120,7 +197,7 @@ struct PromptTokensDetails {
 impl OpenAiBackend {
     pub(super) async fn complete(
         &self, req: CompletionReq, deltas: UnboundedSender<String>,
-    ) -> Result<Usage, String> {
+    ) -> Result<Completion, String> {
         let mut messages = Vec::new();
         if !req.system.is_empty() {
             messages.push(json!({ "role": "system", "content": req.system }));
@@ -128,7 +205,34 @@ impl OpenAiBackend {
         for msg in &req.messages {
             messages.push(match msg {
                 ChatMsg::User(text) => json!({ "role": "user", "content": text }),
-                ChatMsg::Assistant(text) => json!({ "role": "assistant", "content": text }),
+                ChatMsg::Assistant { text, tool_calls } => {
+                    let mut m = json!({ "role": "assistant" });
+                    // Text is null (not "") alongside calls, per the wire's
+                    // own responses.
+                    m["content"] = if text.is_empty() && !tool_calls.is_empty() {
+                        serde_json::Value::Null
+                    } else {
+                        json!(text)
+                    };
+                    if !tool_calls.is_empty() {
+                        // `arguments` is a JSON *string* on this wire.
+                        m["tool_calls"] = tool_calls
+                            .iter()
+                            .map(|c| {
+                                json!({
+                                    "id": c.id,
+                                    "type": "function",
+                                    "function": { "name": c.name, "arguments": c.args.to_string() },
+                                })
+                            })
+                            .collect();
+                    }
+                    m
+                }
+                // No error flag on this wire — the result text carries it.
+                ChatMsg::ToolResult { id, content, .. } => {
+                    json!({ "role": "tool", "tool_call_id": id, "content": content })
+                }
             });
         }
 
@@ -148,6 +252,10 @@ impl OpenAiBackend {
         // (OpenAI, Google's compat layer, xAI, Groq, OpenRouter, Together).
         if let Some(effort) = &self.effort {
             body["reasoning_effort"] = json!(effort);
+        }
+        let mut plain_tools = known.plain_tools;
+        if !req.tools.is_empty() {
+            set_tools(&mut body, &req.tools, plain_tools);
         }
 
         // Rate limits (429) and transient server errors (5xx) back off and
@@ -220,6 +328,18 @@ impl OpenAiBackend {
                     }
                 }
             }
+            // Some compat hosts reject OpenAI's newer tool fields by name.
+            // Strip to the universal tool core and re-send.
+            if !plain_tools
+                && !req.tools.is_empty()
+                && status.as_u16() == 400
+                && (error_body.contains("parallel_tool_calls") || error_body.contains("strict"))
+            {
+                plain_tools = true;
+                learn_quirk(&self.base_url, |q| q.plain_tools = true);
+                set_tools(&mut body, &req.tools, true);
+                continue;
+            }
             return Err(format!("{status}: {}", error_body.chars().take(500).collect::<String>()));
         };
 
@@ -229,6 +349,7 @@ impl OpenAiBackend {
         // chunks split mid-character, and decoding a chunk at a time would
         // corrupt multi-byte glyphs into � (and persist them).
         let mut usage = Usage::default();
+        let mut calls: Vec<PartialCall> = Vec::new();
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();
         loop {
@@ -246,7 +367,7 @@ impl OpenAiBackend {
                 let line = line.trim();
                 let Some(payload) = line.strip_prefix("data:").map(str::trim) else { continue };
                 if payload == "[DONE]" {
-                    return Ok(usage);
+                    return Ok(Completion { tool_calls: finish_calls(calls), usage });
                 }
                 let Ok(chunk) = serde_json::from_str::<Chunk>(payload) else { continue };
                 if let Some(u) = chunk.usage {
@@ -258,14 +379,36 @@ impl OpenAiBackend {
                     usage.output = u.completion_tokens;
                     usage.cache_read = cached;
                 }
-                if let Some(text) = chunk.choices.first().and_then(|c| c.delta.content.clone()) {
-                    if !text.is_empty() {
-                        let _ = deltas.send(text);
+                if let Some(choice) = chunk.choices.into_iter().next() {
+                    if let Some(text) = choice.delta.content {
+                        if !text.is_empty() {
+                            let _ = deltas.send(text);
+                        }
+                    }
+                    // Fragments accumulate per index: id/name land on the
+                    // first fragment (assigned, in case a host re-sends
+                    // them), arguments concatenate across fragments.
+                    for frag in choice.delta.tool_calls {
+                        if calls.len() <= frag.index {
+                            calls.resize_with(frag.index + 1, Default::default);
+                        }
+                        let call = &mut calls[frag.index];
+                        if let Some(id) = frag.id {
+                            call.id = id;
+                        }
+                        if let Some(f) = frag.function {
+                            if let Some(name) = f.name {
+                                call.name = name;
+                            }
+                            if let Some(args) = f.arguments {
+                                call.args.push_str(&args);
+                            }
+                        }
                     }
                 }
             }
         }
-        Ok(usage)
+        Ok(Completion { tool_calls: finish_calls(calls), usage })
     }
 }
 
@@ -585,11 +728,23 @@ mod tests {
     use super::mock::{SSE_HELLO, serve_once};
     use super::*;
 
-    fn complete(base_url: &str) -> (Result<Usage, String>, Vec<String>) {
+    fn complete(base_url: &str) -> (Result<Completion, String>, Vec<String>) {
         complete_with(base_url, 100)
     }
 
-    fn complete_with(base_url: &str, max_tokens: u32) -> (Result<Usage, String>, Vec<String>) {
+    fn complete_with(base_url: &str, max_tokens: u32) -> (Result<Completion, String>, Vec<String>) {
+        let req = CompletionReq {
+            system: "system".into(),
+            messages: vec![ChatMsg::User("hi".into())],
+            max_tokens,
+            tools: vec![],
+        };
+        complete_req(base_url, req)
+    }
+
+    fn complete_req(
+        base_url: &str, req: CompletionReq,
+    ) -> (Result<Completion, String>, Vec<String>) {
         let backend = openai_compat(&Provider {
             name: "mock".into(),
             display_name: None,
@@ -599,11 +754,6 @@ mod tests {
             api_key: Some("test-key".into()),
             effort: None,
         });
-        let req = CompletionReq {
-            system: "system".into(),
-            messages: vec![ChatMsg::User("hi".into())],
-            max_tokens,
-        };
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -615,6 +765,20 @@ mod tests {
             deltas.push(d);
         }
         (result, deltas)
+    }
+
+    /// A schema for wire tests: one required string param, strict-compatible.
+    fn tool() -> ToolSchema {
+        ToolSchema {
+            name: "read_note",
+            description: "Read a note.",
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"],
+                "additionalProperties": false,
+            }),
+        }
     }
 
     /// A configured effort rides the wire as `reasoning_effort`; an absent
@@ -639,6 +803,7 @@ mod tests {
                 system: "s".into(),
                 messages: vec![ChatMsg::User("hi".into())],
                 max_tokens: 100,
+                tools: vec![],
             };
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
             tokio::runtime::Builder::new_current_thread()
@@ -651,6 +816,118 @@ mod tests {
         };
         assert!(run(&provider(Some("high"))).contains("\"reasoning_effort\":\"high\""));
         assert!(!run(&provider(None)).contains("reasoning_effort"));
+    }
+
+    /// Tools ride the wire in OpenAI's function shape with `strict` and the
+    /// one-call-at-a-time flag; a tool-less request sends neither key. Call
+    /// turns re-serialize with `arguments` as a JSON *string*, and results go
+    /// back as `role:"tool"` under the call id.
+    #[test]
+    fn tools_and_call_turns_ride_the_wire() {
+        let (base, body_rx) = super::mock::serve_capturing(SSE_HELLO);
+        let req = CompletionReq {
+            system: "s".into(),
+            messages: vec![
+                ChatMsg::User("add milk".into()),
+                ChatMsg::Assistant {
+                    text: String::new(),
+                    tool_calls: vec![ToolCall {
+                        id: "call_1".into(),
+                        name: "read_note".into(),
+                        args: serde_json::json!({ "path": "/todo.md" }),
+                    }],
+                },
+                ChatMsg::ToolResult {
+                    id: "call_1".into(),
+                    content: "- eggs".into(),
+                    is_error: false,
+                },
+            ],
+            max_tokens: 100,
+            tools: vec![tool()],
+        };
+        let (result, _) = complete_req(&base, req);
+        assert!(result.is_ok(), "{result:?}");
+        let body: serde_json::Value = serde_json::from_str(&body_rx.recv().unwrap()).unwrap();
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["function"]["name"], "read_note");
+        assert_eq!(body["tools"][0]["function"]["strict"], true);
+        assert_eq!(body["parallel_tool_calls"], false);
+        // messages: [system, user, assistant call turn, tool result]
+        let call_turn = &body["messages"][2];
+        assert_eq!(call_turn["content"], serde_json::Value::Null);
+        assert_eq!(call_turn["tool_calls"][0]["id"], "call_1");
+        assert_eq!(
+            call_turn["tool_calls"][0]["function"]["arguments"], "{\"path\":\"/todo.md\"}",
+            "arguments must be a JSON string"
+        );
+        let result_turn = &body["messages"][3];
+        assert_eq!(result_turn["role"], "tool");
+        assert_eq!(result_turn["tool_call_id"], "call_1");
+        assert_eq!(result_turn["content"], "- eggs");
+
+        let (base, body_rx) = super::mock::serve_capturing(SSE_HELLO);
+        let (_, _) = complete_with(&base, 100);
+        let body: serde_json::Value = serde_json::from_str(&body_rx.recv().unwrap()).unwrap();
+        assert!(body.get("tools").is_none(), "tool-less request must omit tools");
+        assert!(body.get("parallel_tool_calls").is_none());
+    }
+
+    /// Tool-call fragments accumulate by index across chunks — id and name on
+    /// the first fragment, arguments split across the rest (and across a
+    /// network chunk boundary mid-fragment).
+    #[test]
+    fn tool_calls_accumulate_across_chunks() {
+        const SSE_CALL: &str = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n\
+             data: {\"choices\":[{\"delta\":{\"content\":\"Let me check.\"}}]}\n\n\
+             data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_9\",\"type\":\"function\",\"function\":{\"name\":\"read_note\",\"arguments\":\"\"}}]}}]}\n\n\
+             data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/to\"}}]}}]}\n\n\
+             data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"do.md\\\"}\"}}]}}]}\n\n\
+             data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":2}}\n\n\
+             data: [DONE]\n\n";
+        // Split inside the second arguments fragment.
+        let split_at = SSE_CALL.find("do.md").unwrap() + 2;
+        let base = super::mock::serve_split(SSE_CALL, split_at);
+        let req = CompletionReq {
+            system: "s".into(),
+            messages: vec![ChatMsg::User("hi".into())],
+            max_tokens: 100,
+            tools: vec![tool()],
+        };
+        let (result, deltas) = complete_req(&base, req);
+        let completion = result.unwrap();
+        assert_eq!(deltas.join(""), "Let me check.");
+        assert_eq!(
+            completion.tool_calls,
+            vec![ToolCall {
+                id: "call_9".into(),
+                name: "read_note".into(),
+                args: serde_json::json!({ "path": "/todo.md" }),
+            }]
+        );
+    }
+
+    /// A 400 naming a newer tool field re-sends with the universal tool core
+    /// (no strict, no parallel flag) instead of surfacing.
+    #[test]
+    fn strips_tool_fields_when_rejected() {
+        let body = r#"{"error":{"message":"Unknown parameter: 'parallel_tool_calls'."}}"#;
+        let resp = format!(
+            "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\
+             Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let base = super::mock::serve_seq(vec![Box::leak(resp.into_boxed_str()), SSE_HELLO]);
+        let req = CompletionReq {
+            system: "s".into(),
+            messages: vec![ChatMsg::User("hi".into())],
+            max_tokens: 100,
+            tools: vec![tool()],
+        };
+        let (result, deltas) = complete_req(&base, req);
+        assert!(result.is_ok(), "{result:?}");
+        assert_eq!(deltas.join(""), "Hello");
     }
 
     /// A 400 naming `max_completion_tokens` re-sends with the renamed cap
@@ -776,8 +1053,10 @@ mod tests {
     fn streams_deltas_and_usage() {
         let base = serve_once(SSE_HELLO);
         let (result, deltas) = complete(&base);
-        let usage = result.unwrap();
+        let completion = result.unwrap();
         assert_eq!(deltas.join(""), "Hello");
+        assert!(completion.tool_calls.is_empty());
+        let usage = completion.usage;
         // input excludes the cached subset: 10 prompt − 3 cached.
         assert_eq!((usage.input, usage.output, usage.cache_read), (7, 2, 3));
     }

--- a/libs/content/workspace/src/tab/chat/settings.rs
+++ b/libs/content/workspace/src/tab/chat/settings.rs
@@ -92,6 +92,15 @@ impl Provider {
             }
         }
     }
+
+    /// Whether this provider runs on this machine (a loopback host). Local
+    /// models egress nothing, so reads skip the approval gate.
+    pub fn is_local(&self) -> bool {
+        url::Url::parse(&self.base_url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_string))
+            .is_some_and(|h| matches!(h.as_str(), "localhost" | "127.0.0.1" | "[::1]" | "::1"))
+    }
 }
 
 pub const DEFAULT_KIND: &str = "openai";
@@ -101,7 +110,10 @@ fn default_kind() -> String {
 }
 
 /// Read every provider file, sorted by name. Unparseable files are logged
-/// and skipped.
+/// and skipped. A file still carrying the template key placeholder is a
+/// half-created provider — skipped too, so an unconfigured provider is, in
+/// every respect (picker, resolution, onboarding), as if its file didn't
+/// exist; the roster's "add provider" flow is where it gets set up.
 pub fn load(core: &Lb) -> Vec<Provider> {
     let Ok(dir) = core.get_by_path(PROVIDERS_DIR) else { return Vec::new() };
     let Ok(children) = core.get_children(&dir.id) else { return Vec::new() };
@@ -112,6 +124,7 @@ pub fn load(core: &Lb) -> Vec<Provider> {
             let name = f.name.trim_end_matches(".json").to_string();
             let bytes = core.read_document(f.id, false).ok()?;
             match parse(&name, &bytes) {
+                Some(p) if p.api_key.as_deref() == Some(super::KEY_PLACEHOLDER) => None,
                 Some(p) => Some(p),
                 None => {
                     tracing::warn!("chat: invalid provider file {PROVIDERS_DIR}/{}", f.name);
@@ -185,6 +198,24 @@ mod tests {
 
     fn sel(provider: &str, model: &str) -> ModelSelection {
         ModelSelection { provider: provider.into(), model: model.into() }
+    }
+
+    /// Loopback hosts are local (reads skip the approval gate); everything
+    /// else — including lookalike domains — egresses.
+    #[test]
+    fn is_local_is_loopback_only() {
+        let at = |url: &str| Provider { base_url: url.into(), ..provider("p", "m") };
+        for url in ["http://localhost:11434/v1", "http://127.0.0.1:8080/v1", "http://[::1]:1/v1"] {
+            assert!(at(url).is_local(), "{url}");
+        }
+        for url in [
+            "https://api.openai.com/v1",
+            "https://mylocalhost.evil.com/v1",
+            "http://192.168.1.10:11434/v1",
+            "not a url",
+        ] {
+            assert!(!at(url).is_local(), "{url}");
+        }
     }
 
     #[test]

--- a/libs/content/workspace/src/tab/chat/settings.rs
+++ b/libs/content/workspace/src/tab/chat/settings.rs
@@ -27,6 +27,32 @@ use serde::Deserialize;
 
 const PROVIDERS_DIR: &str = "/.agent/providers";
 pub const PROMPT_PATH: &str = "/.agent/prompt.md";
+/// The sticky default provider/model for new chats: the most recent pick in
+/// any chat, mirrored here so a fresh chat starts where the last one left off.
+/// Synced like everything under `/.agent`; absent until a first pick, and a
+/// new chat then falls back to the alphabetically-first provider.
+const DEFAULT_PATH: &str = "/.agent/default.json";
+
+/// Read the sticky default selection, if one has been recorded.
+pub fn load_default(core: &Lb) -> Option<lb_rs::model::chat::ModelSelection> {
+    let file = core.get_by_path(DEFAULT_PATH).ok()?;
+    let bytes = core.read_document(file.id, false).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Record the sticky default selection. Best-effort — a convenience, not
+/// load-bearing — so I/O failures are swallowed.
+pub fn write_default(core: &Lb, selection: &lb_rs::model::chat::ModelSelection) {
+    let Ok(bytes) = serde_json::to_vec_pretty(selection) else { return };
+    let id = match core.get_by_path(DEFAULT_PATH) {
+        Ok(f) => f.id,
+        Err(_) => match core.create_at_path(DEFAULT_PATH) {
+            Ok(f) => f.id,
+            Err(_) => return,
+        },
+    };
+    let _ = core.write_document(id, &bytes);
+}
 
 /// Custom system prompt: the whole of `/.agent/prompt.md` whenever the file
 /// exists — an empty file means no system prompt, not the default; deleting

--- a/libs/content/workspace/src/tab/chat/tools.rs
+++ b/libs/content/workspace/src/tab/chat/tools.rs
@@ -1,0 +1,1101 @@
+//! The agent's tools and the per-chat branch they edit.
+//!
+//! # The branch model
+//!
+//! An agent never touches a lockbook document directly. The first time it
+//! observes a note's contents — a `read_note`, or an `edit_note`/`append_note`
+//! that auto-opens — the note is *captured*: its bytes and version (hmac) are
+//! snapshotted into a [`Buffer`] and the note surfaces as an agent-owned tab.
+//! Every edit mutates the buffer, not the file. Each edit is individually
+//! approved by the user (the card shows [`preview_edit`]'s diff); on
+//! approval the harness runs the edit and immediately writes the buffer
+//! back to the note ([`sync_note`], no longer a model tool).
+//!
+//! # Determinism / replay
+//!
+//! The buffer store is never persisted. It is a deterministic fold of the
+//! recorded tool calls: captures load content, edits transform it, syncs mark
+//! it clean. Replaying a chat's [`ToolRecord`](lb_rs::model::chat::ToolRecord)s
+//! rebuilds every buffer, including unsaved ones. The load-bearing invariant:
+//! **a record is a capture exactly when information flows disk → buffer**
+//! (open, and a merge-case sync). Those records persist their content
+//! un-truncated; everything else derives from the call itself.
+
+use std::collections::BTreeMap;
+
+use lb_rs::Lb;
+use lb_rs::model::file_metadata::DocumentHmac;
+use lb_rs::model::text::buffer::Buffer as TextBuffer;
+use serde_json::{Value, json};
+
+use super::backend::ToolSchema;
+
+/// A note the model refuses to open beyond — a truncated capture would corrupt
+/// replay, so oversized notes error instead of loading a partial snapshot.
+const OPEN_CAP: usize = 256 * 1024;
+
+/// The persisted result of a denied edit. Kept identical to what the model
+/// sees, so a restored transcript's context matches the live one.
+pub const DENIED_RESULT: &str = "The user denied this tool call.";
+
+/// One note open on the branch: the captured base (content + version at
+/// capture) and the current edited text. `dirty` ⇔ `text != base_text`.
+#[derive(Clone)]
+pub struct Buffer {
+    /// Version of the last capture/sync. `None`: a new note not yet on disk.
+    pub base_hmac: Option<DocumentHmac>,
+    /// Content at the last capture/sync — the 3-way merge base.
+    pub base_text: String,
+    /// Current branch content.
+    pub text: String,
+}
+
+impl Buffer {
+    /// A fresh capture: branch starts equal to the captured base.
+    fn captured(base_hmac: Option<DocumentHmac>, content: String) -> Self {
+        Self { base_hmac, base_text: content.clone(), text: content }
+    }
+
+    pub fn dirty(&self) -> bool {
+        self.text != self.base_text
+    }
+}
+
+/// The agent's open notes, keyed by lockbook path. Owned by the driver for
+/// the chat session's life; rebuilt on reopen by replaying tool records.
+#[derive(Default)]
+pub struct Buffers {
+    open: BTreeMap<String, Buffer>,
+}
+
+impl Buffers {
+    pub fn get(&self, path: &str) -> Option<&Buffer> {
+        self.open.get(path)
+    }
+
+    pub fn is_open(&self, path: &str) -> bool {
+        self.open.contains_key(path)
+    }
+
+    /// Load a capture into the store (an open, or a merge-case sync result).
+    /// Used both by live dispatch and by replay.
+    pub fn capture(&mut self, path: &str, base_hmac: Option<DocumentHmac>, content: String) {
+        self.open
+            .insert(path.to_string(), Buffer::captured(base_hmac, content));
+    }
+
+    /// Mark an open buffer saved at its current text (a clean sync).
+    pub fn mark_clean(&mut self, path: &str) {
+        if let Some(buf) = self.open.get_mut(path) {
+            buf.base_text = buf.text.clone();
+        }
+    }
+
+    /// Apply an exact-string edit to an open buffer. Returns the outcome line
+    /// (with a size delta) or a steering error naming the match count.
+    /// `replace_all` lifts the uniqueness requirement.
+    pub fn edit(
+        &mut self, path: &str, old: &str, new: &str, replace_all: bool,
+    ) -> Result<String, String> {
+        let Some(buf) = self.open.get_mut(path) else {
+            return Err(format!("error: {path} isn't open. read_note it first."));
+        };
+        let count = buf.text.matches(old).count();
+        match count {
+            0 => Err(format!(
+                "error: old_str not found in {path}. It must match exactly, \
+                 including whitespace. read_note to see the current text."
+            )),
+            n if n > 1 && !replace_all => Err(format!(
+                "error: old_str matches {n} places in {path}. Add surrounding \
+                 context to make it unique, or set replace_all to change all {n}."
+            )),
+            _ => {
+                let before = buf.text.lines().count();
+                buf.text = if replace_all {
+                    buf.text.replace(old, new)
+                } else {
+                    buf.text.replacen(old, new, 1)
+                };
+                Ok(edited_line(path, before, buf.text.lines().count()))
+            }
+        }
+    }
+
+    /// Append to an open buffer.
+    pub fn append(&mut self, path: &str, content: &str) -> String {
+        let buf = self.open.get_mut(path).expect("append on an open buffer");
+        let before = buf.text.lines().count();
+        if !buf.text.is_empty() && !buf.text.ends_with('\n') {
+            buf.text.push('\n');
+        }
+        buf.text.push_str(content);
+        edited_line(path, before, buf.text.lines().count())
+    }
+
+    /// Replace an open buffer's contents wholesale.
+    pub fn write(&mut self, path: &str, content: String) -> String {
+        let buf = self.open.get_mut(path).expect("write on an open buffer");
+        let before = buf.text.lines().count();
+        let after = content.lines().count();
+        buf.text = content;
+        edited_line(path, before, after)
+    }
+}
+
+// The write-back follows approval immediately, so the model never sees an
+// unsaved intermediate state.
+fn edited_line(path: &str, before: usize, after: usize) -> String {
+    format!("edited {path} — now {after} lines (was {before})")
+}
+
+/// Three-way merge of a sync conflict: reconcile our branch edits and the
+/// concurrent on-disk edits over their common capture base, using the editor's
+/// own merge so agent syncs behave like a human tab's save-conflict.
+pub fn merge(base: &str, ours: &str, theirs: &str) -> String {
+    TextBuffer::from(base).merge(ours.to_string(), theirs.to_string())
+}
+
+/// The result of one tool call, plus how the harness should persist it.
+pub struct Outcome {
+    /// What the model sees as the tool result (truncated on persist).
+    pub result: String,
+    /// `is_error` on the wire — a steering failure the model self-corrects.
+    pub is_error: bool,
+    /// Raw content to persist as this call's replay attachment, stored full
+    /// (not truncated) and out of model context: the note a read/auto-open
+    /// captured, or a merge-sync's merged text. On replay it loads the buffer
+    /// (base+text) before this record's own mutation is folded in — so an
+    /// auto-open edit stores the *pre-edit* content here, then the edit
+    /// applies on top.
+    pub capture: Option<String>,
+}
+
+impl Outcome {
+    fn ok(result: String) -> Self {
+        Self { result, is_error: false, capture: None }
+    }
+
+    fn err(result: String) -> Self {
+        Self { result, is_error: true, capture: None }
+    }
+}
+
+/// Replay one persisted tool record into the buffer store: load its capture
+/// attachment (if any), then fold its own mutation. Deterministic — the same
+/// records rebuild the same buffers. Rebuilt buffers carry no base hmac; their
+/// first sync takes the merge path, which degenerates to a clean write when
+/// disk is unchanged.
+///
+/// `is_error` (a steering failure or a denial) suppresses the *mutation* but
+/// not the capture: a failed edit that auto-opened still leaves its note open
+/// at the pre-edit base (matching live), while a denied sync must not mark the
+/// buffer saved and a denied/errored call with no capture is a pure no-op.
+pub fn fold_record(
+    buffers: &mut Buffers, name: &str, args: &Value, capture: Option<String>, is_error: bool,
+) {
+    let path = args.get("path").and_then(Value::as_str).unwrap_or_default();
+    let had_capture = capture.is_some();
+    if let Some(content) = capture {
+        buffers.capture(path, None, content);
+    }
+    if is_error {
+        return;
+    }
+    match name {
+        "edit_note" => {
+            let old = args
+                .get("old_str")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let new = args
+                .get("new_str")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let all = args
+                .get("replace_all")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let _ = buffers.edit(path, old, new, all);
+        }
+        "append_note" => {
+            if let Some(c) = args.get("content").and_then(Value::as_str) {
+                if buffers.is_open(path) {
+                    buffers.append(path, c);
+                }
+            }
+        }
+        "write_note" => {
+            if let Some(c) = args.get("content").and_then(Value::as_str) {
+                if buffers.is_open(path) {
+                    buffers.write(path, c.to_string());
+                }
+            }
+        }
+        // A clean sync (no merged capture) just marks the buffer saved at its
+        // current text; a merge sync's capture already set base+text = merged.
+        "sync_note" if !had_capture => buffers.mark_clean(path),
+        _ => {}
+    }
+}
+
+/// How one recorded call renders in the transcript: a collapsed outcome
+/// metric and an expanded body. Derived, never persisted — [`viz_record`]
+/// produces it from the same fold replay uses, so what a row shows is exactly
+/// the state the call left behind.
+pub struct Viz {
+    /// Right-aligned dim figure on the collapsed row ("42 lines", "+3 -1",
+    /// "7 items", "saved", "error"). Empty renders nothing.
+    pub metric: String,
+    pub body: Body,
+}
+
+/// A tool row's expanded content.
+#[derive(Clone)]
+pub enum Body {
+    /// Raw result text — unknown tools, steering errors, empty listings.
+    Text(String),
+    /// The affected note's new state — the value a read bound, rendered as
+    /// markdown.
+    Note { text: String },
+    /// The change an edit made: stacked del/add segments with one block of
+    /// surrounding context (the approval card's preview shape). The
+    /// write-back receipt row that follows an approved edit carries no diff
+    /// — the card just showed it.
+    Rendered { segments: Vec<super::diff::Segment> },
+    /// Listing rows; document paths open in the workspace on click.
+    List { rows: Vec<String> },
+}
+
+/// Body lines beyond this are elided — an expanded row previews a value, the
+/// note's own tab is the full view.
+const BODY_LINES: usize = 200;
+
+/// Fold one record (exactly like [`fold_record`]) and derive its row's
+/// metric + expanded body from the before/after buffer states.
+pub fn viz_record(
+    buffers: &mut Buffers, name: &str, args: &Value, capture: Option<String>, is_error: bool,
+    result: &str,
+) -> Viz {
+    let path = args.get("path").and_then(Value::as_str).unwrap_or_default();
+    let pre = buffers.get(path).cloned();
+    let had_capture = capture.is_some();
+    fold_record(buffers, name, args, capture, is_error);
+    let post = buffers.get(path).cloned();
+
+    let viz = |metric: &str, body: Body| Viz { metric: metric.into(), body };
+
+    let text_body = || Body::Text(result.to_string());
+    if result == DENIED_RESULT {
+        return viz("denied", text_body());
+    }
+    if is_error {
+        return viz("error", text_body());
+    }
+    match (name, post) {
+        ("list", _) => {
+            if result.ends_with("is empty.") {
+                return viz("empty", text_body());
+            }
+            let rows: Vec<String> = result.lines().map(str::to_string).collect();
+            viz(&count(rows.len(), "item"), Body::List { rows })
+        }
+        ("read_note", Some(buf)) => {
+            viz(&count(buf.text.lines().count(), "line"), Body::Note { text: elide(&buf.text) })
+        }
+        ("edit_note" | "append_note" | "write_note", Some(buf)) => {
+            let old = pre.map(|b| b.text).unwrap_or_default();
+            viz(
+                &line_metric(&old, &buf.text),
+                Body::Rendered { segments: super::diff::segments(&old, &buf.text, 1) },
+            )
+        }
+        ("sync_note", Some(_)) => {
+            // A receipt, not a diff — the approval card already showed the
+            // change; repeating it here would render the same diff twice.
+            let metric = if had_capture {
+                "merged"
+            } else if pre.is_some_and(|b| b.dirty()) {
+                "saved"
+            } else {
+                "no changes"
+            };
+            viz(metric, text_body())
+        }
+        _ => viz("", text_body()),
+    }
+}
+
+/// The change an `edit_note` call proposes, for the approval card: the
+/// target's current text (open buffer, else disk) with the edit applied,
+/// as del/add segments with one block of context. `Err` is the steering
+/// message the call will hit if approved, shown on the card instead.
+pub(super) async fn preview_edit(
+    lb: &Lb, buffers: &Buffers, args: &Value,
+) -> Result<Vec<super::diff::Segment>, String> {
+    let path = arg(args, "path")?;
+    let old = arg(args, "old_str")?;
+    let new = arg(args, "new_str")?;
+    let replace_all = args
+        .get("replace_all")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let base = match buffers.get(path) {
+        Some(b) => b.text.clone(),
+        None => match capture_from_disk(lb, path).await {
+            Ok((_, content)) if content.len() > OPEN_CAP => {
+                return Err(format!(
+                    "error: {path} is too large to open ({} KiB).",
+                    content.len() / 1024
+                ));
+            }
+            Ok((_, content)) => content,
+            Err(NotADoc) => return Err(format!("error: {path} is a folder, not a note.")),
+            Err(Missing) => return Err(format!("error: no note at {path}.")),
+            Err(NotUtf8) => return Err(format!("error: {path} isn't text.")),
+        },
+    };
+    // A scratch store so the preview can't touch the real branch.
+    let mut scratch = Buffers::default();
+    scratch.capture(path, None, base.clone());
+    scratch.edit(path, old, new, replace_all)?;
+    let text = scratch
+        .get(path)
+        .map(|b| b.text.clone())
+        .unwrap_or_default();
+    Ok(super::diff::segments(&base, &text, 1))
+}
+
+fn count(n: usize, noun: &str) -> String {
+    if n == 1 { format!("1 {noun}") } else { format!("{n} {noun}s") }
+}
+
+fn elide(text: &str) -> String {
+    let mut lines = text.lines();
+    let shown: Vec<&str> = lines.by_ref().take(BODY_LINES).collect();
+    let rest = lines.count();
+    if rest == 0 {
+        text.to_string()
+    } else {
+        format!("{}\n… ({rest} more lines)", shown.join("\n"))
+    }
+}
+
+/// "+added -removed" over a line diff, git-style — the collapsed row's
+/// metric (lines are more informative than blocks there).
+fn line_metric(old: &str, new: &str) -> String {
+    use similar::{ChangeTag, TextDiff};
+    let diff = TextDiff::from_lines(old, new);
+    let (mut add, mut del) = (0usize, 0usize);
+    for change in diff.iter_all_changes() {
+        match change.tag() {
+            ChangeTag::Insert => add += 1,
+            ChangeTag::Delete => del += 1,
+            ChangeTag::Equal => {}
+        }
+    }
+    format!("+{add} -{del}")
+}
+
+/// The minimal-slice tools. Order and content are stable across a
+/// conversation — the schema block renders ahead of everything else in the
+/// provider's prompt, so any change invalidates its cache.
+pub fn schemas() -> Vec<ToolSchema> {
+    let one_path = |prop: &str| {
+        json!({
+            "type": "object",
+            "properties": { prop: { "type": "string" } },
+            "required": [prop],
+            "additionalProperties": false,
+        })
+    };
+    vec![
+        ToolSchema {
+            name: "list",
+            description: "List notes and folders. Folders end with '/'. Use \
+                          this to explore the tree before reading.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "Folder to list; defaults to the root." },
+                    "recursive": { "type": "boolean" },
+                },
+                "required": [],
+                "additionalProperties": false,
+            }),
+        },
+        ToolSchema {
+            name: "read_note",
+            description: "Read a note's full contents. Paths are absolute \
+                          and start with '/'.",
+            parameters: one_path("path"),
+        },
+        ToolSchema {
+            name: "edit_note",
+            description: "Replace an exact string in a note. old_str must \
+                          match exactly once, or set replace_all to change \
+                          every occurrence.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "old_str": { "type": "string" },
+                    "new_str": { "type": "string" },
+                    "replace_all": { "type": "boolean" },
+                },
+                "required": ["path", "old_str", "new_str"],
+                "additionalProperties": false,
+            }),
+        },
+    ]
+}
+
+/// A one-line human summary of a call, for the collapsed row and the
+/// approval card — every parameter the model passed is reflected:
+/// "read_note /todo.md", "list /notes/ (recursive)", "edit_note /a.md
+/// (replace all)". Unknown shapes fall back to the raw args so nothing is
+/// ever invisible.
+pub fn detail_for(name: &str, args: &Value) -> String {
+    let flag = |key: &str| args.get(key).and_then(Value::as_bool).unwrap_or(false);
+    let path = args.get("path").and_then(Value::as_str);
+    match (name, path) {
+        ("list", p) => {
+            let recursive = if flag("recursive") { " (recursive)" } else { "" };
+            format!("list {}{recursive}", p.unwrap_or("/"))
+        }
+        ("edit_note", Some(p)) => {
+            let all = if flag("replace_all") { " (replace all)" } else { "" };
+            format!("edit_note {p}{all}")
+        }
+        (_, Some(p)) => format!("{name} {p}"),
+        _ => {
+            let mut s = format!("{name} {args}");
+            if s.len() > 80 {
+                let mut cut = 80;
+                while !s.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                s.truncate(cut);
+                s.push('…');
+            }
+            s
+        }
+    }
+}
+
+/// Plain-language permission prose for the approval card, adapted to the
+/// call's parameters and phrased as a yes/no question. Reads gate on *egress*
+/// — the card only appears for a remote provider — so they name `provider`
+/// and frame it as sending; `list` sends names, `read_note` sends contents.
+/// Edits gate on *mutation* and head the diff below. Unknown shapes fall back
+/// to the terse detail.
+pub fn permission_prose(name: &str, args: &Value, provider: &str) -> String {
+    let path = args.get("path").and_then(Value::as_str);
+    let flag = |key: &str| args.get(key).and_then(Value::as_bool).unwrap_or(false);
+    match name {
+        "read_note" => {
+            format!("Send the full contents of {} to {provider}?", path.unwrap_or_default())
+        }
+        "list" => {
+            let folder = path.filter(|p| *p != "/");
+            match (folder, flag("recursive")) {
+                (None, false) => {
+                    format!("Send {provider} the names of your top-level notes and folders?")
+                }
+                (Some(p), false) => {
+                    format!("Send {provider} the names of the notes and folders in {p}?")
+                }
+                (None, true) => {
+                    format!("Send {provider} the name of every note and folder in your lockbook?")
+                }
+                (Some(p), true) => {
+                    format!("Send {provider} the name of every note and folder under {p}?")
+                }
+            }
+        }
+        "edit_note" => {
+            let p = path.unwrap_or_default();
+            if flag("replace_all") {
+                format!("Apply this change everywhere it matches in {p}?")
+            } else {
+                format!("Apply this change to {p}?")
+            }
+        }
+        _ => format!("Let the model run {}?", detail_for(name, args)),
+    }
+}
+
+/// A string argument, or a steering error naming the omission.
+fn arg<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
+    args.get(key).and_then(Value::as_str).ok_or_else(|| {
+        // Malformed argument JSON arrives wrapped as {"raw": ...}.
+        if let Some(raw) = args.get("raw") {
+            format!("error: couldn't parse arguments ({raw}). Send valid JSON.")
+        } else {
+            format!("error: missing required argument '{key}'.")
+        }
+    })
+}
+
+/// Run one tool call against the branch and the lockbook. `lb` is the async
+/// core (the driver runs its own runtime). Errors are folded into the result
+/// so a failing call steers the model rather than aborting the turn.
+pub async fn dispatch(lb: &Lb, buffers: &mut Buffers, name: &str, args: &Value) -> Outcome {
+    match name {
+        "list" => list(lb, args).await,
+        "read_note" => read_note(lb, buffers, args).await,
+        "edit_note" => edit_note(lb, buffers, args).await,
+        other => Outcome::err(format!("error: no tool named '{other}'.")),
+    }
+}
+
+async fn list(lb: &Lb, args: &Value) -> Outcome {
+    let path = args.get("path").and_then(Value::as_str).unwrap_or("/");
+    let recursive = args
+        .get("recursive")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let folder = match lb.get_by_path(path).await {
+        Ok(f) => f,
+        Err(_) => return Outcome::err(did_you_mean(lb, path).await),
+    };
+    let mut rows: Vec<String> = Vec::new();
+    let children = if recursive {
+        lb.get_and_get_children_recursively(&folder.id).await
+    } else {
+        lb.get_children(&folder.id).await
+    };
+    let Ok(children) = children else {
+        return Outcome::err(format!("error: couldn't list {path}."));
+    };
+    for f in children {
+        if f.id == folder.id {
+            continue;
+        }
+        let p = lb.get_path_by_id(f.id).await.unwrap_or(f.name.clone());
+        rows.push(p);
+    }
+    if rows.is_empty() {
+        return Outcome::ok(format!("{path} is empty."));
+    }
+    // Folders (trailing '/') first, then lexicographic — deterministic.
+    rows.sort_by(|a, b| {
+        let key = |s: &str| (!s.ends_with('/'), s.to_string());
+        key(a).cmp(&key(b))
+    });
+    Outcome::ok(rows.join("\n"))
+}
+
+async fn read_note(lb: &Lb, buffers: &mut Buffers, args: &Value) -> Outcome {
+    let path = match arg(args, "path") {
+        Ok(p) => p,
+        Err(e) => return Outcome::err(e),
+    };
+    // Already open: serve the branch view so a re-read reflects prior edits
+    // (otherwise the model thinks its edit failed and repeats it). Not a new
+    // capture.
+    if let Some(buf) = buffers.get(path) {
+        let n = buf.text.lines().count();
+        return Outcome::ok(format!("[{path} — {n} lines, open]\n{}", buf.text));
+    }
+    match capture_from_disk(lb, path).await {
+        Ok((hmac, content)) => {
+            if content.len() > OPEN_CAP {
+                return Outcome::err(format!(
+                    "error: {path} is too large to open ({} KiB). Not supported yet.",
+                    content.len() / 1024
+                ));
+            }
+            buffers.capture(path, hmac, content.clone());
+            let n = content.lines().count();
+            let mut out = Outcome::ok(format!("[{path} — {n} lines]\n{content}"));
+            // The raw content is the replay attachment (the headered result the
+            // model saw is truncated on persist; the buffer needs the whole
+            // note).
+            out.capture = Some(content);
+            out
+        }
+        Err(NotADoc) => Outcome::err(format!("error: {path} is a folder, not a note.")),
+        Err(Missing) => Outcome::err(did_you_mean(lb, path).await),
+        Err(NotUtf8) => Outcome::err(format!("error: {path} isn't text.")),
+    }
+}
+
+async fn edit_note(lb: &Lb, buffers: &mut Buffers, args: &Value) -> Outcome {
+    let (path, old, new) = match (arg(args, "path"), arg(args, "old_str"), arg(args, "new_str")) {
+        (Ok(p), Ok(o), Ok(n)) => (p, o, n),
+        (Err(e), ..) | (_, Err(e), _) | (.., Err(e)) => return Outcome::err(e),
+    };
+    let replace_all = args
+        .get("replace_all")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    // Auto-open an untouched note. The pre-edit snapshot rides this record as
+    // its capture attachment (context-excluded — the model is editing blind, a
+    // zero-egress transform); on replay it loads the base before the edit
+    // folds on top.
+    let capture = if buffers.is_open(path) {
+        None
+    } else {
+        match capture_from_disk(lb, path).await {
+            Ok((hmac, content)) => {
+                if content.len() > OPEN_CAP {
+                    return Outcome::err(format!(
+                        "error: {path} is too large to open ({} KiB).",
+                        content.len() / 1024
+                    ));
+                }
+                buffers.capture(path, hmac, content.clone());
+                Some(content)
+            }
+            Err(NotADoc) => return Outcome::err(format!("error: {path} is a folder.")),
+            Err(Missing) => return Outcome::err(did_you_mean(lb, path).await),
+            Err(NotUtf8) => return Outcome::err(format!("error: {path} isn't text.")),
+        }
+    };
+
+    match buffers.edit(path, old, new, replace_all) {
+        Ok(result) => Outcome { result, is_error: false, capture },
+        // A failed edit still leaves the auto-open capture in place — the note
+        // is open now, so persist the capture and let the model retry.
+        Err(result) => Outcome { result, is_error: true, capture },
+    }
+}
+
+/// Write a buffer back to the real note — no longer a model tool; the
+/// driver runs it right after each approved edit.
+pub(super) async fn sync_note(lb: &Lb, buffers: &mut Buffers, args: &Value) -> Outcome {
+    let path = match arg(args, "path") {
+        Ok(p) => p,
+        Err(e) => return Outcome::err(e),
+    };
+    let Some(buf) = buffers.get(path).cloned() else {
+        return Outcome::err(format!("error: {path} isn't open, nothing to sync."));
+    };
+    if !buf.dirty() {
+        return Outcome::ok(format!("{path} has no unsaved changes."));
+    }
+    match write_back(lb, path, &buf).await {
+        Ok(Synced { new_hmac, merged }) => {
+            let content = merged.clone().unwrap_or(buf.text);
+            buffers.capture(path, Some(new_hmac), content.clone());
+            match merged {
+                // The merge pulled in concurrent on-disk edits — disk → buffer
+                // inflow — so the merged text rides the record as its capture
+                // attachment (replay sets base+text = merged, clean).
+                Some(_) => Outcome {
+                    result: format!("saved {path} (merged with changes made since you opened it)."),
+                    is_error: false,
+                    capture: Some(content),
+                },
+                None => Outcome::ok(format!("saved {path}.")),
+            }
+        }
+        Err(e) => Outcome::err(format!("error: couldn't save {path}: {e}.")),
+    }
+}
+
+struct Synced {
+    new_hmac: DocumentHmac,
+    /// The merged text when a concurrent edit forced a 3-way merge; `None` on
+    /// a clean write.
+    merged: Option<String>,
+}
+
+/// Write a dirty buffer back with compare-and-swap. On a concurrent on-disk
+/// change, 3-way merge and retry. A brand-new note (no base hmac) is created
+/// first.
+async fn write_back(lb: &Lb, path: &str, buf: &Buffer) -> Result<Synced, String> {
+    let id = match lb.get_by_path(path).await {
+        Ok(f) => f.id,
+        // Never synced: create it, then write with no prior version.
+        Err(_) if buf.base_hmac.is_none() => {
+            lb.create_at_path(path).await.map_err(|e| e.to_string())?.id
+        }
+        Err(e) => return Err(e.to_string()),
+    };
+
+    // CAS against the disk version, merging in anything that landed since our
+    // capture. Loop in case disk moves again between read and write.
+    loop {
+        let (disk_hmac, disk_bytes) = lb
+            .read_document_with_hmac(id, false)
+            .await
+            .map_err(|e| e.to_string())?;
+        let clean = disk_hmac == buf.base_hmac;
+        let to_write = if clean {
+            buf.text.clone()
+        } else {
+            let disk_text = String::from_utf8_lossy(&disk_bytes);
+            merge(&buf.base_text, &buf.text, &disk_text)
+        };
+        match lb
+            .safe_write(id, disk_hmac, to_write.clone().into_bytes())
+            .await
+        {
+            Ok(new_hmac) => {
+                return Ok(Synced { new_hmac, merged: (!clean).then_some(to_write) });
+            }
+            // Disk changed again between read and write — re-read and retry.
+            Err(e) if is_reread(&e) => continue,
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+}
+
+fn is_reread(e: &lb_rs::model::errors::LbErr) -> bool {
+    matches!(e.kind, lb_rs::model::errors::LbErrKind::ReReadRequired)
+}
+
+enum CaptureErr {
+    Missing,
+    NotADoc,
+    NotUtf8,
+}
+use CaptureErr::*;
+
+/// Read a note's bytes and version for capture. A never-written note reads as
+/// empty (not an error) — the model can edit a blank buffer and create it on
+/// sync.
+async fn capture_from_disk(
+    lb: &Lb, path: &str,
+) -> Result<(Option<DocumentHmac>, String), CaptureErr> {
+    let file = lb.get_by_path(path).await.map_err(|_| Missing)?;
+    if !file.is_document() {
+        return Err(NotADoc);
+    }
+    let (hmac, bytes) = lb
+        .read_document_with_hmac(file.id, true)
+        .await
+        .map_err(|_| Missing)?;
+    let content = String::from_utf8(bytes).map_err(|_| NotUtf8)?;
+    Ok((hmac, content))
+}
+
+/// A path miss with the closest actual paths, so the model can self-correct.
+async fn did_you_mean(lb: &Lb, path: &str) -> String {
+    let mut suggestions = Vec::new();
+    if let Ok(paths) = lb.list_paths(None).await {
+        let target = path.to_lowercase();
+        let mut scored: Vec<(usize, String)> = paths
+            .into_iter()
+            .map(|p| {
+                let overlap = p
+                    .to_lowercase()
+                    .chars()
+                    .filter(|c| target.contains(*c))
+                    .count();
+                (overlap, p)
+            })
+            .collect();
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        suggestions = scored.into_iter().take(3).map(|(_, p)| p).collect();
+    }
+    if suggestions.is_empty() {
+        format!("error: no note at {path}.")
+    } else {
+        format!("error: no note at {path}. Closest: {}.", suggestions.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open(buffers: &mut Buffers, path: &str, content: &str) {
+        buffers.capture(path, Some([0u8; 32]), content.to_string());
+    }
+
+    /// Edit requires a unique match unless replace_all; a miss and an
+    /// ambiguous match both steer instead of mutating.
+    #[test]
+    fn edit_uniqueness_and_steering() {
+        let mut b = Buffers::default();
+        open(&mut b, "/n.md", "a\nb\na\n");
+
+        let miss = b.edit("/n.md", "z", "y", false).unwrap_err();
+        assert!(miss.contains("not found"), "{miss}");
+
+        let ambiguous = b.edit("/n.md", "a", "x", false).unwrap_err();
+        assert!(ambiguous.contains("matches 2"), "{ambiguous}");
+        // A steering failure left the buffer untouched.
+        assert_eq!(b.get("/n.md").unwrap().text, "a\nb\na\n");
+
+        b.edit("/n.md", "a", "x", true).unwrap();
+        assert_eq!(b.get("/n.md").unwrap().text, "x\nb\nx\n");
+
+        let mut b2 = Buffers::default();
+        open(&mut b2, "/n.md", "a\nb\na\n");
+        b2.edit("/n.md", "b", "B", false).unwrap();
+        assert_eq!(b2.get("/n.md").unwrap().text, "a\nB\na\n");
+    }
+
+    /// Edit on an unopened path steers (dispatch handles auto-open; the pure
+    /// buffer op does not).
+    #[test]
+    fn edit_unopened_steers() {
+        let mut b = Buffers::default();
+        let e = b.edit("/nope.md", "a", "b", false).unwrap_err();
+        assert!(e.contains("isn't open"), "{e}");
+    }
+
+    /// dirty tracks divergence from the captured base; append newline-joins.
+    #[test]
+    fn append_and_dirty() {
+        let mut b = Buffers::default();
+        open(&mut b, "/n.md", "line one");
+        assert!(!b.get("/n.md").unwrap().dirty());
+        b.append("/n.md", "line two");
+        assert_eq!(b.get("/n.md").unwrap().text, "line one\nline two");
+        assert!(b.get("/n.md").unwrap().dirty());
+    }
+
+    /// Non-overlapping branch and disk edits both survive the 3-way merge — a
+    /// self-referential property (each side's change is present in the result).
+    #[test]
+    fn merge_keeps_both_sides() {
+        let base = "line one\nline two\nline three\n";
+        let ours = "line one EDITED\nline two\nline three\n";
+        let theirs = "line one\nline two\nline three ALSO\n";
+        let merged = merge(base, ours, theirs);
+        assert!(merged.contains("line one EDITED"), "ours lost: {merged}");
+        assert!(merged.contains("line three ALSO"), "theirs lost: {merged}");
+    }
+
+    /// A merge with no concurrent change (theirs == base) is exactly our text
+    /// — the clean path and the merge path agree at the boundary.
+    #[test]
+    fn merge_no_conflict_is_ours() {
+        let base = "a\nb\nc\n";
+        let ours = "a\nB\nc\n";
+        assert_eq!(merge(base, ours, base), ours);
+    }
+
+    /// Replaying a capture then an edit reconstructs the same buffer the live
+    /// run produced — the determinism the persistence layer relies on.
+    #[test]
+    fn replay_reconstructs_buffer() {
+        // Live: capture "v1", edit.
+        let mut live = Buffers::default();
+        live.capture("/n.md", Some([7u8; 32]), "hello world".into());
+        live.edit("/n.md", "world", "there", false).unwrap();
+
+        // Replay: same capture record, same edit record.
+        let mut replay = Buffers::default();
+        replay.capture("/n.md", Some([7u8; 32]), "hello world".into());
+        replay.edit("/n.md", "world", "there", false).unwrap();
+
+        assert_eq!(live.get("/n.md").unwrap().text, replay.get("/n.md").unwrap().text);
+        assert_eq!(replay.get("/n.md").unwrap().text, "hello there");
+    }
+
+    /// `fold_record` rebuilds buffers from persisted records: a read captures,
+    /// an unsynced edit leaves the buffer dirty (the reopen money moment), and
+    /// a clean sync marks it saved.
+    #[test]
+    fn fold_records_rebuilds_dirty_and_clean() {
+        // read /a.md (capture attachment = content), then edit it, no sync.
+        let mut b = Buffers::default();
+        fold_record(
+            &mut b,
+            "read_note",
+            &json!({ "path": "/a.md" }),
+            Some("hello world".into()),
+            false,
+        );
+        fold_record(
+            &mut b,
+            "edit_note",
+            &json!({ "path": "/a.md", "old_str": "world", "new_str": "there" }),
+            None,
+            false,
+        );
+        let a = b.get("/a.md").unwrap();
+        assert_eq!(a.text, "hello there");
+        assert!(a.dirty(), "unsynced edit must reopen dirty");
+
+        // A blind edit auto-opens: the pre-edit content rides the record's
+        // capture; then a clean sync marks it saved.
+        fold_record(
+            &mut b,
+            "edit_note",
+            &json!({ "path": "/b.md", "old_str": "Q3", "new_str": "Q4" }),
+            Some("plan Q3".into()),
+            false,
+        );
+        assert_eq!(b.get("/b.md").unwrap().text, "plan Q4");
+        assert!(b.get("/b.md").unwrap().dirty());
+        fold_record(&mut b, "sync_note", &json!({ "path": "/b.md" }), None, false);
+        assert!(!b.get("/b.md").unwrap().dirty(), "clean sync marks saved");
+
+        // A DENIED sync must not mark the buffer clean on replay.
+        fold_record(
+            &mut b,
+            "edit_note",
+            &json!({ "path": "/a.md", "old_str": "there", "new_str": "gone" }),
+            None,
+            false,
+        );
+        assert!(b.get("/a.md").unwrap().dirty());
+        fold_record(&mut b, "sync_note", &json!({ "path": "/a.md" }), None, true);
+        assert!(b.get("/a.md").unwrap().dirty(), "denied sync must stay dirty");
+    }
+
+    /// A merge-sync record carries the merged text as its capture, so replay
+    /// restores the post-merge buffer (clean).
+    #[test]
+    fn fold_merge_sync_restores_merged() {
+        let mut b = Buffers::default();
+        fold_record(&mut b, "read_note", &json!({ "path": "/m.md" }), Some("base".into()), false);
+        fold_record(
+            &mut b,
+            "sync_note",
+            &json!({ "path": "/m.md" }),
+            Some("merged text".into()),
+            false,
+        );
+        let m = b.get("/m.md").unwrap();
+        assert_eq!(m.text, "merged text");
+        assert!(!m.dirty());
+    }
+
+    /// viz_record folds exactly like fold_record and derives each row's
+    /// metric + body from the before/after states: a read binds the note as
+    /// its body, an edit shows a +/- diff, a sync reports how it saved.
+    #[test]
+    fn viz_derives_metrics_and_bodies() {
+        let mut b = Buffers::default();
+
+        let read = viz_record(
+            &mut b,
+            "read_note",
+            &json!({ "path": "/a.md" }),
+            Some("one\ntwo\n".into()),
+            false,
+            "[/a.md — 2 lines]\none\ntwo",
+        );
+        assert_eq!(read.metric, "2 lines");
+        match read.body {
+            Body::Note { text } => assert_eq!(text, "one\ntwo\n"),
+            _ => panic!("read body should be the bound note"),
+        }
+
+        let edit = viz_record(
+            &mut b,
+            "edit_note",
+            &json!({ "path": "/a.md", "old_str": "two", "new_str": "TWO\nthree" }),
+            None,
+            false,
+            "edited /a.md",
+        );
+        assert_eq!(edit.metric, "+2 -1");
+        match edit.body {
+            Body::Rendered { segments } => {
+                use super::super::diff::SegKind::*;
+                let flat: Vec<_> = segments.iter().map(|s| (s.text.as_str(), s.kind)).collect();
+                assert_eq!(flat, [("one\ntwo", Del), ("one\nTWO\nthree", Add)]);
+            }
+            _ => panic!("edit body should be a rendered diff"),
+        }
+
+        // The write-back receipt row is a receipt, not a diff (the approval
+        // card already showed the change). Folding it marks the buffer clean.
+        let sync = viz_record(
+            &mut b,
+            "sync_note",
+            &json!({ "path": "/a.md" }),
+            None,
+            false,
+            "saved /a.md.",
+        );
+        assert_eq!(sync.metric, "saved");
+        assert!(matches!(sync.body, Body::Text(_)));
+        assert!(!b.get("/a.md").unwrap().dirty());
+
+        let denied =
+            viz_record(&mut b, "sync_note", &json!({ "path": "/a.md" }), None, true, DENIED_RESULT);
+        assert_eq!(denied.metric, "denied");
+
+        let list = viz_record(&mut b, "list", &json!({}), None, false, "/docs/\n/a.md\n/b.md");
+        assert_eq!(list.metric, "3 items");
+        assert!(matches!(list.body, Body::List { ref rows } if rows.len() == 3));
+    }
+
+    /// Permission prose adapts to each call's parameters: reads name the
+    /// provider and frame egress; list distinguishes root/folder × shallow/
+    /// recursive; edits caption the diff.
+    #[test]
+    fn permission_prose_adapts_to_params() {
+        let p = |name: &str, args: Value| permission_prose(name, &args, "Cerebras");
+
+        assert_eq!(
+            p("read_note", json!({ "path": "/todo.md" })),
+            "Send the full contents of /todo.md to Cerebras?"
+        );
+
+        assert_eq!(
+            p("list", json!({})),
+            "Send Cerebras the names of your top-level notes and folders?"
+        );
+        assert_eq!(
+            p("list", json!({ "path": "/" })),
+            "Send Cerebras the names of your top-level notes and folders?"
+        );
+        assert_eq!(
+            p("list", json!({ "path": "/work/" })),
+            "Send Cerebras the names of the notes and folders in /work/?"
+        );
+        assert_eq!(
+            p("list", json!({ "recursive": true })),
+            "Send Cerebras the name of every note and folder in your lockbook?"
+        );
+        assert_eq!(
+            p("list", json!({ "path": "/work/", "recursive": true })),
+            "Send Cerebras the name of every note and folder under /work/?"
+        );
+
+        assert_eq!(p("edit_note", json!({ "path": "/a.md" })), "Apply this change to /a.md?");
+        assert_eq!(
+            p("edit_note", json!({ "path": "/a.md", "replace_all": true })),
+            "Apply this change everywhere it matches in /a.md?"
+        );
+
+        assert_eq!(p("mystery", json!({})), "Let the model run mystery {}?");
+    }
+
+    /// The summary line reflects every parameter the model passed —
+    /// flags parenthesized, unknown shapes falling back to raw args.
+    #[test]
+    fn detail_reflects_params() {
+        assert_eq!(detail_for("list", &json!({})), "list /");
+        assert_eq!(
+            detail_for("list", &json!({ "path": "/notes/", "recursive": true })),
+            "list /notes/ (recursive)"
+        );
+        assert_eq!(detail_for("read_note", &json!({ "path": "/a.md" })), "read_note /a.md");
+        assert_eq!(
+            detail_for(
+                "edit_note",
+                &json!({ "path": "/a.md", "old_str": "x", "new_str": "y", "replace_all": true })
+            ),
+            "edit_note /a.md (replace all)"
+        );
+        // Unknown shape: raw args shown, truncated.
+        let detail = detail_for("mystery", &json!({ "q": "z".repeat(200) }));
+        assert!(detail.starts_with("mystery {\"q\""));
+        assert!(detail.ends_with('…') && detail.len() < 100);
+    }
+
+    /// The four slice tools are advertised, with flat strict-compatible
+    /// schemas (object, additionalProperties:false).
+    #[test]
+    fn schemas_are_flat_and_named() {
+        let names: Vec<_> = schemas().iter().map(|s| s.name).collect();
+        assert_eq!(names, ["list", "read_note", "edit_note"]);
+        for s in schemas() {
+            assert_eq!(s.parameters["type"], "object");
+            assert_eq!(s.parameters["additionalProperties"], false);
+        }
+    }
+}

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -89,6 +89,78 @@ impl CenteredColumn {
     }
 }
 
+/// Tool-container header padding (the table-header-bar look).
+const TOOL_PAD_X: f32 = 10.0;
+const TOOL_PAD_Y: f32 = 6.0;
+
+/// Inter-block spacing for rendered diffs. Band vertical padding is half of
+/// this (the drag-card rule), so adjacent old/new bands sit flush — a
+/// changed pair reads as one card with a color boundary.
+const DIFF_BLOCK_SPACING: f32 = 8.0;
+
+/// Lay out plain tool-result text as one dim mono galley. Notes and diffs
+/// render as markdown via an `MdLabel` instead.
+fn body_galley(ui: &Ui, text: &str, wrap_w: f32, dim: egui::Color32) -> Arc<Galley> {
+    ui.fonts(|f| f.layout(text.into(), egui::FontId::monospace(TOOL_FONT), dim, wrap_w))
+}
+
+/// Total height of stacked diff segments at `width`.
+fn segments_height(label: &mut MdLabel, segs: &[diff::Segment], width: f32) -> f32 {
+    let mut h = 0.0;
+    for (k, seg) in segs.iter().enumerate() {
+        if k > 0 {
+            h += DIFF_BLOCK_SPACING;
+        }
+        h += label.height(&seg.text, width);
+    }
+    h
+}
+
+/// Paint stacked diff segments through `label`; changed ones get a
+/// full-width wash band (the drag-card shape: the segment's own rect padded
+/// by half the stacking gap, so adjacent del/add bands sit flush). Returns
+/// the glyphon areas for the caller's text callback.
+#[allow(clippy::too_many_arguments)]
+fn paint_segments(
+    ui: &mut Ui, label: &mut MdLabel, salt: Id, segs: &[diff::Segment], pos: Pos2, width: f32,
+    band_x: (f32, f32), add_wash: egui::Color32, del_wash: egui::Color32,
+) -> Vec<crate::TextBufferArea> {
+    let mut areas = Vec::new();
+    let mut y = pos.y;
+    for (k, seg) in segs.iter().enumerate() {
+        if k > 0 {
+            y += DIFF_BLOCK_SPACING;
+        }
+        // Wash first: egui-painted content (task checkboxes, rules, code
+        // fills) then paints above it, and glyphon text rides a later layer
+        // regardless — the tint reads as behind everything.
+        let h = label.height(&seg.text, width);
+        let wash = match seg.kind {
+            diff::SegKind::Add => Some(add_wash),
+            diff::SegKind::Del => Some(del_wash),
+            diff::SegKind::Context => None,
+        };
+        if let Some(wash) = wash {
+            let pad = DIFF_BLOCK_SPACING / 2.0;
+            ui.painter().rect_filled(
+                Rect::from_min_max(pos2(band_x.0, y - pad), pos2(band_x.1, y + h + pad)),
+                CornerRadius::same(2),
+                wash,
+            );
+        }
+        // Distinct id scope per segment: the old and new snippets are
+        // near-identical, so their widgets' `ui.id().with(node_range)` ids
+        // would otherwise collide and cross-wire checkbox animations
+        // (a checked and an unchecked box fighting over one lerp).
+        let a = ui
+            .push_id(salt.with(k), |ui| label.paint_at(ui, &seg.text, pos2(pos.x, y), width).0)
+            .inner;
+        areas.extend(a);
+        y += h;
+    }
+    areas
+}
+
 impl Chat {
     /// True for transcript touches (which scroll), so Android doesn't treat a
     /// short transcript scroll as a keyboard-summoning tap. Composer touches
@@ -100,13 +172,15 @@ impl Chat {
     /// changed this frame (user sent or the agent replied — triggers a save),
     /// and the composer's text rect (egui points) used to position the native
     /// iOS text-interaction overlay.
-    pub fn show(&mut self, ui: &mut Ui) -> (bool, Rect) {
+    pub fn show(&mut self, ui: &mut Ui) -> (bool, Rect, bool) {
         self.kick_initial_config_load();
         self.pump_models();
         self.pump_config();
         self.poll_key_connection();
-        self.maybe_prompt_key();
         let agent_changed = self.pump_agent();
+        // Tool-row metrics/bodies derive from a fold of the visible records;
+        // rebuilt only when the timeline fingerprint misses.
+        self.ensure_tool_viz();
 
         // Live agent state for this frame's rendering.
         let (agent_busy, agent_streaming) = match &self.harness {
@@ -129,7 +203,11 @@ impl Chat {
         // painted under the form.
         let connect_open = self.key_entry.is_some();
         let takeover = connect_open || self.chooser_open;
-        let visible = if takeover { Vec::new() } else { self.visible() };
+        let mut visible = if takeover { Vec::new() } else { self.visible() };
+        // Write-back receipts stay in the *data* timeline (they fold and
+        // persist) but not the rendered one — the seed/fold paths call
+        // `self.visible()` themselves and still see them.
+        visible.retain(|row| !user_actioned(&self.entries[row.idx].msg));
         // First-run guidance, only in an empty chat and once config has
         // loaded (else it flashes before the background load lands). A
         // summoned chooser reuses the same surface over an existing chat.
@@ -142,10 +220,22 @@ impl Chat {
         };
         let show_agent_hint = onboard.is_some();
 
+        // A broken key turns the composer's text field into an "add key"
+        // button — the fix always sits where you'd type. Computed regardless
+        // of chat emptiness (an established chat keeps its history above) and
+        // suppressed while the masked field or the roster is up.
+        let need_key = (self.unshared && self.config_loaded && !connect_open && !self.chooser_open)
+            .then(|| match self.onboard_stage() {
+                Some(Onboard::NeedKey { name, label }) => Some((name, label)),
+                _ => None,
+            })
+            .flatten();
+
         // No usable key yet → hide the composer, so there's ever at most one
-        // text field for the native iOS text bridge to own. Everything past a
-        // valid key (Connecting/Unreachable/PickModel) keeps the composer —
-        // PickModel picks its model from the composer's toolbar.
+        // text field for the native iOS text bridge to own. `NeedKey` keeps
+        // the composer surface (its text field becomes the "add key" button);
+        // everything past a valid key (Connecting/Unreachable/PickModel) keeps
+        // the composer too — PickModel picks its model from the toolbar.
         let hide_composer = connect_open || matches!(onboard, Some(Onboard::Choose));
 
         // Retry the last turn when it errored and the agent is idle.
@@ -228,6 +318,35 @@ impl Chat {
                     || (!completions_open && i.consume_key(Modifiers::NONE, Key::Enter))
             });
 
+        // ⌘A approve / ⌘D deny while a call awaits a decision. Consumed
+        // before the composer's input phase so ⌘A can't fall through to
+        // select-all while the card is up.
+        let approve_shortcut = egui::KeyboardShortcut::new(Modifiers::COMMAND, Key::A);
+        let deny_shortcut = egui::KeyboardShortcut::new(Modifiers::COMMAND, Key::D);
+        let mut approve_clicked = false;
+        let mut deny_clicked = false;
+        if self
+            .harness
+            .as_ref()
+            .is_some_and(|h| h.pending_tool.is_some())
+        {
+            ui.ctx().input_mut(|i| {
+                approve_clicked = i.consume_shortcut(&approve_shortcut);
+                deny_clicked = !approve_clicked && i.consume_shortcut(&deny_shortcut);
+            });
+        }
+        let touch_os = matches!(
+            ui.ctx().os(),
+            egui::os::OperatingSystem::Android | egui::os::OperatingSystem::IOS
+        );
+        // Hint labels show where a hardware keyboard is plausible: desktop,
+        // and tablet-width touch screens (iPad); not phones.
+        let show_key_hints = !touch_os || available_width >= 600.0;
+        let approve_hint = ui.ctx().format_shortcut(&approve_shortcut);
+        let deny_hint = ui.ctx().format_shortcut(&deny_shortcut);
+
+        // Return submits the key — the connect step has no Connect button.
+        let mut key_submit = false;
         // Text-input phase — drain workspace-origin events (native iOS text
         // arrives this way: Newline / Indent / Replace pushed by the FFI), then
         // keyboard / completions / internal events. Routes to *one* editor:
@@ -236,9 +355,31 @@ impl Chat {
             let key_field_id = Id::new("chat_key_field");
             // No per-frame request_focus: the render block's one-shot focuses
             // the field, and its interaction + focus lock hold it after that.
+            // Consume Return before handle_input so it submits rather than
+            // reaching the field as a newline (desktop).
+            if ui.memory(|m| m.has_focus(key_field_id))
+                && ui
+                    .ctx()
+                    .input_mut(|i| i.consume_key(Modifiers::NONE, Key::Enter))
+            {
+                key_submit = true;
+            }
             let ws = self.key_field.drain_workspace_events(ui.ctx());
             self.key_field.event.internal_events.extend(ws);
             let _ = self.key_field.handle_input(ui.ctx(), key_field_id);
+            // A single-line key never holds a newline; one that landed came
+            // from the native keyboard's return (iOS) — submit and strip it.
+            if self.key_field.renderer.buffer.current.text.contains('\n') {
+                let cleaned = self
+                    .key_field
+                    .renderer
+                    .buffer
+                    .current
+                    .text
+                    .replace('\n', "");
+                self.key_field.set_text(&cleaned);
+                key_submit = true;
+            }
         } else {
             let workspace_events = self.composer.drain_workspace_events(ui.ctx());
             self.composer.event.internal_events.extend(workspace_events);
@@ -247,8 +388,8 @@ impl Chat {
 
         // Measure at the exact render width so the composer bubble grows
         // same-frame. The re-parse inside `show` below hits the layout cache.
-        // `SIDE_INSET` and `H_PAD` mirror the h_inset / shrink geometry below.
-        let composer_inner_w = (col_width - 2.0 * SIDE_INSET - 2.0 * H_PAD).max(0.0);
+        // `H_MARGIN` and `H_PAD` mirror the h_inset / shrink geometry below.
+        let composer_inner_w = (col_width - 2.0 * H_MARGIN - 2.0 * H_PAD).max(0.0);
         let measured_h = self.composer.measure_height(composer_inner_w);
 
         // Autogrow with a max cap, no lower floor — a lower floor makes a
@@ -270,9 +411,7 @@ impl Chat {
         let mut chooser_cancel = false;
         // Inline "connect a provider" step actions, applied after the scroll
         // closure releases its borrow of `self`.
-        let mut key_connect = false;
         let mut key_cancel = false;
-        let mut key_edit = false;
         // Row actions (hover pill + context menu). Copy always works;
         // everything that mutates the transcript or timeline is gated on no
         // turn being in flight, and the agent-rerunning actions additionally
@@ -280,12 +419,54 @@ impl Chat {
         let mut action: Option<RowAction> = None;
         let can_mutate = !agent_busy;
         let agent_actions = self.harness.is_some();
+        // The call awaiting a decision, rendered as a trailing approval card:
+        // its adapted permission prose, the diff (edits), and Approve / Deny.
+        // Buttons' clicks are applied after the closure.
+        let provider_label = self
+            .provider
+            .as_ref()
+            .map(|p| p.label())
+            .unwrap_or_else(|| "the model".into());
+        let pending_tool = self
+            .harness
+            .as_ref()
+            .and_then(|h| h.pending_tool.as_ref())
+            .map(|p| {
+                (
+                    tools::detail_for(&p.name, &p.args),
+                    tools::permission_prose(&p.name, &p.args, &provider_label),
+                    p.preview.clone(),
+                )
+            });
+        // Soft washes behind rendered diffs' changed blocks.
+        let add_wash = theme.bg().green.gamma_multiply(0.22);
+        let del_wash = theme.bg().red.gamma_multiply(0.22);
+        // Collapsed-row outcome metrics run dimmer than the summary text.
+        let metric_color = theme.neutral_fg_secondary();
+        // A clicked listing row to open, resolved after the closure.
+        let mut open_list_path: Option<String> = None;
 
         // A branch switch suspends stick-to-bottom for the frame — the view
         // holds still while the timeline below the fork is swapped out.
         let branch_anchored = self.branch_anchor.is_some();
+        // Editor-style backdrop: a tap on empty transcript space dismisses
+        // the keyboard. Registered before the scroll content so message
+        // rows, links, and tool containers (higher z) win their own taps;
+        // only bare-canvas taps reach it. Touch-only — desktop has no
+        // on-screen keyboard to dismiss. Suppressed under a takeover (the
+        // key field or chooser owns the surface): a tap there must not yank
+        // focus off the field it's editing.
+        let mut backdrop_tapped = false;
         ui.scope_builder(egui::UiBuilder::new().max_rect(transcript_rect), |ui| {
             ui.set_clip_rect(transcript_rect.intersect(ui.clip_rect()));
+            if touch_os && !takeover {
+                let backdrop = ui.interact(
+                    transcript_rect,
+                    Id::new("chat_transcript_backdrop"),
+                    Sense::click(),
+                );
+                backdrop_tapped = backdrop.clicked();
+            }
             ScrollArea::vertical()
                 .id_salt("chat_messages")
                 .stick_to_bottom(!branch_anchored)
@@ -317,11 +498,13 @@ impl Chat {
                         };
                         // Reserved metadata strip below every row — actions
                         // live in dedicated space, never overlaid on text.
-                        let mut strip = |y: &mut f32, row_rect: Rect, ts: Option<Arc<Galley>>| {
-                            let rect =
-                                Rect::from_min_size(pos2(note_x, *y), vec2(note_wrap_w, STRIP_H));
+                        let mut strip = |y: &mut f32,
+                                         row_rect: Rect,
+                                         ts: Option<Arc<Galley>>,
+                                         h: f32| {
+                            let rect = Rect::from_min_size(pos2(note_x, *y), vec2(note_wrap_w, h));
                             strips.push(StripPlan { vi, rect, row_rect, right: is_mine_row, ts });
-                            *y += STRIP_H + ROW_GAP;
+                            *y += h + ROW_GAP;
                         };
                         if self.entries[i].msg.error {
                             let header = ui.fonts(|f| {
@@ -348,7 +531,188 @@ impl Chat {
                             });
                             let row_rect = Rect::from_min_size(pos2(note_x, y), vec2(w, h));
                             y += h + ROW_GAP;
-                            strip(&mut y, row_rect, None);
+                            strip(&mut y, row_rect, None, STRIP_H);
+                            continue;
+                        }
+
+                        // A tool round-trip: a chevron + one-line summary +
+                        // right-aligned outcome metric, expanding to the call's
+                        // body (bound note state, diff, or listing rows).
+                        // Rendered dim, like a note, not a chat bubble.
+                        if let Some(record) = self.entries[i].msg.tool.clone() {
+                            // A run of consecutive tool rows groups: extra
+                            // padding above its first row and below its last.
+                            let tool_at =
+                                |vj: usize| self.entries[visible[vj].idx].msg.tool.is_some();
+                            if vi == 0 || !tool_at(vi - 1) {
+                                y += TOOL_GROUP_PAD;
+                            }
+                            let last_in_group = vi + 1 >= n || !tool_at(vi + 1);
+                            let id = self.entries[i].msg.id;
+                            let viz = id.and_then(|id| self.tool_viz.get(&id));
+                            let expanded = id.is_some_and(|id| self.expanded_tools.contains(&id));
+                            let summary = ui.fonts(|f| {
+                                f.layout_no_wrap(
+                                    self.entries[i].msg.content.clone(),
+                                    egui::FontId::monospace(TOOL_FONT),
+                                    secondary_color,
+                                )
+                            });
+                            let metric = viz.filter(|v| !v.metric.is_empty()).map(|v| {
+                                let mono = egui::FontId::monospace(TOOL_FONT);
+                                // An edit's "+a -d" reads in the diff colors;
+                                // every other metric stays dim.
+                                let two_tone = v
+                                    .metric
+                                    .split_once(' ')
+                                    .filter(|(a, d)| a.starts_with('+') && d.starts_with('-'));
+                                match two_tone {
+                                    Some((add, del)) => {
+                                        use egui::text::{LayoutJob, TextFormat};
+                                        let mut job = LayoutJob::default();
+                                        job.append(
+                                            add,
+                                            0.0,
+                                            TextFormat {
+                                                font_id: mono.clone(),
+                                                color: theme.fg().green,
+                                                ..Default::default()
+                                            },
+                                        );
+                                        job.append(
+                                            del,
+                                            6.0,
+                                            TextFormat {
+                                                font_id: mono,
+                                                color: theme.fg().red,
+                                                ..Default::default()
+                                            },
+                                        );
+                                        ui.fonts(|f| f.layout_job(job))
+                                    }
+                                    None => ui.fonts(|f| {
+                                        f.layout_no_wrap(v.metric.clone(), mono, metric_color)
+                                    }),
+                                }
+                            });
+                            let header_h = summary.size().y + 2.0 * TOOL_PAD_Y;
+                            let header_rect =
+                                Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, header_h));
+                            let indent = TOOL_PAD_X;
+                            let mut row_h = header_h;
+                            let mut body = None;
+                            let mut body_pos = Pos2::ZERO;
+                            let mut rendered = None;
+                            let mut list_rows = Vec::new();
+                            let mut bottom_pad = TOOL_PAD_Y;
+                            if expanded {
+                                let by = y + header_h + TOOL_PAD_Y;
+                                // Owned so the label (a `self` borrow) can lay
+                                // out the rendered diff below.
+                                let viz_body = viz.map(|v| v.body.clone());
+                                match viz_body {
+                                    Some(tools::Body::List { rows }) => {
+                                        let mut ry = by;
+                                        for row in rows {
+                                            // PLACEHOLDER so paint can color
+                                            // hovered rows.
+                                            let galley = ui.fonts(|f| {
+                                                f.layout_no_wrap(
+                                                    row.clone(),
+                                                    egui::FontId::monospace(TOOL_FONT),
+                                                    egui::Color32::PLACEHOLDER,
+                                                )
+                                            });
+                                            let rh = galley.size().y;
+                                            let rect = Rect::from_min_size(
+                                                pos2(note_x + indent, ry),
+                                                vec2(note_wrap_w - 2.0 * indent, rh),
+                                            );
+                                            let open_path =
+                                                (!row.ends_with('/')).then(|| row.clone());
+                                            list_rows.push(ListRowPlan { galley, rect, open_path });
+                                            ry += rh + 2.0;
+                                        }
+                                        row_h += TOOL_PAD_Y + (ry - by);
+                                    }
+                                    // An edit's diff: del/add segments,
+                                    // nothing else. Separately parsed, so no
+                                    // joining blank line renders between them
+                                    // and lists can't merge.
+                                    Some(tools::Body::Rendered { segments }) => {
+                                        // Flush with the header: the body's
+                                        // top/bottom padding is exactly the
+                                        // band pad, so the first/last washes
+                                        // meet the container edges.
+                                        let pad = DIFF_BLOCK_SPACING / 2.0;
+                                        let by = y + header_h + pad;
+                                        let rw = note_wrap_w - 2.0 * indent;
+                                        let label = &mut self.entries[i].label;
+                                        label.renderer.layout.block_spacing = DIFF_BLOCK_SPACING;
+                                        let rh = segments_height(label, &segments, rw);
+                                        row_h += pad + rh;
+                                        bottom_pad = pad;
+                                        rendered = Some((segments, pos2(note_x + indent, by), rw));
+                                    }
+                                    // A read's note: nothing but the rendered
+                                    // markdown (one unwashed segment).
+                                    Some(tools::Body::Note { text }) => {
+                                        let rw = note_wrap_w - 2.0 * indent;
+                                        let segs = vec![diff::Segment {
+                                            text,
+                                            kind: diff::SegKind::Context,
+                                        }];
+                                        let rh =
+                                            segments_height(&mut self.entries[i].label, &segs, rw);
+                                        row_h += ROW_GAP + rh;
+                                        rendered = Some((segs, pos2(note_x + indent, by), rw));
+                                    }
+                                    other => {
+                                        // Result text, mono; a record with no
+                                        // viz (id-less legacy row) falls back
+                                        // to the raw result.
+                                        let text = match &other {
+                                            Some(tools::Body::Text(t)) => t.as_str(),
+                                            _ => record.result.as_str(),
+                                        };
+                                        let g = body_galley(
+                                            ui,
+                                            text,
+                                            note_wrap_w - 2.0 * indent,
+                                            secondary_color,
+                                        );
+                                        body_pos = pos2(note_x + indent, by);
+                                        row_h += ROW_GAP + g.size().y;
+                                        body = Some(g);
+                                    }
+                                }
+                            }
+                            if expanded {
+                                // Bottom padding inside the bordered body
+                                // (band pad for flush diff bodies).
+                                row_h += bottom_pad;
+                            }
+                            let row_rect =
+                                Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, row_h));
+                            plans.push(RowPlan::Tool {
+                                header_rect,
+                                summary,
+                                metric,
+                                body,
+                                body_pos,
+                                rendered,
+                                list_rows,
+                                border: expanded.then_some(row_rect),
+                            });
+                            y += row_h + ROW_GAP;
+                            // Tool rows show nothing in the strip (no
+                            // timestamp, no icons) — reserve its height only
+                            // when fork arrows need it.
+                            let strip_h = if visible[vi].fork.is_some() { STRIP_H } else { 0.0 };
+                            strip(&mut y, row_rect, None, strip_h);
+                            if last_in_group {
+                                y += TOOL_GROUP_PAD;
+                            }
                             continue;
                         }
 
@@ -412,8 +776,8 @@ impl Chat {
                                 name_h,
                                 content_h,
                             });
-                            y += name_h + content_h + ROW_GAP;
-                            strip(&mut y, row_rect, ts_galley);
+                            y += name_h + content_h + ROW_GAP + AGENT_STRIP_GAP;
+                            strip(&mut y, row_rect, ts_galley, STRIP_H);
                         } else {
                             let content_h =
                                 entry.label.height(&entry.msg.content, max_bubble_content_w);
@@ -433,7 +797,7 @@ impl Chat {
                                 content_h,
                             });
                             y += bubble_h + ROW_GAP;
-                            strip(&mut y, bubble_rect, ts_galley);
+                            strip(&mut y, bubble_rect, ts_galley, STRIP_H);
                         }
                     }
 
@@ -457,8 +821,13 @@ impl Chat {
                         streaming_plan = Some((pos2(note_x, y), name));
                         y += name_h + content_h + ROW_GAP + V_PAD;
                     }
-                    let note_plan =
-                        (agent_busy && agent_streaming.is_empty() && !takeover).then(|| {
+                    // No "thinking…" while an edit awaits approval — the card
+                    // is the active surface, not the model.
+                    let note_plan = (agent_busy
+                        && agent_streaming.is_empty()
+                        && pending_tool.is_none()
+                        && !takeover)
+                        .then(|| {
                             let galley = ui.fonts(|f| {
                                 f.layout(
                                     "thinking…".into(),
@@ -473,13 +842,139 @@ impl Chat {
                             (galley, pos)
                         });
 
+                    // The trailing approval card, shaped like a tool container
+                    // pinned open: a header bar with the command summary, over
+                    // a bordered body holding the permission prose, the
+                    // proposed change, and Approve / Deny.
+                    let review_plan =
+                        pending_tool.as_ref().map(|(summary_text, prose, preview)| {
+                            y += TOOL_GROUP_PAD;
+                            let indent = TOOL_PAD_X;
+
+                            // Header bar: the command summary, left-aligned. No
+                            // right metric — the call hasn't been allowed to run.
+                            let summary = ui.fonts(|f| {
+                                f.layout_no_wrap(
+                                    summary_text.clone(),
+                                    egui::FontId::monospace(TOOL_FONT),
+                                    secondary_color,
+                                )
+                            });
+                            let header_h = summary.size().y + 2.0 * TOOL_PAD_Y;
+                            let header_rect =
+                                Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, header_h));
+                            let mut cy = y + header_h + TOOL_PAD_Y;
+
+                            // Body: the permission request, wrapping. Dimmed mono,
+                            // like the tool summary and result text.
+                            let body_w = note_wrap_w - 2.0 * indent;
+                            let prose = ui.fonts(|f| {
+                                f.layout(
+                                    prose.clone(),
+                                    egui::FontId::monospace(TOOL_FONT),
+                                    secondary_color,
+                                    body_w,
+                                )
+                            });
+                            let prose_pos = pos2(note_x + indent, cy);
+                            cy += prose.size().y;
+
+                            // The proposed change, under the prose.
+                            let body = match preview {
+                                // An edit's diff, rendered with changed blocks
+                                // washed in place.
+                                Some(Ok(segs)) => {
+                                    self.review_label.renderer.layout.block_spacing =
+                                        DIFF_BLOCK_SPACING;
+                                    let h = segments_height(&mut self.review_label, segs, body_w);
+                                    let pos = pos2(note_x + indent, cy + ROW_GAP);
+                                    cy += ROW_GAP + h;
+                                    ReviewBody::Rendered {
+                                        segments: segs.clone(),
+                                        pos,
+                                        width: body_w,
+                                    }
+                                }
+                                // The steering error approval would hit.
+                                Some(Err(e)) => {
+                                    let galley = ui.fonts(|f| {
+                                        f.layout(
+                                            e.clone(),
+                                            egui::FontId::monospace(TOOL_FONT),
+                                            secondary_color,
+                                            body_w,
+                                        )
+                                    });
+                                    let pos = pos2(note_x + indent, cy + ROW_GAP);
+                                    cy += ROW_GAP + galley.size().y;
+                                    ReviewBody::Galley { galley, pos }
+                                }
+                                None => ReviewBody::None,
+                            };
+
+                            // Button row, right-aligned; Approve sits left of Deny
+                            // to match the ⌘A / ⌘D keys. Hints show where a
+                            // hardware keyboard is plausible (desktop, iPad).
+                            cy += V_PAD;
+                            let btn = |ui: &Ui, label: String, accent: bool| {
+                                ui.fonts(|f| {
+                                    f.layout_no_wrap(
+                                        label,
+                                        egui::FontId::proportional(13.0),
+                                        if accent { text_color } else { secondary_color },
+                                    )
+                                })
+                            };
+                            let approve_label = if show_key_hints {
+                                format!("Approve {approve_hint}")
+                            } else {
+                                "Approve".into()
+                            };
+                            let deny_label = if show_key_hints {
+                                format!("Deny {deny_hint}")
+                            } else {
+                                "Deny".into()
+                            };
+                            let approve = btn(ui, approve_label, true);
+                            let deny = btn(ui, deny_label, false);
+                            let btn_h = approve.size().y.max(deny.size().y) + 8.0;
+                            let bpad = 12.0;
+                            let approve_w = approve.size().x + bpad * 2.0;
+                            let deny_w = deny.size().x + bpad * 2.0;
+                            let right = note_x + note_wrap_w - indent;
+                            let deny_rect =
+                                Rect::from_min_size(pos2(right - deny_w, cy), vec2(deny_w, btn_h));
+                            let approve_rect = Rect::from_min_size(
+                                pos2(deny_rect.min.x - STRIP_GAP - approve_w, cy),
+                                vec2(approve_w, btn_h),
+                            );
+                            cy += btn_h + TOOL_PAD_Y;
+
+                            let border =
+                                Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, cy - y));
+                            y = cy + ROW_GAP + TOOL_GROUP_PAD;
+                            ReviewPlan {
+                                header_rect,
+                                summary,
+                                prose,
+                                prose_pos,
+                                body,
+                                approve,
+                                approve_rect,
+                                deny,
+                                deny_rect,
+                                border,
+                            }
+                        });
+
                     // Keep the clicked arrows where they were: correct for
                     // any height change of the swapped fork row (content
                     // above the fork is identical, so that's the whole
                     // delta). Consuming a scroll also un-sticks the area.
-                    if let Some((avi, old_y)) = self.branch_anchor.take() {
+                    if let Some((avi, old_y, row_top)) = self.branch_anchor.take() {
                         if let Some(s) = strips.iter().find(|s| s.vi == avi) {
-                            let delta = old_y - s.rect.min.y;
+                            let new_y = if row_top { s.row_rect.min.y } else { s.rect.min.y };
+                            let delta = old_y - new_y;
                             if delta.abs() > 0.5 {
                                 ui.scroll_with_delta(vec2(0.0, delta));
                             }
@@ -498,15 +993,34 @@ impl Chat {
                         );
                     }
 
+                    // Row-wide widgets register BEFORE content paints, so
+                    // content-level widgets — markdown links, which open on
+                    // cmd-click — sit above them and win the pointer.
+                    let row_resps: Vec<egui::Response> = strips
+                        .iter()
+                        .map(|s| {
+                            ui.interact(
+                                s.row_rect,
+                                Id::new(("chat_row", visible[s.vi].idx)),
+                                Sense::click(),
+                            )
+                        })
+                        .collect();
+
                     // pass 2: paint absolute. No egui layout calls.
                     let editing_id = self.editing;
+                    // Clickable listing rows per tool row (entry index →
+                    // rects+paths), point-tested by the strips loop's row
+                    // widget.
+                    let mut tool_list_hits: HashMap<usize, Vec<(Rect, String)>> = HashMap::new();
                     for (vi, plan) in plans.into_iter().enumerate() {
                         let i = visible[vi].idx;
                         match plan {
                             RowPlan::Bubble { bubble_rect, name_galley, name_h, content_h } => {
+                                // Rounding matches the tool containers.
                                 ui.painter().rect_filled(
                                     bubble_rect,
-                                    CornerRadius::same(CORNER),
+                                    CornerRadius::same(2),
                                     bubble_surface,
                                 );
                                 // The message being edited is outlined in the
@@ -514,7 +1028,7 @@ impl Chat {
                                 if editing_id.is_some() && self.entries[i].msg.id == editing_id {
                                     ui.painter().rect_stroke(
                                         bubble_rect,
-                                        CornerRadius::same(CORNER),
+                                        CornerRadius::same(2),
                                         Stroke::new(
                                             1.0,
                                             theme.fg().get_color(theme.prefs().primary),
@@ -573,19 +1087,109 @@ impl Chat {
                                 ui.painter()
                                     .galley(pos2(pos.x, text_y), galley, error_color);
                             }
+                            RowPlan::Tool {
+                                header_rect,
+                                summary,
+                                metric,
+                                body,
+                                body_pos,
+                                rendered,
+                                list_rows,
+                                border,
+                            } => {
+                                // Paint only — clicks are handled by the
+                                // strips loop's whole-row widget (registered
+                                // after, so it owns the row; a widget here
+                                // would be occluded). Listing hits are
+                                // point-tested against `tool_list_hits`.
+                                //
+                                // The container borrows the markdown table's
+                                // grammar: filled header bar; expanded content
+                                // on the transcript background inside a
+                                // border, corners matching the table's.
+                                let header_rounding = if border.is_some() {
+                                    CornerRadius { nw: 2, ne: 2, sw: 0, se: 0 }
+                                } else {
+                                    CornerRadius::same(2)
+                                };
+                                ui.painter().rect_filled(
+                                    header_rect,
+                                    header_rounding,
+                                    theme.neutral_bg_secondary(),
+                                );
+                                ui.painter().galley(
+                                    pos2(
+                                        header_rect.min.x + TOOL_PAD_X,
+                                        header_rect.center().y - summary.size().y / 2.0,
+                                    ),
+                                    summary,
+                                    secondary_color,
+                                );
+                                if let Some(metric) = metric {
+                                    ui.painter().galley(
+                                        pos2(
+                                            header_rect.max.x - TOOL_PAD_X - metric.size().x,
+                                            header_rect.center().y - metric.size().y / 2.0,
+                                        ),
+                                        metric,
+                                        metric_color,
+                                    );
+                                }
+                                if let Some(body) = body {
+                                    ui.painter().galley(body_pos, body, secondary_color);
+                                }
+                                if let Some((segs, rpos, rwidth)) = rendered {
+                                    // Bands bleed to the container edges
+                                    // (inset for its 1px border).
+                                    let areas = paint_segments(
+                                        ui,
+                                        &mut self.entries[i].label,
+                                        Id::new(("tool_body", i)),
+                                        &segs,
+                                        rpos,
+                                        rwidth,
+                                        (note_x + 1.0, note_x + note_wrap_w - 1.0),
+                                        add_wash,
+                                        del_wash,
+                                    );
+                                    text_areas.extend(areas);
+                                }
+                                for row in list_rows {
+                                    let openable = row.open_path.is_some();
+                                    let color = if openable && ui.rect_contains_pointer(row.rect) {
+                                        text_color
+                                    } else {
+                                        secondary_color
+                                    };
+                                    ui.painter().galley(row.rect.min, row.galley, color);
+                                    if let Some(path) = row.open_path {
+                                        tool_list_hits.entry(i).or_default().push((row.rect, path));
+                                    }
+                                }
+                                if let Some(container) = border {
+                                    ui.painter().rect_stroke(
+                                        container,
+                                        2.0,
+                                        Stroke { width: 1.0, color: theme.neutral_bg_tertiary() },
+                                        StrokeKind::Inside,
+                                    );
+                                }
+                            }
                         }
                     }
 
                     // Metadata strips: timestamp, ‹ 2/3 › arrows, and hover
                     // action icons, in the reserved space under each row.
                     // All row interaction (context menu included) lives here.
-                    for strip in &strips {
+                    for (si, strip) in strips.iter().enumerate() {
                         let vi = strip.vi;
                         let i = visible[vi].idx;
                         let is_tail = vi + 1 == visible.len();
                         let kind = {
                             let m = &self.entries[i].msg;
-                            if m.error {
+                            if m.error || m.tool.is_some() {
+                                // Tool rows carry their own affordance (expand);
+                                // no edit/copy/regen strip.
                                 RowKind::Other
                             } else if m.agent {
                                 RowKind::AgentReply
@@ -599,13 +1203,14 @@ impl Chat {
                             && agent_actions
                             && self.entries[i].msg.id.is_some()
                             && parent_for_sibling(&self.entries, i).is_some();
-                        let regen = editable && kind == RowKind::AgentReply && is_tail;
                         // Retry lives where every other row action lives.
                         let retryable = is_tail && can_retry && self.entries[i].msg.error;
-                        let hovered = ui.rect_contains_pointer(strip.row_rect)
-                            || ui.rect_contains_pointer(strip.rect);
-                        let show_icons =
-                            hovered || (is_tail && kind == RowKind::AgentReply) || retryable;
+                        // Union bridges the gap between the message and its
+                        // strip, so the actions don't blink out when the
+                        // pointer crosses the space between them.
+                        let hovered = ui.rect_contains_pointer(strip.row_rect.union(strip.rect));
+                        // Touch has no hover — reveal actions outright.
+                        let show_icons = touch_os || hovered || retryable;
 
                         // Items lay out from the row's aligned edge inward:
                         // arrows, then timestamp, then action icons. The
@@ -692,12 +1297,16 @@ impl Chat {
                         // hides a reachable target.
                         if show_icons {
                             let mut icons: Vec<(&Icon, Option<RowAction>)> = Vec::new();
+                            // Rerun lives on the *user's* message: resend it
+                            // as a sibling and the turn re-runs.
                             if editable && kind == RowKind::OwnUser {
                                 icons.push((&Icon::PENCIL, Some(RowAction::Edit(i))));
+                                icons.push((&Icon::SYNC, Some(RowAction::ResendFrom(i))));
                             }
-                            icons.push((&Icon::CONTENT_COPY, None));
-                            if regen {
-                                icons.push((&Icon::SYNC, Some(RowAction::Regenerate(i))));
+                            // Tool rows expand instead — nothing worth
+                            // copying in a summary line.
+                            if self.entries[i].msg.tool.is_none() {
+                                icons.push((&Icon::CONTENT_COPY, None));
                             }
                             if retryable {
                                 icons.push((&Icon::SYNC, Some(RowAction::RetryLast)));
@@ -732,17 +1341,36 @@ impl Chat {
                         // Context menu over the message row (secondary path
                         // to the same actions, plus Retry-from-here/Delete).
                         let content = self.entries[i].msg.content.clone();
-                        row_menu(
-                            ui,
-                            strip.row_rect,
-                            i,
-                            &content,
-                            kind,
-                            editable,
-                            regen,
-                            can_mutate,
-                            &mut action,
-                        );
+                        let row_resp = row_resps[si].clone();
+                        row_menu(&row_resp, i, &content, kind, editable, can_mutate, &mut action);
+
+                        // A tool row toggles on a click anywhere on it —
+                        // except its clickable listing rows, which open the
+                        // note instead (point-tested: this row widget owns the
+                        // whole rect, so they can't be their own widgets).
+                        if self.entries[i].msg.tool.is_some() {
+                            let row_resp = row_resp.on_hover_cursor(egui::CursorIcon::PointingHand);
+                            if row_resp.clicked() {
+                                let hit = row_resp.interact_pointer_pos().and_then(|p| {
+                                    tool_list_hits.get(&i).and_then(|rows| {
+                                        rows.iter()
+                                            .find(|(rect, _)| rect.contains(p))
+                                            .map(|(_, path)| path.clone())
+                                    })
+                                });
+                                match (hit, self.entries[i].msg.id) {
+                                    (Some(path), _) => open_list_path = Some(path),
+                                    (None, Some(id)) => {
+                                        action = Some(RowAction::ToggleTool {
+                                            id,
+                                            vi,
+                                            anchor_y: strip.row_rect.min.y,
+                                        });
+                                    }
+                                    (None, None) => {}
+                                }
+                            }
+                        }
                     }
 
                     // Trailing agent rows paint after the transcript.
@@ -761,6 +1389,101 @@ impl Chat {
                         ui.painter().galley(pos, galley, secondary_color);
                     }
 
+                    // The approval card, painted like a tool container pinned
+                    // open: a filled header bar (command summary), a bordered
+                    // body with the permission prose + proposed change, and
+                    // Approve / Deny.
+                    if let Some(r) = review_plan {
+                        // Fill with the bg-family accent (the send button's
+                        // pattern) — the fg accent is for text and strokes.
+                        let accent = theme.bg().get_color(theme.prefs().primary);
+                        // Header bar with top corners rounded, like an expanded
+                        // tool row's.
+                        ui.painter().rect_filled(
+                            r.header_rect,
+                            CornerRadius { nw: 2, ne: 2, sw: 0, se: 0 },
+                            theme.neutral_bg_secondary(),
+                        );
+                        ui.painter().galley(
+                            pos2(
+                                r.header_rect.min.x + TOOL_PAD_X,
+                                r.header_rect.center().y - r.summary.size().y / 2.0,
+                            ),
+                            r.summary,
+                            secondary_color,
+                        );
+                        // The permission request.
+                        ui.painter().galley(r.prose_pos, r.prose, secondary_color);
+                        match r.body {
+                            ReviewBody::None => {}
+                            ReviewBody::Galley { galley, pos } => {
+                                ui.painter().galley(pos, galley, secondary_color);
+                            }
+                            // The proposed change, rendered; changed blocks
+                            // washed in place. Washes paint after the layout
+                            // but under the glyphs — text rides the later
+                            // glyphon callback layer. Bands bleed to the
+                            // container edges (inset for its 1px border).
+                            ReviewBody::Rendered { segments, pos, width } => {
+                                let areas = paint_segments(
+                                    ui,
+                                    &mut self.review_label,
+                                    Id::new("review_body"),
+                                    &segments,
+                                    pos,
+                                    width,
+                                    (note_x + 1.0, note_x + note_wrap_w - 1.0),
+                                    add_wash,
+                                    del_wash,
+                                );
+                                text_areas.extend(areas);
+                            }
+                        }
+
+                        // Deny: bordered. Approve: accent-filled.
+                        let deny = ui
+                            .interact(r.deny_rect, Id::new("chat_review_deny"), Sense::click())
+                            .on_hover_cursor(egui::CursorIcon::PointingHand);
+                        ui.painter().rect_stroke(
+                            r.deny_rect,
+                            CornerRadius::same(6),
+                            Stroke::new(1.0, secondary_color),
+                            StrokeKind::Inside,
+                        );
+                        ui.painter().galley(
+                            r.deny_rect.center() - r.deny.size() / 2.0,
+                            r.deny,
+                            secondary_color,
+                        );
+                        let approve = ui
+                            .interact(
+                                r.approve_rect,
+                                Id::new("chat_review_approve"),
+                                Sense::click(),
+                            )
+                            .on_hover_cursor(egui::CursorIcon::PointingHand);
+                        ui.painter()
+                            .rect_filled(r.approve_rect, CornerRadius::same(6), accent);
+                        ui.painter().galley(
+                            r.approve_rect.center() - r.approve.size() / 2.0,
+                            r.approve,
+                            text_color,
+                        );
+                        if approve.clicked() {
+                            approve_clicked = true;
+                        }
+                        if deny.clicked() {
+                            deny_clicked = true;
+                        }
+                        // Container border, like an expanded tool row's.
+                        ui.painter().rect_stroke(
+                            r.border,
+                            2.0,
+                            Stroke { width: 1.0, color: theme.neutral_bg_tertiary() },
+                            StrokeKind::Inside,
+                        );
+                    }
+
                     // First-run: a minimal centered card. The Choose stage
                     // offers the provider roster as a two-column icon grid;
                     // the later stages track validation with one centered
@@ -777,7 +1500,6 @@ impl Chat {
                         let center_x = note_x + note_wrap_w / 2.0;
                         let card_w = note_wrap_w.min(340.0);
                         let field_w = card_w.min(300.0);
-                        let accent = theme.fg().get_color(theme.prefs().primary);
                         let body_font = egui::FontId::proportional(13.5);
 
                         let entry_ref = self.key_entry.as_ref().unwrap();
@@ -837,34 +1559,13 @@ impl Chat {
                             job.halign = egui::Align::Center;
                             ui.fonts(|f| f.layout_job(job))
                         });
-                        let link = ui.fonts(|f| {
-                            f.layout_no_wrap(
-                                "Edit the provider file instead".into(),
-                                body_font.clone(),
-                                secondary_color,
-                            )
+                        // Minimal: the field submits on return, so the only
+                        // control is a centered text Cancel (like the picker).
+                        let cancel = ui.fonts(|f| {
+                            f.layout_no_wrap("Cancel".into(), body_font.clone(), secondary_color)
                         });
 
-                        let (glyph_sz, field_h, btn_h) = (24.0, 30.0, 28.0);
-
-                        // Connect button width, sized to its widest label so
-                        // the text never wraps and the pair doesn't shift when
-                        // it flips to "Connecting…".
-                        let btn_font = egui::TextStyle::Button.resolve(ui.style());
-                        let connect_w = ["Connect", "Connecting…"]
-                            .iter()
-                            .map(|s| {
-                                ui.fonts(|f| {
-                                    f.layout_no_wrap((*s).into(), btn_font.clone(), text_color)
-                                        .size()
-                                        .x
-                                })
-                            })
-                            .fold(0.0_f32, f32::max)
-                            + 28.0;
-                        let btn_gap = 8.0;
-                        let cancel_w = 80.0;
-                        let pair_w = connect_w + btn_gap + cancel_w;
+                        let (glyph_sz, field_h) = (24.0, 30.0);
 
                         // Lay the whole column in one place — the vertical
                         // spacing follows from the pushed gaps, no hand-summed
@@ -874,17 +1575,16 @@ impl Chat {
                         col.glyph(0.0, tex.id, glyph_sz, text_color);
                         col.galley(14.0, head, false);
                         col.reserve(18.0, vec2(field_w, field_h));
-                        let buttons_gap = match status_galley {
+                        let cancel_gap = match status_galley {
                             Some(g) => {
                                 col.galley(10.0, g, true);
-                                8.0
+                                14.0
                             }
-                            None => 10.0,
+                            None => 16.0,
                         };
-                        col.reserve(buttons_gap, vec2(pair_w, btn_h));
-                        col.reserve(14.0, link.size());
+                        col.reserve(cancel_gap, cancel.size());
                         let rects = col.show(ui, transcript_rect, center_x);
-                        let (field_rect, buttons_rect, link_rect) = (rects[0], rects[1], rects[2]);
+                        let (field_rect, cancel_rect) = (rects[0], rects[1]);
 
                         // Masked field on its own raised surface so the input
                         // is visible before it's focused or hovered.
@@ -907,6 +1607,10 @@ impl Chat {
                             pos2(field_rect.min.x + 8.0, field_rect.center().y - row_h / 2.0),
                             pos2(field_rect.max.x - 8.0, field_rect.center().y + row_h / 2.0),
                         );
+                        // The whole visible box is the tap/gesture target,
+                        // reported to the native text view (the one-row rect
+                        // above is only where the masked text lays out).
+                        self.key_field_hit_rect = field_rect;
                         if self.key_field.renderer.buffer.current.text.is_empty() {
                             let hint = ui.fonts(|f| {
                                 f.layout_no_wrap(
@@ -922,45 +1626,15 @@ impl Chat {
                                 secondary_color,
                             );
                         }
-                        // Connect / Cancel buttons, filling the reserved pair.
-                        let connect_label = if connecting { "Connecting…" } else { "Connect" };
-                        let connect_rect =
-                            Rect::from_min_size(buttons_rect.min, vec2(connect_w, btn_h));
-                        let cancel_rect = Rect::from_min_size(
-                            pos2(buttons_rect.min.x + connect_w + btn_gap, buttons_rect.min.y),
-                            vec2(cancel_w, btn_h),
-                        );
-                        let connect_btn = ui.put(
-                            connect_rect,
-                            egui::Button::new(
-                                egui::RichText::new(connect_label).color(theme.neutral_bg()),
-                            )
-                            .fill(accent)
-                            .corner_radius(CornerRadius::same(6)),
-                        );
-                        if connect_btn.clicked() && !connecting {
-                            key_connect = true;
-                        }
-                        let cancel_btn = ui.put(
-                            cancel_rect,
-                            egui::Button::new(egui::RichText::new("Cancel").color(text_color))
-                                .fill(bubble_surface)
-                                .corner_radius(CornerRadius::same(6)),
-                        );
-                        if cancel_btn.clicked() {
-                            key_cancel = true;
-                        }
-
-                        // Quiet escape hatch to the raw file, filling the
-                        // reserved link rect.
-                        let link_resp = ui
-                            .interact(link_rect, Id::new("chat_key_edit_file"), Sense::click())
+                        // Centered text-only Cancel, filling its reserved rect.
+                        let cancel_resp = ui
+                            .interact(cancel_rect, Id::new("chat_key_cancel"), Sense::click())
                             .on_hover_cursor(egui::CursorIcon::PointingHand);
-                        let link_color =
-                            if link_resp.hovered() { text_color } else { secondary_color };
-                        ui.painter().galley(link_rect.min, link, link_color);
-                        if link_resp.clicked() {
-                            key_edit = true;
+                        let cancel_color =
+                            if cancel_resp.hovered() { text_color } else { secondary_color };
+                        ui.painter().galley(cancel_rect.min, cancel, cancel_color);
+                        if cancel_resp.clicked() {
+                            key_cancel = true;
                         }
                     } else if let Some(stage) = &onboard {
                         let ctx = ui.ctx().clone();
@@ -1064,9 +1738,20 @@ impl Chat {
                                     .collect();
                                 let (row_gap, button_h, glyph_sz, pad, glyph_gap, col_gap) =
                                     (8.0, 34.0, 16.0, 10.0, 10.0, 20.0);
+                                // A configured provider gets a right-aligned
+                                // check; reserve its column so the grid width
+                                // doesn't depend on what's set up.
+                                let check_sz = 14.0;
+                                let added =
+                                    |name: &str| self.providers.iter().any(|p| p.name == name);
                                 let max_label =
                                     labels.iter().map(|g| g.size().x).fold(0.0, f32::max);
-                                let cell_w = pad * 2.0 + glyph_sz + glyph_gap + max_label;
+                                let cell_w = pad * 2.0
+                                    + glyph_sz
+                                    + glyph_gap
+                                    + max_label
+                                    + glyph_gap
+                                    + check_sz;
                                 let grid_w = cell_w * 2.0 + col_gap;
                                 let rows = columns.iter().map(|c| c.len()).max().unwrap_or(0);
                                 let grid_h = rows as f32 * button_h
@@ -1134,6 +1819,25 @@ impl Chat {
                                             label,
                                             text_color,
                                         );
+                                        // Right-aligned check for an already-
+                                        // configured provider.
+                                        if added(name) {
+                                            let check = ui.fonts(|f| {
+                                                f.layout_no_wrap(
+                                                    Icon::DONE.icon.to_string(),
+                                                    egui::FontId::monospace(check_sz),
+                                                    secondary_color,
+                                                )
+                                            });
+                                            ui.painter().galley(
+                                                pos2(
+                                                    cell.max.x - pad - check.size().x,
+                                                    yb + (button_h - check.size().y) / 2.0,
+                                                ),
+                                                check,
+                                                secondary_color,
+                                            );
+                                        }
                                         if resp.clicked() {
                                             onboard_pick = Some(name);
                                         }
@@ -1162,10 +1866,6 @@ impl Chat {
                             | Onboard::Unreachable { label: l, .. }
                             | Onboard::PickModel(l) => {
                                 let text = match stage {
-                                    Onboard::Unreachable { auth: true, .. } => format!(
-                                        "Couldn't reach {l}. Check the API key in its provider \
-                                         file, then come back."
-                                    ),
                                     Onboard::Unreachable { local: true, .. } => {
                                         format!("Can't reach {l}. Is the server running?")
                                     }
@@ -1182,6 +1882,9 @@ impl Chat {
                                 col.galley(0.0, para(ui, text, secondary_color), true);
                                 col.show(ui, transcript_rect, center_x);
                             }
+                            // A missing key needs no centered card — the
+                            // composer's "add key" button is the whole story.
+                            Onboard::NeedKey { .. } => {}
                         }
                     } else if visible.is_empty()
                         && self.unshared
@@ -1240,6 +1943,13 @@ impl Chat {
                 });
         });
 
+        // A bare-canvas tap dismisses the keyboard (composer surrenders
+        // focus; iOS hides the on-screen keyboard).
+        if backdrop_tapped {
+            ui.memory_mut(|m| m.surrender_focus(composer_id));
+            ui.ctx().set_virtual_keyboard_shown(false);
+        }
+
         // Transcript text callback. Submit before composer so the composer's
         // own callback (inside show) lands on a later glyphon layer.
         // `clip_rect` not `max_rect`: egui_wgpu drops a zero-area callback rect.
@@ -1256,24 +1966,23 @@ impl Chat {
         let mut changed = false;
         match action {
             Some(RowAction::Delete(i)) => {
-                self.entries.remove(i);
-                self.seq += 1;
+                self.delete_cascade(i);
                 changed = true;
                 {
-                    let seed = self.visible_seed();
+                    let (seed, buffers) = self.agent_seed();
                     if let Some(harness) = &mut self.harness {
-                        harness.reseed(seed);
+                        harness.reseed(seed, buffers);
                     }
                 }
             }
             Some(RowAction::Switch { parent, target, vi, anchor_y }) => {
                 if let Some(id) = self.entries[target].msg.id {
                     self.branch_choice.insert(parent, id);
-                    self.branch_anchor = Some((vi, anchor_y));
+                    self.branch_anchor = Some((vi, anchor_y, false));
                     {
-                        let seed = self.visible_seed();
+                        let (seed, buffers) = self.agent_seed();
                         if let Some(harness) = &mut self.harness {
-                            harness.reseed(seed);
+                            harness.reseed(seed, buffers);
                         }
                     }
                 }
@@ -1283,23 +1992,53 @@ impl Chat {
                 self.resend_as_sibling(i);
                 changed = true;
             }
-            Some(RowAction::Regenerate(i)) => self.regenerate(i),
             Some(RowAction::RetryLast) => retry_clicked = true,
+            Some(RowAction::ToggleTool { id, vi, anchor_y }) => {
+                if !self.expanded_tools.remove(&id) {
+                    self.expanded_tools.insert(id);
+                }
+                self.branch_anchor = Some((vi, anchor_y, true));
+            }
             _ => {}
+        }
+
+        // Resolve the pending edit.
+        if approve_clicked || deny_clicked {
+            if let Some(harness) = &mut self.harness {
+                if approve_clicked {
+                    harness.approve();
+                } else {
+                    harness.deny();
+                }
+            }
+        }
+
+        // A clicked listing row opens the note in the workspace, resolved
+        // through the same file cache markdown links use.
+        if let Some(path) = open_list_path {
+            use crate::file_cache::FilesExt as _;
+            use crate::tab::ExtendedOutput as _;
+            let target = self
+                .composer
+                .renderer
+                .files
+                .read()
+                .unwrap()
+                .by_path(&path)
+                .filter(|f| f.is_document())
+                .map(|f| f.id);
+            if let Some(id) = target {
+                ui.ctx().open_file(id, true);
+            }
         }
 
         {
             if retry_clicked {
-                // The rerun's reply is a sibling of the error row: same parent.
-                self.pending_parent = self
-                    .visible()
-                    .last()
-                    .and_then(|row| parent_for_sibling(&self.entries, row.idx));
-                self.provider = self.resolve_provider();
-                let system = self.system_prompt.clone();
-                if let (Some(harness), Some(provider)) = (&mut self.harness, self.provider.clone())
-                {
-                    harness.retry(provider, system);
+                // Re-run the turn behind the tail error row. Routed through
+                // regenerate so a turn that failed mid-tool-chain reseeds
+                // from its invoking message, not mid-turn.
+                if let Some(idx) = self.visible().last().map(|row| row.idx) {
+                    self.regenerate(idx);
                 }
             }
             if let Some(name) = onboard_pick {
@@ -1312,21 +2051,13 @@ impl Chat {
             if chooser_cancel {
                 self.chooser_open = false;
             }
-            if key_connect {
+            if key_submit {
                 self.connect_provider_key();
-            } else if key_cancel || key_edit {
-                // Both back out of the connect step. The file still holds the
-                // template placeholder (no real key), so `onboard_stage` shows
-                // the chooser — and it does so on reopen too, since that's read
-                // from the file, not remembered here.
-                let file_id = self.key_entry.as_ref().map(|e| e.file_id);
-                self.key_prompt_dismissed = self.key_entry.as_ref().map(|e| e.name.clone());
+            } else if key_cancel {
+                // Cancel returns to the provider selector — pick a different
+                // provider, or the same one to try again.
                 self.key_entry = None;
-                if key_edit {
-                    if let Some(file_id) = file_id {
-                        self.open_provider_file(file_id);
-                    }
-                }
+                self.chooser_open = true;
             }
         }
 
@@ -1415,7 +2146,8 @@ impl Chat {
         );
         self.composer_rect = if hide_composer { Rect::NOTHING } else { composer_rect };
         let col_pad = (available_width - col_width) / 2.0;
-        let h_inset = col_pad + SIDE_INSET;
+        // The bubble spans the content column, like the message rows.
+        let h_inset = col_pad + H_MARGIN;
         let bubble_rect = Rect::from_min_max(
             pos2(composer_rect.min.x + h_inset, composer_rect.min.y),
             pos2(composer_rect.max.x - h_inset, composer_rect.max.y - composer_bottom_inset),
@@ -1432,8 +2164,41 @@ impl Chat {
             bubble_rect.min,
             pos2(bubble_rect.max.x, bubble_rect.max.y - TOOLBAR_H),
         );
-        let inner_rect = text_rect.shrink2(vec2(H_PAD, V_PAD));
-        if !hide_composer {
+        // Inset the sides and top, but run the bottom to the toolbar rather
+        // than insetting it. The composer is top-anchored, so this rect's
+        // bottom is purely the glyphon clip — insetting it by `V_PAD` pinned
+        // the clip onto the last line's box and shaved descenders (g/y tails,
+        // worst on hi-DPI). The empty space above the toolbar is the padding.
+        let inner_rect = Rect::from_min_max(
+            text_rect.min + vec2(H_PAD, V_PAD),
+            pos2(text_rect.max.x - H_PAD, text_rect.max.y),
+        );
+        // When the key is broken the text field is replaced by an accent
+        // "add key" button — a control, never a place to type a secret.
+        // Clicking it opens the dedicated masked field.
+        let mut add_key_clicked = false;
+        if let Some((_, label)) = &need_key {
+            let btn_rect = Rect::from_min_max(
+                text_rect.min + vec2(H_PAD, V_PAD),
+                pos2(text_rect.max.x - H_PAD, text_rect.max.y - V_PAD),
+            );
+            let resp = ui
+                .interact(btn_rect, Id::new("chat_add_key"), Sense::click())
+                .on_hover_cursor(egui::CursorIcon::PointingHand);
+            let accent = theme.bg().get_color(theme.prefs().primary);
+            ui.painter()
+                .rect_filled(btn_rect, CornerRadius::same(8), accent);
+            let btn_label = ui.fonts(|f| {
+                f.layout_no_wrap(
+                    format!("Fix your {label} key"),
+                    egui::FontId::proportional(15.0),
+                    text_color,
+                )
+            });
+            ui.painter()
+                .galley(btn_rect.center() - btn_label.size() / 2.0, btn_label, text_color);
+            add_key_clicked = resp.clicked();
+        } else if !hide_composer {
             self.composer.show(ui, inner_rect, composer_id);
         }
 
@@ -1447,9 +2212,6 @@ impl Chat {
             if self.unshared && self.harness.is_some() && self.config_loaded {
                 match &self.provider {
                     None => Some("pick an AI provider to start".into()),
-                    Some(p) if p.api_key.as_deref() == Some(KEY_PLACEHOLDER) => {
-                        Some(format!("add your {} API key to start", p.label()))
-                    }
                     Some(p) if p.model.trim().is_empty() => Some("pick a model to start".into()),
                     _ => None,
                 }
@@ -1457,8 +2219,12 @@ impl Chat {
                 None
             };
 
-        // Ghosted placeholder over the empty composer.
-        if !hide_composer && self.composer.renderer.buffer.current.text.is_empty() {
+        // Ghosted placeholder over the empty composer (not while the field is
+        // the "add key" button).
+        if !hide_composer
+            && need_key.is_none()
+            && self.composer.renderer.buffer.current.text.is_empty()
+        {
             let row_h = self.composer.row_height();
             let hint_text = send_block.as_deref().unwrap_or("Type a message");
             let hint = ui.fonts(|f| {
@@ -1829,24 +2595,9 @@ impl Chat {
             }
 
             if let Some((provider, model)) = pick {
-                // A picked provider whose file still holds the template
-                // placeholder was never configured — route through the
-                // connect step instead of landing on a dead credential.
-                let placeholder = self
-                    .providers
-                    .iter()
-                    .find(|p| p.name == provider)
-                    .filter(|p| p.api_key.as_deref() == Some(KEY_PLACEHOLDER))
-                    .map(|p| p.label());
-                self.write_selection(provider.clone(), model);
-                if let Some(label) = placeholder {
-                    if let Ok(file) = self
-                        .core
-                        .get_by_path(&format!("/.agent/providers/{provider}.json"))
-                    {
-                        self.open_key_entry(&provider, label, file.id);
-                    }
-                }
+                // The dropdown only lists configured providers (unconfigured
+                // ones are filtered at load), so a pick always has a key.
+                self.write_selection(provider, model);
                 changed = true;
             }
             if let Some(effort) = effort_pick {
@@ -1855,6 +2606,18 @@ impl Chat {
             }
             if open_chooser {
                 self.chooser_open = true;
+            }
+            // The composer's "add key" button opens the dedicated masked
+            // field for the broken provider — the only secret-entry surface.
+            if add_key_clicked {
+                if let Some((name, label)) = &need_key {
+                    if let Ok(file) = self
+                        .core
+                        .get_by_path(&format!("/.agent/providers/{name}.json"))
+                    {
+                        self.open_key_entry(name, label.clone(), file.id);
+                    }
+                }
             }
             if open_prompt {
                 self.create_prompt_file();
@@ -1870,26 +2633,33 @@ impl Chat {
         let non_empty = !self.composer.renderer.buffer.current.text.trim().is_empty();
         let mut send_clicked = false;
         let mut stop_clicked = false;
-        if !hide_composer {
-            let d = TOOLBAR_H - 8.0;
+        // No send button while the field is the "add key" button.
+        if !hide_composer && need_key.is_none() {
+            let d = if touch_os { TOOLBAR_H - 2.0 } else { TOOLBAR_H - 8.0 };
             let center = pos2(toolbar_rect.max.x - d / 2.0, toolbar_rect.center().y);
             let button_rect = Rect::from_center_size(center, vec2(d, d));
-            let resp = ui.interact(button_rect, Id::new("chat_send"), Sense::click());
-
+            // Touch targets stay ~44pt even where the visual is smaller.
+            let hit_rect = if touch_os { button_rect.expand(7.0) } else { button_rect };
             let active = (non_empty && send_block.is_none()) || agent_busy;
-            let fill = if active {
-                theme.bg().get_color(theme.prefs().primary)
-            } else {
-                theme.neutral_bg().lerp_to_gamma(theme.neutral_fg(), 0.12)
-            };
+            let resp = ui.interact(hit_rect, Id::new("chat_send"), Sense::click());
+            // A pointer cursor when it'll do something (send, or stop a turn).
+            let resp =
+                if active { resp.on_hover_cursor(egui::CursorIcon::PointingHand) } else { resp };
+
             let painter = ui.painter();
-            painter.circle_filled(center, d / 2.0, fill);
+            // The markdown-toolbar icon idiom — no filled disc, just the mark
+            // itself: accent when actionable, foreground when idle.
+            let mark = if active {
+                theme.fg().get_color(theme.prefs().primary)
+            } else {
+                theme.neutral_fg()
+            };
             if agent_busy {
                 let side = d * 0.36;
                 painter.rect_filled(
                     Rect::from_center_size(center, vec2(side, side)),
                     CornerRadius::same(2),
-                    theme.neutral_fg(),
+                    mark,
                 );
                 stop_clicked = resp.clicked();
             } else {
@@ -1897,10 +2667,10 @@ impl Chat {
                     f.layout_no_wrap(
                         Icon::SEND.icon.to_string(),
                         egui::FontId::monospace(d * 0.55),
-                        theme.neutral_fg(),
+                        mark,
                     )
                 });
-                painter.galley(center - icon.size() / 2.0, icon, theme.neutral_fg());
+                painter.galley(center - icon.size() / 2.0, icon, mark);
                 send_clicked = resp.clicked();
             }
         }
@@ -1922,13 +2692,29 @@ impl Chat {
         // The one text field's rect, for the native text overlay: the connect
         // step's key field, else the composer, else nothing (the chooser has
         // no text input, so the keyboard should stay down).
+        //
+        // For the composer, report the whole bubble text region (`text_rect`),
+        // not the padded layout rect — this frame is the iOS text view's, so
+        // it doubles as the tap-to-focus / double-tap-to-select gesture
+        // target, and the padding margins should be tappable too (touch→buffer
+        // mapping is hit-tested separately, so a larger frame is safe). It
+        // stops at the toolbar so the dropdowns and send button keep their own
+        // egui taps.
         let interaction_rect = if self.key_entry.is_some() {
-            self.key_field_rect
+            self.key_field_hit_rect
         } else if hide_composer {
             Rect::NOTHING
         } else {
-            inner_rect
+            text_rect
         };
-        (sent || agent_changed || changed, interaction_rect)
+        // The composer's `seq` bumps on any text/selection change. When it
+        // moved but no native keystroke drove it (a send-clear, edit-prefill,
+        // stash-restore), the native text view still holds the old caret —
+        // report so the bridge re-syncs.
+        let composer_seq = self.composer.renderer.buffer.current.seq;
+        let composer_updated = composer_seq != self.composer_seq;
+        self.composer_seq = composer_seq;
+
+        (sent || agent_changed || changed, interaction_rect, composer_updated)
     }
 }

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -1673,19 +1673,6 @@ impl Chat {
                                         text_color,
                                     )
                                 });
-                                // First-run gets the privacy framing; the
-                                // summoned "add provider" doesn't — the empty
-                                // chat behind it already carries that line.
-                                let body = (!summoned).then(|| {
-                                    para(
-                                        ui,
-                                        "Messages you send go to the AI provider you choose. Pick \
-                                         a local model to keep them on your device."
-                                            .into(),
-                                        secondary_color,
-                                    )
-                                });
-
                                 // Two meaningful columns: the household-name
                                 // model makers (+ `custom`, the hand-rolled
                                 // escape hatch) on the left, third-party hosts
@@ -1767,13 +1754,10 @@ impl Chat {
                                     })
                                 });
 
-                                // headline, optional privacy line, the grid,
-                                // and (when summoned) a cancel — as one column.
+                                // headline, the grid, and (when summoned) a
+                                // cancel — as one column.
                                 let mut col = CenteredColumn::default();
                                 col.galley(0.0, head, false);
-                                if let Some(body) = body {
-                                    col.galley(12.0, body, true);
-                                }
                                 col.reserve(22.0, vec2(grid_w, grid_h));
                                 if let Some(c) = &cancel {
                                     col.reserve(20.0, c.size());

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -4,7 +4,7 @@ use egui::{Color32, Pos2, Rangef, Rect, Sense, Stroke, Ui, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 
 use crate::tab::ExtendedInput as _;
-use crate::tab::markdown_editor::MdEdit;
+use crate::tab::markdown_editor::{MdEdit, MdRender};
 use crate::theme::palette_v2::ThemeExt as _;
 
 use super::{Event, Region};
@@ -24,9 +24,11 @@ pub struct CursorState {
 impl MdEdit {
     /// Highlights the provided range with a faded version of the provided accent color.
     pub fn show_range(&self, ui: &mut Ui, highlight_range: (Grapheme, Grapheme), color: Color32) {
-        for rect in self.range_rects(highlight_range) {
-            ui.painter().rect_filled(rect, 2., color);
-        }
+        self.renderer.show_range(ui, highlight_range, color)
+    }
+
+    pub fn range_rects(&self, range: (Grapheme, Grapheme)) -> Vec<Rect> {
+        self.renderer.range_rects(range)
     }
 
     pub fn selection_tap(&self, pos: Pos2) -> bool {
@@ -55,136 +57,6 @@ impl MdEdit {
                 .iter()
                 .any(|&r| pad_rect(r).contains(pos))
         }
-    }
-
-    pub fn range_rects(&self, range: (Grapheme, Grapheme)) -> Vec<Rect> {
-        use crate::tab::markdown_editor::widget::utils::wrap_layout::FragmentContent;
-        let mut result: Vec<Rect> = Vec::new();
-        for frag in self.renderer.fragments.iter() {
-            let frag_range = frag.source_range;
-            // Empty-range fragments contribute no width — except a chip's pad
-            // spacers, which carry the capsule's real side padding. Include
-            // those when their capsule overlaps the selection so the highlight
-            // spans the full pill (and the last rect — where iOS drops the end
-            // handle — reaches the pill's edge).
-            if frag_range.start() == frag_range.end() {
-                let pad_scope = frag
-                    .style_stack
-                    .last()
-                    .filter(|s| s.chip && matches!(frag.content, FragmentContent::Spacer))
-                    .map(|s| s.source_range);
-                let overlaps =
-                    pad_scope.is_some_and(|s| s.start() < range.end() && range.start() < s.end());
-                if !overlaps {
-                    continue;
-                }
-            }
-            // (pads passed their own scope-overlap check above; their empty
-            // range would always fail this one)
-            if frag_range.start() != frag_range.end()
-                && (frag_range.end() <= range.start() || frag_range.start() >= range.end())
-            {
-                continue;
-            }
-            let mut rect = frag.rect;
-            // Recompute an edge only when the selection endpoint falls
-            // *strictly inside* the fragment. At `==` the fragment's own edge
-            // already is the endpoint — and for capsule fragments, which all
-            // share the atom's full source range, recomputing both edges from
-            // global offsets would mangle every segment's rect.
-            if frag_range.start() < range.start() {
-                rect.min.x = self.renderer.fragment_x(frag, range.start());
-            }
-            if frag_range.end() > range.end() {
-                rect.max.x = self.renderer.fragment_x(frag, range.end());
-            }
-            if rect.area() <= 0.001 {
-                continue;
-            }
-            result.push(rect);
-        }
-
-        // Selected newlines / blank lines have no glyph to highlight. When
-        // the selection crosses a source line's end, add a fixed-width slab
-        // at that row's end so the captured `\n` reads as selected.
-        // (Soft-wrap whitespace shares its boundary offset with the next
-        // row's start, so it isn't covered here.)
-        if !range.is_empty() {
-            let slab_w = self.renderer.layout.row_height * 0.4;
-            let line_count = self.renderer.bounds.source_lines.len();
-            for i in 0..line_count.saturating_sub(1) {
-                // The `\n` grapheme sits at the line's end offset (source
-                // lines exclude their trailing newline).
-                let newline = self.renderer.bounds.source_lines[i].end();
-                if newline < range.start() || newline >= range.end() {
-                    continue;
-                }
-                // Match the row's content rects (bare fragment rect), not
-                // `cursor_line`'s caret-height-expanded range.
-                if let Some(frag) = self.renderer.fragment_at_offset(newline) {
-                    let x = self.renderer.fragment_x(frag, newline);
-                    let (top, bot) = (frag.rect.min.y, frag.rect.max.y);
-                    // Extend the row's content rect rightward into the slab so
-                    // the newline flows out of the row's highlight as one
-                    // rounded shape, rather than a separate notched rect.
-                    if let Some(r) = result.iter_mut().find(|r| {
-                        (r.top() - top).abs() < 0.001
-                            && (r.bottom() - bot).abs() < 0.001
-                            && (r.right() - x).abs() < 0.5
-                    }) {
-                        r.max.x = r.max.x.max(x + slab_w);
-                    } else {
-                        result.push(Rect::from_min_max(
-                            Pos2::new(x, top),
-                            Pos2::new(x + slab_w, bot),
-                        ));
-                    }
-                }
-            }
-        }
-
-        // Reading order: group vertically-overlapping rects into rows, then by
-        // x — so the last rect is the selection's geometric end, where iOS reads
-        // the end handle. A raw top-sort would put a low inter-image space rect
-        // last, dropping the handle on the next image's left edge.
-        let mut by_top: Vec<usize> = (0..result.len()).collect();
-        by_top.sort_by(|&a, &b| result[a].top().total_cmp(&result[b].top()));
-        let mut row_of = vec![0usize; result.len()];
-        let mut row = 0;
-        let mut row_bottom = f32::NEG_INFINITY;
-        for (i, &k) in by_top.iter().enumerate() {
-            if i != 0 && result[k].top() > row_bottom + 0.5 {
-                row += 1;
-                row_bottom = result[k].bottom();
-            } else {
-                row_bottom = row_bottom.max(result[k].bottom());
-            }
-            row_of[k] = row;
-        }
-        let mut ordered: Vec<(usize, Rect)> = result
-            .iter()
-            .enumerate()
-            .map(|(i, r)| (row_of[i], *r))
-            .collect();
-        ordered.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.left().total_cmp(&b.1.left())));
-
-        // Coalesce contiguous same-row rects (post-sort — the fragment list
-        // interleaves rows) so each row's selection paints as one merged
-        // rounded rect: outer corners rounded, no seams at fragment edges.
-        let mut merged: Vec<Rect> = Vec::new();
-        for (_, rect) in ordered {
-            if let Some(last) = merged.last_mut() {
-                let same_row = (last.top() - rect.top()).abs() < 0.001
-                    && (last.bottom() - rect.bottom()).abs() < 0.001;
-                let contiguous = (last.right() - rect.left()).abs() < 0.001;
-                if same_row && contiguous {
-                    last.max.x = last.max.x.max(rect.max.x);
-                    continue;
-                }
-            }
-            merged.push(rect);
-        }
-        merged
     }
 
     /// Draws a cursor at the provided offset with the provided accent color.
@@ -361,5 +233,147 @@ impl MdEdit {
         };
         let y_range = y_range.expand(self.renderer.layout.row_spacing / 2.);
         Some([Pos2 { x, y: y_range.min }, Pos2 { x, y: y_range.max }])
+    }
+}
+
+impl MdRender {
+    /// Highlights the provided range with a faded version of the provided accent color.
+    pub fn show_range(&self, ui: &mut Ui, highlight_range: (Grapheme, Grapheme), color: Color32) {
+        for rect in self.range_rects(highlight_range) {
+            ui.painter().rect_filled(rect, 2., color);
+        }
+    }
+
+    /// Rects covering `range` in the rendered layout — the geometry behind
+    /// selection, find highlights, and diff tints. Read-only labels reach it
+    /// on the renderer directly.
+    pub fn range_rects(&self, range: (Grapheme, Grapheme)) -> Vec<Rect> {
+        use crate::tab::markdown_editor::widget::utils::wrap_layout::FragmentContent;
+        let mut result: Vec<Rect> = Vec::new();
+        for frag in self.fragments.iter() {
+            let frag_range = frag.source_range;
+            // Empty-range fragments contribute no width — except a chip's pad
+            // spacers, which carry the capsule's real side padding. Include
+            // those when their capsule overlaps the selection so the highlight
+            // spans the full pill (and the last rect — where iOS drops the end
+            // handle — reaches the pill's edge).
+            if frag_range.start() == frag_range.end() {
+                let pad_scope = frag
+                    .style_stack
+                    .last()
+                    .filter(|s| s.chip && matches!(frag.content, FragmentContent::Spacer))
+                    .map(|s| s.source_range);
+                let overlaps =
+                    pad_scope.is_some_and(|s| s.start() < range.end() && range.start() < s.end());
+                if !overlaps {
+                    continue;
+                }
+            }
+            // (pads passed their own scope-overlap check above; their empty
+            // range would always fail this one)
+            if frag_range.start() != frag_range.end()
+                && (frag_range.end() <= range.start() || frag_range.start() >= range.end())
+            {
+                continue;
+            }
+            let mut rect = frag.rect;
+            // Recompute an edge only when the selection endpoint falls
+            // *strictly inside* the fragment. At `==` the fragment's own edge
+            // already is the endpoint — and for capsule fragments, which all
+            // share the atom's full source range, recomputing both edges from
+            // global offsets would mangle every segment's rect.
+            if frag_range.start() < range.start() {
+                rect.min.x = self.fragment_x(frag, range.start());
+            }
+            if frag_range.end() > range.end() {
+                rect.max.x = self.fragment_x(frag, range.end());
+            }
+            if rect.area() <= 0.001 {
+                continue;
+            }
+            result.push(rect);
+        }
+
+        // Selected newlines / blank lines have no glyph to highlight. When
+        // the selection crosses a source line's end, add a fixed-width slab
+        // at that row's end so the captured `\n` reads as selected.
+        // (Soft-wrap whitespace shares its boundary offset with the next
+        // row's start, so it isn't covered here.)
+        if !range.is_empty() {
+            let slab_w = self.layout.row_height * 0.4;
+            let line_count = self.bounds.source_lines.len();
+            for i in 0..line_count.saturating_sub(1) {
+                // The `\n` grapheme sits at the line's end offset (source
+                // lines exclude their trailing newline).
+                let newline = self.bounds.source_lines[i].end();
+                if newline < range.start() || newline >= range.end() {
+                    continue;
+                }
+                // Match the row's content rects (bare fragment rect), not
+                // `cursor_line`'s caret-height-expanded range.
+                if let Some(frag) = self.fragment_at_offset(newline) {
+                    let x = self.fragment_x(frag, newline);
+                    let (top, bot) = (frag.rect.min.y, frag.rect.max.y);
+                    // Extend the row's content rect rightward into the slab so
+                    // the newline flows out of the row's highlight as one
+                    // rounded shape, rather than a separate notched rect.
+                    if let Some(r) = result.iter_mut().find(|r| {
+                        (r.top() - top).abs() < 0.001
+                            && (r.bottom() - bot).abs() < 0.001
+                            && (r.right() - x).abs() < 0.5
+                    }) {
+                        r.max.x = r.max.x.max(x + slab_w);
+                    } else {
+                        result.push(Rect::from_min_max(
+                            Pos2::new(x, top),
+                            Pos2::new(x + slab_w, bot),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Reading order: group vertically-overlapping rects into rows, then by
+        // x — so the last rect is the selection's geometric end, where iOS reads
+        // the end handle. A raw top-sort would put a low inter-image space rect
+        // last, dropping the handle on the next image's left edge.
+        let mut by_top: Vec<usize> = (0..result.len()).collect();
+        by_top.sort_by(|&a, &b| result[a].top().total_cmp(&result[b].top()));
+        let mut row_of = vec![0usize; result.len()];
+        let mut row = 0;
+        let mut row_bottom = f32::NEG_INFINITY;
+        for (i, &k) in by_top.iter().enumerate() {
+            if i != 0 && result[k].top() > row_bottom + 0.5 {
+                row += 1;
+                row_bottom = result[k].bottom();
+            } else {
+                row_bottom = row_bottom.max(result[k].bottom());
+            }
+            row_of[k] = row;
+        }
+        let mut ordered: Vec<(usize, Rect)> = result
+            .iter()
+            .enumerate()
+            .map(|(i, r)| (row_of[i], *r))
+            .collect();
+        ordered.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.left().total_cmp(&b.1.left())));
+
+        // Coalesce contiguous same-row rects (post-sort — the fragment list
+        // interleaves rows) so each row's selection paints as one merged
+        // rounded rect: outer corners rounded, no seams at fragment edges.
+        let mut merged: Vec<Rect> = Vec::new();
+        for (_, rect) in ordered {
+            if let Some(last) = merged.last_mut() {
+                let same_row = (last.top() - rect.top()).abs() < 0.001
+                    && (last.bottom() - rect.bottom()).abs() < 0.001;
+                let contiguous = (last.right() - rect.left()).abs() < 0.001;
+                if same_row && contiguous {
+                    last.max.x = last.max.x.max(rect.max.x);
+                    continue;
+                }
+            }
+            merged.push(rect);
+        }
+        merged
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/md_label.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/md_label.rs
@@ -68,8 +68,13 @@ impl MdLabel {
         self.renderer.text_areas.clear();
 
         // Scoped ui for clipping; the scope's cursor side-effects stay local.
+        // Links resolve inside the same scope: `interact_fragments` registers
+        // their widgets keyed to this ui's id, and read-only labels open
+        // them on plain click.
         ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
             self.renderer.show_block(ui, root, top_left);
+            self.renderer.interact_fragments(ui);
+            self.renderer.handle_link_interactions(root, ui);
         });
 
         (std::mem::take(&mut self.renderer.text_areas), rect)

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -192,15 +192,17 @@ impl<'ast> MdRender {
             return;
         }
 
-        // Plain inline link (labeled, or an autolink whose title hasn't resolved):
-        // cmd-click opens (desktop); touch gets a trailing open affordance.
-        let cmd = self.ctx.input(|i| i.modifiers.command);
+        // Plain inline link (labeled, or an autolink whose title hasn't
+        // resolved): cmd-click opens (desktop editor); read-only views have
+        // no cursor to place, so a plain click opens; touch gets a trailing
+        // open affordance.
+        let clickable = self.readonly || self.ctx.input(|i| i.modifiers.command);
         let salt = Self::link_interaction_id_salt(node_range);
-        if cmd {
+        if clickable {
             layout.interaction_open(salt, egui::Sense::click());
         }
         self.layout_circumfix(layout, node, range, link_fmt.clone());
-        if cmd {
+        if clickable {
             layout.interaction_close();
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
@@ -23,13 +23,15 @@ impl<'ast> MdRender {
         let node_range = self.node_range(node);
         let state = self.link_state_for_wikilink(&url);
         let fmt = self.text_format_link(parent, state.clone());
-        let cmd = self.ctx.input(|i| i.modifiers.command);
+        // Read-only views have no cursor to place, so a plain click follows
+        // the link; the editor reserves that for the cursor and requires cmd.
+        let clickable = self.readonly || self.ctx.input(|i| i.modifiers.command);
         let salt = Self::link_interaction_id_salt(node_range);
-        if cmd {
+        if clickable {
             layout.interaction_open(salt, egui::Sense::click());
         }
         self.layout_circumfix(layout, node, range, fmt);
-        if cmd {
+        if clickable {
             layout.interaction_close();
         }
 

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -203,10 +203,14 @@ impl Tab {
                 match content {
                     #[cfg(not(target_family = "wasm"))]
                     TabContent::Chat(chat) => {
-                        let (sent, interaction_rect) = chat.show(ui);
+                        let (sent, interaction_rect, composer_updated) = chat.show(ui);
                         if sent {
                             self.last_changed = Instant::now();
                         }
+                        // App-driven composer edits (send-clear, prefill) must
+                        // re-sync the native text view's caret, same as the
+                        // markdown editor reports.
+                        resp.selection_updated = composer_updated;
                         // `Rect::NOTHING` means "no text field this frame" —
                         // report None like the markdown editor does. Forwarded
                         // as Some it sets the native iOS text view's frame to

--- a/libs/lb/lb-rs/src/blocking.rs
+++ b/libs/lb/lb-rs/src/blocking.rs
@@ -64,6 +64,13 @@ impl Lb {
         Ok(Self { rt, lb })
     }
 
+    /// The underlying async [`crate::Lb`], for callers that run their own
+    /// runtime (the blocking methods `block_on` this wrapper's runtime, which
+    /// panics when called from inside another).
+    pub fn async_lb(&self) -> &crate::Lb {
+        &self.lb
+    }
+
     pub fn create_account(
         &self, username: &str, api_url: &str, welcome_doc: bool,
     ) -> LbResult<Account> {


### PR DESCRIPTION
Without this change, the agent harness is a way to chat with agents from various providers in one tool, compose messages in rendered markdown, and organize your chats alongside your other lockbook files.

With this change, the agent harness can browse, read, and modify your notes, turning it into an embedded librarian that can scale your knowledge management effort. Any data egress asks explicit permission and states the nature of the egress in plain language. Any file modification asks explicit permission and shows a diff of the affected sections of the file.

Includes some refinements to adding new providers, composing messages, and the general chat interface.

<img width="1530" height="1062" alt="image" src="https://github.com/user-attachments/assets/cbdd0b6f-987a-4601-9a07-697b24960f48" />
