### PR TITLE
apple: better onboarding experience generally

### DIFF
--- a/clients/apple/App/Screens/FileTreeView.swift
+++ b/clients/apple/App/Screens/FileTreeView.swift
@@ -11,6 +11,9 @@ struct FileTreeView: View {
 
     let fileTreeModel: FileTreeModel
 
+    #if os(iOS)
+        @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    #endif
     @State private var isRootDropTargeted = false
     @State private var topZoneTargeted = false
     @State private var bottomZoneTargeted = false
@@ -26,13 +29,26 @@ struct FileTreeView: View {
     var body: some View {
         if let root = filesModel.root {
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 2) {
-                    ForEach(fileTreeModel.visibleRows) { row in
-                        FileRowView(file: row.file, level: row.level)
+                if fileTreeModel.visibleRows.isEmpty {
+                    emptyState
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(fileTreeModel.visibleRows) { row in
+                            FileRowView(file: row.file, level: row.level)
+                        }
+                    }
+                    .scrollTargetLayout()
+                    .padding(.horizontal)
+
+                    if showStartHereHint {
+                        startHereHint
                     }
                 }
-                .scrollTargetLayout()
-                .padding(.horizontal)
+            }
+            .overlay(alignment: CreateButtonArrow.alignment) {
+                if fileTreeModel.visibleRows.isEmpty {
+                    CreateButtonArrow()
+                }
             }
             .contextMenu {
                 contextMenuItem("New File", systemImage: "square.and.pencil") {
@@ -126,6 +142,46 @@ struct FileTreeView: View {
         } else {
             ProgressView()
         }
+    }
+
+    private var showStartHereHint: Bool {
+        AppState.shared.accountCreatedThisSession
+    }
+
+    private var startHereHint: some View {
+        StartHereHint(leadingInset: 21)
+            .padding(.top, -10)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 34))
+                .foregroundStyle(Color.accentColor.opacity(0.5))
+
+            Text("Nothing here yet")
+                .font(.headline)
+
+            Text(emptySubtext)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 32)
+        .containerRelativeFrame(.vertical) { height, _ in height * 0.6 }
+    }
+
+    private var emptySubtext: String {
+        #if os(iOS)
+            if horizontalSizeClass == .compact {
+                "Notes, drawings, folders — create your first below."
+            } else {
+                "Tap the pencil in the corner to create your first note."
+            }
+        #else
+            "Notes, drawings, folders — create your first with New."
+        #endif
     }
 
     private func scrollToOpenDoc() {

--- a/clients/apple/App/Screens/HomeView.swift
+++ b/clients/apple/App/Screens/HomeView.swift
@@ -195,6 +195,7 @@ struct HomeView: View {
         .environment(workspaceOutput)
         .onChange(of: workspaceOutput.openDoc) { _, openDoc in
             guard let openDoc else { return }
+            AppState.shared.accountCreatedThisSession = false
             fileTreeModel.docOpened(openDoc)
             sharedTreeModel.docOpened(openDoc)
         }

--- a/clients/apple/App/Screens/OnboardingView.swift
+++ b/clients/apple/App/Screens/OnboardingView.swift
@@ -173,6 +173,7 @@ private struct OnboardingTwoView: View {
             DispatchQueue.main.async {
                 switch operation {
                 case .success:
+                    AppState.shared.accountCreatedThisSession = true
                     createdAccount = true
                 case let .failure(err):
                     working = false

--- a/clients/apple/App/Screens/RecentsView.swift
+++ b/clients/apple/App/Screens/RecentsView.swift
@@ -34,6 +34,9 @@ struct RecentsView: View {
                     title: "No documents yet",
                     subtitle: "Documents you edit will appear here."
                 )
+                .overlay(alignment: CreateButtonArrow.alignment) {
+                    CreateButtonArrow()
+                }
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
@@ -47,6 +50,12 @@ struct RecentsView: View {
                             ForEach(section.files) { file in
                                 VStack(spacing: 0) {
                                     RecentDocRow(file: file, model: model, orderedIds: orderedIds)
+
+                                    if file.id == orderedIds.first, AppState.shared.accountCreatedThisSession {
+                                        StartHereHint(leadingInset: 16)
+                                            .padding(.top, -6)
+                                            .padding(.bottom, 8)
+                                    }
 
                                     if file.id != section.files.last?.id {
                                         Divider()

--- a/clients/apple/App/State/AppState.swift
+++ b/clients/apple/App/State/AppState.swift
@@ -14,6 +14,7 @@ import SwiftWorkspace
     var account: Account? = nil
     var isLoggedIn: Bool = false
     var error: UIError? = nil
+    var accountCreatedThisSession = false
 
     private init() {
         checkIfLoggedIn()
@@ -84,7 +85,7 @@ import SwiftWorkspace
     #endif
 
     static let defaultApiUrl: String =
-        ProcessInfo.processInfo.environment["API_LOCATION"] ?? "https://app.lockbook.net"
+        ProcessInfo.processInfo.environment["API_LOCATION"] ?? "http://localhost:8000"
 
     static let lb: LbAPI = {
         if isPreviewEnvironmentKey.defaultValue {

--- a/clients/apple/App/State/HomeState.swift
+++ b/clients/apple/App/State/HomeState.swift
@@ -2,13 +2,24 @@ import Observation
 import SwiftUI
 
 @Observable class HomeState {
+    private static let compactColumnKey = "lastCompactColumnWasSidebar"
+
     var splitViewVisibility: NavigationSplitViewVisibility = .all
 
-    var compactColumn: NavigationSplitViewColumn = .detail
+    var compactColumn: NavigationSplitViewColumn {
+        didSet {
+            UserDefaults.standard.set(compactColumn == .sidebar, forKey: Self.compactColumnKey)
+        }
+    }
 
     var openingLink = false
 
     var explicitSyncCount = 0
+
+    init() {
+        let wasSidebar = UserDefaults.standard.object(forKey: Self.compactColumnKey) as? Bool ?? true
+        compactColumn = wasSidebar ? .sidebar : .detail
+    }
 
     func explicitSyncRequested() {
         explicitSyncCount += 1

--- a/clients/apple/App/Widgets/WhimsicalHints.swift
+++ b/clients/apple/App/Widgets/WhimsicalHints.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+struct WhimsicalArrow: Shape {
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width
+        let h = rect.height
+
+        let start = CGPoint(x: rect.minX + 0.10 * w, y: rect.minY + 0.05 * h)
+        let control1 = CGPoint(x: rect.minX + 1.05 * w, y: rect.minY + 0.25 * h)
+        let control2 = CGPoint(x: rect.minX + 0.75 * w, y: rect.minY + 0.55 * h)
+        let end = CGPoint(x: rect.minX + 0.85 * w, y: rect.minY + 0.97 * h)
+
+        var path = Path()
+        path.move(to: start)
+        path.addCurve(to: end, control1: control1, control2: control2)
+
+        let angle = atan2(end.y - control2.y, end.x - control2.x)
+        let headLength = min(w, h) * 0.22
+        for headAngle in [angle + .pi * 5 / 6, angle - .pi * 5 / 6] {
+            path.move(to: end)
+            path.addLine(to: CGPoint(
+                x: end.x + cos(headAngle) * headLength,
+                y: end.y + sin(headAngle) * headLength
+            ))
+        }
+
+        return path
+    }
+}
+
+struct AnimatedWhimsicalArrow: View {
+    let width: CGFloat
+    let height: CGFloat
+    var rotated = false
+
+    @State private var progress: CGFloat = 0
+
+    var body: some View {
+        WhimsicalArrow()
+            .trim(from: 0, to: progress)
+            .stroke(
+                Color.accentColor.opacity(0.7),
+                style: StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round)
+            )
+            .frame(width: width, height: height)
+            .rotationEffect(.degrees(rotated ? 180 : 0))
+            .onAppear {
+                progress = 0
+                withAnimation(.easeOut(duration: 0.9).delay(0.4)) {
+                    progress = 1
+                }
+            }
+    }
+}
+
+struct StartHereHint: View {
+    let leadingInset: CGFloat
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            AnimatedWhimsicalArrow(width: 44, height: 64, rotated: true)
+
+            Text("Start here")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(Color.accentColor)
+                .offset(y: 7)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, leadingInset)
+        .allowsHitTesting(false)
+    }
+}
+
+struct CreateButtonArrow: View {
+    static var alignment: Alignment {
+        #if os(iOS)
+            .bottomTrailing
+        #else
+            .topLeading
+        #endif
+    }
+
+    #if os(iOS)
+        @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    #endif
+
+    var body: some View {
+        #if os(iOS)
+            if horizontalSizeClass == .compact {
+                AnimatedWhimsicalArrow(width: 84, height: 140)
+                    .padding(.trailing, 40)
+                    .allowsHitTesting(false)
+            }
+        #else
+            AnimatedWhimsicalArrow(width: 84, height: 140, rotated: true)
+                .padding(.leading, 44)
+                .padding(.top, 6)
+                .allowsHitTesting(false)
+        #endif
+    }
+}


### PR DESCRIPTION
fixes https://github.com/lockbook/lockbook/issues/4949
fixes https://github.com/lockbook/lockbook/issues/4948

Makes it so master vs. detail view selections are persisted. Previously we used to just always put them in the editor. But also when this is not present I default to the master view, which now has this gentle guidance for new users:

<img width="300" alt="onboarding" src="https://github.com/user-attachments/assets/ddbf0069-cbf5-4d35-b0a8-0020460f0066" /><img width="300" alt="empty" src="https://github.com/user-attachments/assets/ff46ffe2-fddc-4fab-ab47-377e956b463a" />
