### PR TITLE
ws: tab history

### DIFF
--- a/clients/apple/App/Screens/CreateFileSheet.swift
+++ b/clients/apple/App/Screens/CreateFileSheet.swift
@@ -285,7 +285,7 @@ struct CreateFileSheet: View {
             filesModel.loadFiles()
 
             if !file.isFolder {
-                workspaceInput.openFile(id: file.id)
+                workspaceInput.openFile(id: file.id, newTab: true)
                 homeState.compactColumn = .detail
             }
 

--- a/clients/apple/App/Widgets/WorkspaceTabsList.swift
+++ b/clients/apple/App/Widgets/WorkspaceTabsList.swift
@@ -317,7 +317,10 @@ struct WorkspaceTabsList: View {
         .padding(.horizontal, 8)
         .contentShape(Rectangle())
         .onTapGesture {
-            workspaceInput.openFile(id: id)
+            workspaceInput.reopenClosedFile(id: id)
+            withAnimation {
+                refresh()
+            }
         }
         .draggable(TabDragItem(id: id))
     }
@@ -358,11 +361,10 @@ struct WorkspaceTabsList: View {
     }
 
     private func reopenLastClosed() {
-        guard let id = recentlyClosed.first else {
-            return
+        workspaceInput.reopenLastClosedTab()
+        withAnimation {
+            refresh()
         }
-
-        workspaceInput.openFile(id: id)
     }
 
     private func dropTab(_ dragged: TabDragItem?, before target: UUID?) -> Bool {
@@ -382,8 +384,15 @@ struct WorkspaceTabsList: View {
                 return false
             }
 
-            workspaceInput.openFile(id: dragged)
-            workspaceInput.moveTab(from: tabIds.count, to: targetIndex)
+            workspaceInput.reopenClosedFile(id: dragged)
+            // Reopen may insert mid-strip; move to the drop target if needed.
+            let openIds = workspaceInput.getTabsIds()
+            if let reopenedFrom = openIds.firstIndex(of: dragged), reopenedFrom != targetIndex {
+                let to = reopenedFrom < targetIndex ? targetIndex - 1 : targetIndex
+                if to != reopenedFrom, to >= 0, to < openIds.count {
+                    workspaceInput.moveTab(from: reopenedFrom, to: to)
+                }
+            }
             withAnimation {
                 refresh()
             }

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
@@ -194,6 +194,22 @@ import Observation
         return tabIds(from: get_recently_closed_tabs(wsHandle))
     }
 
+    /// Restores the most recently closed tab with its back/forward history.
+    public func reopenLastClosedTab() {
+        guard let wsHandle else { return }
+
+        reopen_last_closed_tab(wsHandle)
+        redraw.send(())
+    }
+
+    /// Restores a closed file tab by id (full slot history + placement).
+    public func reopenClosedFile(id: UUID) {
+        guard let wsHandle else { return }
+
+        reopen_closed_file(wsHandle, CUuid(_0: id.uuid))
+        redraw.send(())
+    }
+
     public func moveTab(from: Int, to: Int) {
         guard let wsHandle else { return }
 

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/WorkspaceState.swift
@@ -47,7 +47,10 @@ import Observation
 
     public init() {}
 
-    public func openFile(id: UUID, newTab: Bool = true) {
+    /// Open a file. Default is in place (navigate the current tab, like
+    /// Obsidian / the egui file tree). Pass `newTab: true` for create, reopen,
+    /// multi-window, or explicit "open in new tab".
+    public func openFile(id: UUID, newTab: Bool = false) {
         guard let wsHandle else {
             pendingOpens.append(id)
             return
@@ -61,7 +64,7 @@ import Observation
         //        focus.send(())
     }
 
-    public func openFile(id: UUID, rangeStart: Int, rangeEnd: Int, newTab: Bool = true) {
+    public func openFile(id: UUID, rangeStart: Int, rangeEnd: Int, newTab: Bool = false) {
         guard let wsHandle else { return }
 
         let uuid = CUuid(_0: id.uuid)

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1575,7 +1575,7 @@
             //      FIXME: Can we just do this in rust?
             let newFile = UUID(uuid: output.doc_created._0)
             if !newFile.isNil() {
-                mtkView.workspaceInput?.openFile(id: newFile)
+                mtkView.workspaceInput?.openFile(id: newFile, newTab: true)
             }
 
             if output.urls_opened.size > 0 {

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
@@ -430,7 +430,7 @@
 //      FIXME: Can we just do this in rust?
             let newFile = UUID(uuid: output.doc_created._0)
             if !newFile.isNil() {
-                workspaceInput?.openFile(id: newFile)
+                workspaceInput?.openFile(id: newFile, newTab: true)
             }
 
             if output.urls_opened.size > 0 {

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -434,14 +434,16 @@ pub struct WsStatus {
 
 #[no_mangle]
 pub extern "system" fn Java_app_lockbook_workspace_Workspace_openDoc(
-    mut env: JNIEnv, _: JClass, obj: jlong, jid: JString,
+    mut env: JNIEnv, _: JClass, obj: jlong, jid: JString, new_file: jboolean,
 ) -> jint {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
 
     let rid: String = env.get_string(&jid).unwrap().into();
     let id = Uuid::parse_str(&rid).unwrap();
 
-    obj.workspace.open_file(id, true, true);
+    // Plain open = in place; `new_file` (create / explicit new surface) = new tab.
+    let in_new_tab = new_file != 0;
+    obj.workspace.open_file(id, true, in_new_tab);
     get_current_tab(obj)
 }
 

--- a/libs/content/workspace-ffi/src/android/api.rs
+++ b/libs/content/workspace-ffi/src/android/api.rs
@@ -482,10 +482,7 @@ pub extern "system" fn Java_app_lockbook_workspace_Workspace_closeAllTabs(
     mut _env: JNIEnv, _: JClass, obj: jlong,
 ) {
     let obj = unsafe { &mut *(obj as *mut WgpuWorkspace) };
-
-    while !obj.workspace.tab_strip.is_empty() {
-        obj.workspace.close_tab(0);
-    }
+    obj.workspace.close_all_tabs();
 }
 
 #[no_mangle]

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -912,9 +912,9 @@ pub unsafe extern "C" fn get_recently_closed_tabs(obj: *mut c_void) -> TabsIds {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     let ids: Vec<CUuid> = obj
         .workspace
-        .recently_closed_tabs
-        .iter()
-        .map(|&id| id.into())
+        .recently_closed_tabs()
+        .into_iter()
+        .map(Into::into)
         .collect();
 
     TabsIds { size: ids.len() as i32, ids: Box::into_raw(ids.into_boxed_slice()) as *const CUuid }

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -1102,10 +1102,7 @@ pub unsafe extern "C" fn close_active_tab(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn close_all_tabs(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
-
-    while !obj.workspace.tab_strip.is_empty() {
-        obj.workspace.close_tab(0);
-    }
+    obj.workspace.close_all_tabs();
 }
 
 /// # Safety

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -923,6 +923,22 @@ pub unsafe extern "C" fn get_recently_closed_tabs(obj: *mut c_void) -> TabsIds {
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
+pub unsafe extern "C" fn reopen_last_closed_tab(obj: *mut c_void) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+    obj.workspace.reopen_closed_tab();
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
+pub unsafe extern "C" fn reopen_closed_file(obj: *mut c_void, id: CUuid) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+    obj.workspace.reopen_closed_file(id.into());
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
 pub unsafe extern "C" fn indent_at_cursor(obj: *mut c_void, deindent: bool) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.renderer

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -275,14 +275,13 @@ impl Workspace {
 
                                 // handle responses after showing all tabs because closing a tab invalidates tab indexes
                                 for (i, resp) in responses {
-                                    let dest = self.tab_strip[i].dest.clone();
+                                    let dest = self.tab_strip.get(i).map(|s| s.dest.clone());
                                     match resp {
                                         TabLabelResponse::Clicked => {
+                                            let Some(dest) = dest else { continue };
                                             let is_current =
                                                 self.current_tab.as_ref() == Some(&dest);
                                             if is_current {
-                                                // we should rename the file.
-
                                                 self.out.tab_title_clicked = true;
                                                 let tab = self.tabs.get(&dest).unwrap();
                                                 let active_name = self.tab_title(tab);
@@ -295,7 +294,32 @@ impl Workspace {
                                         TabLabelResponse::Closed => {
                                             self.close_tab(i);
                                         }
+                                        TabLabelResponse::CloseOthers => {
+                                            self.close_other_tabs(i);
+                                        }
+                                        TabLabelResponse::CloseToLeft => {
+                                            self.close_tabs_to_left(i);
+                                        }
+                                        TabLabelResponse::CloseToRight => {
+                                            self.close_tabs_to_right(i);
+                                        }
+                                        TabLabelResponse::CloseAll => {
+                                            self.close_all_tabs();
+                                        }
+                                        TabLabelResponse::Rename => {
+                                            let Some(dest) = dest else { continue };
+                                            if let Some(tab) = self.tabs.get(&dest) {
+                                                let name = self.tab_title(tab);
+                                                self.tab_strip[i].rename = Some(name);
+                                                self.out.tab_title_clicked = true;
+                                            }
+                                        }
+                                        TabLabelResponse::ReopenClosed => {
+                                            self.reopen_closed_tab();
+                                            self.out.selected_file = self.current_tab_id();
+                                        }
                                         TabLabelResponse::Renamed(name) => {
+                                            let Some(dest) = dest else { continue };
                                             self.tab_strip[i].rename = None;
                                             let id = dest.id();
                                             self.rename_file((id, name.clone()), true);
@@ -436,10 +460,7 @@ impl Workspace {
             .input_mut(|i| i.consume_key_exact(COMMAND | SHIFT, egui::Key::W))
             && !self.is_empty()
         {
-            while !self.tab_strip.is_empty() {
-                self.close_tab(0);
-            }
-
+            self.close_all_tabs();
             self.out.selected_file = None;
         }
 
@@ -736,12 +757,20 @@ impl Workspace {
                         Sense::click_and_drag(),
                     );
 
-                    let pointer_pos = ui.input(|i| i.pointer.interact_pos().unwrap_or_default());
+                    // Close gets its own interact *after* the tab-wide one so
+                    // it wins hit-testing. The old path (tab click + point-in-
+                    // rect) failed while the rename field held focus.
                     let close_button_interact_rect =
                         close_button_rect.expand(if touch_mode { 4. } else { 2. });
-                    let close_button_pointed = close_button_interact_rect.contains(pointer_pos);
-                    let close_button_hovered = tab_label_resp.hovered() && close_button_pointed;
-                    let close_button_clicked = tab_label_resp.clicked() && close_button_pointed;
+                    let close_resp = ui.interact(
+                        close_button_interact_rect,
+                        Id::new("tab close").with(t),
+                        Sense::click(),
+                    );
+
+                    let close_button_hovered = close_resp.hovered();
+                    let close_button_clicked =
+                        close_resp.clicked() || tab_label_resp.middle_clicked();
 
                     let text_color = if is_active {
                         ui.visuals().text_color()
@@ -765,7 +794,13 @@ impl Workspace {
                                     .select_on_focus(0, stem_end),
                             );
 
-                            if !res.has_focus() && !res.lost_focus() {
+                            // Keep focus while editing, but not while the user
+                            // is on the close control (or we re-steal focus and
+                            // the close click is lost).
+                            let on_close = close_resp.hovered()
+                                || close_resp.is_pointer_button_down_on()
+                                || close_button_clicked;
+                            if !res.has_focus() && !res.lost_focus() && !on_close {
                                 ui.memory_mut(|m| m.request_focus(res.id));
                             }
 
@@ -773,7 +808,7 @@ impl Workspace {
                                 result = Some(TabLabelResponse::Renamed(str.to_owned()));
                             }
 
-                            if res.lost_focus() {
+                            if res.lost_focus() && !close_button_clicked {
                                 self.tab_strip[t].rename = None;
                             }
                         }
@@ -787,7 +822,11 @@ impl Workspace {
                         );
                     }
 
-                    if close_button_clicked || tab_label_resp.middle_clicked() {
+                    if close_button_clicked {
+                        if is_renaming {
+                            ui.memory_mut(|m| m.surrender_focus(rename_id));
+                            self.tab_strip[t].rename = None;
+                        }
                         result = Some(TabLabelResponse::Closed);
                     }
                     if close_button_hovered {
@@ -800,7 +839,8 @@ impl Workspace {
                         );
                     }
 
-                    let show_close_button = touch_mode || tab_label_resp.hovered() || is_active;
+                    let show_close_button =
+                        touch_mode || tab_label_resp.hovered() || close_resp.hovered() || is_active;
                     if show_close_button {
                         ui.painter().galley(
                             close_button_rect.min,
@@ -808,14 +848,61 @@ impl Workspace {
                             ui.visuals().text_color(),
                         );
                     }
-                    if tab_label_resp.clicked() && !close_button_clicked {
+                    // Tab body click (not the X). While renaming, ignore so we
+                    // don't re-enter rename or fight the text field.
+                    if tab_label_resp.clicked() && !close_button_clicked && !is_renaming {
                         result = Some(TabLabelResponse::Clicked);
                     }
+                    let tab_count = self.tab_strip.len();
+                    let can_rename = matches!(dest, crate::tab::Destination::File(_));
+                    let can_reopen = self.can_reopen_closed_tab();
                     tab_label_resp.context_menu(|ui| {
-                        if ui.button("Close tab").clicked() {
+                        if ui.button("Close").clicked() {
                             result = Some(TabLabelResponse::Closed);
                             ui.close();
                         }
+
+                        ui.add_enabled_ui(tab_count >= 2, |ui| {
+                            if ui.button("Close Others").clicked() {
+                                result = Some(TabLabelResponse::CloseOthers);
+                                ui.close();
+                            }
+                        });
+
+                        ui.add_enabled_ui(t > 0, |ui| {
+                            if ui.button("Close to the Left").clicked() {
+                                result = Some(TabLabelResponse::CloseToLeft);
+                                ui.close();
+                            }
+                        });
+
+                        ui.add_enabled_ui(t + 1 < tab_count, |ui| {
+                            if ui.button("Close to the Right").clicked() {
+                                result = Some(TabLabelResponse::CloseToRight);
+                                ui.close();
+                            }
+                        });
+
+                        if ui.button("Close All").clicked() {
+                            result = Some(TabLabelResponse::CloseAll);
+                            ui.close();
+                        }
+
+                        ui.separator();
+
+                        ui.add_enabled_ui(can_rename, |ui| {
+                            if ui.button("Rename").clicked() {
+                                result = Some(TabLabelResponse::Rename);
+                                ui.close();
+                            }
+                        });
+
+                        ui.add_enabled_ui(can_reopen, |ui| {
+                            if ui.button("Reopen Closed Tab").clicked() {
+                                result = Some(TabLabelResponse::ReopenClosed);
+                                ui.close();
+                            }
+                        });
                     });
 
                     ui.advance_cursor_after_rect(text_rect.union(close_button_rect));
@@ -932,6 +1019,12 @@ fn centered_galley_rect(galley: &Galley) -> Rect {
 enum TabLabelResponse {
     Clicked,
     Closed,
+    CloseOthers,
+    CloseToLeft,
+    CloseToRight,
+    CloseAll,
+    Rename,
+    ReopenClosed,
     Renamed(String),
     Reordered { src: usize, dst: usize },
 }

--- a/libs/content/workspace/src/show.rs
+++ b/libs/content/workspace/src/show.rs
@@ -448,7 +448,7 @@ impl Workspace {
             .ctx
             .input_mut(|i| i.consume_key_exact(COMMAND | SHIFT, egui::Key::T))
         {
-            self.reopen_last_closed_tab();
+            self.reopen_closed_tab();
             self.out.selected_file = self.current_tab_id();
         }
 

--- a/libs/content/workspace/src/tab/chat/config.rs
+++ b/libs/content/workspace/src/tab/chat/config.rs
@@ -474,8 +474,8 @@ impl Chat {
                     .map(|p| p..p + KEY_PLACEHOLDER.len())
             });
         match range {
-            Some(r) => self.ctx.open_file_at_range(file_id, r, true),
-            None => self.ctx.open_file(file_id, true),
+            Some(r) => self.ctx.open_file_at_range(file_id, r, false),
+            None => self.ctx.open_file(file_id, false),
         }
     }
 
@@ -502,6 +502,6 @@ impl Chat {
                 }
             },
         };
-        self.ctx.open_file(file.id, true);
+        self.ctx.open_file(file.id, false);
     }
 }

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -1997,7 +1997,7 @@ impl Chat {
                 .filter(|f| f.is_document())
                 .map(|f| f.id);
             if let Some(id) = target {
-                ui.ctx().open_file(id, true);
+                ui.ctx().open_file(id, false);
             }
         }
 

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -696,7 +696,7 @@ impl MdEdit {
                     LinkMenuAction::Open => {
                         if t.is_wikilink {
                             if let Some(file_id) = self.renderer.resolve_wikilink(&t.url) {
-                                ui.ctx().open_file(file_id, true);
+                                ui.ctx().open_file(file_id, false);
                             }
                         } else {
                             self.renderer.open_resolved_link(&t.url, ui.ctx());

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/mod.rs
@@ -316,11 +316,11 @@ impl<'ast> MdRender {
         self.link_resolver.resolve_link(url)
     }
 
-    /// Open `url` in a new tab, navigating in-app for internal file links and
-    /// to the browser otherwise. Shared by link and image interaction handlers.
+    /// Open `url` in-app (in place) for internal file links, or in the system
+    /// browser for external URLs. Shared by link and image interaction handlers.
     pub fn open_resolved_link(&self, url: &str, ctx: &egui::Context) {
         match self.resolve_link(url) {
-            Some(ResolvedLink::File(file_id)) => ctx.open_file(file_id, true),
+            Some(ResolvedLink::File(file_id)) => ctx.open_file(file_id, false),
             Some(ResolvedLink::External(target)) => {
                 ctx.open_url(egui::OpenUrl { url: target, new_tab: true })
             }
@@ -418,10 +418,11 @@ impl<'ast> MdRender {
         }
     }
 
-    /// Hover → `PointingHand` + Warning/Broken tooltip; click → open
-    /// in a new tab. The producer's interaction scope is the gate: cmd
-    /// held (desktop), read-only, or touch — where the click instead
-    /// selects the link and pops the menu ([`MdEdit::handle_link_menu_taps`]).
+    /// Hover → `PointingHand` + Warning/Broken tooltip; click → open in place
+    /// (Cmd/Ctrl+click can be layered later for new tab). The producer's
+    /// interaction scope is the gate: cmd held (desktop), read-only, or touch
+    /// — where the click instead selects the link and pops the menu
+    /// ([`MdEdit::handle_link_menu_taps`]).
     pub fn handle_link_interactions(&mut self, root: &'ast AstNode<'ast>, ui: &egui::Ui) {
         let parent_base = ui.id();
         for node in root.descendants() {
@@ -465,9 +466,24 @@ impl<'ast> MdRender {
             }
 
             if response.clicked() && (self.readonly || !self.touch_mode) {
+                let new_tab = ui.input(|i| i.modifiers.command);
                 if is_wikilink {
                     if let Some(file_id) = self.resolve_wikilink(&url) {
-                        ui.ctx().open_file(file_id, true);
+                        ui.ctx().open_file(file_id, new_tab);
+                    }
+                } else if new_tab {
+                    match self.resolve_link(&url) {
+                        Some(ResolvedLink::File(file_id)) => {
+                            ui.ctx().open_file(file_id, true);
+                        }
+                        Some(ResolvedLink::External(target)) => {
+                            ui.ctx()
+                                .open_url(egui::OpenUrl { url: target, new_tab: true });
+                        }
+                        None => {
+                            ui.ctx()
+                                .open_url(egui::OpenUrl { url: url.clone(), new_tab: true });
+                        }
                     }
                 } else {
                     self.open_resolved_link(&url, ui.ctx());

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -49,13 +49,21 @@ impl Destination {
             Self::Search => Uuid::nil(),
         }
     }
+
+    /// Underlying file id, if any (e.g. `None` for search).
+    pub fn backing_file(&self) -> Option<Uuid> {
+        match self {
+            Self::File(id) | Self::MindMap(id) | Self::SpaceInspector(id) => Some(*id),
+            Self::Search => None,
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct TabSlot {
     pub dest: Destination,
-    pub back: Vec<Uuid>,
-    pub forward: Vec<Uuid>,
+    pub back: Vec<Destination>,
+    pub forward: Vec<Destination>,
     pub rename: Option<String>,
 }
 

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -54,12 +54,27 @@ use crate::mind_map::show::MindMap;
 #[cfg(not(target_family = "wasm"))]
 use tokio::sync::broadcast::error::TryRecvError;
 
+/// A tab removed from the strip, with enough context to reopen it near where
+/// it lived. Neighbors are destinations (URLs); resolved against the live
+/// strip at reopen time. `index` is a layout fallback when anchors are gone.
+struct ClosedTab {
+    slot: TabSlot,
+    left: Option<Destination>,
+    right: Option<Destination>,
+    index: usize,
+}
+
 pub struct Workspace {
     // User activity
     pub tabs: TabCache,
     pub tab_strip: Vec<TabSlot>,
-    pub recently_closed_tabs: Vec<Uuid>,
     pub current_tab: Option<Destination>,
+
+    /// Most-recently-active last; used to pick focus when the current tab closes.
+    activation_history: Vec<Destination>,
+    /// Closed tabs, most recent last (LIFO for `reopen_closed_tab`).
+    closed_tabs: Vec<ClosedTab>,
+
     pub landing_page: LandingPage,
     pub account: Account,
 
@@ -134,8 +149,9 @@ impl Workspace {
         let mut ws = Self {
             tabs: TabCache::new(),
             tab_strip: Vec::new(),
-            recently_closed_tabs: Vec::new(),
             current_tab: None,
+            activation_history: Vec::new(),
+            closed_tabs: Vec::new(),
             landing_page: cfg.get_landing_page(),
             account: core.get_account().expect("failed to get account"),
 
@@ -177,15 +193,20 @@ impl Workspace {
 
         let (open_tabs, current_tab) = ws.cfg.get_tabs();
 
-        open_tabs.iter().for_each(|&file_id| {
-            if core.get_file_by_id(file_id).is_ok() {
-                info!(id = ?file_id, "opening persisted tab");
-                ws.open_file(file_id, false, true);
+        open_tabs.into_iter().for_each(|dest| {
+            let exists = dest
+                .backing_file()
+                .is_none_or(|id| core.get_file_by_id(id).is_ok());
+            if exists {
+                info!(?dest, "opening persisted tab");
+                ws.create_tab(dest, false);
             }
         });
         if let Some(current_tab) = current_tab {
-            info!(id = ?current_tab, "setting persisted current tab");
-            ws.make_current_by_id(current_tab);
+            if let Some(pos) = ws.tab_strip.iter().position(|s| s.dest == current_tab) {
+                info!(?current_tab, "setting persisted current tab");
+                ws.make_current(pos);
+            }
         }
 
         let core = ws.core.clone();
@@ -201,11 +222,11 @@ impl Workspace {
     /// content from the destination variant. Does not add to tab_strip or
     /// make current — callers decide visibility.
     pub fn open_dest(&mut self, dest: &Destination) {
-        if let Destination::File(id) = dest {
-            self.recently_closed_tabs.retain(|&closed| closed != *id);
-        }
+        self.closed_tabs.retain(|c| c.slot.dest != *dest);
 
+        // Promote from the previous-frame buffer so make_current can see it.
         if self.tabs.contains_key(dest) {
+            self.tabs.promote(dest);
             return;
         }
         let id = dest.id();
@@ -263,10 +284,10 @@ impl Workspace {
         self.open_dest(&dest);
         if !self.tab_strip.iter().any(|s| s.dest == dest) {
             self.tab_strip.push(TabSlot::new(dest.clone()));
+            self.out.tabs_changed = true;
         }
         if make_current {
-            self.current_tab = Some(dest);
-            self.mark_current_tab_changed();
+            self.set_current_tab(Some(dest));
         }
     }
 
@@ -336,6 +357,17 @@ impl Workspace {
         self.out.selected_file = self.current_tab_id();
     }
 
+    fn set_current_tab(&mut self, dest: Option<Destination>) {
+        if let Some(old_dest) = self.current_tab.take() {
+            if Some(&old_dest) != dest.as_ref() {
+                self.activation_history.retain(|d| d != &old_dest);
+                self.activation_history.push(old_dest);
+            }
+        }
+        self.current_tab = dest;
+        self.mark_current_tab_changed();
+    }
+
     /// Reload every open chat's provider config off-thread. Called when an
     /// `/.agent` file changes (edited, deleted from the tree, or synced) so a
     /// chat reflects the change without needing a tab switch.
@@ -396,11 +428,12 @@ impl Workspace {
     pub fn make_current(&mut self, i: usize) -> bool {
         let Some(slot) = self.tab_strip.get(i) else { return false };
         let dest = slot.dest.clone();
+        // Tab content may only live in the previous-frame buffer after close.
+        self.tabs.promote(&dest);
         if self.tabs.get(&dest).is_none() {
             return false;
         };
-        self.current_tab = Some(dest.clone());
-        self.mark_current_tab_changed();
+        self.set_current_tab(Some(dest));
 
         if let Some(md) = self.current_tab_markdown() {
             md.focus(&self.ctx);
@@ -473,13 +506,20 @@ impl Workspace {
 
     pub fn open_file(&mut self, id: Uuid, make_current: bool, in_new_tab: bool) {
         let dest = Destination::File(id);
-        self.recently_closed_tabs.retain(|&closed| closed != id);
 
         // already in strip — just focus it
         if let Some(pos) = self.tab_strip.iter().position(|s| s.dest == dest) {
             if make_current {
                 self.make_current(pos);
             }
+            self.closed_tabs.retain(|c| c.slot.dest != dest);
+            return;
+        }
+
+        // Prefer full closed-tab restore when this dest is still on the closed
+        // stack (preserves back/forward instead of in-place navigate).
+        if self.closed_tabs.iter().any(|c| c.slot.dest == dest) {
+            self.reopen_closed_file(id);
             return;
         }
 
@@ -500,8 +540,8 @@ impl Workspace {
             return;
         };
 
-        // Push old dest id to slot's back, clear forward
-        self.tab_strip[slot_idx].back.push(old_dest.id());
+        // Push old dest to slot's back, clear forward
+        self.tab_strip[slot_idx].back.push(old_dest);
         self.tab_strip[slot_idx].forward.clear();
         // Update the slot's dest to the new destination
         self.tab_strip[slot_idx].dest = dest.clone();
@@ -509,25 +549,11 @@ impl Workspace {
         // Ensure the tab exists in cache for the new destination
         self.open_dest(&dest);
 
-        self.current_tab = Some(dest);
-        self.mark_current_tab_changed();
-    }
-
-    /// Open `id`, consuming the search tab: the selected file takes the search
-    /// tab's place in the strip rather than opening alongside it.
-    pub fn reopen_last_closed_tab(&mut self) {
-        while let Some(id) = self.recently_closed_tabs.first().copied() {
-            if self.core.get_file_by_id(id).is_ok() {
-                self.open_file(id, true, true);
-                return;
-            }
-            self.recently_closed_tabs.remove(0);
-        }
+        self.set_current_tab(Some(dest));
     }
 
     pub fn open_file_replacing_search(&mut self, id: Uuid) {
         let dest = Destination::File(id);
-        self.recently_closed_tabs.retain(|&closed| closed != id);
         let search_idx = self
             .tab_strip
             .iter()
@@ -552,9 +578,8 @@ impl Workspace {
         self.tabs.remove(&Destination::Search);
         self.tab_strip[i] = TabSlot::new(dest.clone());
         self.open_dest(&dest);
-        self.current_tab = Some(dest);
         self.out.tabs_changed = true;
-        self.mark_current_tab_changed();
+        self.set_current_tab(Some(dest));
     }
 
     pub fn open_file_at_range(
@@ -581,15 +606,13 @@ impl Workspace {
         let Some(slot_idx) = self.tab_strip.iter().position(|s| s.dest == current_dest) else {
             return;
         };
-        let Some(back_id) = self.tab_strip[slot_idx].back.pop() else { return };
-        self.tab_strip[slot_idx].forward.push(current_dest.id());
+        let Some(new_dest) = self.tab_strip[slot_idx].back.pop() else { return };
+        self.tab_strip[slot_idx].forward.push(current_dest);
 
-        let new_dest = Destination::File(back_id);
         self.tab_strip[slot_idx].dest = new_dest.clone();
 
         self.open_dest(&new_dest);
-        self.current_tab = Some(new_dest);
-        self.mark_current_tab_changed();
+        self.set_current_tab(Some(new_dest));
     }
 
     pub fn can_back(&self) -> bool {
@@ -606,15 +629,13 @@ impl Workspace {
         let Some(slot_idx) = self.tab_strip.iter().position(|s| s.dest == current_dest) else {
             return;
         };
-        let Some(forward_id) = self.tab_strip[slot_idx].forward.pop() else { return };
-        self.tab_strip[slot_idx].back.push(current_dest.id());
+        let Some(new_dest) = self.tab_strip[slot_idx].forward.pop() else { return };
+        self.tab_strip[slot_idx].back.push(current_dest);
 
-        let new_dest = Destination::File(forward_id);
         self.tab_strip[slot_idx].dest = new_dest.clone();
 
         self.open_dest(&new_dest);
-        self.current_tab = Some(new_dest);
-        self.mark_current_tab_changed();
+        self.set_current_tab(Some(new_dest));
     }
 
     pub fn can_forward(&self) -> bool {
@@ -655,27 +676,179 @@ impl Workspace {
             }
         }
 
-        // Remove from tab_strip
-        self.tab_strip.remove(i);
-        self.out.tabs_changed = true;
+        // Capture placement before remove: adjacent destinations (URLs) + index.
+        let left = i
+            .checked_sub(1)
+            .and_then(|j| self.tab_strip.get(j))
+            .map(|s| s.dest.clone());
+        let right = self.tab_strip.get(i + 1).map(|s| s.dest.clone());
 
-        if let Destination::File(id) = dest {
-            self.recently_closed_tabs.retain(|&closed| closed != id);
-            self.recently_closed_tabs.insert(0, id);
-            self.recently_closed_tabs.truncate(20);
+        // Remove from tab_strip
+        let closed_slot = self.tab_strip.remove(i);
+        self.out.tabs_changed = true;
+        self.activation_history.retain(|d| d != &dest);
+        self.closed_tabs.retain(|c| c.slot.dest != dest);
+        self.closed_tabs
+            .push(ClosedTab { slot: closed_slot, left, right, index: i });
+        const MAX_CLOSED_TABS: usize = 20;
+        if self.closed_tabs.len() > MAX_CLOSED_TABS {
+            self.closed_tabs.remove(0);
         }
 
         // Update current_tab
         if self.current_tab.as_ref() == Some(&dest) {
-            // Pick a neighbor
-            if self.tab_strip.is_empty() {
-                self.current_tab = None;
-            } else {
-                let new_idx = i.min(self.tab_strip.len() - 1);
-                self.current_tab = Some(self.tab_strip[new_idx].dest.clone());
+            // Prefer the most recently active still-open tab; else a neighbor.
+            let mut previous = None;
+            while let Some(d) = self.activation_history.pop() {
+                if self.tab_strip.iter().any(|s| s.dest == d) {
+                    previous = Some(d);
+                    break;
+                }
+            }
+            let next = previous.or_else(|| {
+                if self.tab_strip.is_empty() {
+                    None
+                } else {
+                    let new_idx = i.min(self.tab_strip.len() - 1);
+                    Some(self.tab_strip[new_idx].dest.clone())
+                }
+            });
+            // Clear first so set_current_tab does not re-record the closed dest.
+            self.current_tab = None;
+            self.set_current_tab(next);
+        }
+    }
+
+    pub fn close_all_tabs(&mut self) {
+        while !self.tab_strip.is_empty() {
+            self.close_tab(0);
+        }
+    }
+
+    pub fn close_other_tabs(&mut self, keep: usize) {
+        let Some(keep_dest) = self.tab_strip.get(keep).map(|s| s.dest.clone()) else {
+            return;
+        };
+        for i in (0..self.tab_strip.len()).rev() {
+            if self.tab_strip.get(i).is_some_and(|s| s.dest != keep_dest) {
+                self.close_tab(i);
             }
         }
-        self.mark_current_tab_changed();
+    }
+
+    pub fn close_tabs_to_left(&mut self, i: usize) {
+        if i == 0 || i >= self.tab_strip.len() {
+            return;
+        }
+        for j in (0..i).rev() {
+            self.close_tab(j);
+        }
+    }
+
+    pub fn close_tabs_to_right(&mut self, i: usize) {
+        if i + 1 >= self.tab_strip.len() {
+            return;
+        }
+        for j in (i + 1..self.tab_strip.len()).rev() {
+            self.close_tab(j);
+        }
+    }
+
+    pub fn can_reopen_closed_tab(&self) -> bool {
+        !self.closed_tabs.is_empty()
+    }
+
+    /// Restores the most recently closed tab (with back/forward) near its
+    /// prior place in the strip, and focuses it.
+    pub fn reopen_closed_tab(&mut self) {
+        while let Some(closed) = self.closed_tabs.pop() {
+            if self.restore_closed_tab(closed) {
+                return;
+            }
+        }
+    }
+
+    /// Restores a closed file tab by id (most recent matching entry), preserving
+    /// its back/forward stack and strip placement. Falls back to opening the
+    /// file in a **new** tab if it is not in the closed stack.
+    pub fn reopen_closed_file(&mut self, id: Uuid) {
+        let dest = Destination::File(id);
+
+        if let Some(pos) = self.tab_strip.iter().position(|s| s.dest == dest) {
+            self.closed_tabs.retain(|c| c.slot.dest != dest);
+            self.make_current(pos);
+            return;
+        }
+
+        while let Some(i) = self.closed_tabs.iter().rposition(|c| c.slot.dest == dest) {
+            let closed = self.closed_tabs.remove(i);
+            if self.restore_closed_tab(closed) {
+                return;
+            }
+        }
+
+        // Not in history (or all entries invalid): always new tab, never in-place.
+        self.create_tab(dest, true);
+    }
+
+    /// Insert a closed slot back onto the strip and load content.
+    fn restore_closed_tab(&mut self, closed: ClosedTab) -> bool {
+        let dest = closed.slot.dest.clone();
+        if self.tab_strip.iter().any(|s| s.dest == dest) {
+            return false;
+        }
+        let exists = dest
+            .backing_file()
+            .is_none_or(|id| self.files.read().unwrap().get_by_id(id).is_some());
+        if !exists {
+            return false;
+        }
+
+        let at = self.reopen_insert_index(&closed);
+        self.open_dest(&dest);
+        self.tabs.promote(&dest);
+        self.tab_strip.insert(at, closed.slot);
+        self.out.tabs_changed = true;
+        if !self.make_current(at) {
+            // Content may only have been in the previous-frame buffer; still
+            // mark current so the strip entry is focused.
+            self.set_current_tab(Some(dest));
+        }
+        true
+    }
+
+    /// Resolve where a closed tab should land in the current strip.
+    /// Prefer adjacent destinations still open; else fall back to saved index.
+    fn reopen_insert_index(&self, closed: &ClosedTab) -> usize {
+        let pos = |d: &Destination| self.tab_strip.iter().position(|s| &s.dest == d);
+        let left = closed.left.as_ref().and_then(pos);
+        let right = closed.right.as_ref().and_then(pos);
+
+        if let (Some(l), Some(r)) = (left, right) {
+            if l < r {
+                return l + 1;
+            }
+            // Anchors inverted (strip reordered); fall through.
+        }
+        if let Some(l) = left {
+            return l + 1;
+        }
+        if let Some(r) = right {
+            return r;
+        }
+        closed.index.min(self.tab_strip.len())
+    }
+
+    /// File ids from `closed_tabs`, most recently closed first.
+    pub fn recently_closed_tabs(&self) -> Vec<Uuid> {
+        self.closed_tabs
+            .iter()
+            .rev()
+            .filter_map(|c| match c.slot.dest {
+                Destination::File(id) => Some(id),
+                _ => None,
+            })
+            .collect()
     }
 
     pub fn process_bg_tasks(&mut self) {
@@ -1384,8 +1557,8 @@ pub struct WsPersistentStore {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct WsPresistentData {
-    open_tabs: Vec<Uuid>,
-    current_tab: Option<Uuid>,
+    open_tabs: Vec<Destination>,
+    current_tab: Option<Destination>,
     canvas: CanvasSettings,
     pub markdown: MdPersistence,
     auto_save: bool,
@@ -1449,21 +1622,16 @@ impl WsPersistentStore {
         store
     }
 
-    // todo: store non-file (mind map) tabs?
     pub fn set_tabs(&mut self, tab_strip: &[TabSlot], current_tab: &Option<Destination>) {
         let mut data_lock = self.data.write().unwrap();
-        data_lock.open_tabs = tab_strip
-            .iter()
-            .filter(|s| matches!(s.dest, Destination::File(_)))
-            .map(|s| s.dest.id())
-            .collect();
-        data_lock.current_tab = current_tab.as_ref().map(|d| d.id());
+        data_lock.open_tabs = tab_strip.iter().map(|s| s.dest.clone()).collect();
+        data_lock.current_tab = current_tab.clone();
         self.write_to_file();
     }
 
-    pub fn get_tabs(&self) -> (Vec<Uuid>, Option<Uuid>) {
+    pub fn get_tabs(&self) -> (Vec<Destination>, Option<Destination>) {
         let data_lock = self.data.read().unwrap();
-        (data_lock.open_tabs.clone(), data_lock.current_tab)
+        (data_lock.open_tabs.clone(), data_lock.current_tab.clone())
     }
 
     pub fn set_canvas_settings(&mut self, canvas_settings: CanvasSettings) {


### PR DESCRIPTION
Improves workspace tab management so close, reopen, and in-tab history behave more like a browser.

## New tab behavior
- Aligns macOS, iOS, and android to the windows/linux desktop behavior, except iOS and android also *create* files in place
- **In place**: file tree, recents, pins, create a file on mobile
- **New tab**: cmd+click a link or create a file on desktop

## Tab history & focus
- Closed tabs preserved as typed Destinations (supports non-file tabs like search) with history
- Closing the active tab returns to the most recently active still-open tab
- Persistence handles search, mind map, and space inspector like any other tab

## Reopen
- Cmd+Shift+T reopens the last closed tab, preserving navigation history
- Tabs are reopened in the same position as where they were closed relative to neighbors
- MacOS's “Recently Closed” list is a sourced from the same data model

## Desktop tab strip context menu
Matches Apple’s bulk close actions on the egui strip:
- Close / Close Others / Close to the Left / Close to the Right / Close All
- Rename (file tabs)
- Reopen Closed Tab

## Bugfix
- Tab close button works while renaming

Fixes #4785
Fixes #4786
Fixes #4038
Fixes #2137
