### PR TITLE
macos: scroll without focus

### DIFF
--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
@@ -52,7 +52,7 @@
                 removeTrackingArea(trackingArea!)
             }
             let options: NSTrackingArea.Options =
-                [.mouseEnteredAndExited, .mouseMoved, .enabledDuringMouseDrag, .activeInKeyWindow]
+                [.mouseEnteredAndExited, .mouseMoved, .enabledDuringMouseDrag, .activeAlways]
             trackingArea = NSTrackingArea(rect: bounds, options: options,
                                           owner: self, userInfo: nil)
             addTrackingArea(trackingArea!)
@@ -181,20 +181,12 @@
         }
 
         override public func mouseDragged(with event: NSEvent) {
-            if window?.firstResponder != self {
-                return
-            }
-
             let local = viewCoordinates(event)
             mouse_moved(wsHandle, Float(local.x), Float(local.y))
             setNeedsDisplay(frame)
         }
 
         override public func mouseMoved(with event: NSEvent) {
-            if window?.firstResponder != self {
-                return
-            }
-
             let local = viewCoordinates(event)
             mouse_moved(wsHandle, Float(local.x), Float(local.y))
             setNeedsDisplay(frame)


### PR DESCRIPTION
* Allows scroll without OS-level "key window" focus so scroll responds when we focus another app or another lockbook window
* Allows scroll without app-level "first responder" focus which is generally a keyboard-only concept

fixes https://github.com/lockbook/lockbook/issues/4231