### PR TITLE
apple: sheet & context menu refinements

### DIFF
--- a/clients/apple/App/Screens/CreateFileSheet.swift
+++ b/clients/apple/App/Screens/CreateFileSheet.swift
@@ -49,6 +49,17 @@ struct CreateFileSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
+            #if os(macOS)
+                HStack {
+                    Text(renameTarget == nil ? "New File" : "Rename")
+                        .font(.headline)
+
+                    Spacer()
+
+                    SheetCloseButton()
+                }
+            #endif
+
             if renameTarget == nil {
                 Picker("Type", selection: $type) {
                     ForEach(NewFileType.allCases) { type in
@@ -146,7 +157,7 @@ struct CreateFileSheet: View {
                         location = .root
                     }
 
-                    if let doc = openDocFile, alongsideFolder != nil {
+                    if let doc = openDocFile, alongsideFolder != nil, doc.id != renameTarget?.id {
                         locationChip(
                             "Alongside \(doc.name)",
                             systemImage: "arrow.turn.down.right",

--- a/clients/apple/App/Screens/FolderPickerSheet.swift
+++ b/clients/apple/App/Screens/FolderPickerSheet.swift
@@ -54,10 +54,14 @@ struct FolderPickerSheet: View {
 
             Spacer()
 
-            Button("Cancel") {
-                dismiss()
-            }
-            .keyboardShortcut(.cancelAction)
+            #if os(macOS)
+                SheetCloseButton()
+            #else
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+            #endif
         }
         .padding(.horizontal)
         .padding(.top, 14)

--- a/clients/apple/App/Screens/OnboardingView.swift
+++ b/clients/apple/App/Screens/OnboardingView.swift
@@ -414,6 +414,10 @@ struct SetAPIURLView: View {
                     .bold()
 
                 Spacer()
+
+                #if os(macOS)
+                    SheetCloseButton()
+                #endif
             }
 
             TextField("\(defaultAPIURL)", text: $unsavedAPIURL)

--- a/clients/apple/App/Screens/ShareFileSheet.swift
+++ b/clients/apple/App/Screens/ShareFileSheet.swift
@@ -43,6 +43,10 @@ struct ShareFileSheet: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
+
+                #if os(macOS)
+                    SheetCloseButton()
+                #endif
             }
 
             HStack(spacing: 8) {

--- a/clients/apple/App/Widgets/SelectionViews.swift
+++ b/clients/apple/App/Widgets/SelectionViews.swift
@@ -82,6 +82,15 @@ struct SelectableRowModifier: ViewModifier {
         file.map { filesModel.pinnedIds.contains($0.id) } == true
     }
 
+    private var createLocation: LocationChoice {
+        guard let file else {
+            return .root
+        }
+
+        let folder = file.isFolder ? file : filesModel.idsToFiles[file.parent]
+        return folder.map(LocationChoice.init) ?? .root
+    }
+
     func body(content: Content) -> some View {
         macDraggable(
             swipeable(
@@ -112,18 +121,16 @@ struct SelectableRowModifier: ViewModifier {
                     }
                 }
             } else {
-                if file?.isFolder == true {
-                    contextMenuItem("New File Here", systemImage: "square.and.pencil") {
-                        showCreateFile = true
-                    }
-                }
-
                 if file?.isFolder == false, supportsMultipleWindows {
                     contextMenuItem("Open in New Window", systemImage: "macwindow.badge.plus") {
                         openInNewWindow()
                     }
 
                     Divider()
+                }
+
+                contextMenuItem("New File Here", systemImage: "square.and.pencil") {
+                    showCreateFile = true
                 }
 
                 contextMenuItem("Rename", systemImage: "pencil") {
@@ -142,22 +149,24 @@ struct SelectableRowModifier: ViewModifier {
                     }
                 }
 
+                contextMenuItem("Share", systemImage: "square.and.arrow.up") {
+                    showShare = true
+                }
+
+                Divider()
+
+                contextMenuItem("Select", systemImage: "checkmark.circle") {
+                    withAnimation {
+                        selection.toggle(id)
+                    }
+                }
+
                 contextMenuItem(
                     isPinned ? "Unpin" : "Pin",
                     systemImage: isPinned ? "pin.slash" : "pin"
                 ) {
                     if let file {
                         filesModel.togglePin(file.id)
-                    }
-                }
-
-                contextMenuItem("Share", systemImage: "square.and.arrow.up") {
-                    showShare = true
-                }
-
-                contextMenuItem("Select", systemImage: "checkmark.circle") {
-                    withAnimation {
-                        selection.toggle(id)
                     }
                 }
 
@@ -171,7 +180,7 @@ struct SelectableRowModifier: ViewModifier {
         .sheet(isPresented: $showCreateFile) {
             CreateFileSheet(
                 fileTreeModel: fileTreeModel,
-                mode: .create(location: file.map(LocationChoice.init) ?? .root)
+                mode: .create(location: createLocation)
             )
         }
         .sheet(isPresented: $showRename) {

--- a/clients/apple/App/Widgets/SheetCloseButton.swift
+++ b/clients/apple/App/Widgets/SheetCloseButton.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct SheetCloseButton: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "xmark.circle.fill")
+                .font(.title3)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.cancelAction)
+    }
+}


### PR DESCRIPTION
fixes: #4907 

<img width="479" height="342" alt="image" src="https://github.com/user-attachments/assets/a5b699e2-8ca1-43a9-80f9-0b0501d07c1f" />

fixes: #4908 

<img width="432" height="305" alt="image" src="https://github.com/user-attachments/assets/ffd3cd60-771c-42ca-88f6-9b9d9364f2d6" />

re-organized the context menu, and more options appear in more places

<img width="202" height="266" alt="image" src="https://github.com/user-attachments/assets/774ccfc2-4f34-4497-8551-c07654cb23f8" />