### PR TITLE
chat: assorted fixes & access control improvements

### DIFF
--- a/clients/apple/App/Screens/HomeView.swift
+++ b/clients/apple/App/Screens/HomeView.swift
@@ -182,7 +182,9 @@ struct HomeView: View {
                         )
                     }
                     .overlay(alignment: .bottom) {
-                        if !keyboardVisible {
+                        // Not over chats: the composer owns the bottom edge,
+                        // and the buttons would sit on its controls.
+                        if !keyboardVisible, !chatOpen {
                             HStack {
                                 detailSearchButton
 
@@ -195,6 +197,7 @@ struct HomeView: View {
                         }
                     }
                     .animation(.easeInOut(duration: 0.2), value: keyboardVisible)
+                    .animation(.easeInOut(duration: 0.2), value: chatOpen)
                 #endif
         }
         .overlay {
@@ -437,6 +440,13 @@ struct HomeView: View {
             UIApplication.shared.sendAction(
                 #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
             )
+        }
+
+        // The workspace's own report of what's rendered — not inferred from
+        // the file name, which would re-implement the Rust side's type
+        // mapping and drift.
+        private var chatOpen: Bool {
+            workspaceOutput.currentTab == .Chat
         }
 
         private func searchEverywhere() {

--- a/libs/content/workspace/src/file_cache.rs
+++ b/libs/content/workspace/src/file_cache.rs
@@ -629,6 +629,15 @@ fn match_title(docs: &[&File], title: &str) -> Option<Uuid> {
     }
 }
 
+/// A lockbook path split into its non-empty segments — the shared step
+/// behind every path-boundary comparison here (and `chat::tools::in_scope`):
+/// segment-vector equality is immune to the sibling-prefix trap raw string
+/// slicing invites (`/notes` is not a prefix-match for `/notes2/a.md` once
+/// paths are segments rather than characters).
+pub fn path_segments(path: &str) -> Vec<&str> {
+    path.split('/').filter(|s| !s.is_empty()).collect()
+}
+
 pub fn relative_path(from: &str, to: &str) -> String {
     if from == to {
         if from.ends_with('/') {
@@ -638,8 +647,8 @@ pub fn relative_path(from: &str, to: &str) -> String {
         }
     }
 
-    let from_parts: Vec<&str> = from.split('/').filter(|s| !s.is_empty()).collect();
-    let to_parts: Vec<&str> = to.split('/').filter(|s| !s.is_empty()).collect();
+    let from_parts = path_segments(from);
+    let to_parts = path_segments(to);
 
     let num_common = from_parts
         .iter()
@@ -660,12 +669,12 @@ pub fn relative_path(from: &str, to: &str) -> String {
 
 pub fn canonicalize(path: &str) -> String {
     let mut parts: Vec<&str> = Vec::new();
-    for component in path.split('/') {
+    for component in path_segments(path) {
         match component {
             ".." => {
                 parts.pop();
             }
-            "" | "." => {}
+            "." => {}
             _ => parts.push(component),
         }
     }
@@ -676,6 +685,16 @@ pub fn canonicalize(path: &str) -> String {
 mod tests {
     use super::*;
     use lb_rs::model::file_metadata::FileType;
+
+    #[test]
+    fn path_segments_tests() {
+        assert_eq!(path_segments("/"), Vec::<&str>::new());
+        assert_eq!(path_segments("/a"), vec!["a"]);
+        assert_eq!(path_segments("/a/"), vec!["a"]);
+        assert_eq!(path_segments("/a/b/c"), vec!["a", "b", "c"]);
+        // A doubled slash collapses rather than yielding an empty segment.
+        assert_eq!(path_segments("/a//b"), vec!["a", "b"]);
+    }
 
     #[test]
     fn relative_path_tests() {

--- a/libs/content/workspace/src/tab/chat/config.rs
+++ b/libs/content/workspace/src/tab/chat/config.rs
@@ -137,6 +137,42 @@ impl Chat {
         });
     }
 
+    /// Persist an approved `request_access` grant (the driver already widened
+    /// its own copy for the turn in flight).
+    pub(super) fn write_grant(&mut self, path: String) {
+        let mut scope = super::latest_scope(&self.entries, &self.account.username);
+        if !scope.contains(&path) {
+            scope.push(path);
+            self.write_config(lb_rs::model::chat::ChatConfig {
+                scope: Some(scope),
+                ..Default::default()
+            });
+        }
+    }
+
+    /// Remove a granted root (the chip's revoke). Takes effect next turn — a
+    /// turn in flight keeps the scope it was sent with.
+    pub(super) fn revoke_grant(&mut self, path: &str) {
+        let mut scope = super::latest_scope(&self.entries, &self.account.username);
+        scope.retain(|g| g != path);
+        self.write_config(lb_rs::model::chat::ChatConfig {
+            scope: Some(scope),
+            ..Default::default()
+        });
+    }
+
+    /// Re-record a scope list verbatim — `clear_chat`'s carry-forward, mirroring
+    /// `write_selection`/`write_effort`. Skips the write when there was
+    /// nothing to carry, rather than log an empty scope entry.
+    pub(super) fn restore_scope(&mut self, scope: Vec<String>) {
+        if !scope.is_empty() {
+            self.write_config(lb_rs::model::chat::ChatConfig {
+                scope: Some(scope),
+                ..Default::default()
+            });
+        }
+    }
+
     /// Append a config entry and re-resolve the provider display cache.
     fn write_config(&mut self, config: lb_rs::model::chat::ChatConfig) {
         let msg =

--- a/libs/content/workspace/src/tab/chat/harness.rs
+++ b/libs/content/workspace/src/tab/chat/harness.rs
@@ -18,7 +18,6 @@ use serde_json::Value;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use super::backend::{Backend, ChatMsg, CompletionReq};
-use super::diff;
 use super::settings::Provider;
 use super::tools::{self, Buffers};
 use super::{anthropic, openai};
@@ -47,8 +46,7 @@ enum Cmd {
     /// driver its new truth. Sent only while idle. Buffers are session state
     /// and survive a reseed.
     Reseed(Vec<ChatMsg>, Buffers),
-    /// Approve the pending call — an edit runs and applies to the real note;
-    /// a `request_access` adds its path to the turn's scope.
+    /// Approve the pending `request_access` — its path joins the turn's scope.
     Approve,
     /// Deny the pending call; the model is told and steers.
     Deny,
@@ -75,15 +73,11 @@ enum AgentEvent {
         usage: Option<Usage>,
     },
     /// A tool call wants to run; the UI shows the approval card and the turn
-    /// blocks until approve/deny. Cards show for edits (with the proposed
-    /// diff) and `request_access`; see [`gate`].
+    /// blocks until approve/deny. Only `request_access` cards; see [`gate`].
     ToolRequest {
         name: String,
         /// The call's raw arguments, for the card's adapted permission prose.
         args: Value,
-        /// For edits: the proposed change as diff segments, or the steering
-        /// error approval would hit. `None` for `request_access`.
-        preview: Option<Result<Vec<diff::Segment>, String>>,
     },
     /// A tool call resolved (ran, or was denied) — persist it.
     ToolDone(ToolOutcome),
@@ -103,9 +97,9 @@ pub struct ToolOutcome {
     /// A steering failure — the call had no successful buffer effect, so
     /// replay suppresses its mutation.
     pub is_error: bool,
-    /// A harness-authored consequence of the user's approval (the automatic
-    /// write-back after an approved edit), not a model call — the record
-    /// persists and folds but stays out of model context.
+    /// A harness-authored consequence of a call (the automatic write-back
+    /// after an in-scope edit), not a model call — the record persists and
+    /// folds but stays out of model context.
     pub user_action: bool,
     /// Raw content to persist as this record's replay attachment (full, out of
     /// model context): a read/auto-open capture, or a merge-sync's merged text.
@@ -131,9 +125,6 @@ pub struct Harness {
 pub struct PendingTool {
     pub name: String,
     pub args: Value,
-    /// For edits: the proposed change as diff segments, or the steering
-    /// error approval would hit. `None` for `request_access`.
-    pub preview: Option<Result<Vec<diff::Segment>, String>>,
 }
 
 /// Transcript-bound output of [`Harness::pump`].
@@ -231,8 +222,8 @@ impl Harness {
                         updates.push(HarnessUpdate::Reply { text, usage });
                     }
                 }
-                AgentEvent::ToolRequest { name, args, preview } => {
-                    self.pending_tool = Some(PendingTool { name, args, preview });
+                AgentEvent::ToolRequest { name, args } => {
+                    self.pending_tool = Some(PendingTool { name, args });
                 }
                 AgentEvent::ToolDone(outcome) => {
                     self.pending_tool = None;
@@ -399,9 +390,9 @@ async fn run(
 
             // One call at a time on the wire, but handle a batch defensively —
             // every tool_use needs a matching result. Out-of-scope calls fail
-            // as steering results (no card); edits and access requests block
-            // on the user's approval. An approved edit applies straight
-            // through to the real note; an approved request widens the scope.
+            // as steering results (no card); in-scope calls run, edits
+            // applying straight through to the real note; access requests
+            // block on the user's approval and widen the scope.
             for call in calls {
                 let is_edit = call.name == "edit_note";
                 let is_request = call.name == "request_access";
@@ -426,15 +417,9 @@ async fn run(
                         continue;
                     }
                     Gate::Card => {
-                        let preview = if is_edit {
-                            Some(tools::preview_edit(&lb, &buffers, &call.args).await)
-                        } else {
-                            None
-                        };
                         send(AgentEvent::ToolRequest {
                             name: call.name.clone(),
                             args: call.args.clone(),
-                            preview,
                         });
 
                         // Block on the decision, queuing unrelated commands.
@@ -520,8 +505,8 @@ async fn run(
                     user_action: false,
                 }));
 
-                // The approved edit lands on the real note now. The receipt
-                // record persists and folds (it marks the buffer saved, and
+                // The edit lands on the real note now. The receipt record
+                // persists and folds (it marks the buffer saved, and
                 // captures a merge's inflow) but stays out of model context —
                 // the model's picture is simply that edits apply.
                 if edit_applied {
@@ -566,17 +551,15 @@ enum Gate {
     OutOfScope,
 }
 
-/// The single access choke point, uniform regardless of provider. `request_access`
-/// always cards; everything else is scope-checked; edits additionally card
-/// even in scope.
+/// The single access choke point, uniform regardless of provider.
+/// `request_access` always cards; everything else — edits included — runs
+/// iff in scope. A grant is the standing consent; the transcript's diffed
+/// tool rows are the review surface for what it covered.
 fn gate(name: &str, args: &Value, scope: &[String]) -> Gate {
     if name == "request_access" {
         return Gate::Card;
     }
-    if !tools::in_scope(call_path(args), scope) {
-        return Gate::OutOfScope;
-    }
-    if name == "edit_note" { Gate::Card } else { Gate::Run }
+    if tools::in_scope(call_path(args), scope) { Gate::Run } else { Gate::OutOfScope }
 }
 
 /// The path a call targets; `list`'s default root when absent.
@@ -712,31 +695,18 @@ mod tests {
          data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1}}\n\n\
          data: [DONE]\n\n";
 
-    /// An edit call raises the approval card; approval runs it (a steering
-    /// error on the offline core, so no write-back receipt) and the turn
-    /// completes.
+    /// An in-scope edit runs straight through — no card, no decision step (a
+    /// steering error on the offline core, so no write-back receipt) — and
+    /// the turn completes.
     #[test]
-    fn edit_requests_approval_then_runs() {
+    fn edit_runs_in_scope_without_card() {
         let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
         harness.say("edit my note".into(), provider(base), None, full_scope());
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while Instant::now() < deadline && harness.pending_tool.is_none() {
-            harness.pump();
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        let pending = harness.pending_tool.as_ref().expect("approval card");
-        assert_eq!(pending.name, "edit_note");
-        assert_eq!(pending.args["path"], "/a.md");
-        // No account on the offline core → the preview carries the
-        // steering error approval would hit.
-        assert!(matches!(&pending.preview, Some(Err(e)) if e.starts_with("error:")));
-        assert!(harness.busy);
-
-        harness.approve();
-
+        // Drains to completion unattended — a card would block the turn on a
+        // decision that never comes and time this out.
         let updates = drain(&mut harness);
         let tools: Vec<_> = updates
             .iter()
@@ -752,22 +722,14 @@ mod tests {
         assert!(harness.pending_tool.is_none());
     }
 
-    /// Denying an edit feeds the denial back without running it; the turn
+    /// An out-of-scope edit steers without a card or a decision; the turn
     /// still completes.
     #[test]
-    fn denied_edit_completes_without_running() {
+    fn edit_out_of_scope_steers_without_card() {
         let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
-        harness.say("do it".into(), provider(base), None, full_scope());
-
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while Instant::now() < deadline && harness.pending_tool.is_none() {
-            harness.pump();
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert!(harness.pending_tool.is_some());
-        harness.deny();
+        harness.say("do it".into(), provider(base), None, TurnAccess::default());
 
         let updates = drain(&mut harness);
         let tool = updates
@@ -776,10 +738,11 @@ mod tests {
                 HarnessUpdate::Tool(t) => Some(t),
                 _ => None,
             })
-            .expect("a denied tool row");
-        assert_eq!(tool.result, tools::DENIED_RESULT);
+            .expect("a steered tool row");
+        assert!(tool.result.starts_with("denied:"), "{}", tool.result);
         assert!(tool.is_error);
         assert!(!harness.busy);
+        assert!(harness.pending_tool.is_none());
     }
 
     /// The full tool round-trip: first completion emits a call → in scope, it
@@ -820,8 +783,8 @@ mod tests {
     }
 
     /// The single access choke point, uniform regardless of provider:
-    /// `request_access` always cards; everything else is scope-checked;
-    /// edits additionally card even in scope.
+    /// `request_access` always cards; everything else — edits included —
+    /// runs iff in scope.
     #[test]
     fn gate_routes_by_scope() {
         use serde_json::json;
@@ -836,7 +799,7 @@ mod tests {
         assert_eq!(gate("read_note", &read("/other.md"), &scope), Gate::OutOfScope);
         assert_eq!(gate("list", &json!({}), &scope), Gate::OutOfScope); // default "/"
         assert_eq!(gate("list", &read("/notes/"), &scope), Gate::Run);
-        assert_eq!(gate("edit_note", &read("/notes/a.md"), &scope), Gate::Card);
+        assert_eq!(gate("edit_note", &read("/notes/a.md"), &scope), Gate::Run);
         assert_eq!(gate("edit_note", &read("/other.md"), &scope), Gate::OutOfScope);
 
         // Empty scope — no bypass for anyone, edit or otherwise.
@@ -869,7 +832,6 @@ mod tests {
         let pending = harness.pending_tool.as_ref().expect("grant card");
         assert_eq!(pending.name, "request_access");
         assert_eq!(pending.args["path"], "/notes/");
-        assert!(pending.preview.is_none());
 
         harness.approve();
 

--- a/libs/content/workspace/src/tab/chat/harness.rs
+++ b/libs/content/workspace/src/tab/chat/harness.rs
@@ -306,16 +306,14 @@ async fn run(
             }
         };
 
-        // Reads egress note content to the provider, so a remote model only
-        // reaches paths the user has granted; a local model sees everything
-        // (nothing leaves the machine). Grants made this turn extend the list.
-        let local = provider.is_local();
+        // Scope applies uniformly, local model or not: asking is now a single
+        // request_access round trip rather than a per-call modal, so there's
+        // no friction left to spare a local model from — one code path, one
+        // thing to reason about. Grants made this turn extend the list.
         let TurnAccess { mut scope, chat_folder } = turn_access;
         // Built once per turn, not per completion — see `access_intro` for why.
         let mut system_full = system.clone().unwrap_or_else(preamble);
-        if !local {
-            system_full.push_str(&access_intro(&chat_folder));
-        }
+        system_full.push_str(&access_intro(&chat_folder));
         // The turn's backend, from the provider resolved at send time; reused
         // across the turn's completions.
         let backend = match provider.kind.as_str() {
@@ -407,7 +405,7 @@ async fn run(
             for call in calls {
                 let is_edit = call.name == "edit_note";
                 let is_request = call.name == "request_access";
-                match gate(&call.name, &call.args, local, &scope) {
+                match gate(&call.name, &call.args, &scope) {
                     Gate::OutOfScope => {
                         let path = call_path(&call.args);
                         let result = tools::out_of_scope(path, &scope);
@@ -568,14 +566,14 @@ enum Gate {
     OutOfScope,
 }
 
-/// The single access choke point. `request_access` always cards; everything
-/// else is scope-checked when the provider is remote (reads egress); edits
-/// additionally card even in scope.
-fn gate(name: &str, args: &Value, local: bool, scope: &[String]) -> Gate {
+/// The single access choke point, uniform regardless of provider. `request_access`
+/// always cards; everything else is scope-checked; edits additionally card
+/// even in scope.
+fn gate(name: &str, args: &Value, scope: &[String]) -> Gate {
     if name == "request_access" {
         return Gate::Card;
     }
-    if !local && !tools::in_scope(call_path(args), scope) {
+    if !tools::in_scope(call_path(args), scope) {
         return Gate::OutOfScope;
     }
     if name == "edit_note" { Gate::Card } else { Gate::Run }
@@ -586,11 +584,11 @@ fn call_path(args: &Value) -> &str {
     args.get("path").and_then(Value::as_str).unwrap_or("/")
 }
 
-/// The system prompt's access section for a remote provider: static for the
-/// turn (indeed the whole chat, short of the folder moving) so it never
-/// perturbs the cached prefix. What's actually granted is deliberately
-/// absent — it changes on a mid-turn grant, so it travels as tool results
-/// instead ([`tools::out_of_scope`], the `request_access` outcome below).
+/// The system prompt's access section, static for the turn (indeed the whole
+/// chat, short of the folder moving) so it never perturbs the cached prefix.
+/// What's actually granted is deliberately absent — it changes on a mid-turn
+/// grant, so it travels as tool results instead ([`tools::out_of_scope`], the
+/// `request_access` outcome below).
 fn access_intro(chat_folder: &str) -> String {
     format!(
         "\n\nAccess: you can only read and edit paths the user has granted this chat — a call \
@@ -643,6 +641,13 @@ mod tests {
             client_type: ClientType::Unknown,
         })
         .unwrap()
+    }
+
+    /// A turn granted the whole lockbook — the tests below aren't exercising
+    /// scope itself (see `gate_routes_by_scope` / the `request_access_*`
+    /// tests for that), so they run with nothing to deny.
+    fn full_scope() -> TurnAccess {
+        TurnAccess { scope: vec!["/".into()], chat_folder: "/".into() }
     }
 
     fn provider(base_url: String) -> Provider {
@@ -715,7 +720,7 @@ mod tests {
         let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
-        harness.say("edit my note".into(), provider(base), None, TurnAccess::default());
+        harness.say("edit my note".into(), provider(base), None, full_scope());
 
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline && harness.pending_tool.is_none() {
@@ -754,7 +759,7 @@ mod tests {
         let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
-        harness.say("do it".into(), provider(base), None, TurnAccess::default());
+        harness.say("do it".into(), provider(base), None, full_scope());
 
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline && harness.pending_tool.is_none() {
@@ -777,11 +782,11 @@ mod tests {
         assert!(!harness.busy);
     }
 
-    /// The full tool round-trip: first completion emits a call → it runs
-    /// ungated and feeds a result back → second completion returns the final
-    /// reply → idle.
+    /// The full tool round-trip: first completion emits a call → in scope, it
+    /// runs straight through and feeds a result back → second completion
+    /// returns the final reply → idle.
     #[test]
-    fn tool_call_runs_ungated_then_completes() {
+    fn tool_call_runs_in_scope_then_completes() {
         // First response calls `list`; second (after the result) is the reply.
         const SSE_LIST_CALL: &str = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n\
              data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"list\",\"arguments\":\"{}\"}}]}}]}\n\n\
@@ -790,7 +795,7 @@ mod tests {
         let base = serve_seq(vec![SSE_LIST_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
-        harness.say("what's in my vault?".into(), provider(base), None, TurnAccess::default());
+        harness.say("what's in my vault?".into(), provider(base), None, full_scope());
 
         // Drain to completion: a tool row, then the reply — no decision step.
         let updates = drain(&mut harness);
@@ -814,32 +819,30 @@ mod tests {
         assert!(!harness.busy);
     }
 
-    /// The single access choke point: `request_access` always cards; a remote
-    /// provider's calls are scope-checked (reads run in scope, edits card in
-    /// scope, anything out of scope fails); a local provider skips scope but
-    /// its edits still card.
+    /// The single access choke point, uniform regardless of provider:
+    /// `request_access` always cards; everything else is scope-checked;
+    /// edits additionally card even in scope.
     #[test]
-    fn gate_routes_by_scope_and_locality() {
+    fn gate_routes_by_scope() {
         use serde_json::json;
         let scope = vec!["/notes/".to_string(), "/one.md".to_string()];
         let read = |p: &str| json!({ "path": p });
 
-        assert_eq!(gate("request_access", &read("/x/"), true, &[]), Gate::Card);
-        assert_eq!(gate("request_access", &read("/x/"), false, &[]), Gate::Card);
+        assert_eq!(gate("request_access", &read("/x/"), &[]), Gate::Card);
+        assert_eq!(gate("request_access", &read("/x/"), &scope), Gate::Card);
 
-        // Remote: scope decides.
-        assert_eq!(gate("read_note", &read("/notes/a.md"), false, &scope), Gate::Run);
-        assert_eq!(gate("read_note", &read("/one.md"), false, &scope), Gate::Run);
-        assert_eq!(gate("read_note", &read("/other.md"), false, &scope), Gate::OutOfScope);
-        assert_eq!(gate("list", &json!({}), false, &scope), Gate::OutOfScope); // default "/"
-        assert_eq!(gate("list", &read("/notes/"), false, &scope), Gate::Run);
-        assert_eq!(gate("edit_note", &read("/notes/a.md"), false, &scope), Gate::Card);
-        assert_eq!(gate("edit_note", &read("/other.md"), false, &scope), Gate::OutOfScope);
+        assert_eq!(gate("read_note", &read("/notes/a.md"), &scope), Gate::Run);
+        assert_eq!(gate("read_note", &read("/one.md"), &scope), Gate::Run);
+        assert_eq!(gate("read_note", &read("/other.md"), &scope), Gate::OutOfScope);
+        assert_eq!(gate("list", &json!({}), &scope), Gate::OutOfScope); // default "/"
+        assert_eq!(gate("list", &read("/notes/"), &scope), Gate::Run);
+        assert_eq!(gate("edit_note", &read("/notes/a.md"), &scope), Gate::Card);
+        assert_eq!(gate("edit_note", &read("/other.md"), &scope), Gate::OutOfScope);
 
-        // Local: everything readable, edits still card.
-        assert_eq!(gate("read_note", &read("/other.md"), true, &[]), Gate::Run);
-        assert_eq!(gate("list", &json!({}), true, &[]), Gate::Run);
-        assert_eq!(gate("edit_note", &read("/other.md"), true, &[]), Gate::Card);
+        // Empty scope — no bypass for anyone, edit or otherwise.
+        assert_eq!(gate("read_note", &read("/other.md"), &[]), Gate::OutOfScope);
+        assert_eq!(gate("list", &json!({}), &[]), Gate::OutOfScope);
+        assert_eq!(gate("edit_note", &read("/other.md"), &[]), Gate::OutOfScope);
     }
 
     /// SSE body for a completion invoking `request_access` on a folder.

--- a/libs/content/workspace/src/tab/chat/harness.rs
+++ b/libs/content/workspace/src/tab/chat/harness.rs
@@ -34,22 +34,34 @@ const MAX_TOOL_TURNS: u32 = 30;
 enum Cmd {
     /// A user message to respond to; the caller already appended it to the
     /// transcript. `system` overrides the built-in preamble when the user
-    /// has a prompt file.
-    Say { text: String, provider: Provider, system: Option<String> },
+    /// has a prompt file. `turn` carries the access scope the turn runs
+    /// under and the chat's own folder (for the prompt's access block).
+    Say { text: String, provider: Provider, system: Option<String>, turn: TurnAccess },
     /// Cancel the turn in flight, keeping the text streamed so far.
     Stop,
     /// Re-run the last failed turn — with current config, so "fix the key,
     /// hit retry" works.
-    Retry { provider: Provider, system: Option<String> },
+    Retry { provider: Provider, system: Option<String>, turn: TurnAccess },
     /// Replace model context wholesale — the UI's transcript mutations
     /// (delete, and later edit/regenerate) recompute the seed and hand the
     /// driver its new truth. Sent only while idle. Buffers are session state
     /// and survive a reseed.
     Reseed(Vec<ChatMsg>, Buffers),
-    /// Approve the pending edit — it runs and then applies to the real note.
+    /// Approve the pending call — an edit runs and applies to the real note;
+    /// a `request_access` adds its path to the turn's scope.
     Approve,
-    /// Deny the pending edit; the model is told and steers.
+    /// Deny the pending call; the model is told and steers.
     Deny,
+}
+
+/// Access context a turn runs under, snapshotted at send.
+#[derive(Clone, Default)]
+pub struct TurnAccess {
+    /// Granted roots — folders (trailing '/') and single notes. Grants made
+    /// mid-turn extend the driver's copy; the UI persists them.
+    pub scope: Vec<String>,
+    /// The folder the chat file lives in, for the prompt's access block.
+    pub chat_folder: String,
 }
 
 /// Driver → UI.
@@ -62,19 +74,21 @@ enum AgentEvent {
         text: String,
         usage: Option<Usage>,
     },
-    /// An edit wants to run; the UI shows the approval card (with the
-    /// proposed diff) and the turn blocks until approve/deny. Reads and
-    /// listings run without a gate.
+    /// A tool call wants to run; the UI shows the approval card and the turn
+    /// blocks until approve/deny. Cards show for edits (with the proposed
+    /// diff) and `request_access`; see [`gate`].
     ToolRequest {
         name: String,
         /// The call's raw arguments, for the card's adapted permission prose.
         args: Value,
         /// For edits: the proposed change as diff segments, or the steering
-        /// error approval would hit. `None` for gated reads.
+        /// error approval would hit. `None` for `request_access`.
         preview: Option<Result<Vec<diff::Segment>, String>>,
     },
     /// A tool call resolved (ran, or was denied) — persist it.
     ToolDone(ToolOutcome),
+    /// The user granted `request_access` — the UI persists the widened scope.
+    Granted(String),
     /// The turn failed; any partial text was discarded. Retryable.
     Error(String),
     TurnEnded,
@@ -105,7 +119,7 @@ pub struct Harness {
     pub busy: bool,
     /// Text streamed so far this turn.
     pub streaming: String,
-    /// The edit awaiting the user's decision; `Some` drives the approval
+    /// The call awaiting the user's decision; `Some` drives the approval
     /// card.
     pub pending_tool: Option<PendingTool>,
 
@@ -113,12 +127,12 @@ pub struct Harness {
     events_rx: UnboundedReceiver<AgentEvent>,
 }
 
-/// An edit shown to the user for approval.
+/// A gated tool call shown to the user for approval.
 pub struct PendingTool {
     pub name: String,
     pub args: Value,
     /// For edits: the proposed change as diff segments, or the steering
-    /// error approval would hit. `None` for gated reads.
+    /// error approval would hit. `None` for `request_access`.
     pub preview: Option<Result<Vec<diff::Segment>, String>>,
 }
 
@@ -128,6 +142,8 @@ pub enum HarnessUpdate {
     Reply { text: String, usage: Option<Usage> },
     /// Append a tool record.
     Tool(ToolOutcome),
+    /// Persist a granted scope root as a config entry.
+    Granted(String),
     /// Append as an error row.
     Error(String),
 }
@@ -162,9 +178,11 @@ impl Harness {
 
     /// Send a user message to the agent. The caller has already appended it
     /// to the transcript.
-    pub fn say(&mut self, text: String, provider: Provider, system: Option<String>) {
+    pub fn say(
+        &mut self, text: String, provider: Provider, system: Option<String>, turn: TurnAccess,
+    ) {
         self.busy = true;
-        let _ = self.cmd_tx.send(Cmd::Say { text, provider, system });
+        let _ = self.cmd_tx.send(Cmd::Say { text, provider, system, turn });
     }
 
     /// Cancel the turn in flight; the partial reply arrives as a normal
@@ -174,19 +192,19 @@ impl Harness {
     }
 
     /// Re-run the last failed turn.
-    pub fn retry(&mut self, provider: Provider, system: Option<String>) {
+    pub fn retry(&mut self, provider: Provider, system: Option<String>, turn: TurnAccess) {
         self.busy = true;
-        let _ = self.cmd_tx.send(Cmd::Retry { provider, system });
+        let _ = self.cmd_tx.send(Cmd::Retry { provider, system, turn });
     }
 
-    /// Approve the pending edit. No-op if nothing is pending.
+    /// Approve the pending call. No-op if nothing is pending.
     pub fn approve(&mut self) {
         if self.pending_tool.take().is_some() {
             let _ = self.cmd_tx.send(Cmd::Approve);
         }
     }
 
-    /// Deny the pending edit.
+    /// Deny the pending call.
     pub fn deny(&mut self) {
         if self.pending_tool.take().is_some() {
             let _ = self.cmd_tx.send(Cmd::Deny);
@@ -220,6 +238,7 @@ impl Harness {
                     self.pending_tool = None;
                     updates.push(HarnessUpdate::Tool(outcome));
                 }
+                AgentEvent::Granted(path) => updates.push(HarnessUpdate::Granted(path)),
                 AgentEvent::Error(e) => {
                     self.streaming.clear();
                     updates.push(HarnessUpdate::Error(e));
@@ -256,15 +275,17 @@ async fn run(
                 None => return,
             },
         };
-        let (provider, system) = match cmd {
-            Cmd::Say { text, provider, system } => {
+        let (provider, system, turn_access) = match cmd {
+            Cmd::Say { text, provider, system, turn } => {
                 history.push(ChatMsg::User(text));
-                (provider, system)
+                (provider, system, turn)
             }
             // Retry only makes sense while the last context entry is the
             // user message whose turn failed.
-            Cmd::Retry { provider, system } if matches!(history.last(), Some(ChatMsg::User(_))) => {
-                (provider, system)
+            Cmd::Retry { provider, system, turn }
+                if matches!(history.last(), Some(ChatMsg::User(_))) =>
+            {
+                (provider, system, turn)
             }
             // Not a turn; no busy state to clear. The rebuilt buffers replace
             // the branch (a mutation may have removed tool rows).
@@ -285,10 +306,16 @@ async fn run(
             }
         };
 
-        // Reads egress note content to the provider, so they gate on
-        // approval too — except when the model runs on this machine and
-        // nothing leaves it.
+        // Reads egress note content to the provider, so a remote model only
+        // reaches paths the user has granted; a local model sees everything
+        // (nothing leaves the machine). Grants made this turn extend the list.
         let local = provider.is_local();
+        let TurnAccess { mut scope, chat_folder } = turn_access;
+        // Built once per turn, not per completion — see `access_intro` for why.
+        let mut system_full = system.clone().unwrap_or_else(preamble);
+        if !local {
+            system_full.push_str(&access_intro(&chat_folder));
+        }
         // The turn's backend, from the provider resolved at send time; reused
         // across the turn's completions.
         let backend = match provider.kind.as_str() {
@@ -308,7 +335,7 @@ async fn run(
         'turn: loop {
             turns += 1;
             let req = CompletionReq {
-                system: system.clone().unwrap_or_else(preamble),
+                system: system_full.clone(),
                 messages: history.clone(),
                 max_tokens: MAX_TOKENS,
                 tools: tools::schemas(),
@@ -373,60 +400,110 @@ async fn run(
             }
 
             // One call at a time on the wire, but handle a batch defensively —
-            // every tool_use needs a matching result. Edits always block on
-            // the user's approval (and, once approved and successful, apply
-            // straight through to the real note); reads gate only when the
-            // provider is remote.
+            // every tool_use needs a matching result. Out-of-scope calls fail
+            // as steering results (no card); edits and access requests block
+            // on the user's approval. An approved edit applies straight
+            // through to the real note; an approved request widens the scope.
             for call in calls {
                 let is_edit = call.name == "edit_note";
-                let gated = is_edit || !local;
-                if gated {
-                    let preview = if is_edit {
-                        Some(tools::preview_edit(&lb, &buffers, &call.args).await)
-                    } else {
-                        None
-                    };
-                    send(AgentEvent::ToolRequest {
-                        name: call.name.clone(),
-                        args: call.args.clone(),
-                        preview,
-                    });
-
-                    // Block on the decision, queuing unrelated commands.
-                    let approved = loop {
-                        match cmd_rx.recv().await {
-                            Some(Cmd::Approve) => break Some(true),
-                            Some(Cmd::Deny) => break Some(false),
-                            Some(Cmd::Stop) | None => break None,
-                            Some(other) => pending.push_back(other),
-                        }
-                    };
-                    match approved {
-                        // Stopped mid-approval: end the turn. The assistant's
-                        // call is left unanswered in the driver's history, but
-                        // the next Say reseeds from the transcript.
-                        None => break 'turn,
-                        // Denied: record the refusal (identical text live and
-                        // persisted); the model adjusts.
-                        Some(false) => {
-                            history.push(ChatMsg::ToolResult {
-                                id: call.id.clone(),
-                                content: tools::DENIED_RESULT.into(),
-                                is_error: false,
-                            });
-                            send(AgentEvent::ToolDone(ToolOutcome {
-                                name: call.name,
-                                args: call.args,
-                                result: tools::DENIED_RESULT.into(),
-                                // No buffer effect — replay skips it.
-                                is_error: true,
-                                capture: None,
-                                user_action: false,
-                            }));
-                            continue;
-                        }
-                        Some(true) => {}
+                let is_request = call.name == "request_access";
+                match gate(&call.name, &call.args, local, &scope) {
+                    Gate::OutOfScope => {
+                        let path = call_path(&call.args);
+                        let result = tools::out_of_scope(path, &scope);
+                        history.push(ChatMsg::ToolResult {
+                            id: call.id.clone(),
+                            content: result.clone(),
+                            is_error: false,
+                        });
+                        send(AgentEvent::ToolDone(ToolOutcome {
+                            name: call.name,
+                            args: call.args,
+                            result,
+                            // No buffer effect — replay skips it.
+                            is_error: true,
+                            capture: None,
+                            user_action: false,
+                        }));
+                        continue;
                     }
+                    Gate::Card => {
+                        let preview = if is_edit {
+                            Some(tools::preview_edit(&lb, &buffers, &call.args).await)
+                        } else {
+                            None
+                        };
+                        send(AgentEvent::ToolRequest {
+                            name: call.name.clone(),
+                            args: call.args.clone(),
+                            preview,
+                        });
+
+                        // Block on the decision, queuing unrelated commands.
+                        let approved = loop {
+                            match cmd_rx.recv().await {
+                                Some(Cmd::Approve) => break Some(true),
+                                Some(Cmd::Deny) => break Some(false),
+                                Some(Cmd::Stop) | None => break None,
+                                Some(other) => pending.push_back(other),
+                            }
+                        };
+                        match approved {
+                            // Stopped mid-approval: end the turn. The
+                            // assistant's call is left unanswered in the
+                            // driver's history, but the next Say reseeds from
+                            // the transcript.
+                            None => break 'turn,
+                            // Denied: record the refusal (identical text live
+                            // and persisted); the model adjusts.
+                            Some(false) => {
+                                history.push(ChatMsg::ToolResult {
+                                    id: call.id.clone(),
+                                    content: tools::DENIED_RESULT.into(),
+                                    is_error: false,
+                                });
+                                send(AgentEvent::ToolDone(ToolOutcome {
+                                    name: call.name,
+                                    args: call.args,
+                                    result: tools::DENIED_RESULT.into(),
+                                    // No buffer effect — replay skips it.
+                                    is_error: true,
+                                    capture: None,
+                                    user_action: false,
+                                }));
+                                continue;
+                            }
+                            Some(true) => {}
+                        }
+                    }
+                    Gate::Run => {}
+                }
+
+                // An approved request is answered by the harness, not
+                // dispatched: normalize the path (folders gain their '/'),
+                // widen the turn's scope, and hand the UI the grant to
+                // persist.
+                if is_request {
+                    let grant = tools::normalize_grant(&lb, call_path(&call.args)).await;
+                    scope.push(grant.clone());
+                    send(AgentEvent::Granted(grant.clone()));
+                    // The running total, not just this grant — see `access_intro`.
+                    let result =
+                        format!("granted: {grant}. Currently granted: {}", scope.join(", "));
+                    history.push(ChatMsg::ToolResult {
+                        id: call.id.clone(),
+                        content: result.clone(),
+                        is_error: false,
+                    });
+                    send(AgentEvent::ToolDone(ToolOutcome {
+                        name: call.name,
+                        args: call.args,
+                        result,
+                        is_error: false,
+                        capture: None,
+                        user_action: false,
+                    }));
+                    continue;
                 }
 
                 let out = tools::dispatch(&lb, &mut buffers, &call.name, &call.args).await;
@@ -478,6 +555,49 @@ async fn run(
             send(AgentEvent::TurnEnded);
         }
     }
+}
+
+/// What to do with a tool call before dispatch.
+#[derive(Debug, PartialEq)]
+enum Gate {
+    /// Runs silently.
+    Run,
+    /// Blocks on the approval card.
+    Card,
+    /// Fails with the out-of-scope steering result; no card.
+    OutOfScope,
+}
+
+/// The single access choke point. `request_access` always cards; everything
+/// else is scope-checked when the provider is remote (reads egress); edits
+/// additionally card even in scope.
+fn gate(name: &str, args: &Value, local: bool, scope: &[String]) -> Gate {
+    if name == "request_access" {
+        return Gate::Card;
+    }
+    if !local && !tools::in_scope(call_path(args), scope) {
+        return Gate::OutOfScope;
+    }
+    if name == "edit_note" { Gate::Card } else { Gate::Run }
+}
+
+/// The path a call targets; `list`'s default root when absent.
+fn call_path(args: &Value) -> &str {
+    args.get("path").and_then(Value::as_str).unwrap_or("/")
+}
+
+/// The system prompt's access section for a remote provider: static for the
+/// turn (indeed the whole chat, short of the folder moving) so it never
+/// perturbs the cached prefix. What's actually granted is deliberately
+/// absent — it changes on a mid-turn grant, so it travels as tool results
+/// instead ([`tools::out_of_scope`], the `request_access` outcome below).
+fn access_intro(chat_folder: &str) -> String {
+    format!(
+        "\n\nAccess: you can only read and edit paths the user has granted this chat — a call \
+         outside them fails, naming what's currently granted. Call request_access for the \
+         narrowest scope that covers the task (folder paths end with '/'), and carry on after \
+         the user decides. This chat lives in {chat_folder}."
+    )
 }
 
 /// The prompt's editable substance — also the prompt-file template, so
@@ -555,7 +675,7 @@ mod tests {
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
 
-        harness.say("hi".into(), provider(serve_once(SSE_HELLO)), None);
+        harness.say("hi".into(), provider(serve_once(SSE_HELLO)), None, TurnAccess::default());
         assert!(harness.busy);
 
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -565,6 +685,7 @@ mod tests {
                 match update {
                     HarnessUpdate::Reply { text, usage } => replies.push((text, usage)),
                     HarnessUpdate::Tool(_) => panic!("unexpected tool"),
+                    HarnessUpdate::Granted(g) => panic!("unexpected grant: {g}"),
                     HarnessUpdate::Error(e) => panic!("unexpected error: {e}"),
                 }
             }
@@ -594,7 +715,7 @@ mod tests {
         let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
-        harness.say("edit my note".into(), provider(base), None);
+        harness.say("edit my note".into(), provider(base), None, TurnAccess::default());
 
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline && harness.pending_tool.is_none() {
@@ -633,7 +754,7 @@ mod tests {
         let base = serve_seq(vec![SSE_EDIT_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
-        harness.say("do it".into(), provider(base), None);
+        harness.say("do it".into(), provider(base), None, TurnAccess::default());
 
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline && harness.pending_tool.is_none() {
@@ -669,7 +790,7 @@ mod tests {
         let base = serve_seq(vec![SSE_LIST_CALL, SSE_HELLO]);
         let mut harness =
             Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
-        harness.say("what's in my vault?".into(), provider(base), None);
+        harness.say("what's in my vault?".into(), provider(base), None, TurnAccess::default());
 
         // Drain to completion: a tool row, then the reply — no decision step.
         let updates = drain(&mut harness);
@@ -684,11 +805,122 @@ mod tests {
                     saw_tool = true;
                 }
                 HarnessUpdate::Reply { text, .. } => reply = Some(text),
+                HarnessUpdate::Granted(g) => panic!("unexpected grant: {g}"),
                 HarnessUpdate::Error(e) => panic!("unexpected error: {e}"),
             }
         }
         assert!(saw_tool, "expected a tool row");
         assert_eq!(reply.as_deref(), Some("Hello"));
+        assert!(!harness.busy);
+    }
+
+    /// The single access choke point: `request_access` always cards; a remote
+    /// provider's calls are scope-checked (reads run in scope, edits card in
+    /// scope, anything out of scope fails); a local provider skips scope but
+    /// its edits still card.
+    #[test]
+    fn gate_routes_by_scope_and_locality() {
+        use serde_json::json;
+        let scope = vec!["/notes/".to_string(), "/one.md".to_string()];
+        let read = |p: &str| json!({ "path": p });
+
+        assert_eq!(gate("request_access", &read("/x/"), true, &[]), Gate::Card);
+        assert_eq!(gate("request_access", &read("/x/"), false, &[]), Gate::Card);
+
+        // Remote: scope decides.
+        assert_eq!(gate("read_note", &read("/notes/a.md"), false, &scope), Gate::Run);
+        assert_eq!(gate("read_note", &read("/one.md"), false, &scope), Gate::Run);
+        assert_eq!(gate("read_note", &read("/other.md"), false, &scope), Gate::OutOfScope);
+        assert_eq!(gate("list", &json!({}), false, &scope), Gate::OutOfScope); // default "/"
+        assert_eq!(gate("list", &read("/notes/"), false, &scope), Gate::Run);
+        assert_eq!(gate("edit_note", &read("/notes/a.md"), false, &scope), Gate::Card);
+        assert_eq!(gate("edit_note", &read("/other.md"), false, &scope), Gate::OutOfScope);
+
+        // Local: everything readable, edits still card.
+        assert_eq!(gate("read_note", &read("/other.md"), true, &[]), Gate::Run);
+        assert_eq!(gate("list", &json!({}), true, &[]), Gate::Run);
+        assert_eq!(gate("edit_note", &read("/other.md"), true, &[]), Gate::Card);
+    }
+
+    /// SSE body for a completion invoking `request_access` on a folder.
+    const SSE_REQUEST_CALL: &str = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n\
+         data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"request_access\",\"arguments\":\"{\\\"path\\\":\\\"/notes/\\\",\\\"reason\\\":\\\"to summarize\\\"}\"}}]}}]}\n\n\
+         data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1}}\n\n\
+         data: [DONE]\n\n";
+
+    /// `request_access` raises the card; allowing it emits a Granted update
+    /// (for the UI to persist), answers the model with the grant, and the
+    /// turn completes.
+    #[test]
+    fn request_access_grant_flow() {
+        let base = serve_seq(vec![SSE_REQUEST_CALL, SSE_HELLO]);
+        let mut harness =
+            Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
+        harness.say("summarize my notes".into(), provider(base), None, TurnAccess::default());
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && harness.pending_tool.is_none() {
+            harness.pump();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let pending = harness.pending_tool.as_ref().expect("grant card");
+        assert_eq!(pending.name, "request_access");
+        assert_eq!(pending.args["path"], "/notes/");
+        assert!(pending.preview.is_none());
+
+        harness.approve();
+
+        let updates = drain(&mut harness);
+        let granted = updates.iter().find_map(|u| match u {
+            HarnessUpdate::Granted(p) => Some(p.clone()),
+            _ => None,
+        });
+        // The offline core can't resolve /notes/ — the grant lands verbatim.
+        assert_eq!(granted.as_deref(), Some("/notes/"));
+        let tool = updates
+            .iter()
+            .find_map(|u| match u {
+                HarnessUpdate::Tool(t) => Some(t),
+                _ => None,
+            })
+            .expect("a granted tool row");
+        assert_eq!(tool.name, "request_access");
+        assert_eq!(tool.result, "granted: /notes/. Currently granted: /notes/");
+        assert!(!tool.is_error);
+        assert!(!harness.busy);
+    }
+
+    /// Denying `request_access` steers the model without widening anything.
+    #[test]
+    fn request_access_deny_flow() {
+        let base = serve_seq(vec![SSE_REQUEST_CALL, SSE_HELLO]);
+        let mut harness =
+            Harness::new(egui::Context::default(), offline_core(), Vec::new(), Buffers::default());
+        harness.say("summarize my notes".into(), provider(base), None, TurnAccess::default());
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && harness.pending_tool.is_none() {
+            harness.pump();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(harness.pending_tool.is_some());
+        harness.deny();
+
+        let updates = drain(&mut harness);
+        assert!(
+            !updates
+                .iter()
+                .any(|u| matches!(u, HarnessUpdate::Granted(_))),
+            "deny must not grant"
+        );
+        let tool = updates
+            .iter()
+            .find_map(|u| match u {
+                HarnessUpdate::Tool(t) => Some(t),
+                _ => None,
+            })
+            .expect("a denied tool row");
+        assert_eq!(tool.result, tools::DENIED_RESULT);
         assert!(!harness.busy);
     }
 }

--- a/libs/content/workspace/src/tab/chat/mod.rs
+++ b/libs/content/workspace/src/tab/chat/mod.rs
@@ -280,7 +280,7 @@ struct ListRowPlan {
 /// The trailing approval card for a call awaiting a decision, styled like a
 /// [`RowPlan::Tool`] container pinned open: a filled header bar carrying the
 /// command summary (no right metric — it hasn't run), over a bordered body
-/// holding the permission prose, the proposed change, and Approve / Deny.
+/// holding the permission prose and Allow / Deny.
 /// Laid out in pass 1, painted after the rows.
 struct ReviewPlan {
     header_rect: Rect,
@@ -289,25 +289,15 @@ struct ReviewPlan {
     /// The plain-language permission request, atop the body.
     prose: Arc<Galley>,
     prose_pos: Pos2,
-    /// A `request_access` call's stated reason, set in italic under the
-    /// prose — `None` outside a request or when it gave none.
+    /// The call's stated reason, set in italic under the prose — `None`
+    /// when it gave none.
     reason: Option<(Arc<Galley>, Pos2)>,
-    body: ReviewBody,
     approve: Arc<Galley>,
     approve_rect: Rect,
     deny: Arc<Galley>,
     deny_rect: Rect,
     /// The full container, bordered like an expanded tool row.
     border: Rect,
-}
-
-/// The card body's proposed change, below the permission prose: an edit's
-/// change as stacked markdown segments with changed ones washed, a steering
-/// error as a plain line, or nothing (a gated read is prose-only).
-enum ReviewBody {
-    None,
-    Galley { galley: Arc<Galley>, pos: Pos2 },
-    Rendered { segments: Vec<diff::Segment>, pos: Pos2, width: f32 },
 }
 
 /// The metadata strip under a row, laid out in pass 1 and drawn after the
@@ -396,9 +386,6 @@ pub struct Chat {
     harness: Option<harness::Harness>,
     /// Renders the in-flight streaming reply.
     streaming_label: MdLabel,
-    /// Renders the approval card's proposed change (the combined block
-    /// diff) as markdown.
-    review_label: MdLabel,
     /// Unshared at open — eligible for an agent (setup guidance is shown if
     /// none could be built).
     unshared: bool,
@@ -694,13 +681,6 @@ impl Chat {
             hide_children_of: None,
             harness,
             streaming_label: {
-                let mut label = MdLabel::new(ctx.clone());
-                label.renderer.files = Arc::clone(&files);
-                label.renderer.link_resolver =
-                    Box::new(FileCacheLinkResolver::new(Arc::clone(&files), id));
-                label
-            },
-            review_label: {
                 let mut label = MdLabel::new(ctx.clone());
                 label.renderer.files = Arc::clone(&files);
                 label.renderer.link_resolver = Box::new(FileCacheLinkResolver::new(files, id));

--- a/libs/content/workspace/src/tab/chat/mod.rs
+++ b/libs/content/workspace/src/tab/chat/mod.rs
@@ -289,6 +289,9 @@ struct ReviewPlan {
     /// The plain-language permission request, atop the body.
     prose: Arc<Galley>,
     prose_pos: Pos2,
+    /// A `request_access` call's stated reason, set in italic under the
+    /// prose — `None` outside a request or when it gave none.
+    reason: Option<(Arc<Galley>, Pos2)>,
     body: ReviewBody,
     approve: Arc<Galley>,
     approve_rect: Rect,
@@ -565,6 +568,18 @@ fn latest_effort(entries: &[Entry], username: &str) -> Option<String> {
         .next_back()
 }
 
+/// This user's granted access roots (config entries are ts-sorted with the
+/// log; last wins). Empty until the first grant.
+fn latest_scope(entries: &[Entry], username: &str) -> Vec<String> {
+    entries
+        .iter()
+        .filter(|e| e.msg.from == username)
+        .filter_map(|e| e.msg.config.as_ref())
+        .filter_map(|c| c.scope.clone())
+        .next_back()
+        .unwrap_or_default()
+}
+
 /// The toolbar effort control shows only where the model reasons: Anthropic
 /// drives adaptive thinking natively, and OpenAI-compat reasoning models
 /// take `reasoning_effort`. The compat case is a best-effort id heuristic
@@ -799,11 +814,12 @@ impl Chat {
         self.pending_parent = msg_id;
         self.provider = self.resolve_provider();
         let system = self.system_prompt.clone();
+        let turn = self.turn_access();
         let (mut seed, buffers) = self.agent_seed();
         seed.pop(); // `say` pushes the new message itself
         if let (Some(harness), Some(provider)) = (&mut self.harness, self.provider.clone()) {
             harness.reseed(seed, buffers);
-            harness.say(content, provider, system);
+            harness.say(content, provider, system, turn);
         }
         self.scroll_to_bottom = true;
     }
@@ -820,12 +836,28 @@ impl Chat {
         self.pending_parent = Some(parent);
         self.provider = self.resolve_provider();
         let system = self.system_prompt.clone();
+        let turn = self.turn_access();
         let (seed, buffers) = self.agent_seed();
         if let (Some(harness), Some(provider)) = (&mut self.harness, self.provider.clone()) {
             harness.reseed(seed, buffers);
-            harness.retry(provider, system);
+            harness.retry(provider, system, turn);
         }
         self.scroll_to_bottom = true;
+    }
+
+    /// The access context a turn runs under, snapshotted at send: this
+    /// user's granted roots and the folder the chat file lives in.
+    fn turn_access(&self) -> harness::TurnAccess {
+        let chat_folder = self
+            .core
+            .get_path_by_id(self.id)
+            .ok()
+            .and_then(|p| p.rfind('/').map(|i| p[..=i].to_string()))
+            .unwrap_or_else(|| "/".into());
+        harness::TurnAccess {
+            scope: latest_scope(&self.entries, &self.account.username),
+            chat_folder,
+        }
     }
 
     /// The id of the user message whose turn produced `entries[idx]`: walk
@@ -973,6 +1005,7 @@ impl Chat {
     fn clear_chat(&mut self) {
         let selection = latest_selection(&self.entries, &self.account.username);
         let effort = latest_effort(&self.entries, &self.account.username);
+        let scope = latest_scope(&self.entries, &self.account.username);
         if let Some(h) = &mut self.harness {
             h.reseed(Vec::new(), tools::Buffers::default());
         }
@@ -989,6 +1022,9 @@ impl Chat {
         if let Some(eff) = effort {
             self.write_effort(eff);
         }
+        // Access grants are a standing permission, not conversation
+        // content — clearing the transcript must not revoke them.
+        self.restore_scope(scope);
         // With no re-recorded selection this falls back to the default
         // provider (or none) — same resolution as a brand-new chat.
         self.provider = self.resolve_provider();
@@ -1087,6 +1123,7 @@ impl Chat {
                     self.push_agent_message(text, usage, false)
                 }
                 harness::HarnessUpdate::Tool(outcome) => self.push_tool_message(outcome),
+                harness::HarnessUpdate::Granted(path) => self.write_grant(path),
                 harness::HarnessUpdate::Error(e) => self.push_agent_message(e, None, true),
             }
         }
@@ -1156,9 +1193,10 @@ impl Chat {
             let (mut seed, buffers) = self.agent_seed();
             seed.pop(); // `say` pushes the new message itself
             let system = self.system_prompt.clone();
+            let turn = self.turn_access();
             if let (Some(harness), Some(provider)) = (&mut self.harness, self.provider.clone()) {
                 harness.reseed(seed, buffers);
-                harness.say(content, provider, system);
+                harness.say(content, provider, system, turn);
             }
         }
         self.composer.clear();
@@ -1959,5 +1997,47 @@ mod tests {
         ] {
             assert!(!is_reasoning_model(id), "{id} should not be a reasoning model");
         }
+    }
+
+    /// Grants persist as config entries: the latest scope list wins, repeat
+    /// grants don't duplicate, and revoking removes just the one root — all
+    /// without clobbering the model selection folded from the same log.
+    #[test]
+    fn scope_grants_fold_dedupe_and_revoke() {
+        use lb_rs::model::core_config::{ClientType, Config};
+        let core = lb_rs::blocking::Lb::init(Config {
+            writeable_path: format!("/tmp/{}", Uuid::new_v4()),
+            logs: false,
+            stdout_logs: false,
+            colored_logs: false,
+            background_work: false,
+            client_type: ClientType::Unknown,
+        })
+        .unwrap();
+        let files = Arc::new(RwLock::new(FileCache::empty()));
+        let mut chat = Chat::new(
+            b"",
+            Uuid::new_v4(),
+            None,
+            Account::new("me".into(), "url".into()),
+            egui::Context::default(),
+            files,
+            &core,
+        );
+
+        assert!(latest_scope(&chat.entries, "me").is_empty());
+        chat.write_selection("openai".into(), "gpt-5".into());
+
+        chat.write_grant("/notes/".into());
+        chat.write_grant("/notes/".into()); // repeat: no duplicate
+        chat.write_grant("/one.md".into());
+        assert_eq!(latest_scope(&chat.entries, "me"), ["/notes/", "/one.md"]);
+
+        chat.revoke_grant("/notes/");
+        assert_eq!(latest_scope(&chat.entries, "me"), ["/one.md"]);
+
+        // The scope entries carried no model — the selection still folds.
+        let sel = latest_selection(&chat.entries, "me").expect("selection survives");
+        assert_eq!(sel.provider, "openai");
     }
 }

--- a/libs/content/workspace/src/tab/chat/settings.rs
+++ b/libs/content/workspace/src/tab/chat/settings.rs
@@ -118,15 +118,6 @@ impl Provider {
             }
         }
     }
-
-    /// Whether this provider runs on this machine (a loopback host). Local
-    /// models egress nothing, so reads skip the approval gate.
-    pub fn is_local(&self) -> bool {
-        url::Url::parse(&self.base_url)
-            .ok()
-            .and_then(|u| u.host_str().map(str::to_string))
-            .is_some_and(|h| matches!(h.as_str(), "localhost" | "127.0.0.1" | "[::1]" | "::1"))
-    }
 }
 
 pub const DEFAULT_KIND: &str = "openai";
@@ -224,24 +215,6 @@ mod tests {
 
     fn sel(provider: &str, model: &str) -> ModelSelection {
         ModelSelection { provider: provider.into(), model: model.into() }
-    }
-
-    /// Loopback hosts are local (reads skip the approval gate); everything
-    /// else — including lookalike domains — egresses.
-    #[test]
-    fn is_local_is_loopback_only() {
-        let at = |url: &str| Provider { base_url: url.into(), ..provider("p", "m") };
-        for url in ["http://localhost:11434/v1", "http://127.0.0.1:8080/v1", "http://[::1]:1/v1"] {
-            assert!(at(url).is_local(), "{url}");
-        }
-        for url in [
-            "https://api.openai.com/v1",
-            "https://mylocalhost.evil.com/v1",
-            "http://192.168.1.10:11434/v1",
-            "not a url",
-        ] {
-            assert!(!at(url).is_local(), "{url}");
-        }
     }
 
     #[test]

--- a/libs/content/workspace/src/tab/chat/tools.rs
+++ b/libs/content/workspace/src/tab/chat/tools.rs
@@ -6,10 +6,10 @@
 //! observes a note's contents — a `read_note`, or an `edit_note`/`append_note`
 //! that auto-opens — the note is *captured*: its bytes and version (hmac) are
 //! snapshotted into a [`Buffer`] and the note surfaces as an agent-owned tab.
-//! Every edit mutates the buffer, not the file. Each edit is individually
-//! approved by the user (the card shows [`preview_edit`]'s diff); on
-//! approval the harness runs the edit and immediately writes the buffer
-//! back to the note ([`sync_note`], no longer a model tool).
+//! Every edit mutates the buffer, not the file; the harness gates each call
+//! on the chat's granted scope ([`in_scope`]) and immediately writes an
+//! in-scope edit's buffer back to the note ([`sync_note`], no longer a model
+//! tool). The transcript's diffed tool rows are the review surface.
 //!
 //! # Determinism / replay
 //!
@@ -36,7 +36,7 @@ use super::backend::ToolSchema;
 /// replay, so oversized notes error instead of loading a partial snapshot.
 const OPEN_CAP: usize = 256 * 1024;
 
-/// The persisted result of a denied edit. Kept identical to what the model
+/// The persisted result of a denied call. Kept identical to what the model
 /// sees, so a restored transcript's context matches the live one.
 pub const DENIED_RESULT: &str = "The user denied this tool call.";
 
@@ -375,46 +375,6 @@ pub fn viz_record(
     }
 }
 
-/// The change an `edit_note` call proposes, for the approval card: the
-/// target's current text (open buffer, else disk) with the edit applied,
-/// as del/add segments with one block of context. `Err` is the steering
-/// message the call will hit if approved, shown on the card instead.
-pub(super) async fn preview_edit(
-    lb: &Lb, buffers: &Buffers, args: &Value,
-) -> Result<Vec<super::diff::Segment>, String> {
-    let path = arg(args, "path")?;
-    let old = arg(args, "old_str")?;
-    let new = arg(args, "new_str")?;
-    let replace_all = args
-        .get("replace_all")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let base = match buffers.get(path) {
-        Some(b) => b.text.clone(),
-        None => match capture_from_disk(lb, path).await {
-            Ok((_, content)) if content.len() > OPEN_CAP => {
-                return Err(format!(
-                    "error: {path} is too large to open ({} KiB).",
-                    content.len() / 1024
-                ));
-            }
-            Ok((_, content)) => content,
-            Err(NotADoc) => return Err(format!("error: {path} is a folder, not a note.")),
-            Err(Missing) => return Err(format!("error: no note at {path}.")),
-            Err(NotUtf8) => return Err(format!("error: {path} isn't text.")),
-        },
-    };
-    // A scratch store so the preview can't touch the real branch.
-    let mut scratch = Buffers::default();
-    scratch.capture(path, None, base.clone());
-    scratch.edit(path, old, new, replace_all)?;
-    let text = scratch
-        .get(path)
-        .map(|b| b.text.clone())
-        .unwrap_or_default();
-    Ok(super::diff::segments(&base, &text, 1))
-}
-
 fn count(n: usize, noun: &str) -> String {
     if n == 1 { format!("1 {noun}") } else { format!("{n} {noun}s") }
 }
@@ -549,11 +509,10 @@ pub fn detail_for(name: &str, args: &Value) -> String {
 }
 
 /// Plain-language prose for a tool call, phrased as a yes/no question.
-/// `request_access` and `edit_note` are the only names the harness's `gate`
-/// ever raises as a card today — everything else is scope-checked silently —
-/// but the function still covers every tool name generally, `read_note`/`list`
-/// included, so a future gate can reuse this without new prose. Unknown
-/// shapes fall back to the terse detail.
+/// `request_access` is the only name the harness's `gate` raises as a card
+/// today — everything else runs or steers on scope, silently — but the
+/// function still covers every tool name generally so a future gate can
+/// reuse it without new prose. Unknown shapes fall back to the terse detail.
 pub fn permission_prose(name: &str, args: &Value, provider: &str) -> String {
     let path = args.get("path").and_then(Value::as_str);
     let flag = |key: &str| args.get(key).and_then(Value::as_bool).unwrap_or(false);

--- a/libs/content/workspace/src/tab/chat/tools.rs
+++ b/libs/content/workspace/src/tab/chat/tools.rs
@@ -28,6 +28,8 @@ use lb_rs::model::file_metadata::DocumentHmac;
 use lb_rs::model::text::buffer::Buffer as TextBuffer;
 use serde_json::{Value, json};
 
+use crate::file_cache::path_segments;
+
 use super::backend::ToolSchema;
 
 /// A note the model refuses to open beyond — a truncated capture would corrupt
@@ -40,14 +42,13 @@ pub const DENIED_RESULT: &str = "The user denied this tool call.";
 
 /// Whether `path` falls under any granted root: folder grants (trailing '/')
 /// cover their subtree and the folder itself; note grants cover exactly that
-/// note. `"/"` grants everything.
+/// note. `"/"` grants everything. Compared as path segments, not characters
+/// — `/notes/` must not match `/notes2/a.md` on a shared string prefix.
 pub fn in_scope(path: &str, scope: &[String]) -> bool {
-    let path = path.trim_end_matches('/');
-    scope.iter().any(|g| match g.strip_suffix('/') {
-        Some(folder) => {
-            folder.is_empty() || path == folder || path.starts_with(&format!("{folder}/"))
-        }
-        None => path == g,
+    let path = path_segments(path);
+    scope.iter().any(|g| {
+        let grant = path_segments(g);
+        if g.ends_with('/') { path.starts_with(grant.as_slice()) } else { path == grant }
     })
 }
 

--- a/libs/content/workspace/src/tab/chat/tools.rs
+++ b/libs/content/workspace/src/tab/chat/tools.rs
@@ -540,12 +540,12 @@ pub fn detail_for(name: &str, args: &Value) -> String {
     }
 }
 
-/// Plain-language permission prose for the approval card, adapted to the
-/// call's parameters and phrased as a yes/no question. Reads gate on *egress*
-/// — the card only appears for a remote provider — so they name `provider`
-/// and frame it as sending; `list` sends names, `read_note` sends contents.
-/// Edits gate on *mutation* and head the diff below. Unknown shapes fall back
-/// to the terse detail.
+/// Plain-language prose for a tool call, phrased as a yes/no question.
+/// `request_access` and `edit_note` are the only names the harness's `gate`
+/// ever raises as a card today — everything else is scope-checked silently —
+/// but the function still covers every tool name generally, `read_note`/`list`
+/// included, so a future gate can reuse this without new prose. Unknown
+/// shapes fall back to the terse detail.
 pub fn permission_prose(name: &str, args: &Value, provider: &str) -> String {
     let path = args.get("path").and_then(Value::as_str);
     let flag = |key: &str| args.get(key).and_then(Value::as_bool).unwrap_or(false);

--- a/libs/content/workspace/src/tab/chat/tools.rs
+++ b/libs/content/workspace/src/tab/chat/tools.rs
@@ -38,6 +38,45 @@ const OPEN_CAP: usize = 256 * 1024;
 /// sees, so a restored transcript's context matches the live one.
 pub const DENIED_RESULT: &str = "The user denied this tool call.";
 
+/// Whether `path` falls under any granted root: folder grants (trailing '/')
+/// cover their subtree and the folder itself; note grants cover exactly that
+/// note. `"/"` grants everything.
+pub fn in_scope(path: &str, scope: &[String]) -> bool {
+    let path = path.trim_end_matches('/');
+    scope.iter().any(|g| match g.strip_suffix('/') {
+        Some(folder) => {
+            folder.is_empty() || path == folder || path.starts_with(&format!("{folder}/"))
+        }
+        None => path == g,
+    })
+}
+
+/// The steering result of a call outside the chat's granted scope. Names the
+/// recovery tool and states what's currently granted (the system prompt
+/// deliberately doesn't — see `access_intro` — so this is the model's only
+/// source for it short of scrolling its own history). Silent on whether the
+/// path exists — existence outside scope is itself private.
+pub fn out_of_scope(path: &str, scope: &[String]) -> String {
+    let granted = if scope.is_empty() { "none yet".into() } else { scope.join(", ") };
+    format!(
+        "denied: {path} is outside the folders this chat can access. Currently granted: \
+         {granted}. Call request_access to ask the user, then retry."
+    )
+}
+
+/// A grant as stored: the canonical path, folders with their trailing '/'.
+/// An unresolvable path is granted verbatim — harmless, and a folder created
+/// later under a verbatim folder grant still matches.
+pub(super) async fn normalize_grant(lb: &Lb, path: &str) -> String {
+    match lb.get_by_path(path).await {
+        Ok(f) => lb
+            .get_path_by_id(f.id)
+            .await
+            .unwrap_or_else(|_| path.into()),
+        Err(_) => path.into(),
+    }
+}
+
 /// One note open on the branch: the captured base (content + version at
 /// capture) and the current edited text. `dirty` ⇔ `text != base_text`.
 #[derive(Clone)]
@@ -293,6 +332,8 @@ pub fn viz_record(
         return viz("error", text_body());
     }
     match (name, post) {
+        // Denied requests returned early above; what's left is a grant.
+        ("request_access", _) => viz("granted", text_body()),
         ("list", _) => {
             if result.ends_with("is empty.") {
                 return viz("empty", text_body());
@@ -431,6 +472,22 @@ pub fn schemas() -> Vec<ToolSchema> {
             parameters: one_path("path"),
         },
         ToolSchema {
+            name: "request_access",
+            description: "Ask the user to grant this chat access to a folder \
+                          (path ending in '/') or a single note. Request the \
+                          narrowest scope that covers the task — usually the \
+                          chat's own folder. The user sees your reason.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "reason": { "type": "string", "description": "One short sentence: why you need it." },
+                },
+                "required": ["path"],
+                "additionalProperties": false,
+            }),
+        },
+        ToolSchema {
             name: "edit_note",
             description: "Replace an exact string in a note. old_str must \
                           match exactly once, or set replace_all to change \
@@ -493,6 +550,11 @@ pub fn permission_prose(name: &str, args: &Value, provider: &str) -> String {
     let path = args.get("path").and_then(Value::as_str);
     let flag = |key: &str| args.get(key).and_then(Value::as_bool).unwrap_or(false);
     match name {
+        "request_access" => match path.unwrap_or_default() {
+            "/" => format!("Let {provider} read and edit your entire lockbook?"),
+            p if p.ends_with('/') => format!("Let {provider} read and edit everything in {p}?"),
+            p => format!("Let {provider} read and edit {p}?"),
+        },
         "read_note" => {
             format!("Send the full contents of {} to {provider}?", path.unwrap_or_default())
         }
@@ -523,6 +585,14 @@ pub fn permission_prose(name: &str, args: &Value, provider: &str) -> String {
         }
         _ => format!("Let the model run {}?", detail_for(name, args)),
     }
+}
+
+/// A `request_access` call's stated reason, trimmed — rendered on its own
+/// line under [`permission_prose`]'s ask, set off in the model's own words
+/// rather than folded into the yes/no sentence.
+pub fn request_reason(args: &Value) -> Option<String> {
+    let reason = args.get("reason").and_then(Value::as_str)?.trim();
+    (!reason.is_empty()).then(|| reason.to_string())
 }
 
 /// A string argument, or a steering error naming the omission.
@@ -1087,15 +1157,41 @@ mod tests {
         assert!(detail.ends_with('…') && detail.len() < 100);
     }
 
-    /// The four slice tools are advertised, with flat strict-compatible
+    /// The slice tools are advertised, with flat strict-compatible
     /// schemas (object, additionalProperties:false).
     #[test]
     fn schemas_are_flat_and_named() {
         let names: Vec<_> = schemas().iter().map(|s| s.name).collect();
-        assert_eq!(names, ["list", "read_note", "edit_note"]);
+        assert_eq!(names, ["list", "read_note", "request_access", "edit_note"]);
         for s in schemas() {
             assert_eq!(s.parameters["type"], "object");
             assert_eq!(s.parameters["additionalProperties"], false);
         }
+    }
+
+    /// Folder grants cover their subtree and the folder itself, on path
+    /// boundaries; note grants cover exactly that note; "/" covers all.
+    #[test]
+    fn in_scope_matches_on_path_boundaries() {
+        let scope = |s: &[&str]| s.iter().map(|g| g.to_string()).collect::<Vec<_>>();
+
+        let folder = scope(&["/notes/"]);
+        assert!(in_scope("/notes/a.md", &folder));
+        assert!(in_scope("/notes/deep/b.md", &folder));
+        assert!(in_scope("/notes/", &folder), "listing the granted folder itself");
+        assert!(in_scope("/notes", &folder), "trailing-slash-less spelling");
+        assert!(!in_scope("/notes2/a.md", &folder), "sibling prefix must not match");
+        assert!(!in_scope("/a.md", &folder));
+
+        let note = scope(&["/one.md"]);
+        assert!(in_scope("/one.md", &note));
+        assert!(!in_scope("/one.md.bak", &note));
+        assert!(!in_scope("/", &note));
+
+        let root = scope(&["/"]);
+        assert!(in_scope("/", &root));
+        assert!(in_scope("/anything/x.md", &root));
+
+        assert!(!in_scope("/anything", &[]), "empty scope grants nothing");
     }
 }

--- a/libs/content/workspace/src/tab/chat/tools.rs
+++ b/libs/content/workspace/src/tab/chat/tools.rs
@@ -44,11 +44,18 @@ pub const DENIED_RESULT: &str = "The user denied this tool call.";
 /// cover their subtree and the folder itself; note grants cover exactly that
 /// note. `"/"` grants everything. Compared as path segments, not characters
 /// — `/notes/` must not match `/notes2/a.md` on a shared string prefix.
+///
+/// Dotted segments *beyond the grant* never match: a broad grant must not
+/// implicitly cover `/.agent/` (provider files carry API keys, and the
+/// prompt file steers the agent — silent reads exfiltrate, silent writes
+/// self-modify). Spelling the dots out in the grant is the opt-in.
 pub fn in_scope(path: &str, scope: &[String]) -> bool {
     let path = path_segments(path);
     scope.iter().any(|g| {
         let grant = path_segments(g);
-        if g.ends_with('/') { path.starts_with(grant.as_slice()) } else { path == grant }
+        let covered =
+            if g.ends_with('/') { path.starts_with(grant.as_slice()) } else { path == grant };
+        covered && !path[grant.len()..].iter().any(|s| s.starts_with('.'))
     })
 }
 
@@ -639,11 +646,22 @@ async fn list(lb: &Lb, args: &Value) -> Outcome {
     let Ok(children) = children else {
         return Outcome::err(format!("error: couldn't list {path}."));
     };
+    let listed_depth = path_segments(path).len();
     for f in children {
         if f.id == folder.id {
             continue;
         }
         let p = lb.get_path_by_id(f.id).await.unwrap_or(f.name.clone());
+        // Dotted rows stay hidden unless the listed path itself is inside
+        // them — same opt-in as `in_scope`, so names don't leak what
+        // contents can't back up. (`get`: the name fallback above can be
+        // shallower than the listed path.)
+        let dotted = path_segments(&p)
+            .get(listed_depth..)
+            .is_some_and(|rest| rest.iter().any(|s| s.starts_with('.')));
+        if dotted {
+            continue;
+        }
         rows.push(p);
     }
     if rows.is_empty() {
@@ -1194,5 +1212,30 @@ mod tests {
         assert!(in_scope("/anything/x.md", &root));
 
         assert!(!in_scope("/anything", &[]), "empty scope grants nothing");
+    }
+
+    /// Dotted segments beyond the grant never match — `/.agent/` holds
+    /// provider keys and the prompt, so "everything" must not include it
+    /// implicitly. Spelling the dots out in the grant is the opt-in, and
+    /// deeper dots still need their own.
+    #[test]
+    fn dotted_segments_need_their_own_grant() {
+        let scope = |s: &[&str]| s.iter().map(|g| g.to_string()).collect::<Vec<_>>();
+
+        let root = scope(&["/"]);
+        assert!(!in_scope("/.agent/providers/openai.json", &root));
+        assert!(!in_scope("/.agent/prompt.md", &root));
+        assert!(!in_scope("/.agent/", &root));
+        assert!(!in_scope("/notes/.hidden.md", &scope(&["/notes/"])));
+        // A dot inside a name is an extension, not hiding.
+        assert!(in_scope("/notes/a.md", &root));
+
+        // Explicitly granting the dotted folder (or note) opts in…
+        let agent = scope(&["/.agent/"]);
+        assert!(in_scope("/.agent/providers/openai.json", &agent));
+        assert!(in_scope("/.agent/", &agent));
+        assert!(in_scope("/.agent/prompt.md", &scope(&["/.agent/prompt.md"])));
+        // …but only down to the next dotted segment.
+        assert!(!in_scope("/.agent/.keys/k", &agent));
     }
 }

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -4,6 +4,7 @@
 //! the reviewable state lives in the parent module and `config`.
 
 use super::*;
+use crate::file_cache::path_segments;
 use crate::show::InputStateExt as _;
 
 /// A vertically-stacked, horizontally-centered column painted as one block in
@@ -2329,38 +2330,61 @@ impl Chat {
                     .on_hover_text(format!("{used} / {window} tokens ({:.0}%)", ratio * 100.0));
             }
 
-            let mut dropdown = |ui: &mut Ui, id: &str, text: &str| -> egui::Response {
-                let galley = ui.fonts(|f| {
-                    f.layout_no_wrap(
+            // The ⋯ overflow anchors the strip's right end; chips lay against
+            // the budget it leaves. A chip that can't fit folds into its menu.
+            let more_d = TOOLBAR_H - 8.0;
+            let more_rect = Rect::from_center_size(
+                pos2(toolbar_rect.max.x - more_d / 2.0, toolbar_rect.center().y),
+                vec2(more_d, more_d),
+            );
+            let budget_max_x = more_rect.min.x - STRIP_GAP;
+
+            // Label ⌄ chip. Labels elide at a cap (model ids run long) and at
+            // the remaining budget; `must_fit` chips (provider, model — the
+            // strip's identity) draw regardless, eating what room remains,
+            // while the rest return None for the caller to fold into ⋯.
+            let mut dropdown =
+                |ui: &mut Ui, id: &str, text: &str, must_fit: bool| -> Option<egui::Response> {
+                    let chevron = ui.fonts(|f| {
+                        f.layout_no_wrap(
+                            Icon::CHEVRON_DOWN.icon.to_string(),
+                            egui::FontId::monospace(12.0),
+                            text_color,
+                        )
+                    });
+                    let avail = budget_max_x - cursor_x;
+                    let mut job = egui::text::LayoutJob::simple_singleline(
                         text.to_string(),
                         egui::FontId::proportional(NOTE_FONT),
                         text_color,
-                    )
-                });
-                let chevron = ui.fonts(|f| {
-                    f.layout_no_wrap(
-                        Icon::CHEVRON_DOWN.icon.to_string(),
-                        egui::FontId::monospace(12.0),
+                    );
+                    job.wrap = egui::text::TextWrapping {
+                        max_width: 140.0f32.min(avail - chevron.size().x - 6.0).max(0.0),
+                        max_rows: 1,
+                        break_anywhere: true,
+                        overflow_character: Some('…'),
+                    };
+                    let galley = ui.fonts(|f| f.layout_job(job));
+                    let w = galley.size().x + chevron.size().x + 6.0;
+                    if !must_fit && w > avail {
+                        return None;
+                    }
+                    let rect =
+                        Rect::from_min_size(pos2(cursor_x, toolbar_rect.min.y), vec2(w, TOOLBAR_H));
+                    cursor_x = rect.max.x + STRIP_GAP;
+                    let resp = ui
+                        .interact(rect, Id::new(id), Sense::click())
+                        .on_hover_cursor(egui::CursorIcon::PointingHand);
+                    let text_top = rect.min.y + (TOOLBAR_H - galley.size().y) / 2.0;
+                    ui.painter()
+                        .galley(pos2(rect.min.x, text_top), galley, text_color);
+                    ui.painter().galley(
+                        pos2(rect.max.x - chevron.size().x, text_top),
+                        chevron,
                         text_color,
-                    )
-                });
-                let w = galley.size().x + chevron.size().x + 6.0;
-                let rect =
-                    Rect::from_min_size(pos2(cursor_x, toolbar_rect.min.y), vec2(w, TOOLBAR_H));
-                cursor_x = rect.max.x + STRIP_GAP;
-                let resp = ui
-                    .interact(rect, Id::new(id), Sense::click())
-                    .on_hover_cursor(egui::CursorIcon::PointingHand);
-                let text_top = rect.min.y + (TOOLBAR_H - galley.size().y) / 2.0;
-                ui.painter()
-                    .galley(pos2(rect.min.x, text_top), galley, text_color);
-                ui.painter().galley(
-                    pos2(rect.max.x - chevron.size().x, text_top),
-                    chevron,
-                    text_color,
-                );
-                resp
-            };
+                    );
+                    Some(resp)
+                };
 
             let mut pick: Option<(String, String)> = None;
 
@@ -2379,7 +2403,8 @@ impl Chat {
             let provider_label = current
                 .map(|c| c.label())
                 .unwrap_or_else(|| "select provider".to_string());
-            let provider_resp = dropdown(ui, "chat_provider_btn", &provider_label);
+            let provider_resp =
+                dropdown(ui, "chat_provider_btn", &provider_label, true).expect("must_fit chip");
             let glyphs = &mut self.glyphs;
             // A row with the provider's brand mark, tinted like its text —
             // similar names in this space (Groq vs Grok) make a wordlist
@@ -2453,6 +2478,27 @@ impl Chat {
             // the whole toolbar until one resolves.
             let mut effort_pick: Option<String> = None;
             let mut revoke: Option<String> = None;
+            // Chips the budget folded into the ⋯ menu, where they reappear
+            // as submenus.
+            let mut effort_folded = false;
+            let mut access_folded = false;
+            let scope = latest_scope(&self.entries, &self.account.username);
+            // "/" subsumes any other listed root, so it reads as one grant
+            // rather than "N paths"; a single grant shows its leaf name —
+            // full paths overwhelm a chip, and the popover has them whole.
+            let access_label = if scope.iter().any(|g| g == "/") {
+                "access: everything".to_string()
+            } else {
+                match scope.as_slice() {
+                    [] => String::new(),
+                    [one] => {
+                        let name = path_segments(one).last().copied().unwrap_or_default();
+                        let slash = if one.ends_with('/') { "/" } else { "" };
+                        format!("access: {name}{slash}")
+                    }
+                    many => format!("access: {} paths", many.len()),
+                }
+            };
             if let Some(current) = current {
                 // The button shows the selected model's display name when the
                 // listing has landed; the id (what's actually configured) until
@@ -2471,7 +2517,8 @@ impl Chat {
                         .map(|m| m.label().to_string())
                         .unwrap_or_else(|| current.model.clone())
                 };
-                let model_resp = dropdown(ui, "chat_model_btn", &model_label);
+                let model_resp =
+                    dropdown(ui, "chat_model_btn", &model_label, true).expect("must_fit chip");
                 egui::Popup::menu(&model_resp)
                     .align(egui::RectAlign::TOP_START)
                     .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
@@ -2526,74 +2573,73 @@ impl Chat {
                     // read as an effort control next to provider/model names.
                     let label =
                         format!("effort: {}", current.effort.as_deref().unwrap_or(EFFORT_AUTO));
-                    let effort_resp = dropdown(ui, "chat_effort_btn", &label).on_hover_text(
-                        "how hard the model reasons before replying — auto uses its own default",
-                    );
-                    egui::Popup::menu(&effort_resp)
-                        .align(egui::RectAlign::TOP_START)
-                        .show(|ui| {
-                            ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
-                            ui.set_min_width(100.0);
-                            if ui
-                                .button(row_text(EFFORT_AUTO, current.effort.is_none()))
-                                .clicked()
-                            {
-                                effort_pick = Some(EFFORT_AUTO.into());
-                                ui.close();
-                            }
-                            for level in EFFORT_LEVELS {
-                                let selected = current.effort.as_deref() == Some(*level);
-                                if ui.button(row_text(level, selected)).clicked() {
-                                    effort_pick = Some((*level).into());
-                                    ui.close();
-                                }
-                            }
-                        });
+                    match dropdown(ui, "chat_effort_btn", &label, false) {
+                        Some(effort_resp) => {
+                            let effort_resp = effort_resp.on_hover_text(
+                                "how hard the model reasons before replying — auto uses its own \
+                                 default",
+                            );
+                            egui::Popup::menu(&effort_resp)
+                                .align(egui::RectAlign::TOP_START)
+                                .show(|ui| {
+                                    ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
+                                    ui.set_min_width(100.0);
+                                    if ui
+                                        .button(row_text(EFFORT_AUTO, current.effort.is_none()))
+                                        .clicked()
+                                    {
+                                        effort_pick = Some(EFFORT_AUTO.into());
+                                        ui.close();
+                                    }
+                                    for level in EFFORT_LEVELS {
+                                        let selected = current.effort.as_deref() == Some(*level);
+                                        if ui.button(row_text(level, selected)).clicked() {
+                                            effort_pick = Some((*level).into());
+                                            ui.close();
+                                        }
+                                    }
+                                });
+                        }
+                        None => effort_folded = true,
+                    }
                 }
 
                 // Access chip: what the agent can reach, granted strictly
                 // through its own request_access cards, no manual grant here
                 // — only revoke. Uniform regardless of provider: no chip
                 // until something's actually been granted.
-                let scope = latest_scope(&self.entries, &self.account.username);
                 if !scope.is_empty() {
-                    // "/" subsumes any other listed root, so it reads as one
-                    // grant rather than "N paths" once it's in the list.
-                    let access_label = if scope.iter().any(|g| g == "/") {
-                        "access: everything".to_string()
-                    } else {
-                        match scope.as_slice() {
-                            [one] => format!("access: {one}"),
-                            many => format!("access: {} paths", many.len()),
+                    match dropdown(ui, "chat_access_btn", &access_label, false) {
+                        Some(access_resp) => {
+                            let access_resp = access_resp.on_hover_text(
+                                "the notes and folders this chat's agent can read and edit",
+                            );
+                            egui::Popup::menu(&access_resp)
+                                .align(egui::RectAlign::TOP_START)
+                                .show(|ui| {
+                                    ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
+                                    ui.set_min_width(180.0);
+                                    ui.weak("click a grant to revoke it");
+                                    for g in &scope {
+                                        let label = if g == "/" { "everything" } else { g };
+                                        if ui.button(row_text(label, false)).clicked() {
+                                            revoke = Some(g.clone());
+                                            ui.close();
+                                        }
+                                    }
+                                });
                         }
-                    };
-                    let access_resp = dropdown(ui, "chat_access_btn", &access_label)
-                        .on_hover_text("the notes and folders this chat's agent can read and edit");
-                    egui::Popup::menu(&access_resp)
-                        .align(egui::RectAlign::TOP_START)
-                        .show(|ui| {
-                            ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
-                            ui.set_min_width(180.0);
-                            ui.weak("click a grant to revoke it");
-                            for g in &scope {
-                                let label = if g == "/" { "everything" } else { g };
-                                if ui.button(row_text(label, false)).clicked() {
-                                    revoke = Some(g.clone());
-                                    ui.close();
-                                }
-                            }
-                        });
+                        None => access_folded = true,
+                    }
                 }
             }
 
             // Conversation-scoped actions live in a ⋯ overflow at the
             // toolbar's right end — not in the provider picker, which stays
             // a pure provider list. Right-aligned so the rare actions sit
-            // away from the per-message controls.
+            // away from the per-message controls. Chips the budget folded
+            // lead the menu as submenus, above the standing actions.
             {
-                let d = TOOLBAR_H - 8.0;
-                let center = pos2(toolbar_rect.max.x - d / 2.0, toolbar_rect.center().y);
-                let more_rect = Rect::from_center_size(center, vec2(d, d));
                 let more_resp = ui
                     .interact(more_rect, Id::new("chat_more_btn"), Sense::click())
                     .on_hover_cursor(egui::CursorIcon::PointingHand);
@@ -2612,6 +2658,47 @@ impl Chat {
                     .show(|ui| {
                         ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
                         ui.set_min_width(140.0);
+                        if effort_folded {
+                            if let Some(current) = current {
+                                let label = format!(
+                                    "effort: {}",
+                                    current.effort.as_deref().unwrap_or(EFFORT_AUTO)
+                                );
+                                ui.menu_button(row_text(&label, false), |ui| {
+                                    ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
+                                    if ui
+                                        .button(row_text(EFFORT_AUTO, current.effort.is_none()))
+                                        .clicked()
+                                    {
+                                        effort_pick = Some(EFFORT_AUTO.into());
+                                        ui.close();
+                                    }
+                                    for level in EFFORT_LEVELS {
+                                        let selected = current.effort.as_deref() == Some(*level);
+                                        if ui.button(row_text(level, selected)).clicked() {
+                                            effort_pick = Some((*level).into());
+                                            ui.close();
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                        if access_folded {
+                            ui.menu_button(row_text(&access_label, false), |ui| {
+                                ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
+                                ui.weak("tap a grant to revoke it");
+                                for g in &scope {
+                                    let label = if g == "/" { "everything" } else { g };
+                                    if ui.button(row_text(label, false)).clicked() {
+                                        revoke = Some(g.clone());
+                                        ui.close();
+                                    }
+                                }
+                            });
+                        }
+                        if effort_folded || access_folded {
+                            ui.separator();
+                        }
                         // The system prompt, as an editable file. "system
                         // prompt" is the real term and reads unambiguously to
                         // anyone who's used an agent; the tooltip covers the

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -2556,19 +2556,15 @@ impl Chat {
                         });
                 }
 
-                // Access chip: what the agent can reach. A local model reads
-                // everything (nothing egresses); a remote one only the
-                // granted roots, given out strictly through the agent's own
-                // request_access cards — no manual grant here, only revoke.
-                // Nothing to say (remote, nothing granted yet) → no chip.
+                // Access chip: what the agent can reach, granted strictly
+                // through its own request_access cards, no manual grant here
+                // — only revoke. Uniform regardless of provider: no chip
+                // until something's actually been granted.
                 let scope = latest_scope(&self.entries, &self.account.username);
-                if current.is_local() || !scope.is_empty() {
+                if !scope.is_empty() {
                     // "/" subsumes any other listed root, so it reads as one
                     // grant rather than "N paths" once it's in the list.
-                    let root_granted = scope.iter().any(|g| g == "/");
-                    let access_label = if current.is_local() {
-                        "access: all (local)".to_string()
-                    } else if root_granted {
+                    let access_label = if scope.iter().any(|g| g == "/") {
                         "access: everything".to_string()
                     } else {
                         match scope.as_slice() {
@@ -2583,16 +2579,12 @@ impl Chat {
                         .show(|ui| {
                             ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
                             ui.set_min_width(180.0);
-                            if current.is_local() {
-                                ui.weak("local model — notes never leave this machine");
-                            } else {
-                                ui.weak("click a grant to revoke it");
-                                for g in &scope {
-                                    let label = if g == "/" { "everything" } else { g };
-                                    if ui.button(row_text(label, false)).clicked() {
-                                        revoke = Some(g.clone());
-                                        ui.close();
-                                    }
+                            ui.weak("click a grant to revoke it");
+                            for g in &scope {
+                                let label = if g == "/" { "everything" } else { g };
+                                if ui.button(row_text(label, false)).clicked() {
+                                    revoke = Some(g.clone());
+                                    ui.close();
                                 }
                             }
                         });

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -441,8 +441,6 @@ impl Chat {
                 (
                     tools::detail_for(&p.name, &p.args),
                     tools::permission_prose(&p.name, &p.args, &provider_label),
-                    p.preview.clone(),
-                    p.name == "request_access",
                     tools::request_reason(&p.args),
                 )
             });
@@ -850,154 +848,117 @@ impl Chat {
                             (galley, pos)
                         });
 
-                    // The trailing approval card, shaped like a tool container
-                    // pinned open: a header bar with the command summary, over
-                    // a bordered body holding the permission prose, the
-                    // proposed change, and Approve / Deny.
-                    let review_plan = pending_tool.as_ref().map(
-                        |(summary_text, prose, preview, is_request, reason)| {
-                            y += TOOL_GROUP_PAD;
-                            let indent = TOOL_PAD_X;
+                    // The trailing approval card (request_access — the only
+                    // gated call), shaped like a tool container pinned open:
+                    // a header bar with the command summary, over a bordered
+                    // body holding the permission prose and Allow / Deny.
+                    let review_plan = pending_tool.as_ref().map(|(summary_text, prose, reason)| {
+                        y += TOOL_GROUP_PAD;
+                        let indent = TOOL_PAD_X;
 
-                            // Header bar: the command summary, left-aligned. No
-                            // right metric — the call hasn't been allowed to run.
-                            let summary = ui.fonts(|f| {
-                                f.layout_no_wrap(
-                                    summary_text.clone(),
-                                    egui::FontId::monospace(TOOL_FONT),
-                                    secondary_color,
-                                )
-                            });
-                            let header_h = summary.size().y + 2.0 * TOOL_PAD_Y;
-                            let header_rect =
-                                Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, header_h));
-                            let mut cy = y + header_h + TOOL_PAD_Y;
+                        // Header bar: the command summary, left-aligned. No
+                        // right metric — the call hasn't been allowed to run.
+                        let summary = ui.fonts(|f| {
+                            f.layout_no_wrap(
+                                summary_text.clone(),
+                                egui::FontId::monospace(TOOL_FONT),
+                                secondary_color,
+                            )
+                        });
+                        let header_h = summary.size().y + 2.0 * TOOL_PAD_Y;
+                        let header_rect =
+                            Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, header_h));
+                        let mut cy = y + header_h + TOOL_PAD_Y;
 
-                            // Body: the permission request, wrapping. Dimmed mono,
-                            // like the tool summary and result text.
-                            let body_w = note_wrap_w - 2.0 * indent;
-                            let prose = ui.fonts(|f| {
+                        // Body: the permission request, wrapping. Dimmed mono,
+                        // like the tool summary and result text.
+                        let body_w = note_wrap_w - 2.0 * indent;
+                        let prose = ui.fonts(|f| {
+                            f.layout(
+                                prose.clone(),
+                                egui::FontId::monospace(TOOL_FONT),
+                                secondary_color,
+                                body_w,
+                            )
+                        });
+                        let prose_pos = pos2(note_x + indent, cy);
+                        cy += prose.size().y;
+
+                        // The call's stated reason, in the model's own
+                        // words — italic sans sets it apart from the ask
+                        // sentence's dimmed mono.
+                        let reason_plan = reason.as_ref().map(|r| {
+                            let galley = ui.fonts(|f| {
                                 f.layout(
-                                    prose.clone(),
-                                    egui::FontId::monospace(TOOL_FONT),
+                                    format!("“{r}”"),
+                                    egui::FontId {
+                                        size: TOOL_FONT,
+                                        family: egui::FontFamily::Name("Italic".into()),
+                                    },
                                     secondary_color,
                                     body_w,
                                 )
                             });
-                            let prose_pos = pos2(note_x + indent, cy);
-                            cy += prose.size().y;
+                            let pos = pos2(note_x + indent, cy + ROW_GAP);
+                            cy += ROW_GAP + galley.size().y;
+                            (galley, pos)
+                        });
 
-                            // A request_access call's stated reason, in
-                            // the model's own words — italic sans sets it
-                            // apart from the ask sentence's dimmed mono.
-                            let reason_plan = reason.as_ref().map(|r| {
-                                let galley = ui.fonts(|f| {
-                                    f.layout(
-                                        format!("“{r}”"),
-                                        egui::FontId {
-                                            size: TOOL_FONT,
-                                            family: egui::FontFamily::Name("Italic".into()),
-                                        },
-                                        secondary_color,
-                                        body_w,
-                                    )
-                                });
-                                let pos = pos2(note_x + indent, cy + ROW_GAP);
-                                cy += ROW_GAP + galley.size().y;
-                                (galley, pos)
-                            });
+                        // Button row, right-aligned. Hints show where a
+                        // hardware keyboard is plausible (desktop, iPad).
+                        cy += V_PAD;
+                        let btn = |ui: &Ui, label: String, accent: bool| {
+                            ui.fonts(|f| {
+                                f.layout_no_wrap(
+                                    label,
+                                    egui::FontId::proportional(13.0),
+                                    if accent { text_color } else { secondary_color },
+                                )
+                            })
+                        };
+                        // A grant reads as "Allow" — it confers standing
+                        // access, not a one-shot approval.
+                        let approve_label = if show_key_hints {
+                            format!("Allow {approve_hint}")
+                        } else {
+                            "Allow".into()
+                        };
+                        let deny_label = if show_key_hints {
+                            format!("Deny {deny_hint}")
+                        } else {
+                            "Deny".into()
+                        };
+                        let approve = btn(ui, approve_label, true);
+                        let deny = btn(ui, deny_label, false);
+                        let btn_h = approve.size().y.max(deny.size().y) + 8.0;
+                        let bpad = 12.0;
+                        let approve_w = approve.size().x + bpad * 2.0;
+                        let deny_w = deny.size().x + bpad * 2.0;
+                        let right = note_x + note_wrap_w - indent;
+                        let deny_rect =
+                            Rect::from_min_size(pos2(right - deny_w, cy), vec2(deny_w, btn_h));
+                        let approve_rect = Rect::from_min_size(
+                            pos2(deny_rect.min.x - STRIP_GAP - approve_w, cy),
+                            vec2(approve_w, btn_h),
+                        );
+                        cy += btn_h + TOOL_PAD_Y;
 
-                            // The proposed change, under the prose.
-                            let body = match preview {
-                                // An edit's diff, rendered with changed blocks
-                                // washed in place.
-                                Some(Ok(segs)) => {
-                                    self.review_label.renderer.layout.block_spacing =
-                                        DIFF_BLOCK_SPACING;
-                                    let h = segments_height(&mut self.review_label, segs, body_w);
-                                    let pos = pos2(note_x + indent, cy + ROW_GAP);
-                                    cy += ROW_GAP + h;
-                                    ReviewBody::Rendered {
-                                        segments: segs.clone(),
-                                        pos,
-                                        width: body_w,
-                                    }
-                                }
-                                // The steering error approval would hit.
-                                Some(Err(e)) => {
-                                    let galley = ui.fonts(|f| {
-                                        f.layout(
-                                            e.clone(),
-                                            egui::FontId::monospace(TOOL_FONT),
-                                            secondary_color,
-                                            body_w,
-                                        )
-                                    });
-                                    let pos = pos2(note_x + indent, cy + ROW_GAP);
-                                    cy += ROW_GAP + galley.size().y;
-                                    ReviewBody::Galley { galley, pos }
-                                }
-                                None => ReviewBody::None,
-                            };
-
-                            // Button row, right-aligned. Hints show where a
-                            // hardware keyboard is plausible (desktop, iPad).
-                            cy += V_PAD;
-                            let btn = |ui: &Ui, label: String, accent: bool| {
-                                ui.fonts(|f| {
-                                    f.layout_no_wrap(
-                                        label,
-                                        egui::FontId::proportional(13.0),
-                                        if accent { text_color } else { secondary_color },
-                                    )
-                                })
-                            };
-                            // A grant reads as "Allow" — it confers standing
-                            // access, not a one-shot approval.
-                            let verb = if *is_request { "Allow" } else { "Approve" };
-                            let approve_label = if show_key_hints {
-                                format!("{verb} {approve_hint}")
-                            } else {
-                                verb.into()
-                            };
-                            let deny_label = if show_key_hints {
-                                format!("Deny {deny_hint}")
-                            } else {
-                                "Deny".into()
-                            };
-                            let approve = btn(ui, approve_label, true);
-                            let deny = btn(ui, deny_label, false);
-                            let btn_h = approve.size().y.max(deny.size().y) + 8.0;
-                            let bpad = 12.0;
-                            let approve_w = approve.size().x + bpad * 2.0;
-                            let deny_w = deny.size().x + bpad * 2.0;
-                            let right = note_x + note_wrap_w - indent;
-                            let deny_rect =
-                                Rect::from_min_size(pos2(right - deny_w, cy), vec2(deny_w, btn_h));
-                            let approve_rect = Rect::from_min_size(
-                                pos2(deny_rect.min.x - STRIP_GAP - approve_w, cy),
-                                vec2(approve_w, btn_h),
-                            );
-                            cy += btn_h + TOOL_PAD_Y;
-
-                            let border =
-                                Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, cy - y));
-                            y = cy + ROW_GAP + TOOL_GROUP_PAD;
-                            ReviewPlan {
-                                header_rect,
-                                summary,
-                                prose,
-                                prose_pos,
-                                reason: reason_plan,
-                                body,
-                                approve,
-                                approve_rect,
-                                deny,
-                                deny_rect,
-                                border,
-                            }
-                        },
-                    );
+                        let border =
+                            Rect::from_min_size(pos2(note_x, y), vec2(note_wrap_w, cy - y));
+                        y = cy + ROW_GAP + TOOL_GROUP_PAD;
+                        ReviewPlan {
+                            header_rect,
+                            summary,
+                            prose,
+                            prose_pos,
+                            reason: reason_plan,
+                            approve,
+                            approve_rect,
+                            deny,
+                            deny_rect,
+                            border,
+                        }
+                    });
 
                     // Keep the clicked arrows where they were: correct for
                     // any height change of the swapped fork row (content
@@ -1450,33 +1411,8 @@ impl Chat {
                         if let Some((galley, pos)) = r.reason {
                             ui.painter().galley(pos, galley, secondary_color);
                         }
-                        match r.body {
-                            ReviewBody::None => {}
-                            ReviewBody::Galley { galley, pos } => {
-                                ui.painter().galley(pos, galley, secondary_color);
-                            }
-                            // The proposed change, rendered; changed blocks
-                            // washed in place. Washes paint after the layout
-                            // but under the glyphs — text rides the later
-                            // glyphon callback layer. Bands bleed to the
-                            // container edges (inset for its 1px border).
-                            ReviewBody::Rendered { segments, pos, width } => {
-                                let areas = paint_segments(
-                                    ui,
-                                    &mut self.review_label,
-                                    Id::new("review_body"),
-                                    &segments,
-                                    pos,
-                                    width,
-                                    (note_x + 1.0, note_x + note_wrap_w - 1.0),
-                                    add_wash,
-                                    del_wash,
-                                );
-                                text_areas.extend(areas);
-                            }
-                        }
 
-                        // Deny: bordered. Approve: accent-filled.
+                        // Deny: bordered. Allow: accent-filled.
                         let deny = ui
                             .interact(r.deny_rect, Id::new("chat_review_deny"), Sense::click())
                             .on_hover_cursor(egui::CursorIcon::PointingHand);

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -392,10 +392,16 @@ impl Chat {
             let _ = self.composer.handle_input(ui.ctx(), composer_id);
         }
 
+        // Send/stop sits inside the text area at its trailing edge
+        // (messaging-app idiom) — the text column narrows to wrap clear of it.
+        let send_d = if touch_os { TOOLBAR_H - 2.0 } else { TOOLBAR_H - 8.0 };
+        let send_zone = send_d + H_PAD;
+
         // Measure at the exact render width so the composer bubble grows
         // same-frame. The re-parse inside `show` below hits the layout cache.
-        // `H_MARGIN` and `H_PAD` mirror the h_inset / shrink geometry below.
-        let composer_inner_w = (col_width - 2.0 * H_MARGIN - 2.0 * H_PAD).max(0.0);
+        // `H_MARGIN`, `H_PAD`, and `send_zone` mirror the h_inset / shrink
+        // geometry below.
+        let composer_inner_w = (col_width - 2.0 * H_MARGIN - 2.0 * H_PAD - send_zone).max(0.0);
         let measured_h = self.composer.measure_height(composer_inner_w);
 
         // Autogrow with a max cap, no lower floor — a lower floor makes a
@@ -2125,9 +2131,10 @@ impl Chat {
         // bottom is purely the glyphon clip — insetting it by `V_PAD` pinned
         // the clip onto the last line's box and shaved descenders (g/y tails,
         // worst on hi-DPI). The empty space above the toolbar is the padding.
+        // The right side additionally clears the send button's zone.
         let inner_rect = Rect::from_min_max(
             text_rect.min + vec2(H_PAD, V_PAD),
-            pos2(text_rect.max.x - H_PAD, text_rect.max.y),
+            pos2(text_rect.max.x - H_PAD - send_zone, text_rect.max.y),
         );
         // When the key is broken the text field is replaced by an accent
         // "add key" button — a control, never a place to type a secret.
@@ -2174,6 +2181,58 @@ impl Chat {
             } else {
                 None
             };
+
+        // Send/stop at the text area's trailing edge, bottom-aligned so it
+        // tracks the newest line as the composer grows (centered while a
+        // single line leaves the area shorter than the button). While a turn
+        // streams the button is a stop square (the reply keeps what streamed
+        // so far).
+        let non_empty = !self.composer.renderer.buffer.current.text.trim().is_empty();
+        let mut send_clicked = false;
+        let mut stop_clicked = false;
+        // No send button while the field is the "add key" button.
+        if !hide_composer && need_key.is_none() {
+            let center = pos2(
+                text_rect.max.x - H_PAD - send_d / 2.0,
+                (text_rect.max.y - V_PAD - send_d / 2.0).max(text_rect.center().y),
+            );
+            let button_rect = Rect::from_center_size(center, vec2(send_d, send_d));
+            // Touch targets stay ~44pt even where the visual is smaller.
+            let hit_rect = if touch_os { button_rect.expand(7.0) } else { button_rect };
+            let active = (non_empty && send_block.is_none()) || agent_busy;
+            let resp = ui.interact(hit_rect, Id::new("chat_send"), Sense::click());
+            // A pointer cursor when it'll do something (send, or stop a turn).
+            let resp =
+                if active { resp.on_hover_cursor(egui::CursorIcon::PointingHand) } else { resp };
+
+            let painter = ui.painter();
+            // The markdown-toolbar icon idiom — no filled disc, just the mark
+            // itself: accent when actionable, foreground when idle.
+            let mark = if active {
+                theme.fg().get_color(theme.prefs().primary)
+            } else {
+                theme.neutral_fg()
+            };
+            if agent_busy {
+                let side = send_d * 0.36;
+                painter.rect_filled(
+                    Rect::from_center_size(center, vec2(side, side)),
+                    CornerRadius::same(2),
+                    mark,
+                );
+                stop_clicked = resp.clicked();
+            } else {
+                let icon = ui.fonts(|f| {
+                    f.layout_no_wrap(
+                        Icon::SEND.icon.to_string(),
+                        egui::FontId::monospace(send_d * 0.55),
+                        mark,
+                    )
+                });
+                painter.galley(center - icon.size() / 2.0, icon, mark);
+                send_clicked = resp.clicked();
+            }
+        }
 
         // Ghosted placeholder over the empty composer (not while the field is
         // the "add key" button).
@@ -2528,13 +2587,12 @@ impl Chat {
             }
 
             // Conversation-scoped actions live in a ⋯ overflow at the
-            // toolbar's right, beside send — not in the provider picker,
-            // which stays a pure provider list. Right-aligned so the rare
-            // actions sit away from the per-message controls.
+            // toolbar's right end — not in the provider picker, which stays
+            // a pure provider list. Right-aligned so the rare actions sit
+            // away from the per-message controls.
             {
                 let d = TOOLBAR_H - 8.0;
-                let center =
-                    pos2(toolbar_rect.max.x - d - STRIP_GAP - d / 2.0, toolbar_rect.center().y);
+                let center = pos2(toolbar_rect.max.x - d / 2.0, toolbar_rect.center().y);
                 let more_rect = Rect::from_center_size(center, vec2(d, d));
                 let more_resp = ui
                     .interact(more_rect, Id::new("chat_more_btn"), Sense::click())
@@ -2623,53 +2681,6 @@ impl Chat {
             }
         }
 
-        // Send/stop at the toolbar's right end. While a turn streams the
-        // button is a stop square (the reply keeps what streamed so far).
-        let non_empty = !self.composer.renderer.buffer.current.text.trim().is_empty();
-        let mut send_clicked = false;
-        let mut stop_clicked = false;
-        // No send button while the field is the "add key" button.
-        if !hide_composer && need_key.is_none() {
-            let d = if touch_os { TOOLBAR_H - 2.0 } else { TOOLBAR_H - 8.0 };
-            let center = pos2(toolbar_rect.max.x - d / 2.0, toolbar_rect.center().y);
-            let button_rect = Rect::from_center_size(center, vec2(d, d));
-            // Touch targets stay ~44pt even where the visual is smaller.
-            let hit_rect = if touch_os { button_rect.expand(7.0) } else { button_rect };
-            let active = (non_empty && send_block.is_none()) || agent_busy;
-            let resp = ui.interact(hit_rect, Id::new("chat_send"), Sense::click());
-            // A pointer cursor when it'll do something (send, or stop a turn).
-            let resp =
-                if active { resp.on_hover_cursor(egui::CursorIcon::PointingHand) } else { resp };
-
-            let painter = ui.painter();
-            // The markdown-toolbar icon idiom — no filled disc, just the mark
-            // itself: accent when actionable, foreground when idle.
-            let mark = if active {
-                theme.fg().get_color(theme.prefs().primary)
-            } else {
-                theme.neutral_fg()
-            };
-            if agent_busy {
-                let side = d * 0.36;
-                painter.rect_filled(
-                    Rect::from_center_size(center, vec2(side, side)),
-                    CornerRadius::same(2),
-                    mark,
-                );
-                stop_clicked = resp.clicked();
-            } else {
-                let icon = ui.fonts(|f| {
-                    f.layout_no_wrap(
-                        Icon::SEND.icon.to_string(),
-                        egui::FontId::monospace(d * 0.55),
-                        mark,
-                    )
-                });
-                painter.galley(center - icon.size() / 2.0, icon, mark);
-                send_clicked = resp.clicked();
-            }
-        }
-
         if stop_clicked {
             if let Some(harness) = &mut self.harness {
                 harness.stop();
@@ -2693,14 +2704,14 @@ impl Chat {
         // it doubles as the tap-to-focus / double-tap-to-select gesture
         // target, and the padding margins should be tappable too (touch→buffer
         // mapping is hit-tested separately, so a larger frame is safe). It
-        // stops at the toolbar so the dropdowns and send button keep their own
-        // egui taps.
+        // stops at the toolbar and short of the send button's zone so those
+        // keep their own egui taps.
         let interaction_rect = if self.key_entry.is_some() {
             self.key_field_hit_rect
         } else if hide_composer {
             Rect::NOTHING
         } else {
-            text_rect
+            Rect::from_min_max(text_rect.min, pos2(text_rect.max.x - send_zone, text_rect.max.y))
         };
         // The composer's `seq` bumps on any text/selection change. When it
         // moved but no native keystroke drove it (a send-clear, edit-prefill,

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -320,17 +320,20 @@ impl Chat {
                     || (!completions_open && i.consume_key_exact(Modifiers::NONE, Key::Enter))
             });
 
-        // ⌘A approve / ⌘D deny while a call awaits a decision. Consumed
-        // before the composer's input phase so ⌘A can't fall through to
-        // select-all while the card is up.
-        let approve_shortcut = egui::KeyboardShortcut::new(Modifiers::COMMAND, Key::A);
-        let deny_shortcut = egui::KeyboardShortcut::new(Modifiers::COMMAND, Key::D);
+        // ⌘Enter approve / Esc deny while a call awaits a decision. A send
+        // can't fire mid-turn, so the send stroke is free to mean "yes, go"
+        // while the card is up. Consumed before the composer's input phase
+        // so neither falls through to the editor; stood down while the
+        // chooser owns the canvas (its own Esc closes it).
+        let approve_shortcut = egui::KeyboardShortcut::new(Modifiers::COMMAND, Key::Enter);
+        let deny_shortcut = egui::KeyboardShortcut::new(Modifiers::NONE, Key::Escape);
         let mut approve_clicked = false;
         let mut deny_clicked = false;
         if self
             .harness
             .as_ref()
             .is_some_and(|h| h.pending_tool.is_some())
+            && !self.chooser_open
         {
             ui.ctx().input_mut(|i| {
                 approve_clicked = i.consume_shortcut(&approve_shortcut);
@@ -345,7 +348,8 @@ impl Chat {
         // and tablet-width touch screens (iPad); not phones.
         let show_key_hints = !touch_os || available_width >= 600.0;
         let approve_hint = ui.ctx().format_shortcut(&approve_shortcut);
-        let deny_hint = ui.ctx().format_shortcut(&deny_shortcut);
+        // format_shortcut spells it "Escape" — every editor's label is "esc".
+        let deny_hint = "esc".to_string();
 
         // Return submits the key — the connect step has no Connect button.
         let mut key_submit = false;
@@ -914,8 +918,7 @@ impl Chat {
                                 None => ReviewBody::None,
                             };
 
-                            // Button row, right-aligned; Approve sits left of Deny
-                            // to match the ⌘A / ⌘D keys. Hints show where a
+                            // Button row, right-aligned. Hints show where a
                             // hardware keyboard is plausible (desktop, iPad).
                             cy += V_PAD;
                             let btn = |ui: &Ui, label: String, accent: bool| {

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -442,6 +442,8 @@ impl Chat {
                     tools::detail_for(&p.name, &p.args),
                     tools::permission_prose(&p.name, &p.args, &provider_label),
                     p.preview.clone(),
+                    p.name == "request_access",
+                    tools::request_reason(&p.args),
                 )
             });
         // Soft washes behind rendered diffs' changed blocks.
@@ -852,8 +854,8 @@ impl Chat {
                     // pinned open: a header bar with the command summary, over
                     // a bordered body holding the permission prose, the
                     // proposed change, and Approve / Deny.
-                    let review_plan =
-                        pending_tool.as_ref().map(|(summary_text, prose, preview)| {
+                    let review_plan = pending_tool.as_ref().map(
+                        |(summary_text, prose, preview, is_request, reason)| {
                             y += TOOL_GROUP_PAD;
                             let indent = TOOL_PAD_X;
 
@@ -884,6 +886,26 @@ impl Chat {
                             });
                             let prose_pos = pos2(note_x + indent, cy);
                             cy += prose.size().y;
+
+                            // A request_access call's stated reason, in
+                            // the model's own words — italic sans sets it
+                            // apart from the ask sentence's dimmed mono.
+                            let reason_plan = reason.as_ref().map(|r| {
+                                let galley = ui.fonts(|f| {
+                                    f.layout(
+                                        format!("“{r}”"),
+                                        egui::FontId {
+                                            size: TOOL_FONT,
+                                            family: egui::FontFamily::Name("Italic".into()),
+                                        },
+                                        secondary_color,
+                                        body_w,
+                                    )
+                                });
+                                let pos = pos2(note_x + indent, cy + ROW_GAP);
+                                cy += ROW_GAP + galley.size().y;
+                                (galley, pos)
+                            });
 
                             // The proposed change, under the prose.
                             let body = match preview {
@@ -930,10 +952,13 @@ impl Chat {
                                     )
                                 })
                             };
+                            // A grant reads as "Allow" — it confers standing
+                            // access, not a one-shot approval.
+                            let verb = if *is_request { "Allow" } else { "Approve" };
                             let approve_label = if show_key_hints {
-                                format!("Approve {approve_hint}")
+                                format!("{verb} {approve_hint}")
                             } else {
-                                "Approve".into()
+                                verb.into()
                             };
                             let deny_label = if show_key_hints {
                                 format!("Deny {deny_hint}")
@@ -963,6 +988,7 @@ impl Chat {
                                 summary,
                                 prose,
                                 prose_pos,
+                                reason: reason_plan,
                                 body,
                                 approve,
                                 approve_rect,
@@ -970,7 +996,8 @@ impl Chat {
                                 deny_rect,
                                 border,
                             }
-                        });
+                        },
+                    );
 
                     // Keep the clicked arrows where they were: correct for
                     // any height change of the swapped fork row (content
@@ -1419,6 +1446,10 @@ impl Chat {
                         );
                         // The permission request.
                         ui.painter().galley(r.prose_pos, r.prose, secondary_color);
+                        // The agent's stated reason, italic, under the ask.
+                        if let Some((galley, pos)) = r.reason {
+                            ui.painter().galley(pos, galley, secondary_color);
+                        }
                         match r.body {
                             ReviewBody::None => {}
                             ReviewBody::Galley { galley, pos } => {
@@ -2426,6 +2457,7 @@ impl Chat {
             // Model and effort need a resolved provider; the picker above is
             // the whole toolbar until one resolves.
             let mut effort_pick: Option<String> = None;
+            let mut revoke: Option<String> = None;
             if let Some(current) = current {
                 // The button shows the selected model's display name when the
                 // listing has landed; the id (what's actually configured) until
@@ -2523,6 +2555,48 @@ impl Chat {
                             }
                         });
                 }
+
+                // Access chip: what the agent can reach. A local model reads
+                // everything (nothing egresses); a remote one only the
+                // granted roots, given out strictly through the agent's own
+                // request_access cards — no manual grant here, only revoke.
+                // Nothing to say (remote, nothing granted yet) → no chip.
+                let scope = latest_scope(&self.entries, &self.account.username);
+                if current.is_local() || !scope.is_empty() {
+                    // "/" subsumes any other listed root, so it reads as one
+                    // grant rather than "N paths" once it's in the list.
+                    let root_granted = scope.iter().any(|g| g == "/");
+                    let access_label = if current.is_local() {
+                        "access: all (local)".to_string()
+                    } else if root_granted {
+                        "access: everything".to_string()
+                    } else {
+                        match scope.as_slice() {
+                            [one] => format!("access: {one}"),
+                            many => format!("access: {} paths", many.len()),
+                        }
+                    };
+                    let access_resp = dropdown(ui, "chat_access_btn", &access_label)
+                        .on_hover_text("the notes and folders this chat's agent can read and edit");
+                    egui::Popup::menu(&access_resp)
+                        .align(egui::RectAlign::TOP_START)
+                        .show(|ui| {
+                            ui.spacing_mut().button_padding = egui::vec2(4.0, 4.0);
+                            ui.set_min_width(180.0);
+                            if current.is_local() {
+                                ui.weak("local model — notes never leave this machine");
+                            } else {
+                                ui.weak("click a grant to revoke it");
+                                for g in &scope {
+                                    let label = if g == "/" { "everything" } else { g };
+                                    if ui.button(row_text(label, false)).clicked() {
+                                        revoke = Some(g.clone());
+                                        ui.close();
+                                    }
+                                }
+                            }
+                        });
+                }
             }
 
             // Conversation-scoped actions live in a ⋯ overflow at the
@@ -2591,6 +2665,10 @@ impl Chat {
             }
             if let Some(effort) = effort_pick {
                 self.write_effort(effort);
+                changed = true;
+            }
+            if let Some(path) = revoke {
+                self.revoke_grant(&path);
                 changed = true;
             }
             if open_chooser {

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -4,6 +4,7 @@
 //! the reviewable state lives in the parent module and `config`.
 
 use super::*;
+use crate::show::InputStateExt as _;
 
 /// A vertically-stacked, horizontally-centered column painted as one block in
 /// a rect — the shared skeleton of the onboarding chooser, connect step,
@@ -307,7 +308,8 @@ impl Chat {
         // completion popup is up (which accepts with Enter itself), and not
         // while a turn is streaming: a send can't fire then, and consuming
         // the key would eat the stroke with no feedback. Left unconsumed it
-        // types a newline, which at least shows the key landed.
+        // types a newline, which at least shows the key landed. Exact match:
+        // `consume_key` ignores extra Shift, so it'd treat Shift+Enter as a send.
         let composer_focused = ui.memory(|m| m.has_focus(composer_id));
         let completions_open =
             self.composer.emoji_completions.active || self.composer.link_completions.active;
@@ -315,7 +317,7 @@ impl Chat {
             && !agent_busy
             && ui.ctx().input_mut(|i| {
                 i.consume_key(Modifiers::COMMAND, Key::Enter)
-                    || (!completions_open && i.consume_key(Modifiers::NONE, Key::Enter))
+                    || (!completions_open && i.consume_key_exact(Modifiers::NONE, Key::Enter))
             });
 
         // ⌘A approve / ⌘D deny while a call awaits a decision. Consumed

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1816,13 +1816,20 @@ fn print_recursive<'a>(node: &'a AstNode<'a>, indent: &str) {
 }
 
 pub fn register_fonts(fonts: &mut FontDefinitions) {
-    let (sans, mono, bold, base_scale) = if cfg!(target_vendor = "apple") {
-        (lb_fonts::SF_PRO_TEXT_REGULAR, lb_fonts::SF_MONO_REGULAR, lb_fonts::SF_PRO_TEXT_BOLD, 0.9)
+    let (sans, mono, bold, italic, base_scale) = if cfg!(target_vendor = "apple") {
+        (
+            lb_fonts::SF_PRO_TEXT_REGULAR,
+            lb_fonts::SF_MONO_REGULAR,
+            lb_fonts::SF_PRO_TEXT_BOLD,
+            lb_fonts::SF_PRO_TEXT_ITALIC,
+            0.9,
+        )
     } else {
         (
             lb_fonts::NOTO_SANS_REGULAR,
             lb_fonts::NOTO_SANS_MONO_REGULAR,
             lb_fonts::NOTO_SANS_BOLD,
+            lb_fonts::NOTO_SANS_ITALIC,
             1.,
         )
     };
@@ -1861,6 +1868,14 @@ pub fn register_fonts(fonts: &mut FontDefinitions) {
         FontData {
             tweak: FontTweak { scale: base_scale, ..FontTweak::default() },
             ..FontData::from_static(bold)
+        }
+        .into(),
+    );
+    fonts.font_data.insert(
+        "italic".to_string(),
+        FontData {
+            tweak: FontTweak { scale: base_scale, ..FontTweak::default() },
+            ..FontData::from_static(italic)
         }
         .into(),
     );
@@ -1946,6 +1961,9 @@ pub fn register_fonts(fonts: &mut FontDefinitions) {
     fonts
         .families
         .insert(FontFamily::Name(Arc::from("Bold")), vec!["bold".into()]);
+    fonts
+        .families
+        .insert(FontFamily::Name(Arc::from("Italic")), vec!["italic".into()]);
     fonts
         .families
         .insert(FontFamily::Name(Arc::from("SansSuper")), vec!["sans_super".into()]);

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -249,6 +249,16 @@ pub struct MdEdit {
     /// shown rect. Maintained by [`MdEdit::show`]; 0 outside single-line mode.
     pub single_line_scroll: f32,
 
+    /// Vertical scroll (px) of a multi-line field whose content outgrew its
+    /// rect (the chat composer at max height). Maintained by [`MdEdit::show`];
+    /// 0 while the content fits.
+    pub overflow_scroll: f32,
+
+    /// Buffer (seq, selection) and rect at the last cursor-follow of
+    /// `overflow_scroll` — the follow runs when these change, leaving a
+    /// wheel scroll free to move the cursor out of view.
+    overflow_follow: (usize, (Grapheme, Grapheme), Rect),
+
     /// Momentum from the last scroll-area frame; used by `will_consume_touch`
     /// to block touch cursor placement during momentum scroll.
     pub scroll_area_velocity: Vec2,
@@ -290,6 +300,8 @@ impl MdEdit {
             pending_block_move: None,
             pending_scroll: None,
             single_line_scroll: 0.0,
+            overflow_scroll: 0.0,
+            overflow_follow: (0, Default::default(), Rect::ZERO),
             scroll_area_velocity: Default::default(),
             file_id,
             emoji_completions: Default::default(),
@@ -742,6 +754,8 @@ impl Editor {
                 pending_block_move: None,
                 pending_scroll: None,
                 single_line_scroll: 0.0,
+                overflow_scroll: 0.0,
+                overflow_follow: (0, Default::default(), Rect::ZERO),
                 scroll_area_velocity: Default::default(),
                 file_id,
                 emoji_completions: Default::default(),

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -241,6 +241,9 @@ impl MdEdit {
         self.handle_block_drag(ui);
         self.post_render(ui, rect, id, pre);
         self.draw_dragged_overlay(ui, root);
+        if overflow > 0.0 {
+            self.show_overflow_scrollbar(ui, rect, id, height, overflow);
+        }
 
         // Keep the cursor inside the rect: fragments (and so `cursor_line`)
         // are in shifted screen coords, so edge overshoot maps 1:1 onto a
@@ -294,6 +297,58 @@ impl MdEdit {
                 ui.ctx().request_repaint();
             }
         }
+    }
+
+    /// Overlay scrollbar on the right edge of an overflowing bounded field,
+    /// styled after the document scroll area's bar. Same semantics too: a
+    /// thumb grab drags relatively; any other press jumps the thumb to the
+    /// pointer.
+    fn show_overflow_scrollbar(
+        &mut self, ui: &mut Ui, rect: Rect, id: Id, height: f32, overflow: f32,
+    ) {
+        const BAR_WIDTH: f32 = 10.0;
+        const BAR_INSET: f32 = 3.0;
+        const MIN_THUMB: f32 = 12.0;
+        let track = Rect::from_min_max(
+            Pos2::new(rect.max.x - BAR_WIDTH - BAR_INSET, rect.min.y),
+            Pos2::new(rect.max.x - BAR_INSET, rect.max.y),
+        );
+        let thumb_h = (track.height() * rect.height() / height).max(MIN_THUMB);
+        let movable = track.height() - thumb_h;
+        let thumb_at = |scroll: f32| {
+            Rect::from_min_size(
+                Pos2::new(track.min.x, track.min.y + movable * (scroll / overflow)),
+                egui::Vec2::new(track.width(), thumb_h),
+            )
+        };
+
+        // Registered after the field's own interact so the bar wins the strip.
+        let resp = ui.interact(track, id.with("overflow_scrollbar"), Sense::click_and_drag());
+        if movable > 0.0 {
+            if let Some(pos) = resp.interact_pointer_pos() {
+                let on_thumb = thumb_at(self.overflow_scroll).contains(pos);
+                if (resp.drag_started() || resp.clicked()) && !on_thumb {
+                    let target = (pos.y - track.min.y - thumb_h / 2.0).clamp(0.0, movable);
+                    self.overflow_scroll = target / movable * overflow;
+                } else if resp.dragged() && !resp.drag_started() {
+                    self.overflow_scroll = (self.overflow_scroll
+                        + resp.drag_delta().y / movable * overflow)
+                        .clamp(0.0, overflow);
+                }
+                ui.ctx().request_repaint();
+            }
+        }
+
+        let theme = ui.ctx().get_lb_theme();
+        let track_color = theme.neutral_bg().lerp_to_gamma(theme.neutral(), 0.3);
+        ui.painter().rect_filled(track, 3.0, track_color);
+        ui.painter().rect(
+            thumb_at(self.overflow_scroll),
+            3.0,
+            theme.neutral(),
+            Stroke::NONE,
+            egui::epaint::StrokeKind::Inside,
+        );
     }
 
     /// Consume the marker's [`BlockDragAction`] for the frame and, on

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -199,9 +199,22 @@ impl MdEdit {
         // `single_line_scroll` shifts the layout to keep the cursor in view.
         let layout_width = if self.renderer.single_line { 100_000.0 } else { rect.width() };
         self.renderer.set_width(layout_width);
-        let origin = rect.min - egui::vec2(self.single_line_scroll, 0.0);
         let arena = Arena::new();
         let root = self.renderer.reparse(&arena);
+
+        // A multi-line field shorter than its content (the chat composer at
+        // max height) scrolls vertically: wheel here, cursor-follow at the
+        // bottom of this fn. `height` is memoized — computing it early is free.
+        let height = self.renderer.height(root);
+        let overflow =
+            if self.renderer.single_line { 0.0 } else { (height - rect.height()).max(0.0) };
+        if overflow > 0.0 && ui.rect_contains_pointer(rect) {
+            let delta = ui.input_mut(|i| std::mem::take(&mut i.smooth_scroll_delta.y));
+            self.overflow_scroll -= delta;
+        }
+        self.overflow_scroll = self.overflow_scroll.clamp(0.0, overflow);
+
+        let origin = rect.min - egui::vec2(self.single_line_scroll, self.overflow_scroll);
         // Composer entry point (chat); no keyboard-state plumbing — image
         // taps there fall back to desktop/cmd gating via `touch_mode`.
         let pre = self.pre_render(ui, rect, id, root, false);
@@ -212,11 +225,10 @@ impl MdEdit {
         self.renderer.bounds.wrap_lines.clear();
         self.renderer.text_areas.clear();
         self.renderer.deco_lines.clear();
-        let height = self.renderer.height(root);
         let render_rect = Rect::from_min_size(rect.min, egui::Vec2::new(rect.width(), height));
         ui.scope_builder(UiBuilder::new().max_rect(render_rect), |ui| {
-            // Clip the (possibly overflowing) one-line layout to the field.
-            if self.renderer.single_line {
+            // Clip the (possibly overflowing) layout to the field.
+            if self.renderer.single_line || overflow > 0.0 {
                 ui.set_clip_rect(rect.intersect(ui.clip_rect()));
             }
             self.renderer.show_block(ui, root, origin);
@@ -251,6 +263,34 @@ impl MdEdit {
             let scroll = scroll.max(0.0);
             if scroll != self.single_line_scroll {
                 self.single_line_scroll = scroll;
+                ui.ctx().request_repaint();
+            }
+        }
+
+        // The same correction vertically for a bounded multi-line field, but
+        // only when the buffer / rect changed or a drag-selection is in
+        // flight — a wheel scroll can move the cursor out of view.
+        let follow =
+            (self.renderer.buffer.current.seq, self.renderer.buffer.current.selection, rect);
+        if !self.renderer.single_line
+            && (follow != self.overflow_follow || self.in_progress_selection.is_some())
+        {
+            self.overflow_follow = follow;
+            let sel_end = self
+                .in_progress_selection
+                .unwrap_or(self.renderer.buffer.current.selection)
+                .1;
+            let mut scroll = self.overflow_scroll;
+            if let Some([top, bot]) = self.cursor_line(sel_end) {
+                if bot.y > rect.bottom() {
+                    scroll += bot.y - rect.bottom();
+                } else if top.y < rect.top() {
+                    scroll -= rect.top() - top.y;
+                }
+            }
+            let scroll = scroll.clamp(0.0, overflow);
+            if scroll != self.overflow_scroll {
+                self.overflow_scroll = scroll;
                 ui.ctx().request_repaint();
             }
         }

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -1788,3 +1788,59 @@ fn masked_plaintext_mdedit_renders_glyphs() {
         edit.single_line_scroll
     );
 }
+
+/// The chat composer: a multi-line `MdEdit` in a height-capped rect must
+/// scroll vertically to keep the cursor in view instead of clipping it
+/// under the bottom edge.
+#[test]
+fn bounded_composer_scrolls_cursor_into_view() {
+    use crate::tab::markdown_editor::MdEdit;
+    use crate::theme::palette_v2::{Mode, Theme, ThemeExt as _};
+
+    let ctx = egui::Context::default();
+    let mut edit = MdEdit::empty(ctx.clone());
+    // Enough lines that a 140px-tall composer must overflow several times over.
+    let draft: String = (0..30).map(|i| format!("- line {i}\n")).collect();
+    edit.set_text(&draft);
+
+    let rect = egui::Rect::from_min_size(egui::pos2(100., 100.), egui::vec2(600., 140.));
+    let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::Vec2::new(800., 600.));
+    let frame = |edit: &mut MdEdit| {
+        let _ =
+            ctx.run(egui::RawInput { screen_rect: Some(screen), ..Default::default() }, |ctx| {
+                ctx.set_lb_theme(Theme::default(Mode::Dark));
+                crate::register_font_system(ctx);
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    edit.show(ui, rect, egui::Id::new("composer"));
+                });
+            });
+    };
+
+    let end = {
+        frame(&mut edit);
+        edit.renderer.buffer.current.segs.last_cursor_position()
+    };
+    edit.renderer.buffer.current.selection = (end, end);
+    for _ in 0..3 {
+        frame(&mut edit);
+    }
+    assert!(edit.overflow_scroll > 0.0, "overflowing composer did not scroll");
+    // `cursor_line` pads the fragment box by row_spacing/2 per side; the
+    // glyphs themselves must land inside the rect.
+    let slack = edit.renderer.layout.row_spacing / 2.0 + 0.5;
+    let [top, bot] = edit.cursor_line(end).unwrap();
+    assert!(
+        top.y >= rect.top() - slack && bot.y <= rect.bottom() + slack,
+        "caret line ({}..{}) outside composer {rect:?} at scroll {}",
+        top.y,
+        bot.y,
+        edit.overflow_scroll
+    );
+
+    // Cursor back at the top: the view follows back up.
+    edit.renderer.buffer.current.selection = (0.into(), 0.into());
+    for _ in 0..3 {
+        frame(&mut edit);
+    }
+    assert_eq!(edit.overflow_scroll, 0.0, "cursor at start should scroll back to the top");
+}

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -1036,6 +1036,12 @@ impl Workspace {
                             md.initialized = true;
                             md.id_salt = egui::Id::new("search_preview");
                         }
+                        // A chat's first frame would focus its composer,
+                        // stealing focus from the search query.
+                        #[cfg(not(target_family = "wasm"))]
+                        if let Some(chat) = tab.chat_mut() {
+                            chat.initialized = true;
+                        }
                     } else {
                         self.out.tabs_changed = true;
                     }

--- a/libs/lb/lb-rs/src/model/chat.rs
+++ b/libs/lb/lb-rs/src/model/chat.rs
@@ -61,6 +61,11 @@ pub struct ChatConfig {
     /// default where the model supports it; absent → the file default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
+    /// Config fields this client doesn't know about, preserved verbatim so a
+    /// merge performed by an older client can't strip them (mirrors
+    /// [`Message::extra`]).
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
 }
 
 /// A provider+model selection. `provider` names a provider config file
@@ -228,5 +233,20 @@ mod tests {
 
         assert!(merged.contains("\"reactions\":\"abc\""), "unknown field stripped: {merged}");
         assert!(merged.contains("\"agent\":true"));
+    }
+
+    /// Same guarantee one level down: unknown `config` fields survive an
+    /// older client's parse → merge → serialize.
+    #[test]
+    fn merge_preserves_unknown_config_fields() {
+        let base = line("a", "hello", 1);
+        let remote = base.clone()
+            + "{\"from\":\"b\",\"content\":\"\",\"ts\":2,\"config\":{\"scope\":[\"/x/\"],\"future_knob\":7}}\n";
+
+        let merged = Buffer::merge(base.as_bytes(), base.as_bytes(), remote.as_bytes());
+        let merged = String::from_utf8(merged).unwrap();
+
+        assert!(merged.contains("\"scope\":[\"/x/\"]"), "scope stripped: {merged}");
+        assert!(merged.contains("\"future_knob\":7"), "unknown config field stripped: {merged}");
     }
 }

--- a/libs/lb/lb-rs/src/model/chat.rs
+++ b/libs/lb/lb-rs/src/model/chat.rs
@@ -61,6 +61,12 @@ pub struct ChatConfig {
     /// default where the model supports it; absent → the file default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
+    /// The paths this chat's agent may read and edit when the model is
+    /// remote: folder roots (trailing '/') and single notes. The full list
+    /// is carried per entry; absent → no change, latest wins. Absent in
+    /// every entry → nothing granted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<Vec<String>>,
     /// Config fields this client doesn't know about, preserved verbatim so a
     /// merge performed by an older client can't strip them (mirrors
     /// [`Message::extra`]).


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4897, https://github.com/lockbook/lockbook/issues/4887, https://github.com/lockbook/lockbook/issues/4883

access control changes:
* shortcuts are now cmd+enter to allow or esc to deny
* agent gains access by requesting with a tool call; granted access sticks & can be reduced
* folders that start with `.`, including `.agent/`, are invisible to agents - they don't come up in list tool results unless specifically targeted and read/edit access is denied unless specifically requested/allowed
* local connections no longer receive special treatment w.r.t. permissions

<img width="3060" height="2124" alt="CleanShot 2026-07-15 at 18 17 30@2x" src="https://github.com/user-attachments/assets/b3b5764b-4837-476b-a461-1fe98ddd8ec2" />
