### PR TITLE
releaser: stamp apple build number at archive time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,6 +4179,7 @@ dependencies = [
 name = "lbdev"
 version = "26.7.8"
 dependencies = [
+ "chrono-tz",
  "cli-rs 0.1.13",
  "dotenvy",
  "gh_release",
@@ -4167,7 +4190,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "time",
  "tokio",
  "toml",
  "toml_edit 0.19.15",
@@ -5553,6 +5575,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5641,6 +5672,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
@@ -5668,6 +5708,16 @@ checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]

--- a/utils/lbdev/Cargo.toml
+++ b/utils/lbdev/Cargo.toml
@@ -18,4 +18,4 @@ zip = "0.6.4"
 google-androidpublisher3 = "5.0.2"
 tokio = { version = "1.20.1", features = ["rt-multi-thread"] }
 regex = "1.7.1"
-time = "0.3.20"
+chrono-tz = "0.9"

--- a/utils/lbdev/src/releaser/apple/ios.rs
+++ b/utils/lbdev/src/releaser/apple/ios.rs
@@ -5,7 +5,7 @@ use crate::releaser::secrets::AppStore;
 use crate::utils::CommandRunner;
 use std::process::Command;
 
-use super::clean_build_dir;
+use super::{build_number, clean_build_dir};
 
 pub fn release(clean_and_build: bool) -> CliResult<()> {
     if clean_and_build {
@@ -33,6 +33,7 @@ fn archive() -> CliResult<()> {
             "clients/apple/build/Lockbook-iOS.xcarchive",
             "archive",
         ])
+        .arg(format!("CURRENT_PROJECT_VERSION={}", build_number()))
         .assert_success()?;
 
     Command::new("xcodebuild")

--- a/utils/lbdev/src/releaser/apple/mac.rs
+++ b/utils/lbdev/src/releaser/apple/mac.rs
@@ -7,7 +7,7 @@ use gh_release::ReleaseClient;
 use std::fs::File;
 use std::process::Command;
 
-use super::clean_build_dir;
+use super::{build_number, clean_build_dir};
 
 pub fn release(clean_and_build: bool, gh: bool, app_store: bool) -> CliResult<()> {
     if clean_and_build {
@@ -42,6 +42,7 @@ fn archive() -> CliResult<()> {
             "clients/apple/build/Lockbook-macOS.xcarchive",
             "archive",
         ])
+        .arg(format!("CURRENT_PROJECT_VERSION={}", build_number()))
         .assert_success()?;
 
     // creates .app to upload to github

--- a/utils/lbdev/src/releaser/apple/mod.rs
+++ b/utils/lbdev/src/releaser/apple/mod.rs
@@ -3,6 +3,7 @@ pub mod ios;
 pub mod mac;
 
 use cli_rs::cli_error::CliResult;
+use time::OffsetDateTime;
 
 use std::fs;
 use std::path::Path;
@@ -16,6 +17,19 @@ pub fn release() -> CliResult<()> {
     ios::release(false)?;
     mac::release(false, true, true)?;
     Ok(())
+}
+
+pub fn build_number() -> String {
+    let now = OffsetDateTime::now_utc();
+
+    let year = now.year();
+    let month = now.month() as u8;
+    let day = now.day();
+    let hour = now.hour();
+    let minute = now.minute();
+    let second = now.second();
+
+    format!("{year}{month:0>2}{day:0>2}.{hour:0>2}{minute:0>2}{second:0>2}")
 }
 
 fn clean_build_dir() {

--- a/utils/lbdev/src/releaser/apple/mod.rs
+++ b/utils/lbdev/src/releaser/apple/mod.rs
@@ -2,8 +2,9 @@ pub mod cli;
 pub mod ios;
 pub mod mac;
 
+use chrono_tz::America::New_York;
 use cli_rs::cli_error::CliResult;
-use time::OffsetDateTime;
+use google_androidpublisher3::chrono::Utc;
 
 use std::fs;
 use std::path::Path;
@@ -20,16 +21,10 @@ pub fn release() -> CliResult<()> {
 }
 
 pub fn build_number() -> String {
-    let now = OffsetDateTime::now_utc();
-
-    let year = now.year();
-    let month = now.month() as u8;
-    let day = now.day();
-    let hour = now.hour();
-    let minute = now.minute();
-    let second = now.second();
-
-    format!("{year}{month:0>2}{day:0>2}.{hour:0>2}{minute:0>2}{second:0>2}")
+    Utc::now()
+        .with_timezone(&New_York)
+        .format("%Y%m%d.%H%M%S")
+        .to_string()
 }
 
 fn clean_build_dir() {

--- a/utils/lbdev/src/releaser/version.rs
+++ b/utils/lbdev/src/releaser/version.rs
@@ -5,7 +5,6 @@ use std::fmt::{Display, Formatter};
 use std::fs;
 use std::process::Command;
 use std::str::FromStr;
-use time::OffsetDateTime;
 use toml_edit::{Document, value};
 
 use crate::utils::CommandRunner;
@@ -94,14 +93,7 @@ fn handle_apple(version: &str) -> CliResult<()> {
     let path = "clients/apple/lockbook.xcodeproj/project.pbxproj";
     let mut pbxproj = fs::read_to_string(path).unwrap();
 
-    let now = OffsetDateTime::now_utc();
-
-    let month = now.month() as u8;
-    let day = now.day();
-    let year = now.year();
-
-    // add leading zeros where missing
-    let build = format!("{year}{month:0>2}{day:0>2}");
+    let build = super::apple::build_number();
 
     let marketing_re = Regex::new(r"MARKETING_VERSION = [^;]+;").unwrap();
     pbxproj = marketing_re


### PR DESCRIPTION
Apple uploads were failing with 409s ("CFBundleVersion must contain a higher version than the previously uploaded version") because the build number was only stamped as `YYYYMMDD` when bump-versions ran — every master push between bumps re-uploaded the same build number, so only the first upload after each bump succeeded.

Now the iOS and macOS archive steps pass `CURRENT_PROJECT_VERSION=YYYYMMDD.HHMMSS` (UTC) as an xcodebuild override, so every archive gets a unique, monotonically increasing build number — including CI retries of the same commit. The first segment matches the old date-only format, so ordering against already-uploaded builds (`20260710`) is preserved. bump-versions reuses the same helper, keeping the committed pbxproj value in the same format as a fallback.