### PR TITLE
ws: copy image to clipboard

### DIFF
--- a/clients/desktop/src/host.rs
+++ b/clients/desktop/src/host.rs
@@ -268,10 +268,15 @@ impl AppState {
                     let _ = self.clipboard.set_text(text.clone());
                 }
                 egui::OutputCommand::CopyImage(image) => {
+                    let bytes: Vec<u8> = image
+                        .pixels
+                        .iter()
+                        .flat_map(|px| px.to_srgba_unmultiplied())
+                        .collect();
                     let _ = self.clipboard.set_image(arboard::ImageData {
                         width: image.width(),
                         height: image.height(),
-                        bytes: std::borrow::Cow::Borrowed(image.as_raw()),
+                        bytes: std::borrow::Cow::Owned(bytes),
                     });
                 }
                 _ => {}

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Util.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/Util.swift
@@ -58,6 +58,15 @@ func textFromPtr(s: UnsafeMutablePointer<CChar>!) -> String {
     return str
 }
 
+func dataFromBytes(b: CBytes) -> Data? {
+    guard b.size > 0, let bytes = b.bytes else {
+        return nil
+    }
+    let data = Data(bytes: bytes, count: Int(b.size))
+    free_bytes(b)
+    return data
+}
+
 extension UUID {
     func isNil() -> Bool {
         uuid.0 == 0 &&

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1065,6 +1065,7 @@
         // menu
         var menuDelegate: SvgMenuDelegate?
         var menuInteraction: UIEditMenuInteraction?
+        var editMenuForImage = false
 
         init(mtkView: iOSMTK) {
             self.mtkView = mtkView
@@ -1147,6 +1148,7 @@
 
             addInteraction(menuInteraction)
 
+            menuDelegate.view = self
             self.menuDelegate = menuDelegate
             self.menuInteraction = menuInteraction
         }
@@ -1175,6 +1177,10 @@
                 return
             }
 
+            if isImageTab {
+                return
+            }
+
             // Check if we have any valid actions before presenting
             let location = gesture.location(in: mtkView)
             if will_consume_touch(wsHandle, Float(location.x), Float(location.y))
@@ -1183,13 +1189,27 @@
                 return
             }
 
+            editMenuForImage = false
             let config = UIEditMenuConfiguration(identifier: nil, sourcePoint: location)
+            menuInteraction.presentEditMenu(with: config)
+        }
+
+        var isImageTab: Bool {
+            WorkspaceTab(rawValue: Int(current_tab(wsHandle))) == .Image
+        }
+
+        func presentImageEditMenu(at point: CGPoint) {
+            guard let menuInteraction else { return }
+
+            editMenuForImage = true
+            let config = UIEditMenuConfiguration(identifier: nil, sourcePoint: point)
             menuInteraction.presentEditMenu(with: config)
         }
 
         override public func canPerformAction(_ action: Selector, withSender _: Any?) -> Bool {
             if action == #selector(paste(_:)) {
-                return UIPasteboard.general.hasStrings || UIPasteboard.general.hasImages
+                return !isImageTab
+                    && (UIPasteboard.general.hasStrings || UIPasteboard.general.hasImages)
             }
 
             return false
@@ -1273,6 +1293,10 @@
         }
 
         override public func paste(_: Any?) {
+            if isImageTab {
+                return
+            }
+
             if let image = UIPasteboard.general.image {
                 mtkView.importContent(.image(image), isPaste: true)
             } else if let string = UIPasteboard.general.string {
@@ -1347,7 +1371,27 @@
 
     // MARK: - SvgEditMenuDelegate
 
-    public class SvgMenuDelegate: NSObject, UIEditMenuInteractionDelegate {}
+    public class SvgMenuDelegate: NSObject, UIEditMenuInteractionDelegate {
+        weak var view: SvgView?
+
+        public func editMenuInteraction(
+            _: UIEditMenuInteraction, menuFor _: UIEditMenuConfiguration,
+            suggestedActions: [UIMenuElement]
+        ) -> UIMenu? {
+            guard let view, view.editMenuForImage else {
+                return UIMenu(children: suggestedActions)
+            }
+
+            let copy = UIAction(
+                title: "Copy image", image: UIImage(systemName: "doc.on.doc")
+            ) { [weak view] _ in
+                guard let view else { return }
+                copy_image(view.wsHandle)
+                view.mtkView.setNeedsDisplay(view.mtkView.frame)
+            }
+            return UIMenu(children: [copy])
+        }
+    }
 
     // MARK: - MdMenuDelegate
 
@@ -1505,6 +1549,16 @@
                     mtkView.workspaceOutput!.currentTab = currentTab
                     mtkView.currentTabChanged?(currentTab)
                 }
+            }
+
+            if output.has_context_menu, output.context_menu_for_image,
+               let currentWrapper = mtkView.currentWrapper as? SvgView
+            {
+                currentWrapper.presentImageEditMenu(
+                    at: CGPoint(
+                        x: CGFloat(output.context_menu_x), y: CGFloat(output.context_menu_y)
+                    )
+                )
             }
 
             if currentTab == .Welcome, mtkView.currentOpenDoc != nil {

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/iOSMTK.swift
@@ -1601,6 +1601,10 @@
                 }
             }
 
+            if let png = dataFromBytes(b: output.copied_image) {
+                UIPasteboard.general.setData(png, forPasteboardType: UTType.png.identifier)
+            }
+
             mtkView.redrawTask?.cancel()
             mtkView.redrawTask = nil
             mtkView.redrawDeadline = nil

--- a/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
+++ b/libs/content/workspace-ffi/SwiftWorkspace/Sources/Workspace/macMTK.swift
@@ -508,6 +508,11 @@
                 }
             }
 
+            if let png = dataFromBytes(b: output.copied_image), let image = NSImage(data: png) {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.writeObjects([image])
+            }
+
             let cursor = NSCursor.fromCCursor(c: output.cursor)
             if cursor != lastCursor {
                 lastCursor = cursor

--- a/libs/content/workspace-ffi/src/android/response.rs
+++ b/libs/content/workspace-ffi/src/android/response.rs
@@ -54,6 +54,7 @@ impl From<crate::Response> for AndroidResponse {
                 },
             redraw_in,
             copied_text,
+            copied_image: _,
             urls_opened,
             cursor: _,
             virtual_keyboard_shown,

--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -129,6 +129,16 @@ pub unsafe extern "C" fn copy_selection(obj: *mut c_void) {
 /// # Safety
 /// obj must be a valid pointer to WgpuEditor
 #[no_mangle]
+pub unsafe extern "C" fn copy_image(obj: *mut c_void) {
+    let obj = &mut *(obj as *mut WgpuWorkspace);
+    if let Some(image_viewer) = obj.workspace.current_tab_image() {
+        image_viewer.copy_image(&obj.renderer.context);
+    }
+}
+
+/// # Safety
+/// obj must be a valid pointer to WgpuEditor
+#[no_mangle]
 pub unsafe extern "C" fn cut_selection(obj: *mut c_void) {
     let obj = &mut *(obj as *mut WgpuWorkspace);
     obj.renderer.context.push_markdown_event(Event::Cut);

--- a/libs/content/workspace-ffi/src/apple/ios/response.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/response.rs
@@ -3,7 +3,7 @@ use lb_c::model::text::offset_types::{Grapheme, RangeExt as _};
 use std::ffi::{CString, c_char};
 use workspace_rs::tab::markdown_editor::input::{Bound, Location, Region};
 
-use super::super::macos::response::CUrls;
+use super::super::macos::response::{CBytes, CUrls};
 use super::super::response::*;
 
 #[repr(C)]
@@ -11,6 +11,7 @@ pub struct IOSResponse {
     // platform response
     pub redraw_in: u64,
     pub copied_text: *mut c_char,
+    pub copied_image: CBytes,
     pub urls_opened: CUrls,
     pub open_camera: bool,
     pub has_virtual_keyboard_shown: bool,
@@ -69,6 +70,7 @@ impl From<crate::Response> for IOSResponse {
                 },
             redraw_in,
             copied_text,
+            copied_image,
             urls_opened,
             cursor: _,
             virtual_keyboard_shown,
@@ -95,6 +97,7 @@ impl From<crate::Response> for IOSResponse {
             tabs_changed,
             redraw_in: redraw_in.unwrap_or(u64::MAX),
             copied_text: CString::new(copied_text).unwrap().into_raw(),
+            copied_image: copied_image.into(),
             urls_opened,
             open_camera,
             text_updated: markdown_editor_text_updated,

--- a/libs/content/workspace-ffi/src/apple/ios/response.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/response.rs
@@ -43,6 +43,7 @@ pub struct IOSResponse {
     /// The menu is over a selected atom (image, link card/capsule) — offer "Edit"
     /// (`enter_selected_atom`) alongside the standard actions.
     pub context_menu_for_atom: bool,
+    pub context_menu_for_image: bool,
 }
 
 impl From<crate::Response> for IOSResponse {
@@ -123,6 +124,10 @@ impl From<crate::Response> for IOSResponse {
             context_menu_for_atom: matches!(
                 context_menu,
                 Some((_, workspace_rs::tab::ContextMenuTarget::Atom))
+            ),
+            context_menu_for_image: matches!(
+                context_menu,
+                Some((_, workspace_rs::tab::ContextMenuTarget::Image))
             ),
         }
     }

--- a/libs/content/workspace-ffi/src/apple/macos/response.rs
+++ b/libs/content/workspace-ffi/src/apple/macos/response.rs
@@ -12,10 +12,28 @@ pub struct CUrls {
 }
 
 #[repr(C)]
+pub struct CBytes {
+    pub size: i32,
+    pub bytes: *mut u8,
+}
+
+impl From<Vec<u8>> for CBytes {
+    fn from(value: Vec<u8>) -> Self {
+        if value.is_empty() {
+            return Self { size: 0, bytes: std::ptr::null_mut() };
+        }
+        let size = value.len() as i32;
+        let bytes = Box::into_raw(value.into_boxed_slice()) as *mut u8;
+        Self { size, bytes }
+    }
+}
+
+#[repr(C)]
 pub struct MacOSResponse {
     // platform response
     pub redraw_in: u64,
     pub copied_text: *mut c_char,
+    pub copied_image: CBytes,
     pub urls_opened: CUrls,
     pub cursor: CCursorIcon,
     pub request_paste: bool,
@@ -52,6 +70,7 @@ impl From<crate::Response> for MacOSResponse {
                 },
             redraw_in,
             copied_text,
+            copied_image,
             urls_opened,
             cursor,
             virtual_keyboard_shown: _,
@@ -80,12 +99,23 @@ impl From<crate::Response> for MacOSResponse {
             tabs_changed,
             redraw_in: redraw_in.unwrap_or(u64::MAX),
             copied_text: CString::new(copied_text).unwrap().into_raw(),
+            copied_image: copied_image.into(),
             urls_opened,
             cursor: cursor.into(),
             request_paste,
             selected_folder_changed,
         }
     }
+}
+
+/// # Safety
+/// Must be called with a CBytes returned from macos_frame or ios_frame.
+#[no_mangle]
+pub unsafe extern "C" fn free_bytes(bytes: CBytes) {
+    if bytes.bytes.is_null() {
+        return;
+    }
+    drop(Box::from_raw(std::slice::from_raw_parts_mut(bytes.bytes, bytes.size as usize)));
 }
 
 /// # Safety

--- a/libs/content/workspace-ffi/src/response.rs
+++ b/libs/content/workspace-ffi/src/response.rs
@@ -3,6 +3,7 @@ use egui::{
     ViewportOutput,
 };
 use workspace_rs::tab::{ContextMenuTarget, ExtendedOutput};
+use workspace_rs::widgets::image_cache::encode_png;
 
 // This general purpose workspace-ffi response captures the workspace widget response and platform response, but each
 // platform translates the workspace response into its own platform-specific response with just those fields that make
@@ -15,6 +16,7 @@ pub struct Response {
     // platform response
     pub redraw_in: Option<u64>,
     pub copied_text: String,
+    pub copied_image: Vec<u8>,
     pub urls_opened: Vec<String>,
     pub cursor: CursorIcon,
     pub virtual_keyboard_shown: Option<bool>,
@@ -53,6 +55,18 @@ impl Response {
                 .find_map(
                     |c| if let OutputCommand::CopyText(t) = c { Some(t.clone()) } else { None },
                 )
+                .unwrap_or_default(),
+            copied_image: platform
+                .commands
+                .iter()
+                .find_map(|c| if let OutputCommand::CopyImage(i) = c { Some(i) } else { None })
+                .and_then(|i| match encode_png(i) {
+                    Ok(png) => Some(png),
+                    Err(err) => {
+                        eprintln!("failed to encode copied image: {err}");
+                        None
+                    }
+                })
                 .unwrap_or_default(),
             urls_opened: platform
                 .commands

--- a/libs/content/workspace/src/tab/image_viewer.rs
+++ b/libs/content/workspace/src/tab/image_viewer.rs
@@ -6,17 +6,17 @@ use lb_rs::Uuid;
 use resvg::usvg::Transform;
 use tracing::error;
 
-use crate::tab::ExtendedInput as _;
 use crate::tab::input_controller::{
     InputController, InputControllerConfig, InputControllerEvent, LayoutContext,
 };
+use crate::tab::{ContextMenuTarget, ExtendedInput as _, ExtendedOutput as _};
 use crate::theme::icons::Icon;
 use crate::widgets::Button;
 use crate::widgets::image_cache::{ImageCache, ImageState};
 
 const MIN_ZOOM_LEVEL: f32 = 0.1;
 const ZOOM_STEP: f32 = 10.0;
-const VIEWPORT_ISLAND_FALLBACK_WIDTH: f32 = 178.0;
+const VIEWPORT_ISLAND_FALLBACK_WIDTH: f32 = 136.0;
 const ZOOM_STOPS_POPOVER_WIDTH: f32 = 80.0;
 const BRING_BACK_FALLBACK_WIDTH: f32 = 220.0;
 const SCREEN_PADDING: egui::Pos2 =
@@ -219,17 +219,6 @@ impl ImageViewer {
             };
 
             ui.add_space((50.0 - zoom_pct_btn.rect.width()).max(0.0));
-
-            ui.add(egui::Separator::default().vertical().shrink(4.0));
-
-            if Button::default()
-                .icon(&Icon::CONTENT_COPY.size(size))
-                .show(ui)
-                .on_hover_text("Copy image")
-                .clicked()
-            {
-                self.copy_image(ui);
-            }
         });
     }
 
@@ -244,6 +233,15 @@ impl ImageViewer {
             egui::Sense::click(),
         );
 
+        if cfg!(target_os = "ios") {
+            if response.clicked() {
+                if let Some(pos) = response.interact_pointer_pos() {
+                    ui.ctx().set_context_menu(pos, ContextMenuTarget::Image);
+                }
+            }
+            return;
+        }
+
         let mut copy = false;
         response.context_menu(|ui| {
             if ui.button("Copy image").clicked() {
@@ -252,13 +250,13 @@ impl ImageViewer {
             }
         });
         if copy {
-            self.copy_image(ui);
+            self.copy_image(ui.ctx());
         }
     }
 
-    fn copy_image(&self, ui: &egui::Ui) {
+    pub fn copy_image(&self, ctx: &egui::Context) {
         match self.images.color_image(self.id) {
-            Ok(image) => ui.ctx().copy_image(image),
+            Ok(image) => ctx.copy_image(image),
             Err(err) => error!("failed to copy image to clipboard: {err}"),
         }
     }

--- a/libs/content/workspace/src/tab/image_viewer.rs
+++ b/libs/content/workspace/src/tab/image_viewer.rs
@@ -4,6 +4,7 @@ use egui::{self, Color32, Pos2, Rect, Vec2};
 use epaint::RectShape;
 use lb_rs::Uuid;
 use resvg::usvg::Transform;
+use tracing::error;
 
 use crate::tab::ExtendedInput as _;
 use crate::tab::input_controller::{
@@ -15,7 +16,7 @@ use crate::widgets::image_cache::{ImageCache, ImageState};
 
 const MIN_ZOOM_LEVEL: f32 = 0.1;
 const ZOOM_STEP: f32 = 10.0;
-const VIEWPORT_ISLAND_FALLBACK_WIDTH: f32 = 136.0;
+const VIEWPORT_ISLAND_FALLBACK_WIDTH: f32 = 178.0;
 const ZOOM_STOPS_POPOVER_WIDTH: f32 = 80.0;
 const BRING_BACK_FALLBACK_WIDTH: f32 = 220.0;
 const SCREEN_PADDING: egui::Pos2 =
@@ -84,6 +85,7 @@ impl ImageViewer {
                     Rect::from_min_max(Pos2::new(0.0, 0.0), Pos2::new(1.0, 1.0)),
                 ));
 
+                self.show_image_context_menu(ui, available, rect);
                 self.show_viewport_controls(ui, available, rect);
             }
             ImageState::Failed(ref msg) => {
@@ -217,7 +219,48 @@ impl ImageViewer {
             };
 
             ui.add_space((50.0 - zoom_pct_btn.rect.width()).max(0.0));
+
+            ui.add(egui::Separator::default().vertical().shrink(4.0));
+
+            if Button::default()
+                .icon(&Icon::CONTENT_COPY.size(size))
+                .show(ui)
+                .on_hover_text("Copy image")
+                .clicked()
+            {
+                self.copy_image(ui);
+            }
         });
+    }
+
+    fn show_image_context_menu(&mut self, ui: &mut egui::Ui, available: Rect, image_rect: Rect) {
+        if !available.intersects(image_rect) {
+            return;
+        }
+
+        let response = ui.interact(
+            available.intersect(image_rect),
+            ui.id().with("image_viewer_image"),
+            egui::Sense::click(),
+        );
+
+        let mut copy = false;
+        response.context_menu(|ui| {
+            if ui.button("Copy image").clicked() {
+                copy = true;
+                ui.close();
+            }
+        });
+        if copy {
+            self.copy_image(ui);
+        }
+    }
+
+    fn copy_image(&self, ui: &egui::Ui) {
+        match self.images.color_image(self.id) {
+            Ok(image) => ui.ctx().copy_image(image),
+            Err(err) => error!("failed to copy image to clipboard: {err}"),
+        }
     }
 
     fn show_popovers(&mut self, ui: &mut egui::Ui, available: Rect, viewport_island_rect: Rect) {

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -144,6 +144,13 @@ impl Tab {
         }
     }
 
+    pub fn image_viewer(&self) -> Option<&ImageViewer> {
+        match &self.content {
+            ContentState::Open(TabContent::Image(img)) => Some(img),
+            _ => None,
+        }
+    }
+
     pub fn svg(&self) -> Option<&SVGEditor> {
         match &self.content {
             ContentState::Open(TabContent::Svg(svg)) => Some(svg),
@@ -539,6 +546,7 @@ pub enum ContextMenuTarget {
     #[default]
     Text,
     Atom,
+    Image,
 }
 
 // todo: find a better place for the code that attaches additional things to egui::Context

--- a/libs/content/workspace/src/widgets/image_cache.rs
+++ b/libs/content/workspace/src/widgets/image_cache.rs
@@ -147,6 +147,16 @@ impl ImageCache {
             .map(|[w, h]| Vec2::new(w, h))
     }
 
+    pub fn color_image(&self, id: Uuid) -> Result<ColorImage, String> {
+        let bytes = self
+            .core
+            .read_document(id, false)
+            .map_err(|e| e.to_string())?;
+        let image = decode_with_orientation(&bytes)?;
+        let size = [image.width() as usize, image.height() as usize];
+        Ok(ColorImage::from_rgba_unmultiplied(size, &image.to_rgba8()))
+    }
+
     /// Whether `url`'s texture is decoded and ready to paint this session — the
     /// real `Loaded` state, not just persisted dims (which outlive the texture).
     pub fn is_loaded(&self, url: &str) -> bool {

--- a/libs/content/workspace/src/widgets/image_cache.rs
+++ b/libs/content/workspace/src/widgets/image_cache.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use egui::{ColorImage, Context, TextureId, Vec2};
-use image::{DynamicImage, ImageDecoder};
+use image::{DynamicImage, ImageDecoder, ImageEncoder as _};
 use lb_rs::blocking::Lb;
 use lb_rs::{Uuid, spawn};
 use resvg::tiny_skia::Pixmap;
@@ -342,6 +342,25 @@ fn rasterize_svg(
         .map_err(|e| e.to_string())?;
     resvg::render(&tree, transform, &mut pix_map.as_mut());
     pix_map.encode_png().map_err(|e| e.to_string())
+}
+
+pub fn encode_png(color_image: &ColorImage) -> Result<Vec<u8>, String> {
+    let pixels: Vec<u8> = color_image
+        .pixels
+        .iter()
+        .flat_map(|px| px.to_srgba_unmultiplied())
+        .collect();
+
+    let mut png = Vec::new();
+    image::codecs::png::PngEncoder::new(&mut png)
+        .write_image(
+            &pixels,
+            color_image.width() as u32,
+            color_image.height() as u32,
+            image::ExtendedColorType::Rgba8,
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(png)
 }
 
 /// Decode image bytes into a `DynamicImage` with EXIF orientation applied.

--- a/libs/content/workspace/src/workspace.rs
+++ b/libs/content/workspace/src/workspace.rs
@@ -402,6 +402,10 @@ impl Workspace {
         self.current_tab_mut()?.svg_mut()
     }
 
+    pub fn current_tab_image(&self) -> Option<&ImageViewer> {
+        self.current_tab()?.image_viewer()
+    }
+
     /// The active editable text widget for native (iOS) text input — the
     /// markdown document's editor or the chat tab's composer. Lets the
     /// `UITextInput` FFI bridge target whichever editor is current without


### PR DESCRIPTION
On desktop this adds a context menu for copying images. For iOS it uses a native context menu. I made sure that this didn't regress canvas in any way. 

<img height="600" alt="ScreenRecording_08-20-2026 15-00-14_1" src="https://github.com/user-attachments/assets/204f6268-872b-42d3-9e44-f399d8c5cd46" />

Fixes #4944