### PR TITLE
build: clone cargo deps with git cli

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[net]
+git-fetch-with-cli = true
+
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 


### PR DESCRIPTION
Configures Cargo to fetch Git dependencies with the system Git CLI instead of its built-in Git client.

This allows dependency fetches to use existing Git and SSH configuration, including keys available to OpenSSH but not loaded into `ssh-agent`. It fixes misleading "revision not found" failures when GitHub HTTPS URLs are rewritten to SSH.

Verified with:

```sh
cargo fetch --locked
```
