### PR TITLE
apple: repaint_after, and tab refinements

### DIFF
--- a/clients/apple/App/Screens/CreateFileSheet.swift
+++ b/clients/apple/App/Screens/CreateFileSheet.swift
@@ -35,6 +35,7 @@ struct CreateFileSheet: View {
     @State private var type: NewFileType = .markdown
     @State private var renameExt: String? = nil
     @State private var name = Self.defaultName
+    @State private var lastAutoName = Self.defaultName
     @State private var selection: TextSelection? = nil
     @State private var location: LocationChoice = .root
     @State private var showFolderPicker = false
@@ -121,10 +122,18 @@ struct CreateFileSheet: View {
                 location = parent.isRoot ? .root : .custom(parent)
             }
 
+            refreshAutoName()
+
             #if os(macOS)
                 nameFocused = true
                 selection = TextSelection(range: name.startIndex ..< name.endIndex)
             #endif
+        }
+        .onChange(of: location) {
+            refreshAutoName()
+        }
+        .onChange(of: type) {
+            refreshAutoName()
         }
         #if os(iOS)
             .onChange(of: nameFocused) { _, focused in
@@ -244,6 +253,35 @@ struct CreateFileSheet: View {
         }
 
         return (String(file.name[..<dot]), String(file.name[dot...]))
+    }
+
+    private func refreshAutoName() {
+        guard renameTarget == nil, name == lastAutoName, let parent = destination else {
+            return
+        }
+
+        let desired = Self.defaultName + (type.ext ?? "")
+
+        guard case let .success(next) = AppState.lb.nextName(parent: parent.id, desired: desired) else {
+            return
+        }
+
+        var base = next
+        if let ext = type.ext, base.hasSuffix(ext) {
+            base = String(base.dropLast(ext.count))
+        }
+
+        guard base != name else {
+            return
+        }
+
+        selection = nil
+        name = base
+        lastAutoName = base
+
+        if nameFocused {
+            selection = TextSelection(range: name.startIndex ..< name.endIndex)
+        }
     }
 
     private func submit() {

--- a/clients/apple/App/Screens/HomeView.swift
+++ b/clients/apple/App/Screens/HomeView.swift
@@ -111,7 +111,7 @@ struct HomeView: View {
                         }
                     }
 
-                    if workspaceOutput.tabCount > 0, !keyboardObscuresToolbar {
+                    if !keyboardObscuresToolbar {
                         ToolbarItem(placement: sharePlacement) {
                             Button {
                                 showTabsSidebar.toggle()
@@ -256,11 +256,6 @@ struct HomeView: View {
                 #if os(macOS)
                     .frame(minWidth: 420, minHeight: 520)
                 #endif
-            }
-        }
-        .onChange(of: workspaceOutput.tabCount) { _, count in
-            if count == 0 {
-                showTabsSidebar = false
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .createNewFile)) { _ in
@@ -426,7 +421,7 @@ struct HomeView: View {
                 chrome += 58
             } else {
                 if openDocFile != nil { chrome += 50 }
-                if workspaceOutput.tabCount > 0 { chrome += 50 }
+                chrome += 50
                 if horizontalSizeClass == .regular, homeState.splitViewVisibility != .all {
                     chrome += 50
                 }

--- a/clients/apple/App/State/AppState.swift
+++ b/clients/apple/App/State/AppState.swift
@@ -2,15 +2,35 @@ import Foundation
 import Observation
 import SwiftWorkspace
 
+#if os(macOS)
+    import AppKit
+#else
+    import UIKit
+#endif
+
 @Observable class AppState {
     static let shared = AppState()
-    
+
     var account: Account? = nil
     var isLoggedIn: Bool = false
     var error: UIError? = nil
 
     private init() {
         checkIfLoggedIn()
+
+        #if os(macOS)
+            let foregroundNotification = NSApplication.didBecomeActiveNotification
+        #else
+            let foregroundNotification = UIApplication.didBecomeActiveNotification
+        #endif
+
+        NotificationCenter.default.addObserver(
+            forName: foregroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            AppState.lb.appForegrounded()
+        }
     }
 
     static let LB_LOC: String = {

--- a/clients/apple/App/Utils/MiddleClick.swift
+++ b/clients/apple/App/Utils/MiddleClick.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+extension View {
+    func onMiddleClick(perform action: @escaping () -> Void) -> some View {
+        #if os(macOS)
+            overlay {
+                MiddleClickCatcher(action: action)
+            }
+        #else
+            self
+        #endif
+    }
+}
+
+#if os(macOS)
+    private struct MiddleClickCatcher: NSViewRepresentable {
+        let action: () -> Void
+
+        func makeNSView(context: Context) -> MiddleClickView {
+            let view = MiddleClickView()
+            view.action = action
+            return view
+        }
+
+        func updateNSView(_ nsView: MiddleClickView, context: Context) {
+            nsView.action = action
+        }
+
+        final class MiddleClickView: NSView {
+            var action: (() -> Void)?
+
+            override func hitTest(_ point: NSPoint) -> NSView? {
+                switch NSApp.currentEvent?.type {
+                case .otherMouseDown, .otherMouseUp, .otherMouseDragged:
+                    super.hitTest(point)
+                default:
+                    nil
+                }
+            }
+
+            override func otherMouseDown(with event: NSEvent) {}
+
+            override func otherMouseUp(with event: NSEvent) {
+                guard event.buttonNumber == 2,
+                      bounds.contains(convert(event.locationInWindow, from: nil))
+                else {
+                    return
+                }
+
+                action?()
+            }
+        }
+    }
+#endif

--- a/clients/apple/App/Widgets/WorkspaceTabsList.swift
+++ b/clients/apple/App/Widgets/WorkspaceTabsList.swift
@@ -33,29 +33,42 @@ struct WorkspaceTabsList: View {
     @State private var canNavForward = false
 
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 2) {
-                ForEach(tabIds, id: \.self) { id in
-                    tabRow(id)
-                }
+        Group {
+            if tabIds.isEmpty, recentlyClosed.isEmpty {
+                emptyTabs
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 2) {
+                        if tabIds.isEmpty {
+                            emptyTabs
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 28)
+                        } else {
+                            ForEach(tabIds, id: \.self) { id in
+                                tabRow(id)
+                            }
+                        }
 
-                endDropZone
+                        endDropZone
 
-                if !recentlyClosed.isEmpty {
-                    Text("Recently Closed")
-                        .font(.caption)
-                        .fontWeight(.medium)
-                        .foregroundStyle(.secondary)
-                        .padding(.top, 14)
-                        .padding(.leading, 10)
+                        if !recentlyClosed.isEmpty {
+                            Text("Recently Closed")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundStyle(.secondary)
+                                .padding(.top, 14)
+                                .padding(.leading, 10)
 
-                    ForEach(recentlyClosed, id: \.self) { id in
-                        recentlyClosedRow(id)
+                            ForEach(recentlyClosed, id: \.self) { id in
+                                recentlyClosedRow(id)
+                            }
+                        }
                     }
+                    .padding(.horizontal, 8)
+                    .padding(.top, 4)
                 }
             }
-            .padding(.horizontal, 8)
-            .padding(.top, 4)
         }
         .safeAreaInset(edge: .top) {
             header
@@ -125,7 +138,7 @@ struct WorkspaceTabsList: View {
             .disabled(selection.selectedIds.isEmpty)
             .padding(.bottom, 10)
             .transition(.move(edge: .bottom).combined(with: .opacity))
-        } else {
+        } else if !tabIds.isEmpty {
             Button {
                 workspaceInput.closeAllTabs()
             } label: {
@@ -135,6 +148,29 @@ struct WorkspaceTabsList: View {
             .buttonStyle(.bordered)
             .padding()
         }
+    }
+
+    private var emptyTabs: some View {
+        VStack(spacing: 6) {
+            Image(systemName: recentlyClosed.isEmpty ? "rectangle.on.rectangle" : "arrow.uturn.left")
+                .font(.system(size: 30, weight: .light))
+                .foregroundStyle(.tertiary)
+                .padding(.bottom, 6)
+
+            Text("No open tabs")
+                .font(.callout)
+                .fontWeight(.semibold)
+
+            Text(
+                recentlyClosed.isEmpty
+                    ? "Files you open will appear here."
+                    : "Reopen a recently closed tab below."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 20)
     }
 
     private func tabRow(_ id: UUID) -> some View {
@@ -192,6 +228,9 @@ struct WorkspaceTabsList: View {
             selection.handleTap(id: id, orderedIds: { tabIds }) {
                 workspaceInput.openFile(id: id)
             }
+        }
+        .onMiddleClick {
+            close([id])
         }
         .selectSwipe(selection, id: id)
         .contextMenu {

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Lb.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Lb/Lb.swift
@@ -15,6 +15,7 @@ public protocol LbAPI {
     func exportAccountPhrase() -> Result<String, LbError>
     func createFile(name: String, parent: UUID, fileType: FileType) -> Result<File, LbError>
     func createLink(name: String, parent: UUID, target: UUID) -> Result<File, LbError>
+    func nextName(parent: UUID, desired: String) -> Result<String, LbError>
     func getFile(id: UUID) -> Result<File, LbError>
     func deleteFile(id: UUID) -> Result<Void, LbError>
     func duplicateFile(id: UUID) -> Result<File, LbError>
@@ -28,6 +29,7 @@ public protocol LbAPI {
     func deletePendingShare(id: UUID) -> Result<Void, LbError>
     func debugInfo() -> String
     func sync() -> Result<Void, LbError>
+    func appForegrounded()
     func pinFile(id: UUID) -> Result<Void, LbError>
     func unpinFile(id: UUID) -> Result<Void, LbError>
     func listPinned() -> Result<[UUID], LbError>
@@ -174,6 +176,17 @@ public class Lb: LbAPI {
         }
 
         return .success(File(res.file))
+    }
+
+    public func nextName(parent: UUID, desired: String) -> Result<String, LbError> {
+        let res = lb_next_name(lb, parent.toLbUuid(), desired)
+        defer { lb_free_next_name_res(res) }
+
+        guard res.err == nil else {
+            return .failure(LbError(res.err.pointee))
+        }
+
+        return .success(String(cString: res.name))
     }
 
     public func getFile(id: UUID) -> Result<File, LbError> {
@@ -331,6 +344,10 @@ public class Lb: LbAPI {
         }
 
         return .success(())
+    }
+
+    public func appForegrounded() {
+        lb_app_foregrounded(lb)
     }
 
     public func pinFile(id: UUID) -> Result<Void, LbError> {
@@ -541,6 +558,7 @@ public class MockLb: LbAPI {
     public func exportAccountPhrase() -> Result<String, LbError> { .success(accountPhrase) }
     public func createFile(name: String, parent: UUID, fileType: FileType) -> Result<File, LbError> { .success(file1) }
     public func createLink(name: String, parent: UUID, target: UUID) -> Result<File, LbError> { .success(File(id: UUID(), parent: UUID(), name: "about-link.md", type: .link(file2.id), lastModifiedBy: "smail", lastModified: 1735857215, shares: [])) }
+    public func nextName(parent: UUID, desired: String) -> Result<String, LbError> { .success(desired) }
     public func getFile(id: UUID) -> Result<File, LbError> { .success(file1) }
     public func deleteFile(id: UUID) -> Result<Void, LbError> { .success(()) }
     public func duplicateFile(id: UUID) -> Result<File, LbError> { .success(file1) }
@@ -554,6 +572,7 @@ public class MockLb: LbAPI {
     public func deletePendingShare(id: UUID) -> Result<Void, LbError> { .success(()) }
     public func debugInfo() -> String { "No debug info. This is a preview." }
     public func sync() -> Result<Void, LbError> { .success(()) }
+    public func appForegrounded() {}
     public func pinFile(id: UUID) -> Result<Void, LbError> { .success(()) }
     public func unpinFile(id: UUID) -> Result<Void, LbError> { .success(()) }
     public func listPinned() -> Result<[UUID], LbError> { .success([file1.id]) }

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/RepaintRelay.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/RepaintRelay.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum RepaintRelay {
+    private static let lock = NSLock()
+    private static var handlers: [UnsafeMutableRawPointer: (UInt64) -> Void] = [:]
+
+    static func register(
+        _ key: UnsafeMutableRawPointer, _ handler: @escaping (UInt64) -> Void
+    ) {
+        lock.lock()
+        handlers[key] = handler
+        lock.unlock()
+    }
+
+    static func unregister(_ key: UnsafeMutableRawPointer) {
+        lock.lock()
+        handlers.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    static func fire(_ key: UnsafeMutableRawPointer?, _ delayMs: UInt64) {
+        guard let key else { return }
+
+        lock.lock()
+        let handler = handlers[key]
+        lock.unlock()
+
+        handler?(delayMs)
+    }
+}

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1602,20 +1602,11 @@
             }
 
             mtkView.redrawTask?.cancel()
+            mtkView.redrawTask = nil
+            mtkView.redrawDeadline = nil
             mtkView.isPaused = output.redraw_in > 50
-            if mtkView.isPaused {
-                let redrawIn = UInt64(truncatingIfNeeded: output.redraw_in)
-                let redrawInInterval = DispatchTimeInterval.milliseconds(
-                    Int(truncatingIfNeeded: min(500, redrawIn))
-                )
-
-                let newRedrawTask = DispatchWorkItem {
-                    mtkView.drawImmediately()
-                }
-                DispatchQueue.main.asyncAfter(
-                    deadline: .now() + redrawInInterval, execute: newRedrawTask
-                )
-                mtkView.redrawTask = newRedrawTask
+            if mtkView.isPaused, output.redraw_in != UInt64.max {
+                mtkView.scheduleRedraw(inMs: UInt64(truncatingIfNeeded: output.redraw_in))
             }
 
             mtkView.enableSetNeedsDisplay = mtkView.isPaused
@@ -1723,6 +1714,7 @@
         // mtk
         var mtkDelegate: iOSMTKViewDelegate?
         var redrawTask: DispatchWorkItem?
+        var redrawDeadline: DispatchTime?
 
         // workspace
         var workspaceOutput: WorkspaceOutputState?
@@ -1954,11 +1946,48 @@
             claimedPersistence = true
             wsHandle = init_ws(coreHandle, metalLayer, isDarkMode(), false, WorkspacePersistence.claim())
             workspaceInput?.wsHandle = wsHandle
+
+            if let wsHandle {
+                RepaintRelay.register(wsHandle) { [weak self] delayMs in
+                    DispatchQueue.main.async {
+                        self?.repaintRequested(inMs: delayMs)
+                    }
+                }
+                set_repaint_callback(wsHandle, wsHandle) { context, delayMs in
+                    RepaintRelay.fire(context, delayMs)
+                }
+            }
+        }
+
+        func repaintRequested(inMs delayMs: UInt64) {
+            if delayMs == 0 {
+                setNeedsDisplay(frame)
+            } else {
+                scheduleRedraw(inMs: delayMs)
+            }
+        }
+
+        func scheduleRedraw(inMs delayMs: UInt64) {
+            let deadline = DispatchTime.now()
+                + .milliseconds(Int(min(delayMs, UInt64(Int32.max))))
+
+            if redrawTask != nil, let existing = redrawDeadline, existing <= deadline {
+                return
+            }
+
+            redrawTask?.cancel()
+            let task = DispatchWorkItem { [weak self] in
+                self?.drawImmediately()
+            }
+            redrawTask = task
+            redrawDeadline = deadline
+            DispatchQueue.main.asyncAfter(deadline: deadline, execute: task)
         }
 
         public func drawImmediately() {
             redrawTask?.cancel()
             redrawTask = nil
+            redrawDeadline = nil
 
             ignoreSelectionUpdate = true
             ignoreTextUpdate = true
@@ -2207,6 +2236,9 @@
         }
 
         deinit {
+            if let wsHandle {
+                RepaintRelay.unregister(wsHandle)
+            }
             deinit_editor(wsHandle)
 
             if claimedPersistence {

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
@@ -17,6 +17,7 @@
         var currentOpenDoc: UUID?
 
         var redrawTask: DispatchWorkItem?
+        var redrawDeadline: DispatchTime?
 
         var lastCursor: NSCursor = .arrow
         var cursorHidden: Bool = false
@@ -98,6 +99,17 @@
             wsHandle = init_ws(coreHandle, metalLayer, isDarkMode(), false, WorkspacePersistence.claim())
             workspaceInput?.wsHandle = wsHandle
 
+            if let wsHandle {
+                RepaintRelay.register(wsHandle) { [weak self] delayMs in
+                    DispatchQueue.main.async {
+                        self?.repaintRequested(inMs: delayMs)
+                    }
+                }
+                set_repaint_callback(wsHandle, wsHandle) { context, delayMs in
+                    RepaintRelay.fire(context, delayMs)
+                }
+            }
+
             modifierEventHandle = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
                 self?.modifiersChanged(event: event) ?? event
             }
@@ -120,6 +132,32 @@
             ) { [weak self] _ in
                 self?.syncModifiers()
             }
+        }
+
+        func repaintRequested(inMs delayMs: UInt64) {
+            if delayMs == 0 {
+                setNeedsDisplay(frame)
+            } else {
+                scheduleRedraw(inMs: delayMs)
+            }
+        }
+
+        func scheduleRedraw(inMs delayMs: UInt64) {
+            let deadline = DispatchTime.now()
+                + .milliseconds(Int(min(delayMs, UInt64(Int32.max))))
+
+            if redrawTask != nil, let existing = redrawDeadline, existing <= deadline {
+                return
+            }
+
+            redrawTask?.cancel()
+            let task = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                setNeedsDisplay(frame)
+            }
+            redrawTask = task
+            redrawDeadline = deadline
+            DispatchQueue.main.asyncAfter(deadline: deadline, execute: task)
         }
 
         func syncModifiers() {
@@ -399,6 +437,7 @@
         public func drawImmediately() {
             redrawTask?.cancel()
             redrawTask = nil
+            redrawDeadline = nil
 
             isPaused = true
             enableSetNeedsDisplay = false
@@ -502,17 +541,10 @@
 
             redrawTask?.cancel()
             redrawTask = nil
+            redrawDeadline = nil
             isPaused = output.redraw_in > 50
-            if isPaused {
-                let redrawIn = UInt64(truncatingIfNeeded: output.redraw_in)
-                let redrawInInterval = DispatchTimeInterval.milliseconds(Int(truncatingIfNeeded: min(500, redrawIn)))
-
-                let newRedrawTask = DispatchWorkItem { [weak self] in
-                    guard let self else { return }
-                    setNeedsDisplay(frame)
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + redrawInInterval, execute: newRedrawTask)
-                redrawTask = newRedrawTask
+            if isPaused, output.redraw_in != UInt64.max {
+                scheduleRedraw(inMs: UInt64(truncatingIfNeeded: output.redraw_in))
             }
 
             enableSetNeedsDisplay = isPaused
@@ -520,6 +552,7 @@
 
         deinit {
             if let wsHandle {
+                RepaintRelay.unregister(wsHandle)
                 deinit_editor(wsHandle)
             }
 

--- a/libs/content/workspace-ffi/src/apple/api.rs
+++ b/libs/content/workspace-ffi/src/apple/api.rs
@@ -303,6 +303,32 @@ pub unsafe extern "C" fn deinit_editor(obj: *mut c_void) {
     let _ = Box::from_raw(obj as *mut WgpuWorkspace);
 }
 
+pub type WSRepaintCallback = extern "C" fn(*mut c_void, u64);
+
+struct RepaintCallbackContext(*mut c_void);
+unsafe impl Send for RepaintCallbackContext {}
+unsafe impl Sync for RepaintCallbackContext {}
+
+impl RepaintCallbackContext {
+    fn get(&self) -> *mut c_void {
+        self.0
+    }
+}
+
+/// # Safety
+#[no_mangle]
+pub unsafe extern "C" fn set_repaint_callback(
+    obj: *mut c_void, context: *mut c_void, callback: WSRepaintCallback,
+) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+    let context = RepaintCallbackContext(context);
+    obj.renderer
+        .context
+        .set_request_repaint_callback(move |info| {
+            callback(context.get(), info.delay.as_millis().min(u64::MAX as u128) as u64);
+        });
+}
+
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn mouse_moved(obj: *mut c_void, x: f32, y: f32) {

--- a/libs/lb/lb-c/src/lib.rs
+++ b/libs/lb/lb-c/src/lib.rs
@@ -12,6 +12,7 @@ use lb_file::{LbFile, LbFileList, LbFileType};
 pub use lb_rs::blocking::Lb;
 pub use lb_rs::model::core_config::{ClientType, Config};
 use lb_rs::model::file::ShareMode;
+use lb_rs::model::filename::NameComponents;
 use lb_rs::service::activity::RankingWeights;
 use lb_rs::service::debug::DebugInfoDisplay;
 use lb_rs::service::events::Event;
@@ -240,6 +241,31 @@ pub extern "C" fn lb_create_file(
     }
 }
 
+#[repr(C)]
+pub struct LbNextNameRes {
+    err: *mut LbFfiErr,
+    name: *mut c_char,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn lb_next_name(
+    lb: *mut Lb, parent: LbUuid, desired: *const c_char,
+) -> LbNextNameRes {
+    let lb = rlb(lb);
+
+    match lb.get_children(&parent.into()) {
+        Ok(children) => {
+            let mut name = NameComponents::from(rstr(desired));
+            if let Some(variant) = name.variant.take() {
+                name.name = format!("{}-{}", name.name, variant);
+            }
+            name.next_in_children(children);
+            LbNextNameRes { err: null_mut(), name: cstring(name.to_name()) }
+        }
+        Err(err) => LbNextNameRes { err: lb_err(err), name: null_mut() },
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn lb_write_document(
     lb: *mut Lb, id: LbUuid, ptr: *mut u8, len: usize,
@@ -293,6 +319,12 @@ pub extern "C" fn lb_get_and_get_children_recursively(lb: *mut Lb, id: LbUuid) -
         }
         Err(e) => LbFileListRes { err: lb_err(e), list: Default::default() },
     }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn lb_app_foregrounded(lb: *mut Lb) {
+    let lb = rlb(lb);
+    lb.app_foregrounded();
 }
 
 #[unsafe(no_mangle)]

--- a/libs/lb/lb-c/src/mem_cleanup.rs
+++ b/libs/lb/lb-c/src/mem_cleanup.rs
@@ -9,8 +9,8 @@ use crate::lb_file::LbFile;
 use crate::{
     LbAccountRes, LbContentSearcherResults, LbContentSearcherSnippet, LbDocRes,
     LbExportAccountQRRes, LbExportAccountRes, LbFileListRes, LbFileRes, LbGetFileLinkUrlRes,
-    LbIdListRes, LbInitRes, LbLastSyncedHuman, LbLastSyncedi64, LbPathRes, LbPathSearcherResults,
-    LbPathsRes, LbStatus, LbSubscriptionInfoRes, LbUsageMetricsRes,
+    LbIdListRes, LbInitRes, LbLastSyncedHuman, LbLastSyncedi64, LbNextNameRes, LbPathRes,
+    LbPathSearcherResults, LbPathsRes, LbStatus, LbSubscriptionInfoRes, LbUsageMetricsRes,
 };
 
 #[unsafe(no_mangle)]
@@ -104,6 +104,17 @@ pub extern "C" fn lb_free_get_file_link_url_res(res: LbGetFileLinkUrlRes) {
 
     if !res.link_url.is_null() {
         unsafe { drop(CString::from_raw(res.link_url)) };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn lb_free_next_name_res(res: LbNextNameRes) {
+    if !res.err.is_null() {
+        lb_free_err(res.err);
+    }
+
+    if !res.name.is_null() {
+        unsafe { drop(CString::from_raw(res.name)) };
     }
 }
 

--- a/libs/lb/lb-rs/src/lib.rs
+++ b/libs/lb/lb-rs/src/lib.rs
@@ -41,6 +41,7 @@ pub struct Lb {
 pub struct LocalLb {
     pub config: Config,
     pub user_last_seen: Arc<RwLock<Instant>>,
+    pub user_wake: Arc<Notify>,
     pub keychain: Keychain,
     pub db: LbDb,
     pub docs: AsyncDocs,
@@ -67,9 +68,20 @@ impl LocalLb {
         let syncer = Default::default();
         let events = EventSubs::default();
         let user_last_seen = Arc::new(RwLock::new(Instant::now()));
+        let user_wake = Arc::new(Notify::new());
 
-        let result =
-            Self { config, keychain, db, docs, client, syncer, events, status, user_last_seen };
+        let result = Self {
+            config,
+            keychain,
+            db,
+            docs,
+            client,
+            syncer,
+            events,
+            status,
+            user_last_seen,
+            user_wake,
+        };
 
         #[cfg(not(target_family = "wasm"))]
         {
@@ -683,7 +695,7 @@ use service::events::EventSubs;
 use service::keychain::Keychain;
 use std::sync::{Arc, OnceLock};
 use subscribers::status::StatusUpdater;
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 pub use uuid::Uuid;
 use web_time::Instant;
 

--- a/libs/lb/lb-rs/src/service/activity.rs
+++ b/libs/lb/lb-rs/src/service/activity.rs
@@ -126,6 +126,7 @@ impl LocalLb {
         let bg_lb = self.clone();
         tokio::spawn(async move {
             *bg_lb.user_last_seen.write().await = web_time::Instant::now();
+            bg_lb.user_wake.notify_one();
         });
     }
 }

--- a/libs/lb/lb-rs/src/subscribers/syncer.rs
+++ b/libs/lb/lb-rs/src/subscribers/syncer.rs
@@ -1353,7 +1353,10 @@ impl LocalLb {
                 if self.user_active().await {
                     tokio::time::sleep(Duration::from_secs(3)).await;
                 } else {
-                    tokio::time::sleep(Duration::from_secs(5 * 60)).await;
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(5 * 60)) => {}
+                        _ = self.user_wake.notified() => {}
+                    }
                 }
                 self.sync().await.map_unexpected().log_and_ignore();
             }
@@ -1362,7 +1365,7 @@ impl LocalLb {
 
     async fn user_active(&self) -> bool {
         let last_seen = self.user_last_seen.read().await;
-        last_seen.elapsed() < Duration::from_secs(3 * 60)
+        last_seen.elapsed() < Duration::from_secs(15)
     }
 
     fn post_sync_worker(self) {

--- a/libs/lb/lb-rs/src/wasm.rs
+++ b/libs/lb/lb-rs/src/wasm.rs
@@ -27,6 +27,7 @@ impl LocalLb {
 
         Ok(Self {
             user_last_seen,
+            user_wake: Default::default(),
             config: config.clone(),
             keychain: Default::default(),
             db: Arc::new(RwLock::new(db)),


### PR DESCRIPTION
my workflow was disrupted due to the github outage, so a few things ended up in this PR:

This PR adds proper repaint after support to apple allowing us to go down to 0fps when nothing is happening.

fixes: #3449 

Also properly detects a user re-entering foreground: fixes #4604

This makes our polling centric networking now the bottleneck with regards to energy efficiency (right on time).

This PR also fixes some tab nuisances:

fixes #4919
fixes #3821 
fixes #4917 

<img width="187" height="88" alt="image" src="https://github.com/user-attachments/assets/2291ec08-458c-49b3-b74a-412acf973ff0" />

and now that we see the tab sidebar when it's empty, we have a nice empty representation:

<img width="220" height="131" alt="image" src="https://github.com/user-attachments/assets/6685eca9-0ed4-44f1-ab4a-3f521f47675a" />

this PR also fixes #4913
