### PR TITLE
md: link preview refinements

### DIFF
--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -568,6 +568,8 @@ class WorkspaceView(
         const val SPEN_ACTION_UP = 212
 
         const val EDIT_ATOM_MENU_ID = 0x00E0170A // arbitrary; distinct from android.R.id.*
+        const val OPEN_LINK_MENU_ID = 0x00E0170B
+        const val COPY_LINK_MENU_ID = 0x00E0170C
     }
 
     inner class FloatingTextEditorContextMenu(
@@ -617,6 +619,9 @@ class WorkspaceView(
         private val textInputWrapper: WorkspaceTextInputWrapper,
         private val forAtom: Boolean = false,
     ) : ActionMode.Callback {
+        // URL under the selection when the menu was built; feeds "Copy Link"
+        private var openTarget: String? = null
+
         override fun onCreateActionMode(
             mode: ActionMode?,
             menu: Menu?,
@@ -635,8 +640,20 @@ class WorkspaceView(
         }
 
         private fun populateMenuWithItems(menu: Menu) {
+            // link (or wikilink/image) in the selection → offer open + copy
+            openTarget = Workspace.selectionOpenTarget(wgpuObj)
+            if (openTarget != null) {
+                menu
+                    .add(Menu.NONE, OPEN_LINK_MENU_ID, 0, "Open Link")
+                    .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+
+                menu
+                    .add(Menu.NONE, COPY_LINK_MENU_ID, 0, "Copy Link")
+                    .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+            }
+
             if (forAtom) {
-                // select the URL inside the image atom, revealing its source —
+                // select the URL inside the atom, revealing its source —
                 // the only touch path in, since mobile has no arrow keys
                 menu
                     .add(Menu.NONE, EDIT_ATOM_MENU_ID, 0, "Edit")
@@ -678,13 +695,29 @@ class WorkspaceView(
             item: MenuItem?,
         ): Boolean {
             if (item != null) {
-                if (item.itemId == EDIT_ATOM_MENU_ID) {
-                    Workspace.enterSelectedAtom(wgpuObj)
-                    // schedule the frame that processes the event, whose selection
-                    // update then flows back via `response.selectionUpdated`
-                    invalidate()
-                } else {
-                    textInputWrapper.wsInputConnection.performContextMenuAction(item.itemId)
+                when (item.itemId) {
+                    EDIT_ATOM_MENU_ID -> {
+                        Workspace.enterSelectedAtom(wgpuObj)
+                        // schedule the frame that processes the event, whose selection
+                        // update then flows back via `response.selectionUpdated`
+                        invalidate()
+                    }
+                    OPEN_LINK_MENU_ID -> {
+                        Workspace.openSelectionLinks(wgpuObj)
+                        // schedule the frame that processes the open, which flows
+                        // back via `response.urlOpened` / `response.selectedFile`
+                        invalidate()
+                    }
+                    COPY_LINK_MENU_ID -> {
+                        openTarget?.let {
+                            (
+                                context.getSystemService(Context.CLIPBOARD_SERVICE)
+                                    as ClipboardManager
+                            ).setPrimaryClip(ClipData.newPlainText("", it))
+                        }
+                    }
+                    else ->
+                        textInputWrapper.wsInputConnection.performContextMenuAction(item.itemId)
                 }
             }
 

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -709,16 +709,19 @@ class WorkspaceView(
                         // update then flows back via `response.selectionUpdated`
                         invalidate()
                     }
+
                     OPEN_LINK_MENU_ID -> {
                         Workspace.openSelectionLinks(wgpuObj)
                         // schedule the frame that processes the open, which flows
                         // back via `response.urlOpened` / `response.selectedFile`
                         invalidate()
                     }
+
                     REFRESH_PREVIEW_MENU_ID -> {
                         Workspace.refreshSelectionPreviews(wgpuObj)
                         invalidate()
                     }
+
                     COPY_LINK_MENU_ID -> {
                         openTarget?.let {
                             (
@@ -727,8 +730,10 @@ class WorkspaceView(
                             ).setPrimaryClip(ClipData.newPlainText("", it))
                         }
                     }
-                    else ->
+
+                    else -> {
                         textInputWrapper.wsInputConnection.performContextMenuAction(item.itemId)
+                    }
                 }
             }
 

--- a/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
+++ b/clients/android/app/src/main/java/app/lockbook/util/WorkspaceView.kt
@@ -570,6 +570,7 @@ class WorkspaceView(
         const val EDIT_ATOM_MENU_ID = 0x00E0170A // arbitrary; distinct from android.R.id.*
         const val OPEN_LINK_MENU_ID = 0x00E0170B
         const val COPY_LINK_MENU_ID = 0x00E0170C
+        const val REFRESH_PREVIEW_MENU_ID = 0x00E0170D
     }
 
     inner class FloatingTextEditorContextMenu(
@@ -658,6 +659,12 @@ class WorkspaceView(
                 menu
                     .add(Menu.NONE, EDIT_ATOM_MENU_ID, 0, "Edit")
                     .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+
+                if (openTarget != null) {
+                    menu
+                        .add(Menu.NONE, REFRESH_PREVIEW_MENU_ID, 0, "Refresh Preview")
+                        .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+                }
             }
 
             if (!textInputWrapper.wsInputConnection.wsEditable
@@ -706,6 +713,10 @@ class WorkspaceView(
                         Workspace.openSelectionLinks(wgpuObj)
                         // schedule the frame that processes the open, which flows
                         // back via `response.urlOpened` / `response.selectedFile`
+                        invalidate()
+                    }
+                    REFRESH_PREVIEW_MENU_ID -> {
+                        Workspace.refreshSelectionPreviews(wgpuObj)
                         invalidate()
                     }
                     COPY_LINK_MENU_ID -> {

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -103,6 +103,7 @@ object Workspace {
     external fun enterSelectedAtom(rustObj: Long)
     external fun selectionOpenTarget(rustObj: Long): String?
     external fun openSelectionLinks(rustObj: Long)
+    external fun refreshSelectionPreviews(rustObj: Long)
     external fun setContactLinkedSites(rustObj: Long, value: Boolean)
 }
 

--- a/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
+++ b/clients/android/workspace/src/main/java/app/lockbook/workspace/Workspace.kt
@@ -101,6 +101,8 @@ object Workspace {
     external fun isPenOnlyDraw(rustObj: Long) : Boolean
     external fun insertTextAtCursor(rustObj: Long, text: String)
     external fun enterSelectedAtom(rustObj: Long)
+    external fun selectionOpenTarget(rustObj: Long): String?
+    external fun openSelectionLinks(rustObj: Long)
     external fun setContactLinkedSites(rustObj: Long, value: Boolean)
 }
 

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceView.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceView.swift
@@ -200,6 +200,7 @@ import SwiftUI
                     }
 
                     mtkView.onSelectionChanged = nil
+                    mtkView.onSelectionGeometryChanged = nil
                     mtkView.onTextChanged = nil
                     currentWrapper?.removeFromSuperview()
 
@@ -214,6 +215,7 @@ import SwiftUI
                     }
 
                     mtkView.onSelectionChanged = nil
+                    mtkView.onSelectionGeometryChanged = nil
                     mtkView.onTextChanged = nil
                     currentWrapper?.removeFromSuperview()
 

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1379,6 +1379,18 @@
             }
             return UIMenu(children: children)
         }
+
+        /// Anchor the menu to the selection's full footprint — the tapped
+        /// atom (image / preview) or word — so UIKit places it clear of the
+        /// content instead of flipping below the source point and covering it.
+        public func editMenuInteraction(
+            _: UIEditMenuInteraction, targetRectFor _: UIEditMenuConfiguration
+        ) -> CGRect {
+            guard let view, let range = view.selectedTextRange else { return .null }
+            let union = view.selectionRects(for: range)
+                .reduce(CGRect.null) { $0.union($1.rect) }
+            return union
+        }
     }
 
     // MARK: - iOSMTKViewDelegate

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1384,7 +1384,9 @@
                 children.insert(open, at: 0)
             }
             if let view, view.editMenuForAtom {
-                let edit = UIAction(title: "Edit") { [weak view] _ in
+                let edit = UIAction(
+                    title: "Edit", image: UIImage(systemName: "pencil")
+                ) { [weak view] _ in
                     guard let view else { return }
                     enter_selected_atom(view.wsHandle)
                     // schedule the frame that processes the event, whose selection

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -561,10 +561,15 @@
                 return
             }
 
+            // Replacing moves the caret; without the selection brackets UIKit
+            // keeps stale caret/selection geometry (the immediate draw
+            // swallows the frame's own selection_updated).
+            inputDelegate?.selectionWillChange(self)
             inputDelegate?.textWillChange(self)
             replace_text(wsHandle, range.c, text)
             mtkView.drawImmediately()
             inputDelegate?.textDidChange(self)
+            inputDelegate?.selectionDidChange(self)
         }
 
         public var selectedTextRange: UITextRange? {

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -119,11 +119,22 @@
                 }
             }
 
+            // The change already happened Rust-side by notify time, so pair
+            // will/did back-to-back — an unpaired `did` sometimes leaves
+            // UIKit's cached selection geometry (caret, handles) stale.
             mtkView.onSelectionChanged = { [weak self] in
+                self?.inputDelegate?.selectionWillChange(self)
                 self?.inputDelegate?.selectionDidChange(self)
             }
             mtkView.onTextChanged = { [weak self] in
+                self?.inputDelegate?.textWillChange(self)
                 self?.inputDelegate?.textDidChange(self)
+            }
+            // Geometry-only moves (scroll, embed loads): re-fetch rects with a
+            // bare `did` — the will/did pair resets the keyboard's QuickType
+            // context, and a per-frame reset flickers the suggestion bar.
+            mtkView.onSelectionGeometryChanged = { [weak self] in
+                self?.inputDelegate?.selectionDidChange(self)
             }
 
             // pan (iPad trackpad support)
@@ -1506,7 +1517,7 @@
                 }
 
                 if output.scroll_updated {
-                    mtkView.onSelectionChanged?()
+                    mtkView.onSelectionGeometryChanged?()
                 }
 
                 if output.text_updated, !mtkView.ignoreTextUpdate {
@@ -1711,6 +1722,7 @@
         // view hierarchy management
         var tabSwitchTask: (() -> Void)? // facilitates switching wrapper views in response to tab change
         var onSelectionChanged: (() -> Void)? // only populated when wrapper is markdown
+        var onSelectionGeometryChanged: (() -> Void)? // ditto; rects moved, selection didn't
         var onTextChanged: (() -> Void)? // also only populated when wrapper is markdown
         var ignoreSelectionUpdate = false // don't invoke corresponding handler when drawing immediately
         var ignoreTextUpdate = false // also don't invoke corresponding handler when drawing immediately

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1335,10 +1335,11 @@
 
     // MARK: - MdMenuDelegate
 
-    /// Augments the markdown edit menu: "Open Link" when the selection holds a
-    /// link or image (e.g. a tapped link-preview card or inline image), and
-    /// "Edit" when it's over a selected image atom — select the URL inside the
-    /// atom, revealing its source, since mobile has no arrow keys.
+    /// Augments the markdown edit menu: "Open Link" and "Copy Link" when the
+    /// selection holds a link or image (a tapped link, preview card/capsule,
+    /// or inline image), and "Edit" when it's over a selected atom — select
+    /// the URL inside the atom, revealing its source, since mobile has no
+    /// arrow keys.
     public class MdMenuDelegate: NSObject, UIEditMenuInteractionDelegate {
         weak var mtkView: iOSMTK?
         weak var view: MdView?
@@ -1349,7 +1350,14 @@
         ) -> UIMenu? {
             var children = suggestedActions
             if let wsHandle = mtkView?.wsHandle, let target = selection_open_target(wsHandle) {
+                let url = String(cString: target)
                 free_text(target)
+                let copy = UIAction(
+                    title: "Copy Link", image: UIImage(systemName: "link")
+                ) { _ in
+                    UIPasteboard.general.string = url
+                }
+                children.insert(copy, at: 0)
                 let open = UIAction(
                     title: "Open Link", image: UIImage(systemName: "arrow.up.forward.app")
                 ) { [weak self] _ in

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1392,6 +1392,15 @@
                     view.mtkView.setNeedsDisplay(view.mtkView.frame)
                 }
                 children.insert(edit, at: 0)
+
+                let refresh = UIAction(
+                    title: "Refresh Preview", image: UIImage(systemName: "arrow.clockwise")
+                ) { [weak view] _ in
+                    guard let view else { return }
+                    refresh_selection_previews(view.wsHandle)
+                    view.mtkView.setNeedsDisplay(view.mtkView.frame)
+                }
+                children.append(refresh)
             }
             return UIMenu(children: children)
         }

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -182,6 +182,37 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_enterSelectedAtom(
     obj.renderer.context.push_markdown_event(Event::EnterAtom);
 }
 
+/// URL (or wikilink target) of an openable link in the current selection, or
+/// null — gates and feeds the edit menu's "Open Link" / "Copy Link".
+#[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_selectionOpenTarget(
+    env: JNIEnv, _: JClass, obj: jlong,
+) -> jstring {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+    let target = obj
+        .workspace
+        .focused_mdedit_mut()
+        .and_then(|md| md.renderer.selection_open_target());
+    match target {
+        Some(url) => env
+            .new_string(url)
+            .expect("Couldn't create java string!")
+            .into_raw(),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Edit-menu "Open Link": open every link/image in the current selection.
+#[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_openSelectionLinks(
+    _env: JNIEnv, _: JClass, obj: jlong,
+) {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+    if let Some(md) = obj.workspace.focused_mdedit_mut() {
+        md.renderer.open_selection_links();
+    }
+}
+
 /// Push real IME visibility (from the Android inset listener) into the
 /// editor so touch long-press can pick drag-reorder vs text selection.
 #[no_mangle]

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -213,6 +213,18 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_openSelectionLinks(
     }
 }
 
+/// Edit-menu "Refresh Preview": re-fetch preview metadata for links in the
+/// current selection.
+#[no_mangle]
+pub extern "system" fn Java_app_lockbook_workspace_Workspace_refreshSelectionPreviews(
+    _env: JNIEnv, _: JClass, obj: jlong,
+) {
+    let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
+    if let Some(md) = obj.workspace.focused_mdedit_mut() {
+        md.renderer.refresh_selection_previews();
+    }
+}
+
 /// Push real IME visibility (from the Android inset listener) into the
 /// editor so touch long-press can pick drag-reorder vs text selection.
 #[no_mangle]

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -286,6 +286,17 @@ pub unsafe extern "C" fn open_selection_links(obj: *mut c_void) {
     }
 }
 
+/// Edit-menu "Refresh Preview": re-fetch preview metadata for links in the
+/// current selection.
+/// # Safety
+#[no_mangle]
+pub unsafe extern "C" fn refresh_selection_previews(obj: *mut c_void) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+    if let Some(md) = obj.workspace.focused_mdedit_mut() {
+        md.renderer.refresh_selection_previews();
+    }
+}
+
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn deinit_editor(obj: *mut c_void) {

--- a/libs/content/workspace/src/egress.rs
+++ b/libs/content/workspace/src/egress.rs
@@ -49,9 +49,12 @@ pub enum FetchError {
     /// The host answered 429/503 (or is still cooling down from one).
     /// `until` is the next desired retry time.
     RateLimited { until: Instant },
+    /// A bot wall: a challenge page (`cf-mitigated`) or 401/403. Another
+    /// user agent may pass, and the site's posture may change — eventually.
+    Blocked(String),
     /// Deterministic failure (blocked URL, 4xx, not HTML) — retrying won't help.
     Permanent(String),
-    /// Network-level failure (timeout, reset). Not currently retried.
+    /// Network-level failure (timeout, reset). Retryable after a backoff.
     Transient(String),
 }
 
@@ -59,7 +62,9 @@ impl fmt::Display for FetchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FetchError::RateLimited { .. } => write!(f, "rate limited"),
-            FetchError::Permanent(msg) | FetchError::Transient(msg) => write!(f, "{msg}"),
+            FetchError::Blocked(msg) | FetchError::Permanent(msg) | FetchError::Transient(msg) => {
+                write!(f, "{msg}")
+            }
         }
     }
 }
@@ -264,6 +269,28 @@ mod imp {
         _client: &reqwest::blocking::Client, url: &str, user_agent: &str,
     ) -> Result<String, FetchError> {
         let resp = open(url, user_agent)?;
+        // Cloudflare marks challenge pages explicitly; they otherwise look
+        // like a normal HTML response with a junk <title>.
+        if resp
+            .headers()
+            .get("cf-mitigated")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.eq_ignore_ascii_case("challenge"))
+        {
+            return Err(FetchError::Blocked("challenge page".into()));
+        }
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(FetchError::Blocked(format!("{}", status.as_u16())));
+        }
+        // Error pages ship a <title> too ("404 Not Found") — status first.
+        if !status.is_success() {
+            return Err(FetchError::Permanent(format!(
+                "{} {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("")
+            )));
+        }
         let is_html = resp
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
@@ -393,6 +420,28 @@ mod imp {
         client: &reqwest::Client, url: &str, user_agent: &str,
     ) -> Result<String, FetchError> {
         let resp = open(client, url, user_agent).await?;
+        // Cloudflare marks challenge pages explicitly; they otherwise look
+        // like a normal HTML response with a junk <title>.
+        if resp
+            .headers()
+            .get("cf-mitigated")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.eq_ignore_ascii_case("challenge"))
+        {
+            return Err(FetchError::Blocked("challenge page".into()));
+        }
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(FetchError::Blocked(format!("{}", status.as_u16())));
+        }
+        // Error pages ship a <title> too ("404 Not Found") — status first.
+        if !status.is_success() {
+            return Err(FetchError::Permanent(format!(
+                "{} {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("")
+            )));
+        }
         let is_html = resp
             .headers()
             .get(reqwest::header::CONTENT_TYPE)

--- a/libs/content/workspace/src/resolvers/image_embed.rs
+++ b/libs/content/workspace/src/resolvers/image_embed.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref as _;
 
-use egui::{Align2, Color32, CornerRadius, FontId, Pos2, Rect, Stroke, Ui, UiBuilder, Vec2};
+use egui::{Align2, Color32, CornerRadius, FontId, Pos2, Rect, Stroke, Ui, Vec2};
 use epaint::RectShape;
 use lb_rs::Uuid;
 
@@ -39,14 +39,14 @@ impl EmbedResolver for ImageEmbedResolver {
             ImageState::Loaded(texture_id) => {
                 // Paint only — interaction (open vs. select) is driven by the
                 // fragment's `Sense::click` scope via `handle_image_interactions`.
-                ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
-                    ui.painter().add(
-                        RectShape::filled(rect, rounding, Color32::WHITE).with_texture(
-                            texture_id,
-                            Rect { min: Pos2 { x: 0.0, y: 0.0 }, max: Pos2 { x: 1.0, y: 1.0 } },
-                        ),
-                    );
-                });
+                // No allocation: paint runs for off-screen neighbor rows too,
+                // and advancing the layout cursor there displaces siblings
+                // laid out after the editor (the mobile toolbar, #4892).
+                ui.painter()
+                    .add(RectShape::filled(rect, rounding, Color32::WHITE).with_texture(
+                        texture_id,
+                        Rect { min: Pos2 { x: 0.0, y: 0.0 }, max: Pos2 { x: 1.0, y: 1.0 } },
+                    ));
             }
             ImageState::Failed(message) => {
                 show_placeholder(ui, rect, Icon::NO_IMAGE, &message);

--- a/libs/content/workspace/src/tab/markdown_editor/fold.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/fold.rs
@@ -151,7 +151,7 @@ impl<'ast> MdRender {
             // iOS routes touches through `touch_consuming_rects` —
             // without this entry a tap on the chip would place the
             // cursor instead of reaching the expand handler below.
-            self.touch_consuming_rects.push(response.rect);
+            self.touch_consume_interaction(id);
 
             if response.hovered() {
                 ui.ctx()

--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -214,8 +214,8 @@ impl MdEdit {
         let frag = self.renderer.fragment_at_offset(offset)?;
         let x = self.renderer.fragment_x(frag, offset);
         let row_h = self.renderer.layout.row_height;
-        // A caret bordering a collapsed image (just before or just after it)
-        // spans the image's height.
+        // A caret bordering a collapsed embed (image or link card) spans the
+        // embed's height — it reads as one big glyph.
         let border_image = self.renderer.fragments.iter().find(|f| {
             matches!(f.content, FragmentContent::Embed { .. })
                 && (f.source_range.start() == offset || f.source_range.end() == offset)

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -1397,13 +1397,7 @@ impl Editor {
                         // the scrollbar (so taps on the bar don't).
                         let begun = self.edit.scroll_area.begin(ui);
 
-                        let pre = self.edit.pre_render(
-                            ui,
-                            canvas_rect,
-                            scroll_id,
-                            root,
-                            self.keyboard_visible,
-                        );
+                        let pre = self.edit.pre_render(ui, canvas_rect, scroll_id, root);
 
                         self.edit.renderer.fragments.clear();
                         self.edit.renderer.block_boxes.clear();

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -940,12 +940,11 @@ impl Editor {
                 .edit
                 .in_progress_selection
                 .unwrap_or(self.edit.renderer.buffer.current.selection);
-        // Loads completing (embed textures, link-preview metadata) reflow
-        // layout, moving the selection's on-screen rects without a selection
-        // change — signal so iOS re-queries its native selection/caret rects.
-        // Likewise entering/leaving an atom: Edit on a capsule re-selects the
-        // same range, but the reveal swaps the capsule for its raw source.
-        resp.selection_updated |= embeds_updated
+        // Loads completing (embeds, link meta) and atom enter/exit reflow
+        // layout, moving the selection's rects without moving the selection.
+        // Report as a scroll: iOS re-fetches geometry on either signal, but a
+        // selection report also resets the keyboard's QuickType context.
+        resp.scroll_updated |= embeds_updated
             || link_meta_updated
             || prior_entered_atom != self.edit.renderer.entered_atom;
 

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -347,6 +347,9 @@ pub struct Editor {
     pub find: Find,
 
     // misc
+    /// Where the phone toolbar was allocated this frame — the layout-level
+    /// signal that embed painting hasn't dragged it off screen (#4892).
+    pub mobile_toolbar_rect: Option<egui::Rect>,
     pub virtual_keyboard_shown: bool,
     /// Real platform IME visibility, pushed by the client (Android inset
     /// listener, iOS keyboard callbacks). Unlike `virtual_keyboard_shown`
@@ -791,6 +794,7 @@ impl Editor {
             find: Default::default(),
 
             // this is used to toggle the mobile toolbar
+            mobile_toolbar_rect: None,
             virtual_keyboard_shown: cfg!(target_os = "android"),
             keyboard_visible: false,
             unprocessed_scroll: Default::default(),
@@ -1043,6 +1047,7 @@ impl Editor {
                     {
                         let (_, rect) =
                             ui.allocate_space(egui::vec2(available_width, MOBILE_TOOL_BAR_SIZE));
+                        self.mobile_toolbar_rect = Some(rect);
                         ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
                             self.show_toolbar(root, ui);
                         });

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -133,6 +133,9 @@ pub struct MdRender {
     /// Per-frame, keyed by `ui.id().with(salt)`; populated by
     /// `interact_fragments`, consumed by handlers in each node type.
     pub interaction_responses: std::collections::HashMap<egui::Id, egui::Response>,
+    /// Per-scope interact rects behind `interaction_responses`, whose merged
+    /// rect is only a bounding box; read by `touch_consume_interaction`.
+    pub interaction_rects: std::collections::HashMap<egui::Id, Vec<Rect>>,
     /// Spoilers the user has tapped to reveal. Persistent across frames;
     /// cleared by `bump_text_seq` whenever the doc text changes so a
     /// fresh edit re-hides every spoiler.
@@ -474,6 +477,7 @@ impl MdRender {
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
             interaction_responses: Default::default(),
+            interaction_rects: Default::default(),
             revealed_spoilers: Default::default(),
             in_progress_selection: None,
             in_progress_block_drag: None,
@@ -548,6 +552,7 @@ impl MdRender {
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
             interaction_responses: Default::default(),
+            interaction_rects: Default::default(),
             revealed_spoilers: Default::default(),
             reveal_selection: None,
             entered_atom: None,
@@ -705,6 +710,7 @@ impl Editor {
             render_events: Vec::new(),
             touch_consuming_rects: Default::default(),
             interaction_responses: Default::default(),
+            interaction_rects: Default::default(),
             revealed_spoilers: Default::default(),
 
             in_progress_selection: None,

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -278,6 +278,11 @@ pub struct MdEdit {
     /// File link / wikilink / image-link completion popup (`[[`, `[`, `![`).
     pub link_completions: LinkCompletions,
 
+    /// The link-like node under the last desktop right-click, captured when
+    /// the click lands so the context menu's link section stays stable while
+    /// the menu is open and the pointer moves.
+    pub context_menu_link: Option<widget::inline::link::LinkMenuTarget>,
+
     /// Owns the per-row scroll state (offset, momentum) and renders
     /// the scrollbar. `id_salt` derived from `file_id` at construction.
     pub scroll_area: AffineScrollArea<DocRowId>,
@@ -311,6 +316,7 @@ impl MdEdit {
             file_id,
             emoji_completions: Default::default(),
             link_completions: Default::default(),
+            context_menu_link: None,
             scroll_area: AffineScrollArea::new(file_id),
         }
     }
@@ -768,6 +774,7 @@ impl Editor {
                 file_id,
                 emoji_completions: Default::default(),
                 link_completions: Default::default(),
+                context_menu_link: None,
                 scroll_area: AffineScrollArea::new(file_id),
             },
 

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -167,6 +167,24 @@ impl MdEdit {
             });
         }
 
+        self.sync_reveal_selection(ctx, id, prior_entered_atom);
+        self.renderer.search_range = self
+            .emoji_completions
+            .search_term_range
+            .or(self.link_completions.search_term_range);
+
+        buf_resp
+    }
+
+    /// Sync `reveal_selection` to the buffer selection, bumping `reveal_seq`
+    /// (and requesting a repaint) when it or `entered_atom` changed. Runs in
+    /// `handle_input` and again after [`Self::pre_render`] applies
+    /// pointer/tap ops, so the frame that reports a selection change also
+    /// paints its reveal — iOS queries caret and selection geometry
+    /// synchronously on that report.
+    fn sync_reveal_selection(
+        &mut self, ctx: &Context, id: Id, prior_entered_atom: Option<(Grapheme, Grapheme)>,
+    ) {
         let new_reveal_selection = (!self.renderer.readonly && ctx.memory(|m| m.has_focus(id)))
             .then_some(self.renderer.buffer.current.selection);
         if self.renderer.reveal_selection != new_reveal_selection
@@ -179,12 +197,6 @@ impl MdEdit {
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             ctx.request_repaint();
         }
-        self.renderer.search_range = self
-            .emoji_completions
-            .search_term_range
-            .or(self.link_completions.search_term_range);
-
-        buf_resp
     }
 
     /// Draw the document inline at `rect`: pointer + context menu via
@@ -606,6 +618,7 @@ impl MdEdit {
     ) -> PreRenderState {
         self.renderer.dark_mode = ui.style().visuals.dark_mode;
         self.renderer.viewport_height = ui.clip_rect().height();
+        let prior_entered_atom = self.renderer.entered_atom;
 
         ui.ctx().check_for_id_clash(id, rect, "");
         let prev_focused = ui.memory(|m| m.has_focus(id));
@@ -831,9 +844,10 @@ impl MdEdit {
         self.renderer.buffer.queue(ops);
         self.renderer.buffer.update();
         // Pointer only emits Select ops (no text change), so no re-parse
-        // needed. A pointer-driven selection change means reveal_ranges (set
-        // in handle_input) reflects the pre-click selection — the new
-        // selection appears in reveal_ranges next frame. Accepted lag.
+        // needed — but reveal must reflect the applied ops (and any
+        // `entered_atom` a menu "Edit" set) in this frame's paint: iOS
+        // queries geometry as soon as the change is reported.
+        self.sync_reveal_selection(ui.ctx(), id, prior_entered_atom);
 
         self.renderer.in_progress_selection = self.in_progress_selection;
 

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -215,9 +215,8 @@ impl MdEdit {
         self.overflow_scroll = self.overflow_scroll.clamp(0.0, overflow);
 
         let origin = rect.min - egui::vec2(self.single_line_scroll, self.overflow_scroll);
-        // Composer entry point (chat); no keyboard-state plumbing — image
-        // taps there fall back to desktop/cmd gating via `touch_mode`.
-        let pre = self.pre_render(ui, rect, id, root, false);
+        // Composer entry point (chat).
+        let pre = self.pre_render(ui, rect, id, root);
 
         self.renderer.fragments.clear();
         self.renderer.block_boxes.clear();
@@ -603,7 +602,6 @@ impl MdEdit {
     /// selection. Returns the focus state for [`MdEdit::post_render`].
     pub fn pre_render<'a>(
         &mut self, ui: &mut Ui, rect: Rect, id: Id, root: &'a comrak::nodes::AstNode<'a>,
-        keyboard_visible: bool,
     ) -> PreRenderState {
         self.renderer.dark_mode = ui.style().visuals.dark_mode;
         self.renderer.viewport_height = ui.clip_rect().height();
@@ -636,10 +634,11 @@ impl MdEdit {
 
         let mut ops = Vec::new();
 
-        // image / card taps → open (cmd / keyboard-hidden) or select
-        self.handle_image_interactions(root, ui, id, keyboard_visible, &mut ops);
-        self.handle_card_interactions(root, ui, id, keyboard_visible, &mut ops);
-        self.handle_link_capsule_interactions(root, ui, id, keyboard_visible, &mut ops);
+        // image / card / link taps → open (cmd) or select + menu (touch)
+        self.handle_image_interactions(root, ui, id, &mut ops);
+        self.handle_card_interactions(root, ui, id, &mut ops);
+        self.handle_link_capsule_interactions(root, ui, id, &mut ops);
+        self.handle_link_menu_taps(root, ui, id, &mut ops);
 
         // --- context menu (desktop only) -------------------------------------
         ui.ctx()

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -29,6 +29,7 @@ use super::MdEdit;
 use super::input::cursor::SELECTION_HANDLE_HEIGHT;
 use super::input::{Bound, Event, Location, Region};
 use super::widget::block::drag::{BlockBox, BlockDragAction, TouchReorder};
+use super::widget::inline::link::{LinkMenuAction, link_menu_buttons};
 
 /// Hand-off between [`MdEdit::pre_render`] and [`MdEdit::post_render`].
 pub struct PreRenderState {
@@ -650,9 +651,23 @@ impl MdEdit {
         ui.ctx()
             .style_mut(|s| s.visuals.window_stroke = Stroke::NONE);
         if !cfg!(target_os = "ios") && !cfg!(target_os = "android") {
+            // Capture the link under the click when it lands, so the menu's
+            // link section stays stable while the pointer moves over it.
+            if response.secondary_clicked() {
+                self.context_menu_link = response
+                    .interact_pointer_pos()
+                    .and_then(|pos| self.link_target_at_pos(root, pos));
+            }
+            let link_target = self.context_menu_link.clone();
+            let mut link_action = None;
+
             let readonly = self.renderer.readonly;
             let mut menu_events: Vec<Event> = Vec::new();
             response.context_menu(|ui| {
+                if let Some(t) = &link_target {
+                    link_action = link_menu_buttons(ui, t.is_image, !readonly);
+                    ui.separator();
+                }
                 ui.horizontal(|ui| {
                     ui.set_min_height(30.);
                     ui.style_mut().spacing.button_padding = egui::vec2(5.0, 5.0);
@@ -687,6 +702,31 @@ impl MdEdit {
                     }
                 });
             });
+            if let (Some(action), Some(t)) = (link_action, &link_target) {
+                match action {
+                    LinkMenuAction::Open => {
+                        if t.is_wikilink {
+                            if let Some(file_id) = self.renderer.resolve_wikilink(&t.url) {
+                                ui.ctx().open_file(file_id, true);
+                            }
+                        } else {
+                            self.renderer.open_resolved_link(&t.url, ui.ctx());
+                        }
+                    }
+                    LinkMenuAction::Copy => ui.ctx().copy_text(t.url.clone()),
+                    LinkMenuAction::Edit => {
+                        if t.force_reveal {
+                            self.renderer.entered_atom = Some(t.node_range);
+                        }
+                        menu_events.push(Event::Select {
+                            region: Region::BetweenLocations {
+                                start: Location::Grapheme(t.select.start()),
+                                end: Location::Grapheme(t.select.end()),
+                            },
+                        });
+                    }
+                }
+            }
             for ev in menu_events {
                 self.calc_operations(ui.ctx(), root, ev, &mut ops);
             }

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -678,7 +678,8 @@ impl MdEdit {
             let mut menu_events: Vec<Event> = Vec::new();
             response.context_menu(|ui| {
                 if let Some(t) = &link_target {
-                    link_action = link_menu_buttons(ui, t.is_image, !readonly);
+                    // plain links never render a preview — nothing to refresh
+                    link_action = link_menu_buttons(ui, t.is_image, !readonly, false);
                     ui.separator();
                 }
                 ui.horizontal(|ui| {
@@ -727,6 +728,7 @@ impl MdEdit {
                         }
                     }
                     LinkMenuAction::Copy => ui.ctx().copy_text(t.url.clone()),
+                    LinkMenuAction::Refresh => self.renderer.refresh_link_meta(&t.url),
                     LinkMenuAction::Edit => {
                         if t.force_reveal {
                             self.renderer.entered_atom = Some(t.node_range);

--- a/libs/content/workspace/src/tab/markdown_editor/tests/harness.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/harness.rs
@@ -194,7 +194,13 @@ impl EmbedResolver for TestEmbeds {
     fn is_loaded(&self, url: &str) -> bool {
         self.sizes.lock().unwrap().contains_key(url)
     }
-    fn show(&self, _ui: &mut Ui, _url: &str, _rect: Rect, _rounding: egui::CornerRadius) {}
+    /// Worst-case resolver: allocates its rect. Real resolvers are paint-only,
+    /// but callers must survive an allocating one — embeds paint for
+    /// off-screen neighbor rows, where an allocation drags the layout cursor
+    /// off the viewport (#4892). Callers pass a non-advancing child ui.
+    fn show(&self, ui: &mut Ui, _url: &str, rect: Rect, _rounding: egui::CornerRadius) {
+        ui.allocate_rect(rect, egui::Sense::hover());
+    }
     fn prefetch(&self, _url: &str) {}
     fn seq(&self) -> u64 {
         self.seq.load(Ordering::Relaxed)

--- a/libs/content/workspace/src/tab/markdown_editor/tests/link_card.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/link_card.rs
@@ -342,6 +342,7 @@ fn rate_limited_meta_degrades_and_gates_refetch() {
     let mut ws = TestEditor::new("https://example.com\n");
     let arc = Arc::new(Mutex::new(LinkMetaState::Failed {
         retry_at: Some(web_time::Instant::now() + std::time::Duration::from_secs(60)),
+        attempts: 1,
     }));
     ws.editor
         .edit
@@ -355,7 +356,8 @@ fn rate_limited_meta_degrades_and_gates_refetch() {
 
     // Timestamp lapses, but fetching is off (the default): the entry must be
     // left untouched — no Loading swap-in, no spawned request.
-    *arc.lock().unwrap() = LinkMetaState::Failed { retry_at: Some(web_time::Instant::now()) };
+    *arc.lock().unwrap() =
+        LinkMetaState::Failed { retry_at: Some(web_time::Instant::now()), attempts: 1 };
     ws.enter_frame();
     let entry = ws.editor.edit.renderer.layout_cache.link_meta.borrow()[url].clone();
     assert!(Arc::ptr_eq(&arc, &entry), "fetching off: expired retry_at doesn't refetch");

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -2176,14 +2176,18 @@ fn phone_toolbar_never_pushed_off_screen() {
 
     let mut md = String::new();
     for i in 0..10 {
+        md.push_str(&format!("## section {i}\n\n"));
         md.push_str(&format!("paragraph {i} with a line of text\n\nhttps://example{i}.com\n\n"));
         // mid-sentence capsule; the long seeded title wraps it across rows
         md.push_str(&format!(
             "some leading words then https://inline{i}.example.com and trailing text to wrap\n\n"
         ));
+        md.push_str(&format!("![an image](https://img{i}.example.com/i.png)\n\n"));
     }
 
     let files = Arc::new(RwLock::new(FileCache::empty()));
+    // The canary resolver allocates in `show` — the worst-case embed painter.
+    let embeds = Arc::new(super::harness::TestEmbeds::default());
     let mut editor = super::super::Editor::new(
         &md,
         Uuid::new_v4(),
@@ -2197,7 +2201,7 @@ fn phone_toolbar_never_pushed_off_screen() {
                 true,
             ),
             link_resolver: Box::new(super::harness::TestLinks),
-            embeds: Box::new(()),
+            embeds: Box::new(embeds.clone()),
             files,
         },
         super::super::MdConfig { readonly: false, ext: "md".into(), tablet_or_desktop: false },
@@ -2220,6 +2224,7 @@ fn phone_toolbar_never_pushed_off_screen() {
                          card body so every card is several rows tall"
                             .into(),
                     ),
+                    thumbnail_url: Some(format!("https://example{i}.com/hero.png")),
                     ..Default::default()
                 }))),
             );
@@ -2235,13 +2240,26 @@ fn phone_toolbar_never_pushed_off_screen() {
                     title: format!(
                         "a sufficiently long inline preview title number {i} that wraps"
                     ),
+                    favicon_url: Some(format!("https://inline{i}.example.com/favicon.ico")),
                     ..Default::default()
                 }))),
             );
+        // mark every texture loaded so the canary's `show` actually runs
+        for url in [
+            format!("https://example{i}.com/hero.png"),
+            format!("https://inline{i}.example.com/favicon.ico"),
+            format!("https://img{i}.example.com/i.png"),
+        ] {
+            embeds.complete(&url, egui::Vec2::new(200.0, 150.0));
+        }
     }
+    // favicons/capsules only render with link fetching on; all metadata is
+    // seeded above, so no request actually leaves the test
+    editor.persistence.set_contact_linked_sites(true);
     editor.virtual_keyboard_shown = true;
 
     let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::Vec2::new(390., 700.));
+    let frames_run = std::cell::Cell::new(0u32);
     let frame = |editor: &mut super::super::Editor, events: Vec<egui::Event>| -> (f32, f32) {
         let mut content = (f32::NAN, f32::NAN);
         let _ = ctx.run(
@@ -2256,6 +2274,17 @@ fn phone_toolbar_never_pushed_off_screen() {
                 });
             },
         );
+        // The layout-level signal: embed painting (which runs for off-screen
+        // neighbor rows) must never drag the toolbar allocation off screen.
+        // The first frames lay out before fonts/virtualization settle.
+        frames_run.set(frames_run.get() + 1);
+        if frames_run.get() > 4 {
+            let toolbar = editor.mobile_toolbar_rect.expect("toolbar allocated");
+            assert!(
+                toolbar.max.y <= screen.max.y + 0.5,
+                "toolbar allocated off screen: {toolbar:?} (#4892)"
+            );
+        }
         content
     };
 

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -2087,3 +2087,203 @@ fn selection_open_target_includes_wikilinks() {
     ws.enter_frame();
     assert_eq!(ws.editor.edit.renderer.selection_open_target().as_deref(), Some("todo"));
 }
+
+/// A caret bordering a collapsed embed — inline image or link preview card —
+/// spans the embed's full height: it reads as one big glyph. Pins the
+/// intermittent short-caret bug's fixed behavior.
+#[test]
+fn caret_bordering_embeds_spans_their_height() {
+    use std::sync::{Arc, Mutex};
+
+    use crate::tab::markdown_editor::widget::inline::link::meta::{LinkMeta, LinkMetaState};
+
+    // image: caret at the image's start spans its (test-embed 200pt) height
+    let (mut ws, _embeds) = TestEditor::with_test_embeds(
+        super::harness::build_lb(),
+        "![alt](https://example.com/i.png)\n",
+    );
+    ws.enter_frame();
+    let [top, bot] = ws.editor.edit.cursor_line((0).into()).expect("image caret");
+    let row_h = ws.editor.edit.renderer.layout.row_height;
+    assert!(
+        bot.y - top.y > 3.0 * row_h,
+        "caret bordering an image spans it: {} vs row {row_h}",
+        bot.y - top.y
+    );
+
+    // card: caret at the card's start spans the card
+    let mut ws = TestEditor::new("https://example.com\n");
+    ws.editor
+        .edit
+        .renderer
+        .layout_cache
+        .link_meta
+        .borrow_mut()
+        .insert(
+            "https://example.com".to_string(),
+            Arc::new(Mutex::new(LinkMetaState::Loaded(LinkMeta {
+                title: "Example Title".into(),
+                description: Some(
+                    "A description long enough to wrap onto multiple lines of the \
+                     card body, giving the card several rows of height beyond its \
+                     title so the guard below holds."
+                        .into(),
+                ),
+                ..Default::default()
+            }))),
+        );
+    ws.enter_frame();
+    ws.enter_frame();
+    let card = ws
+        .editor
+        .edit
+        .renderer
+        .fragments
+        .iter()
+        .find(|f| matches!(f.content, FragmentContent::Embed { .. }))
+        .expect("card embed fragment")
+        .rect;
+    let row_h = ws.editor.edit.renderer.layout.row_height;
+    assert!(card.height() > 3.0 * row_h, "card is tall: {}", card.height());
+    let [top, bot] = ws.editor.edit.cursor_line((0).into()).expect("card caret");
+    assert!(
+        bot.y - top.y >= card.height(),
+        "caret bordering a card spans it: {} vs card {}",
+        bot.y - top.y,
+        card.height()
+    );
+}
+
+/// Phone-mode layout (#4892): with link preview cards in the doc and the
+/// keyboard up, the editor content must not outgrow its allocation — the
+/// bottom toolbar is the next allocation, so any overflow pushes it off
+/// screen. Swept across scroll positions.
+#[test]
+fn phone_toolbar_never_pushed_off_screen() {
+    use std::sync::{Arc, Mutex, RwLock};
+
+    use lb_rs::Uuid;
+
+    use crate::file_cache::FileCache;
+    use crate::tab::markdown_editor::widget::inline::link::meta::{LinkMeta, LinkMetaState};
+    use crate::theme::palette_v2::{Mode, Theme, ThemeExt as _};
+    use crate::workspace::WsPersistentStore;
+
+    let lb = super::harness::build_lb();
+    let ctx = egui::Context::default();
+    ctx.set_os(egui::os::OperatingSystem::IOS);
+
+    let mut md = String::new();
+    for i in 0..10 {
+        md.push_str(&format!("paragraph {i} with a line of text\n\nhttps://example{i}.com\n\n"));
+    }
+
+    let files = Arc::new(RwLock::new(FileCache::empty()));
+    let mut editor = super::super::Editor::new(
+        &md,
+        Uuid::new_v4(),
+        None,
+        super::super::MdResources {
+            ctx: ctx.clone(),
+            core: lb,
+            persistence: WsPersistentStore::new(
+                false,
+                format!("/tmp/{}", Uuid::new_v4()).into(),
+                true,
+            ),
+            link_resolver: Box::new(super::harness::TestLinks),
+            embeds: Box::new(()),
+            files,
+        },
+        super::super::MdConfig { readonly: false, ext: "md".into(), tablet_or_desktop: false },
+    );
+    assert!(editor.edit.renderer.touch_mode, "touch mode");
+    assert!(editor.edit.phone_mode, "phone mode");
+    for i in 0..10 {
+        editor
+            .edit
+            .renderer
+            .layout_cache
+            .link_meta
+            .borrow_mut()
+            .insert(
+                format!("https://example{i}.com"),
+                Arc::new(Mutex::new(LinkMetaState::Loaded(LinkMeta {
+                    title: format!("Example {i}"),
+                    description: Some(
+                        "a description that adds a couple of wrapped lines to the \
+                         card body so every card is several rows tall"
+                            .into(),
+                    ),
+                    ..Default::default()
+                }))),
+            );
+    }
+    editor.virtual_keyboard_shown = true;
+
+    let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::Vec2::new(390., 700.));
+    let mut frame = |editor: &mut super::super::Editor, events: Vec<egui::Event>| -> (f32, f32) {
+        let mut content = (f32::NAN, f32::NAN);
+        let _ = ctx.run(
+            egui::RawInput { screen_rect: Some(screen), events, ..Default::default() },
+            |ctx| {
+                ctx.set_lb_theme(Theme::default(Mode::Dark));
+                crate::register_font_system(ctx);
+                editor.focus(ctx);
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    editor.show(ui);
+                    content = (ui.min_rect().max.y, ui.max_rect().max.y);
+                });
+            },
+        );
+        content
+    };
+
+    for _ in 0..4 {
+        frame(&mut editor, vec![]);
+    }
+
+    // Sweep scroll; every few steps park the cursor at a card boundary —
+    // the reported repro is cursor-near-preview — which also runs the
+    // scroll-to-cursor reveal against the caret rect.
+    let card_offsets: Vec<usize> = (0..10)
+        .map(|i| {
+            editor
+                .edit
+                .renderer
+                .buffer
+                .current
+                .text
+                .find(&format!("https://example{i}.com"))
+                .unwrap()
+        })
+        .collect();
+    let pointer = screen.center();
+    for step in 0..60 {
+        if step % 6 == 0 {
+            use crate::tab::ExtendedInput as _;
+            let offset: Grapheme = card_offsets[step / 6].into();
+            ctx.push_markdown_event(Event::Select {
+                region: Region::BetweenLocations {
+                    start: Location::Grapheme(offset),
+                    end: Location::Grapheme(offset),
+                },
+            });
+        }
+        let (bottom, allowed) = frame(
+            &mut editor,
+            vec![
+                egui::Event::PointerMoved(pointer),
+                egui::Event::MouseWheel {
+                    unit: egui::MouseWheelUnit::Point,
+                    delta: egui::vec2(0.0, -40.0),
+                    modifiers: Default::default(),
+                },
+            ],
+        );
+        assert!(
+            bottom <= allowed + 0.5,
+            "content bottom {bottom} exceeds allocation {allowed} at scroll step {step} (#4892)"
+        );
+    }
+}

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -2075,3 +2075,15 @@ fn touch_image_tap_selects_and_pops_menu() {
         "atom context menu popped: {menu:?}"
     );
 }
+
+/// `selection_open_target` gates the platform edit menu's "Open Link" /
+/// "Copy Link" — it must see wikilinks, not just links and images.
+#[test]
+fn selection_open_target_includes_wikilinks() {
+    let mut ws = TestEditor::new("a [[todo]] wikilink\n");
+    let link = ((2).into(), (10).into());
+    assert_eq!(&ws.editor.edit.renderer.buffer[link], "[[todo]]");
+    ws.push(Event::Select { region: link.into() });
+    ws.enter_frame();
+    assert_eq!(ws.editor.edit.renderer.selection_open_target().as_deref(), Some("todo"));
+}

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -1973,3 +1973,105 @@ fn wrapped_capsule_touch_region_matches_pill() {
         "tap after the preview must place the cursor (#4895)"
     );
 }
+
+/// Touch tap on a plain rendered link: selects the whole link and pops the
+/// `Atom` context menu ("Open Link" / "Edit" on the platform side) instead
+/// of opening the link or placing the cursor.
+#[test]
+fn touch_link_tap_selects_and_pops_menu() {
+    use crate::tab::{ContextMenuTarget, ExtendedOutput as _};
+
+    let mut ws = TestEditor::new("some [title](https://example.com) text\n");
+    ws.editor.edit.renderer.touch_mode = true;
+    // One frame to lay out with touch-mode scopes, one more because
+    // interaction runs against the previous frame's fragments.
+    ws.enter_frame();
+    ws.enter_frame();
+
+    let link = ((5).into(), (33).into());
+    assert_eq!(&ws.editor.edit.renderer.buffer[link], "[title](https://example.com)");
+    let frag = ws
+        .editor
+        .edit
+        .renderer
+        .fragments
+        .iter()
+        .find(|f| f.interaction.is_some() && f.source_range.start() >= link.0)
+        .expect("link interaction fragment");
+    let pos = frag.rect.center();
+
+    let modifiers = egui::Modifiers::default();
+    ws.enter_frame_with_input(vec![
+        egui::Event::PointerMoved(pos),
+        egui::Event::PointerButton {
+            pos,
+            button: egui::PointerButton::Primary,
+            pressed: true,
+            modifiers,
+        },
+        egui::Event::PointerButton {
+            pos,
+            button: egui::PointerButton::Primary,
+            pressed: false,
+            modifiers,
+        },
+    ]);
+
+    assert_eq!(ws.editor.edit.renderer.buffer.current.selection, link, "link selected");
+    let menu = ws.editor.edit.renderer.ctx.pop_context_menu();
+    assert!(
+        matches!(menu, Some((_, ContextMenuTarget::Atom))),
+        "atom context menu popped: {menu:?}"
+    );
+}
+
+/// Touch tap on a collapsed inline image: selects the atom and pops the
+/// `Atom` context menu — never opens the URL directly (opening moved into
+/// the menu's "Open Link").
+#[test]
+fn touch_image_tap_selects_and_pops_menu() {
+    use crate::tab::{ContextMenuTarget, ExtendedOutput as _};
+
+    let (mut ws, _embeds) = TestEditor::with_test_embeds(
+        super::harness::build_lb(),
+        "![alt](https://example.com/i.png)\n",
+    );
+    ws.editor.edit.renderer.touch_mode = true;
+    ws.enter_frame();
+    ws.enter_frame();
+
+    let img = ws.editor.edit.renderer.bounds.images[0];
+    let frag = ws
+        .editor
+        .edit
+        .renderer
+        .fragments
+        .iter()
+        .find(|f| matches!(f.content, FragmentContent::Embed { .. }))
+        .expect("image embed fragment");
+    let pos = frag.rect.center();
+
+    let modifiers = egui::Modifiers::default();
+    ws.enter_frame_with_input(vec![
+        egui::Event::PointerMoved(pos),
+        egui::Event::PointerButton {
+            pos,
+            button: egui::PointerButton::Primary,
+            pressed: true,
+            modifiers,
+        },
+        egui::Event::PointerButton {
+            pos,
+            button: egui::PointerButton::Primary,
+            pressed: false,
+            modifiers,
+        },
+    ]);
+
+    assert_eq!(ws.editor.edit.renderer.buffer.current.selection, img, "image selected");
+    let menu = ws.editor.edit.renderer.ctx.pop_context_menu();
+    assert!(
+        matches!(menu, Some((_, ContextMenuTarget::Atom))),
+        "atom context menu popped: {menu:?}"
+    );
+}

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -1844,3 +1844,94 @@ fn bounded_composer_scrolls_cursor_into_view() {
     }
     assert_eq!(edit.overflow_scroll, 0.0, "cursor at start should scroll back to the top");
 }
+
+/// A wrapped capsule's touch region matches its painted pill: a tap between
+/// the pill's own rows hits the pill (#4894), while taps beside or trailing
+/// it — inside the scope's bounding box — still place the cursor (#4895).
+#[test]
+fn wrapped_capsule_touch_region_matches_pill() {
+    use std::sync::{Arc, Mutex};
+
+    use egui::{Pos2, Rect, Vec2};
+
+    use crate::tab::markdown_editor::widget::inline::link::meta::{LinkMeta, LinkMetaState};
+
+    let mut ws = TestEditor::new("before https://example.com after\n");
+    ws.editor
+        .edit
+        .renderer
+        .layout_cache
+        .link_meta
+        .borrow_mut()
+        .insert(
+            "https://example.com".to_string(),
+            Arc::new(Mutex::new(LinkMetaState::Loaded(LinkMeta {
+                title: "a sufficiently long example title that wraps across rows".into(),
+                ..Default::default()
+            }))),
+        );
+    // Interaction runs against the previous frame's fragments, and the first
+    // frame after a resize still wraps at the old width — settle the layout.
+    let size = Vec2::new(300., 600.);
+    for _ in 0..3 {
+        ws.enter_frame_at(size);
+    }
+
+    // The capsule's fragments are the ones inside its chip style scope.
+    let chip_rects: Vec<Rect> = ws
+        .editor
+        .edit
+        .renderer
+        .fragments
+        .iter()
+        .filter(|f| f.style_stack.iter().any(|s| s.chip))
+        .map(|f| f.rect)
+        .collect();
+    assert!(!chip_rects.is_empty(), "capsule did not render");
+
+    let mut rows: Vec<Rect> = Vec::new();
+    for r in &chip_rects {
+        match rows
+            .iter_mut()
+            .find(|row| (row.min.y - r.min.y).abs() < 0.5)
+        {
+            Some(row) => *row = row.union(*r),
+            None => rows.push(*r),
+        }
+    }
+    rows.sort_by(|a, b| a.min.y.total_cmp(&b.min.y));
+    assert!(rows.len() >= 2, "capsule expected to wrap: {rows:?}");
+    let (first, second) = (rows[0], rows[1]);
+    assert!(first.max.y < second.min.y, "rows expected to be separated by row spacing");
+
+    // Taps on the capsule are consumed.
+    assert!(ws.editor.touches_interactive_element(first.center()));
+    assert!(ws.editor.touches_interactive_element(second.center()));
+
+    // Between the pill's own rows — visually on the button — the tap
+    // hits the pill (#4894), whether nearer the upper or lower row.
+    let gap_y = (first.max.y + second.min.y) / 2.0;
+    for y in [gap_y - 1.0, gap_y + 1.0] {
+        let gap = Pos2::new(second.center().x, y);
+        assert!(
+            ws.editor.touches_interactive_element(gap),
+            "tap between the pill's rows must hit the pill (#4894): {gap:?}"
+        );
+    }
+
+    // Beside the pill in the same gap band — lower half, right of the
+    // second row's end — there's no ink, so the tap places the cursor.
+    let beside = Pos2::new(second.max.x + 10.0, gap_y + 1.0);
+    assert!(
+        !ws.editor.touches_interactive_element(beside),
+        "tap beside the pill must place the cursor: {beside:?}"
+    );
+
+    // Trailing the capsule's last row segment: must also place the cursor.
+    let last = *rows.last().unwrap();
+    let after = Pos2::new(last.max.x + 10.0, last.center().y);
+    assert!(
+        !ws.editor.touches_interactive_element(after),
+        "tap after the preview must place the cursor (#4895)"
+    );
+}

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -2172,10 +2172,15 @@ fn phone_toolbar_never_pushed_off_screen() {
     let lb = super::harness::build_lb();
     let ctx = egui::Context::default();
     ctx.set_os(egui::os::OperatingSystem::IOS);
+    ctx.set_pixels_per_point(3.0); // fractional row geometry, like a real phone
 
     let mut md = String::new();
     for i in 0..10 {
         md.push_str(&format!("paragraph {i} with a line of text\n\nhttps://example{i}.com\n\n"));
+        // mid-sentence capsule; the long seeded title wraps it across rows
+        md.push_str(&format!(
+            "some leading words then https://inline{i}.example.com and trailing text to wrap\n\n"
+        ));
     }
 
     let files = Arc::new(RwLock::new(FileCache::empty()));
@@ -2214,6 +2219,21 @@ fn phone_toolbar_never_pushed_off_screen() {
                         "a description that adds a couple of wrapped lines to the \
                          card body so every card is several rows tall"
                             .into(),
+                    ),
+                    ..Default::default()
+                }))),
+            );
+        editor
+            .edit
+            .renderer
+            .layout_cache
+            .link_meta
+            .borrow_mut()
+            .insert(
+                format!("https://inline{i}.example.com"),
+                Arc::new(Mutex::new(LinkMetaState::Loaded(LinkMeta {
+                    title: format!(
+                        "a sufficiently long inline preview title number {i} that wraps"
                     ),
                     ..Default::default()
                 }))),
@@ -2285,5 +2305,98 @@ fn phone_toolbar_never_pushed_off_screen() {
             bottom <= allowed + 0.5,
             "content bottom {bottom} exceeds allocation {allowed} at scroll step {step} (#4892)"
         );
+    }
+    // ...and back up — the reported repro is upward scroll near wrapped
+    // inline previews.
+    for step in 0..80 {
+        if step % 8 == 0 {
+            use crate::tab::ExtendedInput as _;
+            let offset: Grapheme = card_offsets[step / 8].into();
+            ctx.push_markdown_event(Event::Select {
+                region: Region::BetweenLocations {
+                    start: Location::Grapheme(offset),
+                    end: Location::Grapheme(offset),
+                },
+            });
+        }
+        let (bottom, allowed) = frame(
+            &mut editor,
+            vec![
+                egui::Event::PointerMoved(pointer),
+                egui::Event::MouseWheel {
+                    unit: egui::MouseWheelUnit::Point,
+                    delta: egui::vec2(0.0, 35.0),
+                    modifiers: Default::default(),
+                },
+            ],
+        );
+        assert!(
+            bottom <= allowed + 0.5,
+            "content bottom {bottom} exceeds allocation {allowed} at up-scroll step {step} (#4892)"
+        );
+    }
+
+    // Touch-drag scrolling exercises AffineScrollArea's touch + momentum
+    // path (not the wheel path); drag in both directions with pauses so
+    // momentum runs between gestures.
+    for dir in [-1.0f32, 1.0] {
+        for gesture in 0..6 {
+            let y0 = 400.0;
+            let steps = 8;
+            let dy = 30.0 * dir;
+            let mk = |phase: egui::TouchPhase, pos: egui::Pos2| egui::Event::Touch {
+                device_id: egui::TouchDeviceId(0),
+                id: egui::TouchId(gesture as u64),
+                phase,
+                pos,
+                force: None,
+            };
+            let p0 = egui::Pos2::new(200.0, y0);
+            frame(
+                &mut editor,
+                vec![
+                    mk(egui::TouchPhase::Start, p0),
+                    egui::Event::PointerMoved(p0),
+                    egui::Event::PointerButton {
+                        pos: p0,
+                        button: egui::PointerButton::Primary,
+                        pressed: true,
+                        modifiers: Default::default(),
+                    },
+                ],
+            );
+            for i in 1..=steps {
+                let p = egui::Pos2::new(200.0, y0 + dy * i as f32);
+                let (bottom, allowed) = frame(
+                    &mut editor,
+                    vec![mk(egui::TouchPhase::Move, p), egui::Event::PointerMoved(p)],
+                );
+                assert!(
+                    bottom <= allowed + 0.5,
+                    "content bottom {bottom} exceeds allocation {allowed} mid-drag (#4892)"
+                );
+            }
+            let p_end = egui::Pos2::new(200.0, y0 + dy * steps as f32);
+            frame(
+                &mut editor,
+                vec![
+                    mk(egui::TouchPhase::End, p_end),
+                    egui::Event::PointerButton {
+                        pos: p_end,
+                        button: egui::PointerButton::Primary,
+                        pressed: false,
+                        modifiers: Default::default(),
+                    },
+                ],
+            );
+            // let momentum play out
+            for _ in 0..10 {
+                let (bottom, allowed) = frame(&mut editor, vec![]);
+                assert!(
+                    bottom <= allowed + 0.5,
+                    "content bottom {bottom} exceeds allocation {allowed} in momentum (#4892)"
+                );
+            }
+        }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -2222,7 +2222,7 @@ fn phone_toolbar_never_pushed_off_screen() {
     editor.virtual_keyboard_shown = true;
 
     let screen = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::Vec2::new(390., 700.));
-    let mut frame = |editor: &mut super::super::Editor, events: Vec<egui::Event>| -> (f32, f32) {
+    let frame = |editor: &mut super::super::Editor, events: Vec<egui::Event>| -> (f32, f32) {
         let mut content = (f32::NAN, f32::NAN);
         let _ = ctx.run(
             egui::RawInput { screen_rect: Some(screen), events, ..Default::default() },

--- a/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/tests/regressions.rs
@@ -144,6 +144,44 @@ fn enter_atom_selects_image_url() {
     assert!(ws.editor.edit.renderer.range_revealed_interior(img), "source revealed");
 }
 
+/// Mobile edit-menu "Edit" on a labeled link: with the selection exactly
+/// covering `[title](url)`, `Event::EnterAtom` selects the destination —
+/// the hidden part, mirroring [`enter_atom_selects_image_url`].
+#[test]
+fn enter_atom_selects_link_destination() {
+    let url = "https://example.com";
+    let mut ws = TestEditor::new(&format!("some [title]({url}) text\n"));
+    ws.enter_frame();
+
+    let link = ((5).into(), (14 + url.len()).into());
+    assert_eq!(&ws.editor.edit.renderer.buffer[link], format!("[title]({url})"));
+    ws.push(Event::Select { region: link.into() });
+    ws.enter_frame();
+    ws.push(Event::EnterAtom);
+    ws.enter_frame();
+
+    let sel = ws.editor.edit.renderer.buffer.current.selection;
+    assert_eq!(&ws.editor.edit.renderer.buffer[sel], url, "destination selected: {sel:?}");
+}
+
+/// Mobile edit-menu "Edit" on a wikilink: with the selection exactly covering
+/// `[[target]]`, `Event::EnterAtom` selects the interior.
+#[test]
+fn enter_atom_selects_wikilink_interior() {
+    let mut ws = TestEditor::new("some [[target]] text\n");
+    ws.enter_frame();
+
+    let link = ((5).into(), (15).into());
+    assert_eq!(&ws.editor.edit.renderer.buffer[link], "[[target]]");
+    ws.push(Event::Select { region: link.into() });
+    ws.enter_frame();
+    ws.push(Event::EnterAtom);
+    ws.enter_frame();
+
+    let sel = ws.editor.edit.renderer.buffer.current.selection;
+    assert_eq!(&ws.editor.edit.renderer.buffer[sel], "target", "interior selected: {sel:?}");
+}
+
 #[test]
 fn long_link_stays_inside_render_area() {
     // Long links should wrap at UAX#14 break opportunities (`/`,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/block/leaf/heading.rs
@@ -434,7 +434,11 @@ impl<'ast> MdRender {
         self.touch_consuming_rects.push(space);
 
         if self.fold(node).is_some() {
-            ui.scope_builder(UiBuilder::new().max_rect(space), |ui| {
+            // Non-advancing child: this paints for off-screen neighbor rows
+            // too, and advancing the layout cursor there displaces siblings
+            // laid out after the editor (the mobile toolbar, #4892).
+            let ui = &mut ui.new_child(UiBuilder::new().max_rect(space));
+            {
                 let theme = self.ctx.get_lb_theme();
                 let icon = Icon::CHEVRON_RIGHT.size(icon_size).color(if fold_reveal {
                     theme.neutral_fg_secondary()
@@ -449,9 +453,10 @@ impl<'ast> MdRender {
                 {
                     self.apply_fold(node, contents, true);
                 }
-            });
+            }
         } else if self.foldable(node).is_some() {
-            ui.scope_builder(UiBuilder::new().max_rect(space), |ui| {
+            let ui = &mut ui.new_child(UiBuilder::new().max_rect(space));
+            {
                 let icon = Icon::CHEVRON_DOWN
                     .size(icon_size)
                     .color(self.ctx.get_lb_theme().neutral_fg_secondary());
@@ -463,7 +468,7 @@ impl<'ast> MdRender {
                 {
                     self.apply_fold(node, contents, false);
                 }
-            });
+            }
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -166,7 +166,7 @@ impl<'ast> MdEdit {
     /// Shared tap handling for one embed fragment (inline image, link card, or
     /// capsule): when `open`, a click opens `url`, else it selects `node_range`
     /// and pops the touch edit menu as an `Atom` target, so the platform offers
-    /// "Edit" (`Event::EnterAtom`). Registers the rect in
+    /// "Edit" (`Event::EnterAtom`). Registers the fragment rects in
     /// `touch_consuming_rects` so iOS routes the tap here; `salt` identifies
     /// the fragment's `Sense::click` scope. No-op if the embed wasn't rendered
     /// this frame. The per-kind handlers differ only in node lookup.
@@ -181,7 +181,7 @@ impl<'ast> MdEdit {
             None => return,
         };
 
-        self.renderer.touch_consuming_rects.push(response.rect);
+        self.renderer.touch_consume_interaction(ui.id().with(salt));
 
         if open && response.hovered() {
             ui.ctx()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -154,13 +154,10 @@ impl<'ast> MdRender {
 
 impl<'ast> MdEdit {
     /// The gesture that *opens* an embed rather than selecting it: a cmd-click
-    /// (desktop) or a keyboard-hidden tap (mobile). Shared by every embed kind.
-    pub fn embed_tap_opens(&self, ui: &egui::Ui, keyboard_visible: bool) -> bool {
-        if self.renderer.touch_mode {
-            !keyboard_visible
-        } else {
-            ui.ctx().input(|i| i.modifiers.command)
-        }
+    /// (desktop). Touch taps always select and pop the context menu, whose
+    /// "Open Link" action opens. Shared by every embed kind.
+    pub fn embed_tap_opens(&self, ui: &egui::Ui) -> bool {
+        !self.renderer.touch_mode && ui.ctx().input(|i| i.modifiers.command)
     }
 
     /// Shared tap handling for one embed fragment (inline image, link card, or
@@ -207,10 +204,9 @@ impl<'ast> MdEdit {
 
     /// Open or select an inline image clicked this frame (see [`Self::handle_embed_tap`]).
     pub fn handle_image_interactions(
-        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, keyboard_visible: bool,
-        ops: &mut Vec<Operation>,
+        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, ops: &mut Vec<Operation>,
     ) {
-        let open = self.embed_tap_opens(ui, keyboard_visible);
+        let open = self.embed_tap_opens(ui);
         for node in root.descendants() {
             let url = match &node.data.borrow().value {
                 NodeValue::Image(link) => link.url.clone(),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -223,11 +223,11 @@ impl<'ast> MdEdit {
     }
 
     /// If the selection exactly covers a collapsed image (i.e. a tap-selected
-    /// atom), select its URL — the selection endpoints inside the syntax
-    /// reveal the source, and the likeliest edit becomes type-to-replace.
-    /// Touch platforms trigger this from the edit menu's "Edit" action — with
-    /// no arrow keys, there's otherwise no way to move the cursor into the
-    /// syntax. True if handled (op pushed).
+    /// atom), select its URL ([`Self::atom_edit_selection`]) — the selection
+    /// endpoints inside the syntax reveal the source, and the likeliest edit
+    /// becomes type-to-replace. Touch platforms trigger this from the edit
+    /// menu's "Edit" action — with no arrow keys, there's otherwise no way to
+    /// move the cursor into the syntax. True if handled (op pushed).
     pub fn enter_at_image(
         &self, root: &'ast AstNode<'ast>, operations: &mut Vec<Operation>,
     ) -> bool {
@@ -240,18 +240,7 @@ impl<'ast> MdEdit {
             if selection != img || self.renderer.range_revealed_interior(img) {
                 continue;
             }
-            // `![alt](url)` — the postfix is `](url)`; without an alt there
-            // are no children (no postfix) and the url starts after `![](`.
-            let url_range = match self.renderer.postfix_range(node) {
-                Some(postfix) => (postfix.start() + 2, postfix.end() - 1),
-                None => (img.start() + 4, img.end() - 1),
-            };
-            let url_range = if url_range.0 <= url_range.1 {
-                url_range
-            } else {
-                (img.start() + 2, img.start() + 2) // degenerate: interior caret
-            };
-            operations.push(Operation::Select(url_range));
+            operations.push(Operation::Select(self.atom_edit_selection(node).0));
             return true;
         }
         false

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -6,6 +6,7 @@ use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 use lb_rs::model::text::operation_types::Operation;
 
 use crate::tab::markdown_editor::input::{Advance, Bound, Event, Increment, Location, Region};
+use crate::tab::markdown_editor::widget::inline::link::{LinkMenuAction, link_menu_buttons};
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{EmbedKind, EmbedSpec, Layout};
 use crate::tab::markdown_editor::{MdEdit, MdRender};
@@ -161,17 +162,17 @@ impl<'ast> MdEdit {
     }
 
     /// Shared tap handling for one embed fragment (inline image, link card, or
-    /// capsule): when `open`, a click opens `url`, else it selects `node_range`
-    /// and pops the touch edit menu as an `Atom` target, so the platform offers
-    /// "Edit" (`Event::EnterAtom`). Registers the fragment rects in
+    /// capsule): when `open`, a click opens `url`, else it selects the node
+    /// and (touch) pops the edit menu as an `Atom` target, so the platform
+    /// offers "Edit" (`Event::EnterAtom`). Desktop right-click shows the link
+    /// menu ([`link_menu_buttons`]). Registers the fragment rects in
     /// `touch_consuming_rects` so iOS routes the tap here; `salt` identifies
     /// the fragment's `Sense::click` scope. No-op if the embed wasn't rendered
     /// this frame. The per-kind handlers differ only in node lookup.
     #[allow(clippy::too_many_arguments)]
     pub fn handle_embed_tap(
-        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id,
-        ops: &mut Vec<Operation>, node_range: (Grapheme, Grapheme), url: &str, salt: egui::Id,
-        open: bool,
+        &mut self, root: &'ast AstNode<'ast>, node: &'ast AstNode<'ast>, ui: &egui::Ui,
+        id: egui::Id, ops: &mut Vec<Operation>, url: &str, salt: egui::Id, open: bool,
     ) {
         let response = match self.renderer.interaction_responses.get(&ui.id().with(salt)) {
             Some(r) => r.clone(), // clone to release the `renderer` borrow
@@ -180,6 +181,7 @@ impl<'ast> MdEdit {
 
         self.renderer.touch_consume_interaction(ui.id().with(salt));
 
+        let node_range = self.renderer.node_range(node);
         if open && response.hovered() {
             ui.ctx()
                 .output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
@@ -200,6 +202,30 @@ impl<'ast> MdEdit {
                 }
             }
         }
+
+        if !self.renderer.touch_mode {
+            let is_image = matches!(node.data.borrow().value, NodeValue::Image(_));
+            let editable = !self.renderer.readonly;
+            let mut action = None;
+            response.context_menu(|ui| action = link_menu_buttons(ui, is_image, editable));
+            match action {
+                Some(LinkMenuAction::Open) => self.renderer.open_resolved_link(url, ui.ctx()),
+                Some(LinkMenuAction::Copy) => ui.ctx().copy_text(url.to_string()),
+                Some(LinkMenuAction::Edit) => {
+                    let (select, force_reveal) = self.atom_edit_selection(node);
+                    if force_reveal {
+                        self.renderer.entered_atom = Some(node_range);
+                    }
+                    ui.memory_mut(|m| m.request_focus(id));
+                    let region = Region::BetweenLocations {
+                        start: Location::Grapheme(select.start()),
+                        end: Location::Grapheme(select.end()),
+                    };
+                    self.calc_operations(ui.ctx(), root, Event::Select { region }, ops);
+                }
+                None => {}
+            }
+        }
     }
 
     /// Open or select an inline image clicked this frame (see [`Self::handle_embed_tap`]).
@@ -214,7 +240,7 @@ impl<'ast> MdEdit {
             };
             let node_range = self.renderer.node_range(node);
             let salt = MdRender::image_interaction_id_salt(node_range);
-            self.handle_embed_tap(root, ui, id, ops, node_range, &url, salt, open);
+            self.handle_embed_tap(root, node, ui, id, ops, &url, salt, open);
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -206,11 +206,15 @@ impl<'ast> MdEdit {
         if !self.renderer.touch_mode {
             let is_image = matches!(node.data.borrow().value, NodeValue::Image(_));
             let editable = !self.renderer.readonly;
+            // cards/capsules render fetched previews; images don't
+            let refreshable = !is_image && self.renderer.contact_linked_sites;
             let mut action = None;
-            response.context_menu(|ui| action = link_menu_buttons(ui, is_image, editable));
+            response
+                .context_menu(|ui| action = link_menu_buttons(ui, is_image, editable, refreshable));
             match action {
                 Some(LinkMenuAction::Open) => self.renderer.open_resolved_link(url, ui.ctx()),
                 Some(LinkMenuAction::Copy) => ui.ctx().copy_text(url.to_string()),
+                Some(LinkMenuAction::Refresh) => self.renderer.refresh_link_meta(url),
                 Some(LinkMenuAction::Edit) => {
                     let (select, force_reveal) = self.atom_edit_selection(node);
                     if force_reveal {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
@@ -220,8 +220,11 @@ impl<'ast> MdRender {
                 let m = self.card_metrics(rect.width(), &meta);
                 let origin = rect.min.to_vec2();
                 if let Some((img_rect, thumb, rounding)) = &m.image {
-                    self.embeds
-                        .show(ui, thumb, img_rect.translate(origin), *rounding);
+                    // non-advancing child ui — see the embed paint in
+                    // `show_wrap_layout` (#4892)
+                    let rect = img_rect.translate(origin);
+                    let thumb_ui = &mut ui.new_child(egui::UiBuilder::new().max_rect(rect));
+                    self.embeds.show(thumb_ui, thumb, rect, *rounding);
                 }
                 for (pos, galley) in [&m.site, &m.title, &m.desc].into_iter().flatten() {
                     ui.painter()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
@@ -255,9 +255,8 @@ impl<'ast> MdEdit {
             if !self.renderer.link_renders_as_card(node) {
                 continue;
             }
-            let node_range = self.renderer.node_range(node);
-            let salt = MdRender::card_interaction_id_salt(node_range);
-            self.handle_embed_tap(root, ui, id, ops, node_range, &url, salt, open);
+            let salt = MdRender::card_interaction_id_salt(self.renderer.node_range(node));
+            self.handle_embed_tap(root, node, ui, id, ops, &url, salt, open);
         }
     }
 
@@ -273,9 +272,8 @@ impl<'ast> MdEdit {
                 NodeValue::Link(link) => link.url.clone(),
                 _ => continue,
             };
-            let node_range = self.renderer.node_range(node);
-            let salt = MdRender::link_capsule_id_salt(node_range);
-            self.handle_embed_tap(root, ui, id, ops, node_range, &url, salt, open);
+            let salt = MdRender::link_capsule_id_salt(self.renderer.node_range(node));
+            self.handle_embed_tap(root, node, ui, id, ops, &url, salt, open);
         }
     }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
@@ -244,10 +244,9 @@ impl<'ast> MdEdit {
     /// `Link` that `link_renders_as_card`); tap handling is shared via
     /// [`MdEdit::handle_embed_tap`].
     pub fn handle_card_interactions(
-        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, keyboard_visible: bool,
-        ops: &mut Vec<Operation>,
+        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, ops: &mut Vec<Operation>,
     ) {
-        let open = self.embed_tap_opens(ui, keyboard_visible);
+        let open = self.embed_tap_opens(ui);
         for node in root.descendants() {
             let url = match &node.data.borrow().value {
                 NodeValue::Link(link) => link.url.clone(),
@@ -266,10 +265,9 @@ impl<'ast> MdEdit {
     /// counterpart to [`Self::handle_card_interactions`]. Only links that
     /// rendered as a capsule have a registered response.
     pub fn handle_link_capsule_interactions(
-        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, keyboard_visible: bool,
-        ops: &mut Vec<Operation>,
+        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, ops: &mut Vec<Operation>,
     ) {
-        let open = self.embed_tap_opens(ui, keyboard_visible);
+        let open = self.embed_tap_opens(ui);
         for node in root.descendants() {
             let url = match &node.data.borrow().value {
                 NodeValue::Link(link) => link.url.clone(),

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
@@ -281,26 +281,26 @@ impl<'ast> MdEdit {
         }
     }
 
-    /// If the selection exactly covers a link rendered as a preview atom (card
-    /// or capsule), keep the whole URL selected and force-reveal the source via
-    /// `entered_atom` — a bare autolink *is* its URL, so unlike an image there
-    /// is no interior sub-range to select. True if handled.
+    /// If the selection exactly covers a link or wikilink, move it inside
+    /// for editing via [`MdEdit::atom_edit_selection`]. The touch edit
+    /// menu's "Edit" lands here. True if handled.
     pub fn enter_at_link(
         &mut self, root: &'ast AstNode<'ast>, operations: &mut Vec<Operation>,
     ) -> bool {
         let selection = self.renderer.buffer.current.selection;
         for node in root.descendants() {
-            if !matches!(node.data.borrow().value, NodeValue::Link(_)) {
+            if !matches!(node.data.borrow().value, NodeValue::Link(_) | NodeValue::WikiLink(_)) {
                 continue;
             }
-            let url = super::node_link_url(node);
             let node_range = self.renderer.node_range(node);
-            if selection != node_range || url.is_empty() || !self.renderer.link_is_auto(node, &url)
-            {
+            if selection != node_range {
                 continue;
             }
-            self.renderer.entered_atom = Some(node_range);
-            operations.push(Operation::Select(node_range));
+            let (select, force_reveal) = self.atom_edit_selection(node);
+            if force_reveal {
+                self.renderer.entered_atom = Some(node_range);
+            }
+            operations.push(Operation::Select(select));
             return true;
         }
         false

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/meta.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/meta.rs
@@ -279,7 +279,7 @@ mod junk_tests {
         ));
         assert!(is_junk_meta("", &meta("  "), base));
         assert!(is_junk_meta("", &meta("example.com"), base));
-        assert!(is_junk_meta("", &meta("www.example.com"), &format!("https://www.example.com")));
+        assert!(is_junk_meta("", &meta("www.example.com"), "https://www.example.com"));
     }
 
     #[test]

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/meta.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/meta.rs
@@ -34,11 +34,13 @@ pub struct LinkMeta {
 pub enum LinkMetaState {
     Loading,
     Loaded(LinkMeta),
-    /// `retry_at: Some(t)` — rate-limited; eligible for a refetch once `t`
-    /// (the host's next-retry timestamp from `crate::egress`) passes.
-    /// `None` — deterministic failure, no retry this session.
+    /// `retry_at: Some(t)` — eligible for a refetch once `t` passes (the
+    /// host's `Retry-After`, a transient-failure backoff, or a bot-wall
+    /// cooldown). `None` — deterministic failure, no retry this session.
+    /// `attempts` counts consecutive failures and drives the backoff.
     Failed {
         retry_at: Option<web_time::Instant>,
+        attempts: u32,
     },
 }
 
@@ -211,5 +213,80 @@ mod tests {
     fn description_absent_is_none() {
         let html = "<html><head><title>t</title></head></html>";
         assert_eq!(extract_link_meta(html, BASE).unwrap().description, None);
+    }
+}
+
+/// Whether scraped metadata describes the wall between us and the page — a
+/// bot challenge or block/error page served as HTML — or carries nothing the
+/// URL didn't (empty or bare-domain title). The plain URL reads better than
+/// any of these, so callers treat junk as a fetch failure.
+pub fn is_junk_meta(html: &str, meta: &LinkMeta, base_url: &str) -> bool {
+    let title = meta.title.trim();
+    if title.is_empty() {
+        return true;
+    }
+    if let Some(host) = url::Url::parse(base_url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_owned))
+    {
+        if title.eq_ignore_ascii_case(&host)
+            || title.eq_ignore_ascii_case(host.trim_start_matches("www."))
+        {
+            return true;
+        }
+    }
+    // challenge / block page titles (Cloudflare, Akamai, bare server errors)
+    const WALL_TITLES: &[&str] = &[
+        "just a moment",
+        "attention required",
+        "access denied",
+        "verifying you are human",
+        "checking your browser",
+        "robot or human",
+        "are you a robot",
+        "403 forbidden",
+        "404 not found",
+    ];
+    let lower = title.to_lowercase();
+    if WALL_TITLES.iter().any(|w| lower.starts_with(w)) {
+        return true;
+    }
+    // challenge machinery in the body
+    const WALL_MARKERS: &[&str] =
+        &["cf_chl_", "challenges.cloudflare.com", "hcaptcha.com", "google.com/recaptcha"];
+    WALL_MARKERS.iter().any(|m| html.contains(m))
+}
+
+#[cfg(test)]
+mod junk_tests {
+    use super::*;
+
+    fn meta(title: &str) -> LinkMeta {
+        LinkMeta { title: title.into(), ..Default::default() }
+    }
+
+    #[test]
+    fn wall_titles_and_markers_are_junk() {
+        let base = "https://example.com/article";
+        assert!(is_junk_meta("<html></html>", &meta("Just a moment..."), base));
+        assert!(is_junk_meta("<html></html>", &meta("Attention Required! | Cloudflare"), base));
+        assert!(is_junk_meta("<html></html>", &meta("Access Denied"), base));
+        assert!(is_junk_meta("<html></html>", &meta("403 Forbidden"), base));
+        assert!(is_junk_meta(
+            r#"<script src="https://challenges.cloudflare.com/x.js"></script>"#,
+            &meta("Anything"),
+            base
+        ));
+        assert!(is_junk_meta("", &meta("  "), base));
+        assert!(is_junk_meta("", &meta("example.com"), base));
+        assert!(is_junk_meta("", &meta("www.example.com"), &format!("https://www.example.com")));
+    }
+
+    #[test]
+    fn real_titles_are_not_junk() {
+        let base = "https://example.com/article";
+        assert!(!is_junk_meta("<html></html>", &meta("A Real Article Title"), base));
+        assert!(!is_junk_meta("<html></html>", &meta("Home"), base)); // low-quality but real
+        assert!(!is_junk_meta("<html></html>", &meta("Accessibility at Example"), base));
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -13,7 +13,6 @@ use crate::egress::{FetchError, fetch_html};
 use crate::file_cache::{FilesExt as _, ResolvedLink};
 use crate::show::DocType;
 use crate::tab::ExtendedOutput as _;
-use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::inline::link::meta::{
     LinkMeta, LinkMetaState, extract_link_meta,
 };
@@ -21,6 +20,7 @@ use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{
     FontFamily, Format, Layout, StyleInfo,
 };
+use crate::tab::markdown_editor::{MdEdit, MdRender};
 use crate::theme::icons::Icon;
 use crate::theme::palette_v2::ThemeExt as _;
 
@@ -650,4 +650,42 @@ fn alone_on_line<'a>(
         sib = next(s);
     }
     true
+}
+
+impl<'ast> MdEdit {
+    /// The selection that edits a link-like node's hidden part: an image's
+    /// or labeled link's destination, a wikilink's interior, a bare
+    /// autolink's whole URL. `true` if acting on it should force-reveal via
+    /// `entered_atom` — a bare autolink *is* its URL, so there is no
+    /// interior sub-range whose selection would reveal the source.
+    pub fn atom_edit_selection(&self, node: &'ast AstNode<'ast>) -> ((Grapheme, Grapheme), bool) {
+        let node_range = self.renderer.node_range(node);
+        let is_image = matches!(node.data.borrow().value, NodeValue::Image(_));
+        match &node.data.borrow().value {
+            NodeValue::WikiLink(_) => ((node_range.start() + 2, node_range.end() - 2), false),
+            NodeValue::Link(_) | NodeValue::Image(_) => {
+                let url = node_link_url(node);
+                if !is_image && !url.is_empty() && self.renderer.link_is_auto(node, &url) {
+                    (node_range, true)
+                } else {
+                    // `[title](url)` / `![alt](url)` — the postfix is
+                    // `](url)`; without a label there are no children (no
+                    // postfix) and the url starts after the opening syntax.
+                    let open_len = if is_image { 4 } else { 3 };
+                    let url_range = match self.renderer.postfix_range(node) {
+                        Some(postfix) => (postfix.start() + 2, postfix.end() - 1),
+                        None => (node_range.start() + open_len, node_range.end() - 1),
+                    };
+                    if url_range.0 <= url_range.1 {
+                        (url_range, false)
+                    } else {
+                        // degenerate: interior caret
+                        let caret = node_range.start() + (open_len - 2);
+                        ((caret, caret), false)
+                    }
+                }
+            }
+            _ => (node_range, false),
+        }
+    }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -269,6 +269,9 @@ impl<'ast> MdRender {
                         ui.painter()
                             .rect_filled(icon_rect, 3.0, egui::Color32::from_gray(235));
                     }
+                    // non-advancing child ui — see the embed paint in
+                    // `show_wrap_layout` (#4892)
+                    let ui = &mut ui.new_child(egui::UiBuilder::new().max_rect(icon_rect));
                     self.embeds
                         .show(ui, &favicon_url, icon_rect, egui::CornerRadius::same(3));
                 } else {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -642,6 +642,47 @@ impl<'ast> MdRender {
         });
     }
 
+    /// Drop `url`'s cached metadata and fetch it fresh — the context menu's
+    /// "Refresh Preview". Explicitly user-invoked, but still behind the
+    /// contact-linked-sites opt-in (previews don't render without it anyway).
+    pub fn refresh_link_meta(&self, url: &str) {
+        if !self.contact_linked_sites {
+            return;
+        }
+        let resolved_url = match self.resolve_link(url) {
+            Some(ResolvedLink::External(u))
+                if u.starts_with("http://") || u.starts_with("https://") =>
+            {
+                u
+            }
+            _ => return,
+        };
+        let arc = Arc::new(Mutex::new(LinkMetaState::Loading));
+        self.layout_cache
+            .link_meta
+            .borrow_mut()
+            .insert(resolved_url.clone(), arc.clone());
+        self.spawn_meta_fetch(resolved_url, arc, 0);
+    }
+
+    /// Re-fetch preview metadata for every link intersecting the selection —
+    /// the touch edit menu's "Refresh Preview".
+    pub fn refresh_selection_previews(&mut self) {
+        let arena = Arena::new();
+        let root = self.reparse(&arena);
+        let selection = self.buffer.current.selection;
+        let mut urls = vec![];
+        for node in root.descendants() {
+            if let NodeValue::Link(l) = &node.data.borrow().value {
+                if !l.url.is_empty() && self.node_range(node).intersects(&selection, true) {
+                    urls.push(l.url.clone());
+                }
+            }
+        }
+        for url in urls {
+            self.refresh_link_meta(&url);
+        }
+    }
 }
 
 /// Result of a [`MdRender::get_link_meta`] lookup.
@@ -688,6 +729,7 @@ pub enum LinkMenuAction {
     Open,
     Copy,
     Edit,
+    Refresh,
 }
 
 /// What a desktop context menu over a link-like node acts on.
@@ -702,9 +744,10 @@ pub struct LinkMenuTarget {
     pub force_reveal: bool,
 }
 
-/// The link section of a desktop context menu; `editable` gates "Edit".
+/// The link section of a desktop context menu; `editable` gates "Edit",
+/// `refreshable` gates "Refresh Preview" (rendered previews only).
 pub fn link_menu_buttons(
-    ui: &mut egui::Ui, is_image: bool, editable: bool,
+    ui: &mut egui::Ui, is_image: bool, editable: bool, refreshable: bool,
 ) -> Option<LinkMenuAction> {
     let mut action = None;
     let (open, copy, edit) = if is_image {
@@ -722,6 +765,10 @@ pub fn link_menu_buttons(
     }
     if editable && ui.button(edit).clicked() {
         action = Some(LinkMenuAction::Edit);
+        ui.close();
+    }
+    if refreshable && ui.button("Refresh Preview").clicked() {
+        action = Some(LinkMenuAction::Refresh);
         ui.close();
     }
     action

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -318,8 +318,9 @@ impl<'ast> MdRender {
         self.link_resolver.wikilink_state(url)
     }
 
-    /// URL of the first link/image whose source range intersects the current
-    /// selection — what an "Open Link" affordance (the iOS edit menu) acts on.
+    /// URL (or wikilink target) of the first link-like node whose source range
+    /// intersects the current selection — gates and feeds the platform edit
+    /// menu's "Open Link" / "Copy Link".
     pub fn selection_open_target(&mut self) -> Option<String> {
         let arena = Arena::new();
         let root = self.reparse(&arena);
@@ -327,6 +328,7 @@ impl<'ast> MdRender {
         for node in root.descendants() {
             let url = match &node.data.borrow().value {
                 NodeValue::Link(l) | NodeValue::Image(l) => l.url.clone(),
+                NodeValue::WikiLink(nwl) => nwl.url.clone(),
                 _ => continue,
             };
             if !url.is_empty() && self.node_range(node).intersects(&selection, true) {

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -16,7 +16,7 @@ use crate::file_cache::{FilesExt as _, ResolvedLink};
 use crate::show::DocType;
 use crate::tab::markdown_editor::input::{Event, Location, Region};
 use crate::tab::markdown_editor::widget::inline::link::meta::{
-    LinkMeta, LinkMetaState, extract_link_meta,
+    LinkMeta, LinkMetaState, extract_link_meta, is_junk_meta,
 };
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Layout, StyleInfo};
@@ -515,19 +515,22 @@ impl<'ast> MdRender {
             .entry(resolved_url.clone())
         {
             Entry::Occupied(mut e) => {
-                // A rate-limited failure whose next-retry timestamp has passed
-                // is eligible again (still behind the fetch opt-in).
-                let retry_due = matches!(
-                    *e.get().lock().unwrap(),
-                    LinkMetaState::Failed { retry_at: Some(t) } if t <= now
-                );
-                if retry_due && self.contact_linked_sites {
-                    let arc = Arc::new(Mutex::new(LinkMetaState::Loading));
-                    e.insert(arc.clone());
-                    self.spawn_meta_fetch(resolved_url, arc.clone());
-                    arc
-                } else {
-                    e.get().clone()
+                // A failure whose next-retry timestamp has passed is eligible
+                // again (still behind the fetch opt-in).
+                let retry_attempts = match &*e.get().lock().unwrap() {
+                    LinkMetaState::Failed { retry_at: Some(t), attempts } if *t <= now => {
+                        Some(*attempts)
+                    }
+                    _ => None,
+                };
+                match retry_attempts {
+                    Some(attempts) if self.contact_linked_sites => {
+                        let arc = Arc::new(Mutex::new(LinkMetaState::Loading));
+                        e.insert(arc.clone());
+                        self.spawn_meta_fetch(resolved_url, arc.clone(), attempts);
+                        arc
+                    }
+                    _ => e.get().clone(),
                 }
             }
             Entry::Vacant(e) => {
@@ -538,7 +541,7 @@ impl<'ast> MdRender {
                 }
                 let arc = Arc::new(Mutex::new(LinkMetaState::Loading));
                 e.insert(arc.clone());
-                self.spawn_meta_fetch(resolved_url, arc.clone());
+                self.spawn_meta_fetch(resolved_url, arc.clone(), 0);
                 arc
             }
         };
@@ -547,7 +550,7 @@ impl<'ast> MdRender {
         match &*state {
             LinkMetaState::Loaded(meta) => LinkMetaLookup::Loaded(meta.clone()),
             LinkMetaState::Loading => LinkMetaLookup::Loading,
-            LinkMetaState::Failed { retry_at: Some(until) } if *until > now => {
+            LinkMetaState::Failed { retry_at: Some(until), .. } if *until > now => {
                 // Wake a frame when the cooldown lapses — an idle editor never
                 // repaints, so without this the retry waits for user input.
                 self.ctx.request_repaint_after(*until - now);
@@ -558,8 +561,18 @@ impl<'ast> MdRender {
     }
 
     /// Fetch + scrape `resolved_url`'s metadata into `meta_state` off-thread,
-    /// then bump `link_seq` and request a repaint.
-    fn spawn_meta_fetch(&self, resolved_url: String, meta_state: Arc<Mutex<LinkMetaState>>) {
+    /// then bump `link_seq` and request a repaint. `attempts` counts prior
+    /// consecutive failures — it drives the transient-failure backoff.
+    fn spawn_meta_fetch(
+        &self, resolved_url: String, meta_state: Arc<Mutex<LinkMetaState>>, attempts: u32,
+    ) {
+        /// Self-assigned retry-after for network-level failures; doubles per
+        /// consecutive failure up to the cap.
+        const TRANSIENT_RETRY_BASE: std::time::Duration = std::time::Duration::from_secs(60);
+        const TRANSIENT_RETRY_CAP: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+        /// Bot walls outlive short retries — a site's posture changes slowly.
+        const BLOCKED_RETRY: std::time::Duration = std::time::Duration::from_secs(6 * 60 * 60);
+
         let client = self.client.clone();
         let ctx = self.ctx.clone();
         let link_seq = self.layout_cache.link_seq.clone();
@@ -575,11 +588,14 @@ impl<'ast> MdRender {
             let mut html = fetch_html(&client, &resolved_url, CHROME).await;
 
             // Some sites (e.g. Twitter/X) only serve static content to known
-            // crawlers — but never burn a second request on a host that's
-            // rate-limiting us.
-            let parses = |h: &str| extract_link_meta(h, &resolved_url).is_some();
+            // crawlers, and bot walls often whitelist them — but never burn a
+            // second request on a host that's rate-limiting us.
+            let good = |h: &str| {
+                extract_link_meta(h, &resolved_url)
+                    .is_some_and(|m| !is_junk_meta(h, &m, &resolved_url))
+            };
             if !matches!(html, Err(FetchError::RateLimited { .. }))
-                && !html.as_deref().is_ok_and(parses)
+                && !html.as_deref().is_ok_and(good)
             {
                 #[cfg(not(target_arch = "wasm32"))]
                 {
@@ -591,19 +607,41 @@ impl<'ast> MdRender {
                 }
             }
 
+            let now = web_time::Instant::now();
             *meta_state.lock().unwrap() = match html {
-                Ok(h) => extract_link_meta(&h, &resolved_url)
-                    .map(LinkMetaState::Loaded)
-                    .unwrap_or(LinkMetaState::Failed { retry_at: None }),
+                Ok(h) => match extract_link_meta(&h, &resolved_url) {
+                    Some(meta) if !is_junk_meta(&h, &meta, &resolved_url) => {
+                        LinkMetaState::Loaded(meta)
+                    }
+                    // Junk describes the wall, not the page — treat like a
+                    // bot wall rather than rendering it.
+                    Some(_) => LinkMetaState::Failed {
+                        retry_at: Some(now + BLOCKED_RETRY),
+                        attempts: attempts + 1,
+                    },
+                    None => LinkMetaState::Failed { retry_at: None, attempts: attempts + 1 },
+                },
                 Err(FetchError::RateLimited { until }) => {
-                    LinkMetaState::Failed { retry_at: Some(until) }
+                    LinkMetaState::Failed { retry_at: Some(until), attempts: attempts + 1 }
                 }
-                Err(_) => LinkMetaState::Failed { retry_at: None },
+                Err(FetchError::Blocked(_)) => LinkMetaState::Failed {
+                    retry_at: Some(now + BLOCKED_RETRY),
+                    attempts: attempts + 1,
+                },
+                Err(FetchError::Transient(_)) => {
+                    let backoff =
+                        (TRANSIENT_RETRY_BASE * 2u32.pow(attempts.min(4))).min(TRANSIENT_RETRY_CAP);
+                    LinkMetaState::Failed { retry_at: Some(now + backoff), attempts: attempts + 1 }
+                }
+                Err(FetchError::Permanent(_)) => {
+                    LinkMetaState::Failed { retry_at: None, attempts: attempts + 1 }
+                }
             };
             link_seq.store(ws_seq.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
             ctx.request_repaint();
         });
     }
+
 }
 
 /// Result of a [`MdRender::get_link_meta`] lookup.

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -9,19 +9,19 @@ use std::collections::hash_map::Entry;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
+use lb_rs::model::text::operation_types::Operation;
+
 use crate::egress::{FetchError, fetch_html};
 use crate::file_cache::{FilesExt as _, ResolvedLink};
 use crate::show::DocType;
-use crate::tab::ExtendedOutput as _;
+use crate::tab::markdown_editor::input::{Event, Location, Region};
 use crate::tab::markdown_editor::widget::inline::link::meta::{
     LinkMeta, LinkMetaState, extract_link_meta,
 };
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
-use crate::tab::markdown_editor::widget::utils::wrap_layout::{
-    FontFamily, Format, Layout, StyleInfo,
-};
+use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Layout, StyleInfo};
 use crate::tab::markdown_editor::{MdEdit, MdRender};
-use crate::theme::icons::Icon;
+use crate::tab::{ContextMenuTarget, ExtendedOutput as _};
 use crate::theme::palette_v2::ThemeExt as _;
 
 enum DestinationTitle {
@@ -49,17 +49,6 @@ impl<'ast> MdRender {
     pub fn text_format_link_pill(&self, parent: &AstNode<'_>, state: LinkState) -> Format {
         Format {
             background: self.ctx.get_lb_theme().neutral_bg_secondary(),
-            underline: false,
-            ..self.text_format_link(parent, state)
-        }
-    }
-
-    /// `Icon` glyph (no underline) used for the touch-mode "open link"
-    /// affordance appended after each link. Coloured to match the link's
-    /// state so the button doesn't read as healthy-blue on a warning link.
-    pub fn text_format_link_button(&self, parent: &AstNode<'_>, state: LinkState) -> Format {
-        Format {
-            family: FontFamily::Icons,
             underline: false,
             ..self.text_format_link(parent, state)
         }
@@ -129,9 +118,10 @@ impl<'ast> MdRender {
     /// swap the URL bytes for the title via `push_override`. Empty-text
     /// links (`[](url)`) are not autolinks and have nothing to show, so
     /// they render their raw source like other incomplete syntax.
-    /// With cmd held, opens a `Sense::click` interaction scope so egui
-    /// z-order routes cmd-click here; without cmd no scope is opened
-    /// and clicks fall through to the editor.
+    /// A `Sense::click` interaction scope routes clicks here when they
+    /// act on the link (cmd held, read-only, or unrevealed touch);
+    /// otherwise no scope is opened and clicks fall through to the
+    /// editor for cursor placement.
     pub fn layout_link(
         &self, layout: &mut Layout, node: &'ast AstNode<'ast>, range: (Grapheme, Grapheme),
     ) {
@@ -194,29 +184,18 @@ impl<'ast> MdRender {
 
         // Plain inline link (labeled, or an autolink whose title hasn't
         // resolved): cmd-click opens (desktop editor); read-only views have
-        // no cursor to place, so a plain click opens; touch gets a trailing
-        // open affordance.
-        let clickable = self.readonly || self.ctx.input(|i| i.modifiers.command);
+        // no cursor to place, so a plain click opens; touch taps select the
+        // link and pop the menu — unless revealed, when taps place the
+        // cursor in the raw source.
+        let clickable = self.readonly
+            || self.ctx.input(|i| i.modifiers.command)
+            || (self.touch_mode && !revealed);
         let salt = Self::link_interaction_id_salt(node_range);
         if clickable {
             layout.interaction_open(salt, egui::Sense::click());
         }
         self.layout_circumfix(layout, node, range, link_fmt.clone());
         if clickable {
-            layout.interaction_close();
-        }
-
-        let broken = matches!(state, LinkState::Broken { .. });
-        if self.touch_mode && !broken && range.contains_inclusive(node_range.end()) {
-            let anchor = (node_range.end(), node_range.end());
-            let parent_fmt = self.text_format(parent);
-            layout.push_override(anchor, " ", parent_fmt);
-            layout.interaction_open(salt, egui::Sense::click());
-            layout.push_override(
-                anchor,
-                Icon::OPEN_IN_NEW.icon,
-                self.text_format_link_button(parent, state),
-            );
             layout.interaction_close();
         }
     }
@@ -420,9 +399,9 @@ impl<'ast> MdRender {
     }
 
     /// Hover → `PointingHand` + Warning/Broken tooltip; click → open
-    /// in a new tab. The producer only opens an interaction scope when
-    /// cmd is held (desktop) or for the trailing open-link affordance
-    /// (touch); the response's presence is the gate.
+    /// in a new tab. The producer's interaction scope is the gate: cmd
+    /// held (desktop), read-only, or touch — where the click instead
+    /// selects the link and pops the menu ([`MdEdit::handle_link_menu_taps`]).
     pub fn handle_link_interactions(&mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui) {
         let parent_base = ui.id();
         for node in root.descendants() {
@@ -465,7 +444,7 @@ impl<'ast> MdRender {
                 }
             }
 
-            if response.clicked() {
+            if response.clicked() && (self.readonly || !self.touch_mode) {
                 if is_wikilink {
                     if let Some(file_id) = self.resolve_wikilink(&url) {
                         ui.ctx().open_file(file_id, true);
@@ -686,6 +665,46 @@ impl<'ast> MdEdit {
                 }
             }
             _ => (node_range, false),
+        }
+    }
+
+    /// Touch tap on a plain rendered link or wikilink: select the link and
+    /// pop the atom menu ("Open Link" / "Edit"), mirroring embed taps
+    /// ([`Self::handle_embed_tap`]). Applied via `ops` so the selection is
+    /// current when the platform builds the menu.
+    pub fn handle_link_menu_taps(
+        &mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui, id: egui::Id, ops: &mut Vec<Operation>,
+    ) {
+        if !self.renderer.touch_mode || self.renderer.readonly {
+            return;
+        }
+        let parent_base = ui.id();
+        for node in root.descendants() {
+            match &node.data.borrow().value {
+                NodeValue::Link(_) | NodeValue::WikiLink(_) => {}
+                _ => continue,
+            }
+            let node_range = self.renderer.node_range(node);
+            let salt = MdRender::link_interaction_id_salt(node_range);
+            let response = match self
+                .renderer
+                .interaction_responses
+                .get(&parent_base.with(salt))
+            {
+                Some(r) => r.clone(), // clone to release the `renderer` borrow
+                None => continue,
+            };
+            if response.clicked() {
+                ui.memory_mut(|m| m.request_focus(id));
+                let region = Region::BetweenLocations {
+                    start: Location::Grapheme(node_range.start()),
+                    end: Location::Grapheme(node_range.end()),
+                };
+                self.calc_operations(ui.ctx(), root, Event::Select { region }, ops);
+                ui.ctx()
+                    .set_context_menu(response.rect.center_top(), ContextMenuTarget::Atom);
+                return;
+            }
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -432,14 +432,15 @@ impl<'ast> MdRender {
                 _ => continue,
             };
             let id = parent_base.with(Self::link_interaction_id_salt(self.node_range(node)));
+
+            // iOS routes touches through `touch_consuming_rects` —
+            // without these entries a tap on the open-link button would
+            // place the cursor instead of reaching the click handler below.
+            self.touch_consume_interaction(id);
+
             let Some(response) = self.interaction_responses.get(&id) else {
                 continue;
             };
-
-            // iOS routes touches through `touch_consuming_rects` —
-            // without this entry a tap on the open-link button would
-            // place the cursor instead of reaching the click handler below.
-            self.touch_consuming_rects.push(response.rect);
 
             if response.hovered() {
                 ui.ctx()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -22,6 +22,7 @@ use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{Format, Layout, StyleInfo};
 use crate::tab::markdown_editor::{MdEdit, MdRender};
 use crate::tab::{ContextMenuTarget, ExtendedOutput as _};
+use crate::theme::icons::Icon;
 use crate::theme::palette_v2::ThemeExt as _;
 
 enum DestinationTitle {
@@ -248,17 +249,19 @@ impl<'ast> MdRender {
                 continue; // not rendered as a capsule
             }
 
-            // Favicon over the leading em-space slot, once its texture loads.
+            // Favicon over the leading em-space slot; a neutral link glyph
+            // holds the slot while the texture loads — or forever, if it
+            // never does — so the reserved space always reads as an icon.
             if let Some(favicon_url) = self.capsule_favicon_url(&url) {
+                let chip = chip_rects[0];
+                let size = chip.height() * 0.7;
+                let inset = chip.height() * 0.3;
+                let icon_rect = egui::Rect::from_min_size(
+                    egui::Pos2::new(chip.min.x + inset, chip.center().y - size * 0.5),
+                    egui::Vec2::splat(size),
+                );
                 self.embeds.prefetch(&favicon_url);
                 if self.embeds.is_loaded(&favicon_url) {
-                    let chip = chip_rects[0];
-                    let size = chip.height() * 0.7;
-                    let inset = chip.height() * 0.3;
-                    let icon_rect = egui::Rect::from_min_size(
-                        egui::Pos2::new(chip.min.x + inset, chip.center().y - size * 0.5),
-                        egui::Vec2::splat(size),
-                    );
                     // Dark mode: a near-white tile behind the icon so dark
                     // monochrome marks (e.g. GitHub) read against the dark pill;
                     // opaque favicons simply hide it.
@@ -268,6 +271,14 @@ impl<'ast> MdRender {
                     }
                     self.embeds
                         .show(ui, &favicon_url, icon_rect, egui::CornerRadius::same(3));
+                } else {
+                    ui.painter().text(
+                        icon_rect.center(),
+                        egui::Align2::CENTER_CENTER,
+                        Icon::LINK.icon,
+                        egui::FontId::monospace(size),
+                        self.ctx.get_lb_theme().neutral_fg_secondary(),
+                    );
                 }
             }
 

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -631,7 +631,84 @@ fn alone_on_line<'a>(
     true
 }
 
+/// A choice from the desktop link context menu ([`link_menu_buttons`]).
+#[derive(Clone, Copy)]
+pub enum LinkMenuAction {
+    Open,
+    Copy,
+    Edit,
+}
+
+/// What a desktop context menu over a link-like node acts on.
+#[derive(Clone)]
+pub struct LinkMenuTarget {
+    pub url: String,
+    pub is_wikilink: bool,
+    pub is_image: bool,
+    pub node_range: (Grapheme, Grapheme),
+    /// See [`MdEdit::atom_edit_selection`].
+    pub select: (Grapheme, Grapheme),
+    pub force_reveal: bool,
+}
+
+/// The link section of a desktop context menu; `editable` gates "Edit".
+pub fn link_menu_buttons(
+    ui: &mut egui::Ui, is_image: bool, editable: bool,
+) -> Option<LinkMenuAction> {
+    let mut action = None;
+    let (open, copy, edit) = if is_image {
+        ("Open Image", "Copy URL", "Edit Image")
+    } else {
+        ("Open Link", "Copy Link", "Edit Link")
+    };
+    if ui.button(open).clicked() {
+        action = Some(LinkMenuAction::Open);
+        ui.close();
+    }
+    if ui.button(copy).clicked() {
+        action = Some(LinkMenuAction::Copy);
+        ui.close();
+    }
+    if editable && ui.button(edit).clicked() {
+        action = Some(LinkMenuAction::Edit);
+        ui.close();
+    }
+    action
+}
+
 impl<'ast> MdEdit {
+    /// The link-like node under `pos` for a desktop context menu, resolved
+    /// through the fragment actually painted there — no offset snapping
+    /// from empty space beside a link.
+    pub fn link_target_at_pos(
+        &self, root: &'ast AstNode<'ast>, pos: egui::Pos2,
+    ) -> Option<LinkMenuTarget> {
+        let frag = self.renderer.fragment_at_pos(pos)?;
+        let offset = frag.source_range.start();
+        for node in root.descendants() {
+            let (url, is_wikilink, is_image) = match &node.data.borrow().value {
+                NodeValue::WikiLink(nwl) => (nwl.url.clone(), true, false),
+                NodeValue::Image(l) => (l.url.clone(), false, true),
+                NodeValue::Link(l) => (l.url.clone(), false, false),
+                _ => continue,
+            };
+            let node_range = self.renderer.node_range(node);
+            if url.is_empty() || offset < node_range.start() || offset >= node_range.end() {
+                continue;
+            }
+            let (select, force_reveal) = self.atom_edit_selection(node);
+            return Some(LinkMenuTarget {
+                url,
+                is_wikilink,
+                is_image,
+                node_range,
+                select,
+                force_reveal,
+            });
+        }
+        None
+    }
+
     /// The selection that edits a link-like node's hidden part: an image's
     /// or labeled link's destination, a wikilink's interior, a bare
     /// autolink's whole URL. `true` if acting on it should force-reveal via

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/spoilered_text.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/spoilered_text.rs
@@ -59,14 +59,15 @@ impl<'ast> MdRender {
             }
             let salt = Self::spoiler_interaction_id_salt(node);
             let id = parent_base.with(salt);
+
+            // iOS routes touches through `touch_consuming_rects` —
+            // without these entries a tap on a spoiler would place the
+            // cursor instead of reaching the toggle handler below.
+            self.touch_consume_interaction(id);
+
             let Some(response) = self.interaction_responses.get(&id) else {
                 continue;
             };
-
-            // iOS routes touches through `touch_consuming_rects` —
-            // without this entry a tap on a spoiler would place the
-            // cursor instead of reaching the toggle handler below.
-            self.touch_consuming_rects.push(response.rect);
 
             if response.hovered() {
                 ui.ctx()

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/wiki_link.rs
@@ -1,11 +1,9 @@
 use comrak::nodes::AstNode;
 use lb_rs::Uuid;
-use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
+use lb_rs::model::text::offset_types::Grapheme;
 
-use crate::resolvers::link::LinkState;
 use crate::tab::markdown_editor::MdRender;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::Layout;
-use crate::theme::icons::Icon;
 
 impl<'ast> MdRender {
     pub fn resolve_wikilink(&self, url: &str) -> Option<Uuid> {
@@ -22,30 +20,20 @@ impl<'ast> MdRender {
         let parent = node.parent().unwrap();
         let node_range = self.node_range(node);
         let state = self.link_state_for_wikilink(&url);
-        let fmt = self.text_format_link(parent, state.clone());
+        let fmt = self.text_format_link(parent, state);
         // Read-only views have no cursor to place, so a plain click follows
-        // the link; the editor reserves that for the cursor and requires cmd.
-        let clickable = self.readonly || self.ctx.input(|i| i.modifiers.command);
+        // the link; the editor requires cmd, and touch taps select the link
+        // and pop the menu — unless revealed, when taps place the cursor.
+        let revealed = self.range_revealed_interior(node_range);
+        let clickable = self.readonly
+            || self.ctx.input(|i| i.modifiers.command)
+            || (self.touch_mode && !revealed);
         let salt = Self::link_interaction_id_salt(node_range);
         if clickable {
             layout.interaction_open(salt, egui::Sense::click());
         }
         self.layout_circumfix(layout, node, range, fmt);
         if clickable {
-            layout.interaction_close();
-        }
-
-        let broken = matches!(state, LinkState::Broken { .. });
-        if self.touch_mode && !broken && range.contains_inclusive(node_range.end()) {
-            let anchor = (node_range.end(), node_range.end());
-            let parent_fmt = self.text_format(parent);
-            layout.push_override(anchor, " ", parent_fmt);
-            layout.interaction_open(salt, egui::Sense::click());
-            layout.push_override(
-                anchor,
-                Icon::OPEN_IN_NEW.icon,
-                self.text_format_link_button(parent, state),
-            );
             layout.interaction_close();
         }
     }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
@@ -18,7 +18,6 @@ use crate::theme::palette_v2::ThemeExt as _;
 use crate::widgets::GlyphonLabel;
 
 const MAX_RESULTS: usize = 7;
-const MIN_QUERY_LEN: usize = 2;
 const POPUP_PADDING: f32 = 24.0; // 8 left + 8 gap + 8 right
 const TARGET_POPUP_WIDTH: f32 = 320.0; // soft target per row; popup grows to fit actual content
 const MIN_HINT_WIDTH: f32 = 60.0; // always leave at least this much room for the hint
@@ -75,10 +74,15 @@ impl LinkCompletions {
         let dest = matches!(mode, CompletionMode::LinkDest | CompletionMode::ImageLinkDest);
         let qr = query_range(buffer, range, mode);
         let query = &buffer[qr];
-        if !dest && query.len() < MIN_QUERY_LEN {
+        if self.suppressed.as_deref() == Some(query) {
             return;
         }
-        if self.suppressed.as_deref() == Some(query) {
+        // `- [` is far more likely a task item than a link: while the bracket
+        // content could still be a checkbox, hold the popup.
+        if mode == CompletionMode::Link
+            && (query.is_empty() || query == " " || query.eq_ignore_ascii_case("x"))
+            && follows_list_marker(buffer, range.0)
+        {
             return;
         }
         // External and already-resolved destinations aren't file paths;
@@ -357,6 +361,44 @@ fn existing_title(raw: &str, mode: CompletionMode) -> String {
 /// Returns the grapheme `&str` at the given char offset.
 fn grapheme_at(buffer: &Buffer, i: usize) -> &str {
     &buffer[(Grapheme(i), Grapheme(i + 1))]
+}
+
+/// Whether the `[` at `bracket` is the first content of a list item (after
+/// optional indentation and blockquote markers) — where it far more likely
+/// starts a task checkbox than a link.
+fn follows_list_marker(buffer: &Buffer, bracket: Grapheme) -> bool {
+    let mut i = bracket.0;
+    let mut prefix = String::new();
+    while i > 0 {
+        let g = grapheme_at(buffer, i - 1);
+        if g == "\n" {
+            break;
+        }
+        prefix.insert_str(0, g);
+        if prefix.len() > 40 {
+            return false; // marker prefixes are short
+        }
+        i -= 1;
+    }
+
+    let mut s = prefix.trim_start();
+    while let Some(rest) = s.strip_prefix('>') {
+        s = rest.trim_start();
+    }
+    let s = if let Some(rest) = s.strip_prefix(['-', '*', '+']) {
+        rest
+    } else {
+        let digits = s.len() - s.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+        if digits == 0 {
+            return false;
+        }
+        match s[digits..].strip_prefix(['.', ')']) {
+            Some(rest) => rest,
+            None => return false,
+        }
+    };
+    // the marker needs trailing whitespace, and nothing else before the `[`
+    !s.is_empty() && s.chars().all(|c| c == ' ' || c == '\t')
 }
 
 /// Returns the range of a `[[...]]` wikilink token under the cursor.
@@ -1079,6 +1121,30 @@ mod tests {
     /// resolves back to the file it was for. Covers all three insert forms —
     /// bare stem (`todo`), full name when the stem collides (`Pancakes.md`),
     /// and a relative path when the full name collides across folders (`a/Spec`).
+    #[test]
+    fn list_markers_hold_the_popup() {
+        use lb_rs::model::text::buffer::Buffer;
+        use lb_rs::model::text::offset_types::Grapheme;
+
+        use super::follows_list_marker;
+
+        let at_bracket = |md: &str| {
+            let buffer = Buffer::from(md);
+            let bracket = md.rfind('[').unwrap();
+            follows_list_marker(&buffer, Grapheme(bracket))
+        };
+        assert!(at_bracket("- ["));
+        assert!(at_bracket("  * ["));
+        assert!(at_bracket("1. ["));
+        assert!(at_bracket("12) ["));
+        assert!(at_bracket("> - ["));
+        assert!(at_bracket("text\n- ["));
+        assert!(!at_bracket("some ["));
+        assert!(!at_bracket("-[")); // no space: not a list marker
+        assert!(!at_bracket("a - ["));
+        assert!(!at_bracket("["));
+    }
+
     #[test]
     fn destination_context_detected_and_title_kept() {
         use lb_rs::model::text::buffer::Buffer;

--- a/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/link_completions.rs
@@ -32,6 +32,11 @@ pub enum CompletionMode {
     Link,
     /// `![alt text](path)` — image link, shows only image files.
     ImageLink,
+    /// `[display text](des...` — cursor in the destination; completes file
+    /// paths while the display text is kept as-is.
+    LinkDest,
+    /// `![alt text](des...` — destination of an image link.
+    ImageLinkDest,
 }
 
 #[derive(Default)]
@@ -67,12 +72,23 @@ impl LinkCompletions {
         }
 
         let Some((range, mode)) = detect_any(buffer) else { return };
+        let dest = matches!(mode, CompletionMode::LinkDest | CompletionMode::ImageLinkDest);
         let qr = query_range(buffer, range, mode);
         let query = &buffer[qr];
-        if query.len() < MIN_QUERY_LEN {
+        if !dest && query.len() < MIN_QUERY_LEN {
             return;
         }
         if self.suppressed.as_deref() == Some(query) {
+            return;
+        }
+        // External and already-resolved destinations aren't file paths;
+        // anchors aren't completed (yet).
+        if dest
+            && (query.starts_with("http://")
+                || query.starts_with("https://")
+                || query.starts_with("lb://")
+                || query.starts_with('#'))
+        {
             return;
         }
 
@@ -80,16 +96,20 @@ impl LinkCompletions {
         let complete = match mode {
             CompletionMode::WikiLink => raw.ends_with("]]"),
             CompletionMode::Link | CompletionMode::ImageLink => raw.ends_with(')'),
+            // being inside complete syntax is the destination context
+            CompletionMode::LinkDest | CompletionMode::ImageLinkDest => false,
         };
         if complete {
             // cursor navigated into existing syntax
             return;
         }
 
-        // Only activate if there are actual results to show.
+        // Only activate if there are actual results to show — and not when
+        // the destination already is one of them (cursor parked on a valid
+        // link rather than mid-edit).
         let cache = files.read().unwrap();
-        let has_results = !search(&cache, file_id, query, mode).is_empty();
-        if !has_results {
+        let results = search(&cache, file_id, query, mode);
+        if results.is_empty() || (dest && results.iter().any(|r| r.insert == query)) {
             return;
         }
 
@@ -145,10 +165,25 @@ impl LinkCompletions {
             self.selected += 1;
         }
 
+        let display_for = |r: &FileResult| -> String {
+            if matches!(mode, CompletionMode::LinkDest | CompletionMode::ImageLinkDest) {
+                existing_title(&buffer[(bracket_start, replace_end)], mode)
+            } else {
+                r.name.clone()
+            }
+        };
+
         if ctx.input_mut(|i| i.consume_key(Modifiers::NONE, Key::Enter)) {
             let idx = self.selected;
             let r = &results[idx];
-            self.apply_completion(events, bracket_start, replace_end, &r.name, &r.insert, mode);
+            self.apply_completion(
+                events,
+                bracket_start,
+                replace_end,
+                &display_for(r),
+                &r.insert,
+                mode,
+            );
             return;
         }
 
@@ -165,7 +200,14 @@ impl LinkCompletions {
         {
             if ctx.input_mut(|i| i.consume_key(num_modifier, *key)) {
                 let r = &results[idx];
-                self.apply_completion(events, bracket_start, replace_end, &r.name, &r.insert, mode);
+                self.apply_completion(
+                    events,
+                    bracket_start,
+                    replace_end,
+                    &display_for(r),
+                    &r.insert,
+                    mode,
+                );
                 return;
             }
         }
@@ -179,8 +221,12 @@ impl LinkCompletions {
     ) {
         let text = match mode {
             CompletionMode::WikiLink => format!("[[{}]]", path),
-            CompletionMode::Link => format!("[{}]({})", display, path),
-            CompletionMode::ImageLink => format!("![{}]({})", display, path),
+            CompletionMode::Link | CompletionMode::LinkDest => {
+                format!("[{}]({})", display, path)
+            }
+            CompletionMode::ImageLink | CompletionMode::ImageLinkDest => {
+                format!("![{}]({})", display, path)
+            }
         };
         events.push(Event::Replace {
             region: Region::BetweenLocations {
@@ -205,7 +251,107 @@ fn detect_any(buffer: &Buffer) -> Option<((Grapheme, Grapheme), CompletionMode)>
         let mode = if is_image { CompletionMode::ImageLink } else { CompletionMode::Link };
         return Some((range, mode));
     }
+    if let Some((range, is_image)) = detect_destination(buffer) {
+        let mode = if is_image { CompletionMode::ImageLinkDest } else { CompletionMode::LinkDest };
+        return Some((range, mode));
+    }
     None
+}
+
+/// Returns the range of a `[text](path...` link whose *destination* contains
+/// the cursor, plus whether it's an image link. The range spans the whole
+/// link (through the closing `)` when present) so a picked result replaces
+/// it wholesale, keeping the display text (#4893).
+fn detect_destination(buffer: &Buffer) -> Option<((Grapheme, Grapheme), bool)> {
+    let selection = buffer.current.selection;
+    if selection.0 != selection.1 {
+        return None;
+    }
+
+    let cursor_idx = selection.1.0;
+    let len = buffer.current.segs.last_cursor_position().0;
+
+    // Scan backward for the `(` that opened this destination; it must be
+    // preceded by `]` (i.e. we're in `](...`, not a bare paren).
+    let mut i = cursor_idx;
+    let open_paren;
+    loop {
+        if i == 0 {
+            return None;
+        }
+        i -= 1;
+        let g = grapheme_at(buffer, i);
+        if g == "\n" || g == ")" || g == "[" || g == "]" {
+            return None;
+        }
+        if g == "(" {
+            if i == 0 || grapheme_at(buffer, i - 1) != "]" {
+                return None;
+            }
+            open_paren = i;
+            break;
+        }
+        if cursor_idx - i > 200 {
+            return None;
+        }
+    }
+
+    // Scan backward from `](` for the display text's `[`.
+    let mut i = open_paren - 1; // at `]`
+    let open_bracket;
+    loop {
+        if i == 0 {
+            return None;
+        }
+        i -= 1;
+        let g = grapheme_at(buffer, i);
+        if g == "\n" || g == "]" || g == "(" || g == ")" {
+            return None;
+        }
+        if g == "[" {
+            if i > 0 && grapheme_at(buffer, i - 1) == "[" {
+                return None;
+            }
+            open_bracket = i;
+            break;
+        }
+        if open_paren - i > 200 {
+            return None;
+        }
+    }
+
+    let is_image = open_bracket > 0 && grapheme_at(buffer, open_bracket - 1) == "!";
+    let start = if is_image { open_bracket - 1 } else { open_bracket };
+
+    // Forward to the closing `)`; a space or newline ends the destination.
+    let mut j = cursor_idx;
+    while j < len {
+        let g = grapheme_at(buffer, j);
+        if g == ")" {
+            j += 1;
+            break;
+        }
+        if g == "\n" || g == " " || j - cursor_idx > 200 {
+            break;
+        }
+        j += 1;
+    }
+
+    Some(((Grapheme(start), Grapheme(j)), is_image))
+}
+
+/// The display text of the link under completion — preserved when a
+/// destination completion replaces the whole link.
+fn existing_title(raw: &str, mode: CompletionMode) -> String {
+    let start = match mode {
+        CompletionMode::ImageLink | CompletionMode::ImageLinkDest => 2,
+        _ => 1,
+    };
+    raw[start..]
+        .split(']')
+        .next()
+        .unwrap_or_default()
+        .to_string()
 }
 
 /// Returns the grapheme `&str` at the given char offset.
@@ -332,10 +478,21 @@ fn detect_link(buffer: &Buffer) -> Option<((Grapheme, Grapheme), bool)> {
 fn query_range(
     buffer: &Buffer, range: (Grapheme, Grapheme), mode: CompletionMode,
 ) -> (Grapheme, Grapheme) {
+    let raw_full = &buffer[range];
+    if matches!(mode, CompletionMode::LinkDest | CompletionMode::ImageLinkDest) {
+        // query = the destination text: after `](`, before any closing `)`
+        let dest_byte_start = raw_full.find("](").map(|i| i + 2).unwrap_or(raw_full.len());
+        let start = Grapheme(range.0.0 + raw_full[..dest_byte_start].graphemes(true).count());
+        let dest = raw_full[dest_byte_start..].trim_end_matches(')');
+        let end = Grapheme(start.0 + dest.graphemes(true).count());
+        return (start, end);
+    }
+
     let prefix_len = match mode {
         CompletionMode::WikiLink => 2,  // [[
         CompletionMode::Link => 1,      // [
         CompletionMode::ImageLink => 2, // ![
+        CompletionMode::LinkDest | CompletionMode::ImageLinkDest => unreachable!(),
     };
     let start = Grapheme(range.0.0 + prefix_len);
 
@@ -353,6 +510,7 @@ fn query_range(
             let text_grapheme_count = after_prefix[..text_byte_len].graphemes(true).count();
             Grapheme(start.0 + text_grapheme_count)
         }
+        CompletionMode::LinkDest | CompletionMode::ImageLinkDest => unreachable!(),
     };
 
     (start, end)
@@ -396,12 +554,12 @@ fn search(cache: &FileCache, file_id: Uuid, query: &str, mode: CompletionMode) -
 
     let file_allowed = |name: &str| -> bool {
         match mode {
-            CompletionMode::ImageLink => name
+            CompletionMode::ImageLink | CompletionMode::ImageLinkDest => name
                 .rsplit('.')
                 .next()
                 .map(is_supported_image_fmt)
                 .unwrap_or(false),
-            CompletionMode::WikiLink | CompletionMode::Link => true,
+            CompletionMode::WikiLink | CompletionMode::Link | CompletionMode::LinkDest => true,
         }
     };
 
@@ -442,7 +600,7 @@ fn search(cache: &FileCache, file_id: Uuid, query: &str, mode: CompletionMode) -
     };
 
     if query.is_empty() {
-        if mode == CompletionMode::ImageLink {
+        if matches!(mode, CompletionMode::ImageLink | CompletionMode::ImageLinkDest) {
             // Images are rarely in the suggested list (they aren't opened like notes),
             // so for image links show all image files sorted by last_modified desc.
             let mut image_files: Vec<_> = cache
@@ -490,11 +648,12 @@ fn search(cache: &FileCache, file_id: Uuid, query: &str, mode: CompletionMode) -
             if !file_matches(&f.name) {
                 return None;
             }
-            let display_name = if mode == CompletionMode::ImageLink {
-                f.name.clone()
-            } else {
-                strip_ext(&f.name).to_string()
-            };
+            let display_name =
+                if matches!(mode, CompletionMode::ImageLink | CompletionMode::ImageLinkDest) {
+                    f.name.clone()
+                } else {
+                    strip_ext(&f.name).to_string()
+                };
             // Rank exact name/stem matches first, then prefixes. A query with or
             // without the extension can match either.
             let lname = f.name.to_lowercase();
@@ -858,11 +1017,17 @@ impl MdEdit {
         // -- Apply clicked result --------------------------------------------------
         if let Some(idx) = clicked {
             let r = &results[idx];
+            let display =
+                if matches!(mode, CompletionMode::LinkDest | CompletionMode::ImageLinkDest) {
+                    existing_title(&self.renderer.buffer[(bracket_start, replace_end)], mode)
+                } else {
+                    r.name.clone()
+                };
             self.link_completions.apply_completion(
                 &mut self.event.internal_events,
                 bracket_start,
                 replace_end,
-                &r.name,
+                &display,
                 &r.insert,
                 mode,
             );
@@ -914,6 +1079,69 @@ mod tests {
     /// resolves back to the file it was for. Covers all three insert forms —
     /// bare stem (`todo`), full name when the stem collides (`Pancakes.md`),
     /// and a relative path when the full name collides across folders (`a/Spec`).
+    #[test]
+    fn destination_context_detected_and_title_kept() {
+        use lb_rs::model::text::buffer::Buffer;
+        use lb_rs::model::text::offset_types::Grapheme;
+
+        use super::{detect_any, existing_title, query_range};
+
+        // cursor mid-destination of a complete link
+        let mut buffer = Buffer::from("see [My Title](qu) after");
+        buffer.current.selection = (Grapheme(17), Grapheme(17));
+        let ((start, end), mode) = detect_any(&buffer).expect("destination context");
+        assert!(matches!(mode, CompletionMode::LinkDest));
+        assert_eq!(&buffer[(start, end)], "[My Title](qu)");
+        let qr = query_range(&buffer, (start, end), mode);
+        assert_eq!(&buffer[qr], "qu");
+        assert_eq!(existing_title(&buffer[(start, end)], mode), "My Title");
+
+        // image link, destination not yet closed
+        let mut buffer = Buffer::from("![alt](par");
+        buffer.current.selection = (Grapheme(10), Grapheme(10));
+        let ((start, end), mode) = detect_any(&buffer).expect("image destination context");
+        assert!(matches!(mode, CompletionMode::ImageLinkDest));
+        assert_eq!(&buffer[(start, end)], "![alt](par");
+        let qr = query_range(&buffer, (start, end), mode);
+        assert_eq!(&buffer[qr], "par");
+        assert_eq!(existing_title(&buffer[(start, end)], mode), "alt");
+
+        // cursor in the display text is the title context, not destination
+        let mut buffer = Buffer::from("[ti](dest)");
+        buffer.current.selection = (Grapheme(3), Grapheme(3));
+        let (_, mode) = detect_any(&buffer).expect("title context");
+        assert!(matches!(mode, CompletionMode::Link));
+
+        // a bare paren isn't a destination
+        let mut buffer = Buffer::from("just (parens");
+        buffer.current.selection = (Grapheme(9), Grapheme(9));
+        assert!(detect_any(&buffer).is_none());
+    }
+
+    #[test]
+    fn destination_completion_replaces_link_keeping_title() {
+        use super::LinkCompletions;
+        use crate::tab::markdown_editor::input::Event;
+        use lb_rs::model::text::offset_types::Grapheme;
+
+        let mut lc = LinkCompletions::default();
+        let mut events: Vec<Event> = vec![];
+        lc.apply_completion(
+            &mut events,
+            Grapheme(4),
+            Grapheme(18),
+            "My Title",
+            "notes/target.md",
+            CompletionMode::LinkDest,
+        );
+        match &events[..] {
+            [Event::Replace { text, .. }] => {
+                assert_eq!(text, "[My Title](notes/target.md)");
+            }
+            other => panic!("expected one replace, got {other:?}"),
+        }
+    }
+
     #[test]
     fn wikilink_completions_resolve_back() {
         let root_id = Uuid::new_v4();

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1835,12 +1835,19 @@ impl MdRender {
                 }
 
                 if let FragmentContent::Embed { url, kind } = &frag.content {
+                    // Non-advancing child ui: embeds paint for off-screen
+                    // neighbor rows too, and any allocation there would drag
+                    // the layout cursor below the viewport, displacing
+                    // siblings laid out after the editor (#4892).
+                    let embed_ui = &mut ui.new_child(egui::UiBuilder::new().max_rect(screen_rect));
                     match kind {
-                        EmbedKind::Image => {
-                            self.embeds
-                                .show(ui, url, screen_rect, egui::CornerRadius::same(2))
-                        }
-                        EmbedKind::LinkCard => self.paint_link_card(ui, url, screen_rect),
+                        EmbedKind::Image => self.embeds.show(
+                            embed_ui,
+                            url,
+                            screen_rect,
+                            egui::CornerRadius::same(2),
+                        ),
+                        EmbedKind::LinkCard => self.paint_link_card(embed_ui, url, screen_rect),
                     }
 
                     // The embed's opaque fill hides the selection slot behind it,

--- a/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/utils/wrap_layout.rs
@@ -1976,29 +1976,52 @@ impl MdRender {
     }
 
     /// Allocate `ui.interact` for every fragment tagged with
-    /// `(salt, sense)` and union the per-fragment responses by parent
-    /// id into `self.interaction_responses`. Consumers compute
-    /// `ui.id().with(salt)` to look up the merged response.
+    /// `(salt, sense)`; union the responses by parent id into
+    /// `self.interaction_responses` and record the per-fragment rects
+    /// into `self.interaction_rects`. Consumers compute
+    /// `ui.id().with(salt)` to look up either.
     ///
     /// Must run after the editor's own `ui.interact` so per-fragment
     /// rects sit on top in egui's z-order.
     pub fn interact_fragments(&mut self, ui: &mut egui::Ui) {
         let mut per_parent: std::collections::HashMap<egui::Id, egui::Response> =
             std::collections::HashMap::new();
+        let mut per_parent_rects: std::collections::HashMap<egui::Id, Vec<Rect>> =
+            std::collections::HashMap::new();
         let parent_base = ui.id();
         for (i, f) in self.fragments.iter().enumerate() {
             let Some((salt, sense)) = f.interaction else {
                 continue;
             };
+            // Chips paint their pill `inline_pad` (= row_spacing/2) beyond
+            // the text band; match the interact rect to the ink so a wrapped
+            // pill's rows meet across the gap and a tap between them hits it.
+            let rect = if f.style_stack.iter().any(|s| s.chip) {
+                f.rect
+                    .expand2(egui::vec2(0.0, self.layout.row_spacing / 2.0))
+            } else {
+                f.rect
+            };
             let parent_id = parent_base.with(salt);
-            let r = ui.interact(f.rect, parent_id.with(i), sense);
+            let r = ui.interact(rect, parent_id.with(i), sense);
             let merged = match per_parent.remove(&parent_id) {
                 Some(prev) => prev.union(r),
                 None => r,
             };
             per_parent.insert(parent_id, merged);
+            per_parent_rects.entry(parent_id).or_default().push(rect);
         }
         self.interaction_responses = per_parent;
+        self.interaction_rects = per_parent_rects;
+    }
+
+    /// Mark a scope's fragments touch-consuming (iOS routes taps there to
+    /// egui). Per-fragment rects, not the merged bounding box — a wrapped
+    /// scope's bbox would eat cursor taps in its gaps and trailing space.
+    pub fn touch_consume_interaction(&mut self, parent_id: egui::Id) {
+        if let Some(rects) = self.interaction_rects.get(&parent_id) {
+            self.touch_consuming_rects.extend_from_slice(rects);
+        }
     }
 
     /// Find the closest fragment to `pos` by (y_dist, x_dist), with


### PR DESCRIPTION
## Link interaction model
- Tapping any link-like element on touch (markdown link, wikilink, inline preview capsule, preview card, image) now selects it and opens a context menu with Open Link / Copy Link / Edit — replacing the keyboard-visibility mode and the trailing ↗ affordance
- Desktop: right-click on links, previews, and images shows the same menu (Open / Copy / Edit, image-flavored verbs for images); plain click still places the cursor, cmd-click still follows
- "Edit" now works for every link kind: bare autolinks select the whole URL, labeled links select the destination, wikilinks select the interior, images select the URL
- Android edit menu gains Open Link and Copy Link (previously there was no way to open a link on Android); iOS gains Copy Link; wikilinks now gate these items too
- The iOS edit menu anchors to the selection's footprint so it no longer covers the preview it was opened from, and the Edit action has a pencil icon

## Hit-testing and geometry
- Tap targets for wrapped inline previews match the painted pill: taps between a pill's own rows hit the pill (#4894), taps beside or after it place the cursor (#4895)
- Embed and fold-chevron painting no longer advances the egui layout cursor — off-screen link previews were dragging the mobile toolbar off screen while scrolling (#4892)
- Reveal state now updates in the same frame that applies a selection change, so iOS never reads one-frame-stale caret/selection geometry
- iOS selection notifications are properly paired (and sent around text replacement), fixing stale selection rects after Edit expands a link and unreliable caret height next to images
- Layout-only geometry changes (scroll, embed loads) no longer report as selection changes, fixing the QuickType suggestion bar flickering during scroll

## Link previews
- Bot-wall and error pages are no longer rendered as preview titles ("Just a moment...", "Access Denied") — junk metadata is treated as a fetch failure via the cf-mitigated header, status-first checks, and a title/body blocklist
- Failed fetches now retry on a schedule: server Retry-After honored, network errors back off 1–15 min, bot walls 6 h, true permanent failures never
- New "Refresh Preview" action in the link context menu on all platforms re-fetches a preview on demand
- The capsule favicon slot shows a neutral link glyph while the favicon loads (or if it never does) instead of reserving blank space

## Completions
- Link completions fire while editing a destination (`[title](...`), completing workspace file paths and preserving the display text (#4893)
- The two-character minimum is gone — completions pop immediately on `[`, `[[`, `![`, and `](`, held only while `- [` could still become a task checkbox

Fixes #4892, fixes #4893, fixes #4894, fixes #4895
