### PR TITLE
desktop: address performance regressions raised by review

### DIFF
--- a/clients/desktop/src/components/compounds/context_menu.rs
+++ b/clients/desktop/src/components/compounds/context_menu.rs
@@ -225,7 +225,6 @@ pub fn show<T: Clone>(
         ctx.memory_mut(|m| {
             m.data.insert_temp(open_id(), state);
         });
-        ctx.request_repaint();
     }
 
     chosen

--- a/clients/desktop/src/components/compounds/scroll.rs
+++ b/clients/desktop/src/components/compounds/scroll.rs
@@ -18,6 +18,8 @@
 //! area, so it wins shared pixels. [`BAR_OUTER_MARGIN`] (= sidebar `RESIZE_GRAB`)
 //! keeps the floating bar left of that strip.
 
+use std::time::Duration;
+
 use egui::{Context, Id, Ui};
 
 /// How long the bar stays fully “active” after the last scroll / bar leave.
@@ -37,11 +39,13 @@ struct State {
     last_offset_y: f32,
     /// `f64::NEG_INFINITY` until the first real scroll / bar hold.
     last_active: f64,
+    /// Last frame's thumb hover/drag — `prepare` runs before the bar exists.
+    thumb_held: bool,
 }
 
 impl Default for State {
     fn default() -> Self {
-        Self { last_offset_y: f32::NAN, last_active: f64::NEG_INFINITY }
+        Self { last_offset_y: f32::NAN, last_active: f64::NEG_INFINITY, thumb_held: false }
     }
 }
 
@@ -74,10 +78,12 @@ pub fn prepare(ui: &mut Ui, id: Id) {
         .ctx()
         .data(|d| d.get_temp::<State>(id))
         .unwrap_or_default();
-    let show = !separator_dragging(ui) && now - st.last_active < FADE_SECS;
+    let show = !separator_dragging(ui) && (st.thumb_held || now - st.last_active < FADE_SECS);
 
-    if show {
-        ui.ctx().request_repaint();
+    if show && !st.thumb_held {
+        let remaining = (FADE_SECS - (now - st.last_active)).max(0.0);
+        ui.ctx()
+            .request_repaint_after(Duration::from_secs_f64(remaining.max(1.0 / 120.0)));
     }
 
     // egui paints the thumb with *widget* visuals: track hover → `inactive`,
@@ -147,14 +153,20 @@ pub fn note_offset(ui: &Ui, id: Id, offset_y: f32) {
 
 /// Keep the bar in the “active” window while the thumb is hovered or dragged.
 pub fn note_bar_interaction(ui: &Ui, id: Id, bar_held: bool) {
-    if !bar_held {
-        return;
-    }
     let now = ui.input(|i| i.time);
-    ui.ctx().data_mut(|d| {
-        d.get_temp_mut_or_default::<State>(id).last_active = now;
+    let left = ui.ctx().data_mut(|d| {
+        let st = d.get_temp_mut_or_default::<State>(id);
+        let was = st.thumb_held;
+        st.thumb_held = bar_held;
+        if bar_held || was {
+            st.last_active = now;
+        }
+        was && !bar_held
     });
-    ui.ctx().request_repaint();
+    if left {
+        ui.ctx()
+            .request_repaint_after(Duration::from_secs_f64(FADE_SECS));
+    }
 }
 
 /// Scope + prepare style, run `f`, then note offset and bar hold.

--- a/clients/desktop/src/components/domain/tree/folder.rs
+++ b/clients/desktop/src/components/domain/tree/folder.rs
@@ -352,7 +352,7 @@ fn flatten_folders_only(
     if !f.is_folder() {
         return;
     }
-    out.push(FlatRow { id, depth, is_folder: true });
+    out.push(FlatRow { id, depth, is_folder: true, kids_empty: false });
     if !expanded.contains(&id) {
         return;
     }

--- a/clients/desktop/src/components/domain/tree/mod.rs
+++ b/clients/desktop/src/components/domain/tree/mod.rs
@@ -445,6 +445,17 @@ pub(crate) struct FlatRow {
     id: Uuid,
     depth: usize,
     is_folder: bool,
+    /// Folder with no children (context menu hides Expand/Collapse all).
+    kids_empty: bool,
+}
+
+/// Flattened Files-tree walk. Rebuilt when [`Ready::files_epoch`] or `expanded` changes.
+#[derive(Default)]
+pub struct TreeWalkCache {
+    epoch: u64,
+    expanded: std::collections::HashSet<Uuid>,
+    root: Option<Uuid>,
+    flat: Vec<FlatRow>,
 }
 
 // ── Shared FileRow chrome (every sticky / virtualized tree) ─────────────────
@@ -564,27 +575,15 @@ pub fn show_tree(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<Act
         pins::show(ui, t, &*files, &pins, queue);
     }
 
-    let (root, flat) = {
-        let Some(ready) = app.session.ready() else {
-            return;
-        };
-        let files = ready.workspace.files.read().unwrap();
-        let root = files.root().id;
-        let mut flat = Vec::new();
-        flatten(&*files, &ready.expanded, root, 0, &mut flat, true);
-        (root, flat)
+    let Some(root) = ensure_tree_walk(app) else {
+        return;
     };
-
-    if let Some(r) = app.session.ready_mut() {
-        r.expanded.insert(root);
-        r.nav_order = flat.iter().map(|r| r.id).collect();
-    }
+    let flat = app.tree_walk.flat.clone();
 
     if let Some(ready) = app.session.ready() {
-        let expanded = ready.expanded.clone();
-        let status = ready.status.clone();
         let files = ready.workspace.files.read().unwrap();
-        app.sync_dots.refresh(ui.ctx(), &status, &expanded, &*files);
+        app.sync_dots
+            .refresh(ui.ctx(), &ready.status, &ready.expanded, &*files);
     }
 
     // Files tree: uniform single-line pitch (variable path ready for Shared).
@@ -892,22 +891,60 @@ pub(crate) fn paint_sticky_viewport(
     bg_resp
 }
 
+/// Rebuild [`ShellApp::tree_walk`] when the file cache or expand set changed.
+/// Returns the tree root, or `None` when there is no Ready session.
+fn ensure_tree_walk(app: &mut ShellApp) -> Option<Uuid> {
+    let ready = app.session.ready_mut()?;
+    let files = ready.workspace.files.read().unwrap();
+    let root = files.root().id;
+    ready.expanded.insert(root);
+    let epoch = ready.files_epoch;
+    if app.tree_walk.epoch == epoch
+        && app.tree_walk.root == Some(root)
+        && app.tree_walk.expanded == ready.expanded
+    {
+        return Some(root);
+    }
+    let mut flat = Vec::new();
+    flatten(&*files, &ready.expanded, root, 0, &mut flat, true);
+    ready.nav_order = flat.iter().map(|r| r.id).collect();
+    drop(files);
+    app.tree_walk =
+        TreeWalkCache { epoch, expanded: ready.expanded.clone(), root: Some(root), flat };
+    Some(root)
+}
+
 pub(crate) fn flatten(
     files: &impl FilesExt, expanded: &std::collections::HashSet<Uuid>, id: Uuid, depth: usize,
     out: &mut Vec<FlatRow>, skip_self: bool,
 ) {
     if !skip_self {
         let is_folder = files.get_by_id(id).map(|f| f.is_folder()).unwrap_or(false);
-        out.push(FlatRow { id, depth, is_folder });
-        if !is_folder || !expanded.contains(&id) {
+        if !is_folder {
+            out.push(FlatRow { id, depth, is_folder: false, kids_empty: false });
+            return;
+        }
+        if !expanded.contains(&id) {
+            out.push(FlatRow {
+                id,
+                depth,
+                is_folder: true,
+                kids_empty: files.children(id).is_empty(),
+            });
             return;
         }
     }
-    for kid in files.children(id) {
-        if kid.id == id {
-            continue;
-        }
-        flatten(files, expanded, kid.id, if skip_self { 0 } else { depth + 1 }, out, false);
+    let kids: Vec<_> = files
+        .children(id)
+        .into_iter()
+        .filter(|kid| kid.id != id)
+        .collect();
+    if !skip_self {
+        out.push(FlatRow { id, depth, is_folder: true, kids_empty: kids.is_empty() });
+    }
+    let child_depth = if skip_self { 0 } else { depth + 1 };
+    for kid in kids {
+        flatten(files, expanded, kid.id, child_depth, out, false);
     }
 }
 
@@ -1109,18 +1146,18 @@ fn paint_row(
     let Some(ready) = app.session.ready() else {
         return;
     };
-    let (name, kids_empty, create_parent, is_shared) = {
+    let (name, create_parent, is_shared) = {
         let files = ready.workspace.files.read().unwrap();
         let Some(f) = files.get_by_id(row.id) else {
             return;
         };
-        let empty = row.is_folder && files.children(row.id).is_empty();
         // Create under a folder, or alongside a document (same parent).
         let parent = if row.is_folder { row.id } else { f.parent };
         // Classic tree: share chrome when the file itself carries share metadata.
         let shared = !f.shares.is_empty();
-        (f.name.clone(), empty, parent, shared)
+        (f.name.clone(), parent, shared)
     };
+    let kids_empty = row.kids_empty;
     let selected = ready.selected.contains(&row.id) || ready.cursor == Some(row.id);
     let expanded = ready.expanded.contains(&row.id);
     let pinned = is_pinned(ready, row.id);
@@ -1284,10 +1321,10 @@ mod sticky_tests {
     use lb::Uuid;
 
     fn folder(id: u128, depth: usize) -> FlatRow {
-        FlatRow { id: Uuid::from_u128(id), depth, is_folder: true }
+        FlatRow { id: Uuid::from_u128(id), depth, is_folder: true, kids_empty: false }
     }
     fn doc(id: u128, depth: usize) -> FlatRow {
-        FlatRow { id: Uuid::from_u128(id), depth, is_folder: false }
+        FlatRow { id: Uuid::from_u128(id), depth, is_folder: false, kids_empty: false }
     }
     fn uni(flat: &[FlatRow]) -> RowGeom {
         RowGeom::uniform(flat.len(), ROW_H)

--- a/clients/desktop/src/components/domain/tree/shared.rs
+++ b/clients/desktop/src/components/domain/tree/shared.rs
@@ -68,7 +68,7 @@ pub fn show_shared(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<A
     );
     let flat: Vec<FlatRow> = shared_flat
         .iter()
-        .map(|r| FlatRow { id: r.id, depth: r.depth, is_folder: r.is_folder })
+        .map(|r| FlatRow { id: r.id, depth: r.depth, is_folder: r.is_folder, kids_empty: false })
         .collect();
     // Parallel meta by index (ids unique within a share forest for paint).
     let meta = shared_flat;

--- a/clients/desktop/src/components/foundation/style.rs
+++ b/clients/desktop/src/components/foundation/style.rs
@@ -9,6 +9,7 @@ use super::typography;
 
 const MODE_PREF_ID: &str = "design_mode_preference";
 const THEME_FAMILY_ID: &str = "design_theme_family";
+const DETECTED_MODE_ID: &str = "design_detected_system_mode";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum ModePreference {
@@ -156,7 +157,9 @@ pub fn resolved_mode(ctx: &Context) -> Mode {
     }
 }
 
-/// OS appearance: egui `system_theme`, else `dark_light`; unspecified → light.
+/// OS appearance: egui `system_theme`, else one cached `dark_light` probe.
+///
+/// `dark_light::detect()` blocks on a portal / registry read — call it once.
 pub fn system_mode(ctx: &Context) -> Mode {
     if let Some(theme) = ctx.system_theme() {
         return egui_theme_to_mode(theme);
@@ -164,10 +167,15 @@ pub fn system_mode(ctx: &Context) -> Mode {
     if let Some(theme) = ctx.input(|i| i.raw.system_theme) {
         return egui_theme_to_mode(theme);
     }
-    match dark_light::detect() {
+    if let Some(cached) = ctx.data(|d| d.get_temp::<Mode>(Id::new(DETECTED_MODE_ID))) {
+        return cached;
+    }
+    let mode = match dark_light::detect() {
         Ok(dark_light::Mode::Dark) => Mode::Dark,
         Ok(dark_light::Mode::Light | dark_light::Mode::Unspecified) | Err(_) => Mode::Light,
-    }
+    };
+    ctx.data_mut(|d| d.insert_temp(Id::new(DETECTED_MODE_ID), mode));
+    mode
 }
 
 fn egui_theme_to_mode(theme: EguiTheme) -> Mode {

--- a/clients/desktop/src/host.rs
+++ b/clients/desktop/src/host.rs
@@ -106,7 +106,7 @@ impl ApplicationHandler<UserEvent> for App {
             lb.renderer.context.viewport_id(),
             &window,
             Some(window.scale_factor() as f32),
-            None,
+            window.theme(),
             None,
         );
 
@@ -151,7 +151,7 @@ impl ApplicationHandler<UserEvent> for App {
         if is_paste_shortcut(&state.egui_winit, &event) {
             state.pending_paste = true;
             state.window.request_redraw();
-        } else if !matches!(event, WindowEvent::ThemeChanged(_)) {
+        } else {
             let response = state.egui_winit.on_window_event(&state.window, &event);
 
             if response.repaint && !matches!(event, WindowEvent::RedrawRequested) {

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -21,7 +21,7 @@ use super::action::{
     Action as A, CreateKind, CreateLoc, Modal, OnboardLookup, OnboardMode, SettingsCat,
     ShareLookup, UpgradeStage,
 };
-use super::ops::{is_pinned, rebuild_cache, refresh_pinned};
+use super::ops::{is_pinned, refresh_pinned};
 use super::prefs::AccountPanel;
 use super::session::Ready;
 use crate::components::{set_mode_preference, set_theme_family};
@@ -188,7 +188,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                         r.workspace.delete_file(*id);
                         r.selected.remove(id);
                     }
-                    rebuild_cache(r);
                     if let Some(id) = r.workspace.current_tab_id() {
                         r.select_only(id);
                     } else {
@@ -348,7 +347,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                     for id in &ids {
                         r.workspace.move_file((*id, d));
                     }
-                    rebuild_cache(r);
                     r.expanded.insert(d);
                 }
             }
@@ -392,7 +390,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                     }
                     // Core failure lands on workspace.failure_messages → toast in editor.
                     r.workspace.rename_file((id, full), true);
-                    rebuild_cache(r);
                 }
             }
         }
@@ -424,7 +421,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                         FileType::Link { target: id },
                     ) {
                         Ok(_) => {
-                            rebuild_cache(r);
                             r.expanded.insert(parent);
                         }
                         Err(e) => {
@@ -441,7 +437,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
             if let Some(r) = app.session.ready_mut() {
                 match r.workspace.core.delete_pending_share(&id) {
                     Ok(()) => {
-                        rebuild_cache(r);
                         app.modal = None;
                     }
                     Err(e) => {
@@ -505,7 +500,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                         r.workspace.move_file((*id, parent));
                     }
                 }
-                rebuild_cache(r);
                 r.expanded.insert(parent);
             }
         }
@@ -718,7 +712,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                         r.status.space_used = Some(u);
                     }
                     r.sub_info = r.workspace.core.get_subscription_info().ok().flatten();
-                    rebuild_cache(r);
                 }
                 Err(e) => {
                     let msg = format!("{e}");
@@ -974,7 +967,6 @@ fn confirm_create(app: &mut ShellApp) {
         };
         match result {
             Ok(file) => {
-                rebuild_cache(r);
                 r.expanded.insert(parent_id);
                 r.select_only(file.id);
                 if !is_folder {
@@ -1079,7 +1071,6 @@ fn duplicate_files(app: &mut ShellApp, ids: &[Uuid]) {
             }
         }
         if !created.is_empty() {
-            rebuild_cache(r);
             let last = created.last().unwrap().id;
             for (i, f) in created.iter().enumerate() {
                 if f.is_document() {
@@ -1151,7 +1142,6 @@ fn paste_clip(app: &mut ShellApp, dest_override: Option<Uuid>) {
             }
         }
         r.clipboard = Default::default();
-        rebuild_cache(r);
         r.expanded.insert(dest);
     } else {
         for id in &clip.ids {
@@ -1161,7 +1151,6 @@ fn paste_clip(app: &mut ShellApp, dest_override: Option<Uuid>) {
                 }
             }
         }
-        rebuild_cache(r);
         r.expanded.insert(dest);
     }
 }
@@ -1255,7 +1244,6 @@ fn import_paths(app: &mut ShellApp, ctx: &Context, paths: Vec<PathBuf>, parent: 
         r.expanded.insert(parent);
         r.status_msg = format!("Importing {n}…");
     }
-    // Rebuild when StatusUpdated fires (drain_events → rebuild_cache).
     thread::spawn(move || {
         if let Err(e) = core.import_files(&paths, parent, &|_| {}) {
             eprintln!("import failed: {e:?}");

--- a/clients/desktop/src/shell/apply_share.rs
+++ b/clients/desktop/src/shell/apply_share.rs
@@ -6,7 +6,6 @@ use egui::Context;
 
 use super::ShellApp;
 use super::action::{Modal, ShareLookup, ShareStaged};
-use super::ops::rebuild_cache;
 use lb::model::file::ShareMode;
 
 fn share_split_tokens(q: &str) -> (Vec<String>, String) {
@@ -400,7 +399,6 @@ pub(crate) fn share_invite(app: &mut ShellApp, ctx: &Context) {
             }
         }
         if !ok.is_empty() {
-            rebuild_cache(r);
             r.refresh_status();
         }
     }

--- a/clients/desktop/src/shell/editor.rs
+++ b/clients/desktop/src/shell/editor.rs
@@ -35,7 +35,7 @@ pub fn show(app: &mut ShellApp, ui: &mut Ui, _t: &Theme, queue: &mut Vec<Action>
         let out = ready.workspace.show(ui);
 
         if out.file_cache_updated {
-            super::ops::rebuild_cache(ready);
+            super::ops::note_files_changed(ready);
         }
 
         if let Some(Ok(file)) = out.file_created {

--- a/clients/desktop/src/shell/mod.rs
+++ b/clients/desktop/src/shell/mod.rs
@@ -93,6 +93,8 @@ pub struct ShellApp {
     pub recents_cache: RecentsCache,
     /// Derived Shared lists; same epoch rule.
     pub shared_cache: SharedCache,
+    /// Flattened Files-tree walk; same epoch + expanded-set rule.
+    pub tree_walk: tree::TreeWalkCache,
     theme_applied: bool,
     /// macOS: one-shot NSWindow.isMovable=false (see [`macos_window`]).
     /// Set by the host after window creation.
@@ -158,6 +160,7 @@ impl Default for ShellApp {
             lb_rx: None,
             recents_cache: RecentsCache::default(),
             shared_cache: SharedCache::default(),
+            tree_walk: tree::TreeWalkCache::default(),
             theme_applied: false,
             #[cfg(target_os = "macos")]
             macos_window_tweaked: false,

--- a/clients/desktop/src/shell/mod.rs
+++ b/clients/desktop/src/shell/mod.rs
@@ -310,7 +310,6 @@ impl ShellApp {
         match &self.session {
             Session::Loading { kind: session::LoadKind::Cold, .. } => {
                 // Opening local account — empty chrome, no plate / no spinner.
-                ctx.request_repaint();
                 CentralPanel::default()
                     .frame(Frame::new().fill(t.neutral_bg()).inner_margin(0.0))
                     .show(ctx, |_| {});
@@ -323,7 +322,6 @@ impl ShellApp {
             Session::Loading { kind: session::LoadKind::Onboard, status, .. } => {
                 let msg = session::read_load_status(status);
                 boot_screen(ctx, &t, &msg, true);
-                ctx.request_repaint();
                 titlebar::show(self, ctx, &t, &mut queue);
                 for a in queue {
                     apply::apply(self, ctx, a);

--- a/clients/desktop/src/shell/ops.rs
+++ b/clients/desktop/src/shell/ops.rs
@@ -1,14 +1,11 @@
-//! Shared session mutations used from `apply` (cache rebuild, pins).
+//! Shared session mutations used from `apply` (cache epoch, pins).
 
 use lb::Uuid;
-use workspace_rs::file_cache::FileCache;
 
 use super::session::Ready;
 
-pub fn rebuild_cache(r: &mut Ready) {
-    if let Ok(files) = FileCache::new(&r.workspace.core) {
-        *r.workspace.files.write().unwrap() = files;
-    }
+/// Invalidate Recents/Shared after workspace already wrote `files`.
+pub fn note_files_changed(r: &mut Ready) {
     r.files_epoch = r.files_epoch.wrapping_add(1);
     refresh_pinned(r);
     r.refresh_status();

--- a/clients/desktop/src/shell/session.rs
+++ b/clients/desktop/src/shell/session.rs
@@ -93,7 +93,7 @@ pub struct Ready {
     pub sub_info: Option<SubscriptionInfo>,
     /// Flattened visible tree order (Shift-range select).
     pub nav_order: Vec<Uuid>,
-    /// Bumped when [`super::ops::rebuild_cache`] rewrites the file cache.
+    /// Bumped when [`super::ops::note_files_changed`] runs.
     /// Sidebar list panes (Recents / Shared) rebuild derived rows only when this changes.
     pub files_epoch: u64,
     /// Pending Files-tree center-scroll (tab open / reveal). Held until the row


### PR DESCRIPTION
Performance regressions introduced in https://github.com/lockbook/lockbook/pull/4988 to do with:
* os theme detection
* file cache rebuilds
* loading state
* scrollbar animation
* file tree cache
* context menus

see commit messages for more details