### PR TITLE
apple: sync button and status

### DIFF
--- a/clients/apple/App/Screens/FileTreeView.swift
+++ b/clients/apple/App/Screens/FileTreeView.swift
@@ -5,6 +5,9 @@ struct FileTreeView: View {
     @Environment(FilesModel.self) private var filesModel
     @Environment(WorkspaceInputState.self) private var workspaceInput
     @Environment(WorkspaceOutputState.self) private var workspaceOutput
+    #if os(iOS)
+        @Environment(HomeState.self) private var homeState
+    #endif
 
     let fileTreeModel: FileTreeModel
 
@@ -115,6 +118,9 @@ struct FileTreeView: View {
                 }
             }
             .refreshable {
+                #if os(iOS)
+                    homeState.explicitSyncRequested()
+                #endif
                 workspaceInput.requestSync()
             }
             .selectionCommands(fileTreeModel.selection)

--- a/clients/apple/App/Screens/HomeView.swift
+++ b/clients/apple/App/Screens/HomeView.swift
@@ -18,7 +18,10 @@ struct HomeView: View {
     @State private var renameTarget: File? = nil
     @State private var showTabsSidebar = false
     @State private var showOutOfSpaceAlert = false
+    @State private var showUpgrade = false
+    @State private var upgradeModel: SettingsModel? = nil
     @State private var detailWidth: CGFloat = 0
+    @State private var syncPillDisplay: SyncPillDisplay? = nil
     #if os(iOS)
         @State private var showSettings = false
         @State private var keyboardVisible = false
@@ -213,21 +216,47 @@ struct HomeView: View {
         .onChange(of: nativeSidebarOpen) { _, open in
             workspaceInput.setSidebarOpen(open)
         }
-        .onChange(of: AppState.lb.events.status) { _, status in
+        .onChange(of: AppState.lb.events.status, initial: true) { _, status in
             filesModel.recomputeStatusDots(status: status)
+            reconcileSyncPill()
 
             if status.outOfSpace, !hideOutOfSpaceAlert {
                 showOutOfSpaceAlert = true
             }
         }
+        #if os(iOS)
+            .task(id: homeState.explicitSyncCount) {
+                await runSyncPillFlow()
+            }
+        #endif
         .alert("You're out of space", isPresented: $showOutOfSpaceAlert) {
+            Button("Upgrade") {
+                upgradeModel = SettingsModel()
+                showUpgrade = true
+            }
+
             Button("Don't show again") {
                 hideOutOfSpaceAlert = true
             }
 
             Button("Dismiss", role: .cancel) {}
         } message: {
-            Text("Your changes will stop syncing until you free up space or upgrade your account in Settings.")
+            Text("Your changes will stop syncing until you free up space or upgrade for more storage.")
+        }
+        .sheet(isPresented: $showUpgrade) {
+            if let upgradeModel {
+                NavigationStack {
+                    UpgradeAccountView(settingsModel: upgradeModel)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Done") { showUpgrade = false }
+                            }
+                        }
+                }
+                #if os(macOS)
+                    .frame(minWidth: 420, minHeight: 520)
+                #endif
+            }
         }
         .onChange(of: workspaceOutput.tabCount) { _, count in
             if count == 0 {
@@ -468,6 +497,83 @@ struct HomeView: View {
             }
 
             sidebarContent
+
+            #if os(macOS)
+                SyncStatusFooter(action: syncTapped)
+            #else
+                if horizontalSizeClass == .regular {
+                    SyncStatusFooter(action: syncTapped)
+                }
+            #endif
+        }
+    }
+
+    private func syncTapped() {
+        let status = AppState.lb.events.status
+
+        if status.updateRequired {
+            AppState.shared.error = .custom(
+                title: "Your Lockbook is out of date", msg: "Update to the latest version to sync"
+            )
+        } else if status.outOfSpace {
+            showOutOfSpaceAlert = true
+        }
+
+        workspaceInput.requestSync()
+    }
+
+    private static let syncPillAnim: Animation = .spring(response: 0.35, dampingFraction: 0.8)
+
+    private func reconcileSyncPill() {
+        switch syncPillDisplay {
+        case .syncing, .synced:
+            return
+        default:
+            break
+        }
+
+        let target = SyncPillDisplay.attentionOnly(for: AppState.lb.events.status)
+            .map { SyncPillDisplay.attention($0) }
+
+        if syncPillDisplay != target {
+            withAnimation(Self.syncPillAnim) {
+                syncPillDisplay = target
+            }
+        }
+    }
+
+    private func runSyncPillFlow() async {
+        guard homeState.explicitSyncCount != 0 else { return }
+
+        withAnimation(Self.syncPillAnim) {
+            syncPillDisplay = .syncing
+        }
+
+        try? await Task.sleep(for: .milliseconds(600))
+        guard !Task.isCancelled else { return }
+
+        while AppState.lb.events.status.syncing {
+            try? await Task.sleep(for: .milliseconds(100))
+            guard !Task.isCancelled else { return }
+        }
+
+        if let attention = SyncPillDisplay.attentionOnly(for: AppState.lb.events.status) {
+            withAnimation(Self.syncPillAnim) {
+                syncPillDisplay = .attention(attention)
+            }
+            return
+        }
+
+        withAnimation(Self.syncPillAnim) {
+            syncPillDisplay = .synced
+        }
+
+        try? await Task.sleep(for: .milliseconds(1200))
+        guard !Task.isCancelled else { return }
+
+        withAnimation(Self.syncPillAnim) {
+            syncPillDisplay = SyncPillDisplay.attentionOnly(for: AppState.lb.events.status)
+                .map { .attention($0) }
         }
     }
 
@@ -498,6 +604,7 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .fixedSize()
                 }
+                .sharedBackgroundVisibility(.hidden)
             }
 
             #if os(iOS)
@@ -526,6 +633,12 @@ struct HomeView: View {
                         } label: {
                             Image(systemName: "magnifyingglass")
                         }
+                    }
+
+                    ToolbarSpacer(.flexible, placement: .bottomBar)
+
+                    ToolbarItem(placement: .bottomBar) {
+                        SyncStatusPill(display: syncPillDisplay, action: syncTapped)
                     }
 
                     ToolbarSpacer(.flexible, placement: .bottomBar)

--- a/clients/apple/App/Screens/HomeView.swift
+++ b/clients/apple/App/Screens/HomeView.swift
@@ -21,7 +21,7 @@ struct HomeView: View {
     @State private var showUpgrade = false
     @State private var upgradeModel: SettingsModel? = nil
     @State private var detailWidth: CGFloat = 0
-    @State private var syncPillDisplay: SyncPillDisplay? = nil
+    @State private var syncPillDisplay: SyncIndicator? = nil
     #if os(iOS)
         @State private var showSettings = false
         @State private var keyboardVisible = false
@@ -525,15 +525,11 @@ struct HomeView: View {
     private static let syncPillAnim: Animation = .spring(response: 0.35, dampingFraction: 0.8)
 
     private func reconcileSyncPill() {
-        switch syncPillDisplay {
-        case .syncing, .synced:
+        if syncPillDisplay == .syncing || syncPillDisplay == .synced {
             return
-        default:
-            break
         }
 
-        let target = SyncPillDisplay.attentionOnly(for: AppState.lb.events.status)
-            .map { SyncPillDisplay.attention($0) }
+        let target = SyncIndicator.attention(for: AppState.lb.events.status)
 
         if syncPillDisplay != target {
             withAnimation(Self.syncPillAnim) {
@@ -557,9 +553,9 @@ struct HomeView: View {
             guard !Task.isCancelled else { return }
         }
 
-        if let attention = SyncPillDisplay.attentionOnly(for: AppState.lb.events.status) {
+        if let attention = SyncIndicator.attention(for: AppState.lb.events.status) {
             withAnimation(Self.syncPillAnim) {
-                syncPillDisplay = .attention(attention)
+                syncPillDisplay = attention
             }
             return
         }
@@ -572,8 +568,7 @@ struct HomeView: View {
         guard !Task.isCancelled else { return }
 
         withAnimation(Self.syncPillAnim) {
-            syncPillDisplay = SyncPillDisplay.attentionOnly(for: AppState.lb.events.status)
-                .map { .attention($0) }
+            syncPillDisplay = SyncIndicator.attention(for: AppState.lb.events.status)
         }
     }
 
@@ -638,7 +633,7 @@ struct HomeView: View {
                     ToolbarSpacer(.flexible, placement: .bottomBar)
 
                     ToolbarItem(placement: .bottomBar) {
-                        SyncStatusPill(display: syncPillDisplay, action: syncTapped)
+                        SyncStatusPill(indicator: syncPillDisplay, action: syncTapped)
                     }
 
                     ToolbarSpacer(.flexible, placement: .bottomBar)

--- a/clients/apple/App/Screens/RecentsView.swift
+++ b/clients/apple/App/Screens/RecentsView.swift
@@ -3,6 +3,10 @@ import SwiftWorkspace
 
 struct RecentsView: View {
     @Environment(FilesModel.self) private var filesModel
+    @Environment(WorkspaceInputState.self) private var workspaceInput
+    #if os(iOS)
+        @Environment(HomeState.self) private var homeState
+    #endif
 
     let model: RecentsModel
     let fileTreeModel: FileTreeModel
@@ -53,6 +57,12 @@ struct RecentsView: View {
                         }
                     }
                     .padding(.bottom, 20)
+                }
+                .refreshable {
+                    #if os(iOS)
+                        homeState.explicitSyncRequested()
+                    #endif
+                    workspaceInput.requestSync()
                 }
             }
         }

--- a/clients/apple/App/Screens/SettingsView.swift
+++ b/clients/apple/App/Screens/SettingsView.swift
@@ -280,6 +280,9 @@ struct UsageSettingsRows: View {
     let model: SettingsModel
 
     @State private var confirmCancelSubscription = false
+    #if os(macOS)
+        @AppStorage("usageBarMode") private var usageBarMode: UsageBarDisplayMode = .whenHalf
+    #endif
 
     var body: some View {
         if let isPremium = model.isPremium {
@@ -311,6 +314,14 @@ struct UsageSettingsRows: View {
         } else {
             ProgressView()
         }
+
+        #if os(macOS)
+            Picker("Sidebar usage bar", selection: $usageBarMode) {
+                ForEach(UsageBarDisplayMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+        #endif
 
         if model.isPremium == true {
             Button("Cancel Subscription", role: .destructive) {

--- a/clients/apple/App/State/AppState.swift
+++ b/clients/apple/App/State/AppState.swift
@@ -7,7 +7,15 @@ import SwiftWorkspace
     
     var account: Account? = nil
     var isLoggedIn: Bool = false
-    var error: UIError? = nil
+    var error: UIError? = nil {
+        didSet {
+            guard let error else { return }
+            print("‼️ AppState.error set: \(error.title) — \(error.message)")
+            for frame in Thread.callStackSymbols.prefix(12) {
+                print("    \(frame)")
+            }
+        }
+    }
 
     private init() {
         checkIfLoggedIn()

--- a/clients/apple/App/State/AppState.swift
+++ b/clients/apple/App/State/AppState.swift
@@ -7,15 +7,7 @@ import SwiftWorkspace
     
     var account: Account? = nil
     var isLoggedIn: Bool = false
-    var error: UIError? = nil {
-        didSet {
-            guard let error else { return }
-            print("‼️ AppState.error set: \(error.title) — \(error.message)")
-            for frame in Thread.callStackSymbols.prefix(12) {
-                print("    \(frame)")
-            }
-        }
-    }
+    var error: UIError? = nil
 
     private init() {
         checkIfLoggedIn()

--- a/clients/apple/App/State/HomeState.swift
+++ b/clients/apple/App/State/HomeState.swift
@@ -7,4 +7,10 @@ import SwiftUI
     var compactColumn: NavigationSplitViewColumn = .detail
 
     var openingLink = false
+
+    var explicitSyncCount = 0
+
+    func explicitSyncRequested() {
+        explicitSyncCount += 1
+    }
 }

--- a/clients/apple/App/Widgets/SyncStatusIndicator.swift
+++ b/clients/apple/App/Widgets/SyncStatusIndicator.swift
@@ -45,6 +45,13 @@ enum SyncIndicator: Equatable {
         case .syncError: "Error"
         }
     }
+
+    static func attention(for status: Status) -> SyncIndicator? {
+        switch SyncIndicator(status: status) {
+        case .synced, .syncing: nil
+        case let other: other
+        }
+    }
 }
 
 enum UsageBarDisplayMode: String, Codable, CaseIterable, Identifiable {
@@ -91,21 +98,6 @@ struct UsageBar: View {
         guard usage.serverCapExact > 0 else { return 0 }
 
         return Double(usage.serverUsedExact) / Double(usage.serverCapExact)
-    }
-}
-
-struct SyncStatusDot: View {
-    let indicator: SyncIndicator
-
-    var body: some View {
-        if indicator == .syncing {
-            ProgressView()
-                .controlSize(.small)
-        } else {
-            Circle()
-                .fill(indicator.color)
-                .frame(width: 8, height: 8)
-        }
     }
 }
 
@@ -184,55 +176,22 @@ struct SyncStatusFooter: View {
     }
 }
 
-enum SyncPillDisplay: Equatable {
-    case syncing
-    case synced
-    case attention(SyncIndicator)
-
-    static func attentionOnly(for status: Status) -> SyncIndicator? {
-        switch SyncIndicator(status: status) {
-        case .synced, .syncing: nil
-        case let other: other
-        }
-    }
-
-    private var indicator: SyncIndicator {
-        switch self {
-        case .syncing: .syncing
-        case .synced: .synced
-        case let .attention(indicator): indicator
-        }
-    }
-
-    var label: String {
-        indicator.shortLabel
-    }
-
-    var color: Color {
-        indicator.color
-    }
-
-    var showsSpinner: Bool {
-        self == .syncing
-    }
-}
-
 struct SyncStatusPill: View {
-    let display: SyncPillDisplay?
+    let indicator: SyncIndicator?
     let action: () -> Void
 
     var body: some View {
         Group {
-            if let display {
+            if let indicator {
                 Button(action: action) {
                     HStack(spacing: 6) {
-                        if display.showsSpinner {
+                        if indicator == .syncing {
                             ProgressView().controlSize(.small)
                         } else {
-                            Circle().fill(display.color).frame(width: 8, height: 8)
+                            Circle().fill(indicator.color).frame(width: 8, height: 8)
                         }
 
-                        Text(display.label)
+                        Text(indicator.shortLabel)
                             .font(.footnote)
                             .fontWeight(.medium)
                     }
@@ -250,6 +209,6 @@ struct SyncStatusPill: View {
 }
 
 #Preview("Pill") {
-    SyncStatusPill(display: .attention(.offline)) {}
+    SyncStatusPill(indicator: .offline) {}
         .padding()
 }

--- a/clients/apple/App/Widgets/SyncStatusIndicator.swift
+++ b/clients/apple/App/Widgets/SyncStatusIndicator.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+import SwiftWorkspace
+
+enum SyncIndicator: Equatable {
+    case synced
+    case syncing
+    case offline
+    case outOfSpace
+    case updateRequired
+    case syncError
+
+    init(status: Status) {
+        if status.syncing {
+            self = .syncing
+        } else if status.offline {
+            self = .offline
+        } else if status.outOfSpace {
+            self = .outOfSpace
+        } else if status.updateRequired {
+            self = .updateRequired
+        } else if status.unexpectedSyncProblem != nil {
+            self = .syncError
+        } else {
+            self = .synced
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .synced: .green
+        case .syncing: .blue
+        case .offline: .gray
+        case .outOfSpace: .orange
+        case .updateRequired, .syncError: .red
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .synced: "Synced"
+        case .syncing: "Syncing"
+        case .offline: "Offline"
+        case .outOfSpace: "No space"
+        case .updateRequired: "Update"
+        case .syncError: "Error"
+        }
+    }
+}
+
+enum UsageBarDisplayMode: String, Codable, CaseIterable, Identifiable {
+    case always
+    case never
+    case whenHalf
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .always: "Always show"
+        case .never: "Never show"
+        case .whenHalf: "Show above 50%"
+        }
+    }
+}
+
+struct UsageBar: View {
+    @AppStorage("usageBarMode") private var mode: UsageBarDisplayMode = .whenHalf
+
+    private static let halfThreshold = 0.5
+    private static let warnThreshold = 0.7
+
+    var body: some View {
+        if let usage = AppState.lb.events.status.spaceUsed, shouldShow(usage) {
+            ProgressView(value: min(fraction(usage), 1))
+                .tint(fraction(usage) >= Self.warnThreshold ? .yellow : .accentColor)
+                .help("\(usage.serverUsedHuman) / \(usage.serverCapHuman)")
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+        }
+    }
+
+    private func shouldShow(_ usage: UsageMetrics) -> Bool {
+        switch mode {
+        case .always: true
+        case .never: false
+        case .whenHalf: fraction(usage) >= Self.halfThreshold
+        }
+    }
+
+    private func fraction(_ usage: UsageMetrics) -> Double {
+        guard usage.serverCapExact > 0 else { return 0 }
+
+        return Double(usage.serverUsedExact) / Double(usage.serverCapExact)
+    }
+}
+
+struct SyncStatusDot: View {
+    let indicator: SyncIndicator
+
+    var body: some View {
+        if indicator == .syncing {
+            ProgressView()
+                .controlSize(.small)
+        } else {
+            Circle()
+                .fill(indicator.color)
+                .frame(width: 8, height: 8)
+        }
+    }
+}
+
+struct SyncStatusFooter: View {
+    let action: () -> Void
+
+    @State private var stableMessage = ""
+    @State private var spinAngle: Double = 0
+    @State private var isSpinning = false
+
+    var body: some View {
+        let status = AppState.lb.events.status
+        let raw = SyncIndicator(status: status)
+        let indicator: SyncIndicator = raw == .syncing ? .synced : raw
+
+        VStack(spacing: 0) {
+            Divider()
+
+            #if os(macOS)
+                UsageBar()
+            #endif
+
+            Button(action: {
+                if !isSpinning {
+                    isSpinning = true
+                    spinStep()
+                }
+                action()
+            }) {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(indicator.color)
+                        .frame(width: 8, height: 8)
+
+                    Text(stableMessage.isEmpty ? indicator.shortLabel : stableMessage)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(spinAngle))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(status.message)
+        }
+        .onChange(of: AppState.lb.events.status, initial: true) { _, status in
+            if !status.syncing, !status.message.isEmpty {
+                stableMessage = status.message
+            }
+
+            if status.syncing, !isSpinning {
+                isSpinning = true
+                spinStep()
+            }
+        }
+    }
+
+    private func spinStep() {
+        withAnimation(.bouncy(duration: 0.50)) {
+            spinAngle += 180
+        } completion: {
+            if AppState.lb.events.status.syncing {
+                spinStep()
+            } else {
+                isSpinning = false
+            }
+        }
+    }
+}
+
+enum SyncPillDisplay: Equatable {
+    case syncing
+    case synced
+    case attention(SyncIndicator)
+
+    static func attentionOnly(for status: Status) -> SyncIndicator? {
+        switch SyncIndicator(status: status) {
+        case .synced, .syncing: nil
+        case let other: other
+        }
+    }
+
+    private var indicator: SyncIndicator {
+        switch self {
+        case .syncing: .syncing
+        case .synced: .synced
+        case let .attention(indicator): indicator
+        }
+    }
+
+    var label: String {
+        indicator.shortLabel
+    }
+
+    var color: Color {
+        indicator.color
+    }
+
+    var showsSpinner: Bool {
+        self == .syncing
+    }
+}
+
+struct SyncStatusPill: View {
+    let display: SyncPillDisplay?
+    let action: () -> Void
+
+    var body: some View {
+        Group {
+            if let display {
+                Button(action: action) {
+                    HStack(spacing: 6) {
+                        if display.showsSpinner {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Circle().fill(display.color).frame(width: 8, height: 8)
+                        }
+
+                        Text(display.label)
+                            .font(.footnote)
+                            .fontWeight(.medium)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.regularMaterial, in: Capsule())
+                    .overlay(Capsule().strokeBorder(.separator, lineWidth: 0.5))
+                }
+                .tint(.primary)
+                .transition(.scale(scale: 0.8).combined(with: .opacity))
+            }
+        }
+    }
+}
+
+#Preview("Footer") {
+    SyncStatusFooter {}
+        .frame(width: 300)
+}
+
+#Preview("Pill") {
+    SyncStatusPill(display: .attention(.offline)) {}
+        .padding()
+}

--- a/clients/apple/App/Widgets/SyncStatusIndicator.swift
+++ b/clients/apple/App/Widgets/SyncStatusIndicator.swift
@@ -10,9 +10,7 @@ enum SyncIndicator: Equatable {
     case syncError
 
     init(status: Status) {
-        if status.syncing {
-            self = .syncing
-        } else if status.offline {
+        if status.offline {
             self = .offline
         } else if status.outOfSpace {
             self = .outOfSpace
@@ -20,6 +18,8 @@ enum SyncIndicator: Equatable {
             self = .updateRequired
         } else if status.unexpectedSyncProblem != nil {
             self = .syncError
+        } else if status.syncing {
+            self = .syncing
         } else {
             self = .synced
         }
@@ -236,10 +236,6 @@ struct SyncStatusPill: View {
                             .font(.footnote)
                             .fontWeight(.medium)
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(.regularMaterial, in: Capsule())
-                    .overlay(Capsule().strokeBorder(.separator, lineWidth: 0.5))
                 }
                 .tint(.primary)
                 .transition(.scale(scale: 0.8).combined(with: .opacity))

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Error.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Error.swift
@@ -35,7 +35,6 @@ public enum EC: Int {
     case currentUsageIsMoreThanNewTier
     case diskPathInvalid
     case diskPathTaken
-    case drawingInvalid
     case existingRequestPending
     case fileNameContainsSlash
     case fileNameTooLong

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
@@ -133,8 +133,10 @@ import Observation
     public func requestSync() {
         guard let wsHandle else { return }
 
-        request_sync(wsHandle)
         redraw.send(())
+        DispatchQueue.global(qos: .userInitiated).async {
+            request_sync(wsHandle)
+        }
     }
 
     public func closeDoc(id: UUID) {


### PR DESCRIPTION
on macOS where we have space, we show this persistently. It has a nice animation so you always get some feedback if you hit that sync button.

<img width="1062" height="771" alt="image" src="https://github.com/user-attachments/assets/4afcd43b-d915-4b27-a34b-4d25164d2d9a" />

by default iPhone unchanged: 

<img width="100" alt="image" src="https://github.com/user-attachments/assets/b641cc78-918d-4fcb-bf8a-29908f1bc842" />

if you explicitly pull to sync you'll get some feedback:

<img width="200" alt="image" src="https://github.com/user-attachments/assets/8608c7c3-7377-414e-9e36-4e79916865d6" /> <img width="200"  alt="image" src="https://github.com/user-attachments/assets/cd35830b-9ddd-45b3-9ff6-8cd80dd558c9" />

these things animate nicely

error states look like this

<img width="350"  alt="image" src="https://github.com/user-attachments/assets/4ee28230-13af-4dbe-baec-1cf714a51d04" />

Also notice that the double pill is gone (from the #4909 second screenshot). 

Running out of space will offer to put you pretty deep into the payment flow instead of directing you to settings. Verified this with @tvanderstad hopefully he can share some screenshots.

fixes #4904 

Now the blocker to this being a good time is back to rust: https://github.com/lockbook/lockbook/issues/4410