### PR TITLE
desktop: create sheet, file extension hiding, and onboard server

### DIFF
--- a/clients/desktop/src/components/atoms/field.rs
+++ b/clients/desktop/src/components/atoms/field.rs
@@ -42,6 +42,8 @@ pub struct Field<'a> {
     /// After keyboard events, before paint: rewrite buffer + remap caret.
     /// `(old_text, cursor, anchor) -> (new_text, new_cursor, new_anchor)`.
     rewrite: Option<Box<FieldRewrite<'a>>>,
+    /// Re-take focus when a press lands on a non-focusable control (default).
+    sticky: bool,
 }
 
 /// Buffer rewrite after keyboard events (see [`Field::rewrite`]).
@@ -64,6 +66,7 @@ impl<'a> Field<'a> {
             completion_full: None,
             password: false,
             rewrite: None,
+            sticky: true,
         }
     }
 
@@ -130,6 +133,12 @@ impl<'a> Field<'a> {
     /// Always paint `*` per character (account key).
     pub fn password(mut self, on: bool) -> Self {
         self.password = on;
+        self
+    }
+
+    /// When false, a press outside surrenders focus (caption → field blur).
+    pub fn sticky(mut self, on: bool) -> Self {
+        self.sticky = on;
         self
     }
 
@@ -317,7 +326,11 @@ impl<'a> Field<'a> {
             ui.painter().galley(cr.center() - xg.size() / 2.0, xg, ink);
             if cresp.clicked() {
                 self.text.clear();
-                ui.memory_mut(|m| m.request_focus(edit_id));
+                if self.sticky {
+                    ui.memory_mut(|m| m.request_focus(edit_id));
+                } else {
+                    ui.memory_mut(|m| m.surrender_focus(edit_id));
+                }
             }
         }
 
@@ -372,7 +385,7 @@ impl<'a> Field<'a> {
         // claimed focus, re-take it. Keyboard surrender (Esc / Enter submit) has
         // no pointer press, so we leave focus clear.
         let lost = ui.memory(|m| m.had_focus_last_frame(edit_id) && !m.has_focus(edit_id));
-        if lost {
+        if self.sticky && lost {
             let free = ui.memory(|m| m.focused().is_none());
             let pointer = ui.input(|i| i.pointer.any_pressed() || i.pointer.any_down());
             if free && pointer {

--- a/clients/desktop/src/components/atoms/field.rs
+++ b/clients/desktop/src/components/atoms/field.rs
@@ -7,7 +7,7 @@ use egui::{Align, Color32, Id, Layout, Response, Stroke, StrokeKind, Ui, pos2, v
 use workspace_rs::widgets::GlyphonTextEdit;
 
 use crate::components::foundation::chrome::{
-    Radius, STROKE_HAIRLINE, control_height, control_line_height, phosphor_ui_font_id,
+    Radius, STROKE_HAIRLINE, control_height, control_line_height, phosphor, phosphor_ui_font_id,
 };
 use crate::components::foundation::color::{
     FG_HOVER, FG_PRESS, QUIET_PLATE_HOVER, QUIET_PLATE_PRESS, Theme,
@@ -323,6 +323,49 @@ impl<'a> Field<'a> {
 
         response = response.union(edit_resp);
 
+        if response.secondary_clicked() {
+            ui.memory_mut(|m| m.request_focus(edit_id));
+        }
+        if let Some(cmd) = crate::components::context_menu::show(&response, t, |e| {
+            e.item(phosphor::SCISSORS, "Cut", FieldEditCmd::Cut);
+            e.item(phosphor::COPY, "Copy", FieldEditCmd::Copy);
+            e.item(phosphor::CLIPBOARD_TEXT, "Paste", FieldEditCmd::Paste);
+            e.separator();
+            e.item(phosphor::SELECTION_ALL, "Select all", FieldEditCmd::SelectAll);
+        }) {
+            ui.memory_mut(|m| m.request_focus(edit_id));
+            match cmd {
+                FieldEditCmd::Cut => {
+                    ui.ctx().input_mut(|i| i.events.push(egui::Event::Cut));
+                    let _ = GlyphonTextEdit::process_events_ex(
+                        ui,
+                        edit_id,
+                        self.text,
+                        self.completion_full.as_deref(),
+                        true,
+                    );
+                }
+                FieldEditCmd::Copy => {
+                    ui.ctx().input_mut(|i| i.events.push(egui::Event::Copy));
+                    let _ = GlyphonTextEdit::process_events_ex(
+                        ui,
+                        edit_id,
+                        self.text,
+                        self.completion_full.as_deref(),
+                        true,
+                    );
+                }
+                FieldEditCmd::Paste => {
+                    ui.ctx()
+                        .send_viewport_cmd(egui::ViewportCommand::RequestPaste);
+                }
+                FieldEditCmd::SelectAll => {
+                    let len = self.text.len();
+                    GlyphonTextEdit::place_cursor(ui, edit_id, len, 0);
+                }
+            }
+        }
+
         // Sticky text focus: egui surrenders focus on any press outside the
         // focused widget. Non-text controls use `sense_click` (no FOCUSABLE) and
         // do not request focus — if a pointer press cleared us and nothing else
@@ -339,6 +382,14 @@ impl<'a> Field<'a> {
 
         response
     }
+}
+
+#[derive(Clone, Copy)]
+enum FieldEditCmd {
+    Cut,
+    Copy,
+    Paste,
+    SelectAll,
 }
 
 /// Ghost after typed buffer: remainder of `full` when `query` is a

--- a/clients/desktop/src/components/atoms/file_row.rs
+++ b/clients/desktop/src/components/atoms/file_row.rs
@@ -17,7 +17,7 @@ use egui::{Color32, Id, Rect, Response, Sense, Ui, pos2, vec2};
 
 use super::file_name;
 use crate::components::foundation::chrome::{
-    HOVER_ANIM_SECS, Radius, phosphor, phosphor_ui_font_id, row_wash_inset,
+    HOVER_ANIM_SECS, Radius, display_file_name, phosphor, phosphor_ui_font_id, row_wash_inset,
 };
 use crate::components::foundation::color::{FG_HOVER, FG_PRESS, Theme};
 use crate::components::foundation::interact::sense_click;
@@ -267,7 +267,7 @@ impl<'a> FileRow<'a> {
         // File names (and path/from captions) via glyphon — emoji-safe.
         let name_slot =
             Rect::from_min_size(pos2(text_x, name_cy - name_lh / 2.0), vec2(max_w, name_lh));
-        let name_w = file_name::paint_body(ui, &self.label, ink, name_slot);
+        let name_w = file_name::paint_body(ui, display_file_name(&self.label), ink, name_slot);
 
         if let Some(c) = self.sync_dot {
             let cx = (text_x + name_w + SYNC_GAP + SYNC_R).min(content_right - trail_w - SYNC_R);

--- a/clients/desktop/src/components/atoms/mod.rs
+++ b/clients/desktop/src/components/atoms/mod.rs
@@ -24,4 +24,4 @@ pub use quiet_chip::height as quiet_chip_height;
 pub use quiet_chip::{
     QuietChipAlign, QuietChipLabel, labeled_min_width as quiet_chip_labeled_min_width, quiet_chip,
 };
-pub use segmented::{segmented, segmented_h};
+pub use segmented::{segmented, segmented_h, segmented_width};

--- a/clients/desktop/src/components/atoms/quiet_chip.rs
+++ b/clients/desktop/src/components/atoms/quiet_chip.rs
@@ -6,7 +6,7 @@
 use egui::{Color32, Response, Ui, pos2, vec2};
 
 use crate::components::foundation::chrome::{
-    HOVER_ANIM_SECS, Radius, control_height, phosphor_ui_font_id,
+    HOVER_ANIM_SECS, Radius, control_height, display_file_name, phosphor_ui_font_id,
 };
 use crate::components::foundation::color::{FG_HOVER, FG_PRESS, Theme};
 use crate::components::foundation::layout::ui_width;
@@ -109,7 +109,7 @@ pub fn quiet_chip(
             let max_name_w = (rect.right() - pad - x).max(8.0);
             crate::components::atoms::file_name::paint_body(
                 ui,
-                name,
+                display_file_name(name),
                 t.neutral_fg(),
                 egui::Rect::from_min_size(pos2(x, line_top), vec2(max_name_w, lh)),
             );

--- a/clients/desktop/src/components/atoms/segmented.rs
+++ b/clients/desktop/src/components/atoms/segmented.rs
@@ -25,16 +25,15 @@ pub fn segmented_h() -> f32 {
 /// Equalize segment widths so the strip doesn’t look lopsided.
 const EQUALIZE: bool = true;
 
-/// Exclusive segmented control. `options` should be 2–5 short labels.
-/// Marks the response `.changed()` when `selected` updates.
-pub fn segmented(ui: &mut Ui, t: &Theme, options: &[&str], selected: &mut usize) -> Response {
-    let n = options.len().max(1);
-    *selected = (*selected).min(n - 1);
+/// Natural width of a [`segmented`] for `options` (equalized cells).
+pub fn segmented_width(ui: &Ui, t: &Theme, options: &[&str]) -> f32 {
+    segmented_cell_widths(ui, t, options).iter().sum()
+}
 
+fn segmented_cell_widths(ui: &Ui, t: &Theme, options: &[&str]) -> Vec<f32> {
+    let n = options.len().max(1);
     let h = segmented_h();
     let pad_x = Space::Md.pts();
-    let pill_inset = Space::Xxs.pts();
-
     let font = TypeRole::Body.font_id();
     let mut natural = Vec::with_capacity(n);
     let mut max_w = 0.0_f32;
@@ -46,7 +45,19 @@ pub fn segmented(ui: &mut Ui, t: &Theme, options: &[&str], selected: &mut usize)
         natural.push(w);
         max_w = max_w.max(w);
     }
-    let widths: Vec<f32> = if EQUALIZE { vec![max_w; n] } else { natural };
+    if EQUALIZE { vec![max_w; n] } else { natural }
+}
+
+/// Exclusive segmented control. `options` should be 2–5 short labels.
+/// Marks the response `.changed()` when `selected` updates.
+pub fn segmented(ui: &mut Ui, t: &Theme, options: &[&str], selected: &mut usize) -> Response {
+    let n = options.len().max(1);
+    *selected = (*selected).min(n - 1);
+
+    let h = segmented_h();
+    let pill_inset = Space::Xxs.pts();
+    let font = TypeRole::Body.font_id();
+    let widths = segmented_cell_widths(ui, t, options);
     let total_w: f32 = widths.iter().sum();
 
     let (track, mut resp) = ui.allocate_exact_size(vec2(total_w, h), sense_click());

--- a/clients/desktop/src/components/domain/pins.rs
+++ b/clients/desktop/src/components/domain/pins.rs
@@ -48,8 +48,6 @@ struct PinRow {
     name: String,
     is_folder: bool,
     saved_share: bool,
-    /// Create destination: folder id, or parent of a document.
-    create_parent: Uuid,
 }
 
 pub fn show(
@@ -60,13 +58,11 @@ pub fn show(
         .iter()
         .filter_map(|id| {
             let f = files.get_by_id(*id)?;
-            let create_parent = if f.is_folder() { f.id } else { f.parent };
             Some(PinRow {
                 id: *id,
                 name: f.name.clone(),
                 is_folder: f.is_folder(),
                 saved_share: is_saved_share(f, me),
-                create_parent,
             })
         })
         .collect();
@@ -235,7 +231,19 @@ fn pin_chip(ui: &mut Ui, t: &Theme, row: &PinRow, queue: &mut Vec<Action>) {
             PinCmd::Open => queue.push(A::OpenFile(row.id)),
             PinCmd::OpenNewTab => queue.push(A::OpenFileNewTab(row.id)),
             PinCmd::Create => {
-                queue.push(A::OpenCreate { parent: Some(row.create_parent), is_folder: false })
+                if row.is_folder {
+                    queue.push(A::OpenCreate {
+                        folder: Some(row.id),
+                        alongside: None,
+                        is_folder: false,
+                    })
+                } else {
+                    queue.push(A::OpenCreate {
+                        folder: None,
+                        alongside: Some(row.id),
+                        is_folder: false,
+                    })
+                }
             }
             PinCmd::ExpandAll => queue.push(A::ExpandSubtree(row.id)),
             PinCmd::CollapseAll => queue.push(A::CollapseSubtree(row.id)),

--- a/clients/desktop/src/components/domain/pins.rs
+++ b/clients/desktop/src/components/domain/pins.rs
@@ -16,6 +16,7 @@ use crate::components::{
 
 use crate::shell::action::Action;
 use crate::shell::action::Action as A;
+use crate::shell::ops::is_saved_share;
 
 const COLS: usize = 2;
 const MAX_ROWS: usize = 3;
@@ -46,19 +47,27 @@ struct PinRow {
     id: Uuid,
     name: String,
     is_folder: bool,
+    saved_share: bool,
     /// Create destination: folder id, or parent of a document.
     create_parent: Uuid,
 }
 
 pub fn show(
-    ui: &mut Ui, t: &Theme, files: &impl FilesExt, pinned: &[Uuid], queue: &mut Vec<Action>,
+    ui: &mut Ui, t: &Theme, files: &impl FilesExt, pinned: &[Uuid], me: &str,
+    queue: &mut Vec<Action>,
 ) {
     let mut rows: Vec<PinRow> = pinned
         .iter()
         .filter_map(|id| {
             let f = files.get_by_id(*id)?;
             let create_parent = if f.is_folder() { f.id } else { f.parent };
-            Some(PinRow { id: *id, name: f.name.clone(), is_folder: f.is_folder(), create_parent })
+            Some(PinRow {
+                id: *id,
+                name: f.name.clone(),
+                is_folder: f.is_folder(),
+                saved_share: is_saved_share(f, me),
+                create_parent,
+            })
         })
         .collect();
     if rows.is_empty() {
@@ -216,7 +225,11 @@ fn pin_chip(ui: &mut Ui, t: &Theme, row: &PinRow, queue: &mut Vec<Action>) {
             e.item(phosphor::DOWNLOAD_SIMPLE, "Export…", PinCmd::Export);
         }
         e.separator();
-        e.item_danger(phosphor::TRASH, "Delete…", PinCmd::Delete);
+        if row.saved_share {
+            e.item(phosphor::FOLDER_MINUS, "Remove from files…", PinCmd::Delete);
+        } else {
+            e.item_danger(phosphor::TRASH, "Delete…", PinCmd::Delete);
+        }
     }) {
         match cmd {
             PinCmd::Open => queue.push(A::OpenFile(row.id)),

--- a/clients/desktop/src/components/domain/tabs.rs
+++ b/clients/desktop/src/components/domain/tabs.rs
@@ -12,12 +12,11 @@ use egui::{
 };
 use lb::Uuid;
 use workspace_rs::file_cache::FilesExt;
-use workspace_rs::show::DocType;
 use workspace_rs::tab::Destination;
 
 use crate::components::{
     FG_HOVER, FG_PRESS, Radius, STROKE_HAIRLINE, Space, Theme, TypeRole, claim, context_menu,
-    fit_outside_stroke_fill, phosphor, place_at, tab_icon, ui_width,
+    display_file_name, fit_outside_stroke_fill, phosphor, place_at, tab_icon, ui_width,
 };
 
 use crate::shell::ShellApp;
@@ -230,7 +229,7 @@ fn tab_label(ready: &crate::shell::session::Ready, dest: &Destination) -> String
 }
 
 fn measure_tab_w(ui: &Ui, name: &str) -> f32 {
-    let nw = crate::components::measure_file_name(ui, display_name(name));
+    let nw = crate::components::measure_file_name(ui, display_file_name(name));
     let icon_w = TypeRole::Body.size() + Space::Xs.pts();
     (TAB_PAD_X + icon_w + nw + Space::Xs.pts() + CLOSE_SLOT + TAB_PAD_X).clamp(TAB_MIN_W, TAB_MAX_W)
 }
@@ -243,10 +242,6 @@ fn tab_scroll_w(bar_w: f32, left: f32, right: f32, content_w: f32) -> f32 {
     // Keep one tab hittable on a narrow window even if it eats the drag gap.
     let available = if with_gap >= TAB_MIN_W { with_gap } else { (bar_w - chrome).max(0.0) };
     content_w.min(available)
-}
-
-fn display_name(name: &str) -> &str {
-    DocType::from_name(name).display_name(name)
 }
 
 struct TabInfo {
@@ -412,7 +407,7 @@ fn tab_button(ui: &mut Ui, t: &Theme, tab: &TabInfo, tab_count: usize, can_reope
     let icon_g =
         ui.painter()
             .layout_no_wrap(icon.into(), crate::components::phosphor_ui_font_id(), ink);
-    let label = display_name(name);
+    let label = display_file_name(name);
     let show_close = over || active;
     let close_reserve = if show_close { CLOSE_SLOT + 2.0 } else { 0.0 };
     let text_max =

--- a/clients/desktop/src/components/domain/tree/mod.rs
+++ b/clients/desktop/src/components/domain/tree/mod.rs
@@ -821,7 +821,8 @@ pub fn show_tree(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<Act
                         match cmd {
                             FileCmd::Create => {
                                 queue.push(Action::OpenCreate {
-                                    parent: Some(root),
+                                    folder: Some(root),
+                                    alongside: None,
                                     is_folder: false,
                                 });
                             }
@@ -1227,7 +1228,7 @@ fn paint_row(
         let Some(f) = files.get_by_id(row.id) else {
             return;
         };
-        // Create under a folder, or alongside a document (same parent).
+        // Drop dest: into a folder, or alongside a document (same parent).
         let parent = if row.is_folder { row.id } else { f.parent };
         // Classic tree: share chrome when the file itself carries share metadata.
         let shared = !f.shares.is_empty();
@@ -1376,9 +1377,21 @@ fn paint_row(
             FileCmd::Move => queue.push(Action::OpenMove(targets.clone())),
             FileCmd::Delete => queue.push(Action::OpenDelete(targets.clone())),
             FileCmd::Create => {
-                // Location = into folder / alongside file; type stays Note (not “Folder”
-                // just because the row is a folder — users pick Folder on the sheet).
-                queue.push(Action::OpenCreate { parent: Some(create_parent), is_folder: false });
+                // Folder-context selects Choose; file-context selects Alongside.
+                // Type stays Note (not “Folder” just because the row is a folder).
+                if row.is_folder {
+                    queue.push(Action::OpenCreate {
+                        folder: Some(row.id),
+                        alongside: None,
+                        is_folder: false,
+                    });
+                } else {
+                    queue.push(Action::OpenCreate {
+                        folder: None,
+                        alongside: Some(row.id),
+                        is_folder: false,
+                    });
+                }
             }
             FileCmd::Duplicate => queue.push(Action::Duplicate(targets.clone())),
             FileCmd::Export => queue.push(Action::Export(targets.clone())),

--- a/clients/desktop/src/components/domain/tree/mod.rs
+++ b/clients/desktop/src/components/domain/tree/mod.rs
@@ -40,7 +40,7 @@ use crate::components::{
 };
 use crate::shell::ShellApp;
 use crate::shell::action::Action;
-use crate::shell::ops::is_pinned;
+use crate::shell::ops::{ids_are_saved_shares, is_pinned};
 
 /// Dwell before expanding a collapsed folder under a drag.
 const DROP_EXPAND_SECS: f64 = 0.6;
@@ -625,7 +625,7 @@ pub fn show_tree(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<Act
     if let Some(ready) = app.session.ready() {
         let pins = ready.pinned.clone();
         let files = ready.workspace.files.read().unwrap();
-        pins::show(ui, t, &*files, &pins, queue);
+        pins::show(ui, t, &*files, &pins, &ready.workspace.account.username, queue);
     }
 
     let Some(root) = ensure_tree_walk(app) else {
@@ -1217,7 +1217,12 @@ fn paint_row(
     let Some(ready) = app.session.ready() else {
         return;
     };
-    let (name, create_parent, is_shared) = {
+    let kids_empty = row.kids_empty;
+    let selected = ready.selected.contains(&row.id) || ready.cursor == Some(row.id);
+    let expanded = ready.expanded.contains(&row.id);
+    let pinned = is_pinned(ready, row.id);
+    let multi = ready.selection_vec();
+    let (name, create_parent, is_shared, targets_are_saved_shares) = {
         let files = ready.workspace.files.read().unwrap();
         let Some(f) = files.get_by_id(row.id) else {
             return;
@@ -1226,13 +1231,11 @@ fn paint_row(
         let parent = if row.is_folder { row.id } else { f.parent };
         // Classic tree: share chrome when the file itself carries share metadata.
         let shared = !f.shares.is_empty();
-        (f.name.clone(), parent, shared)
+        let targets =
+            if multi.len() > 1 && multi.contains(&row.id) { &multi[..] } else { &[row.id][..] };
+        let links = ids_are_saved_shares(&*files, targets, &ready.workspace.account.username);
+        (f.name.clone(), parent, shared, links)
     };
-    let kids_empty = row.kids_empty;
-    let selected = ready.selected.contains(&row.id) || ready.cursor == Some(row.id);
-    let expanded = ready.expanded.contains(&row.id);
-    let pinned = is_pinned(ready, row.id);
-    let multi = ready.selection_vec();
     let sync_dot = app.sync_dots.color_for(row.id, t);
 
     // Open/closed folder icon (no chevron). Whole-row click toggles.
@@ -1347,7 +1350,12 @@ fn paint_row(
             e.item(phosphor::DOWNLOAD_SIMPLE, "Export…", FileCmd::Export);
         }
         e.separator();
-        e.item_danger(phosphor::TRASH, "Delete…", FileCmd::Delete);
+        if targets_are_saved_shares {
+            // Opposite of Shared with me → "Save to your files…".
+            e.item(phosphor::FOLDER_MINUS, "Remove from files…", FileCmd::Delete);
+        } else {
+            e.item_danger(phosphor::TRASH, "Delete…", FileCmd::Delete);
+        }
     }) {
         match cmd {
             FileCmd::Open => {

--- a/clients/desktop/src/components/domain/tree/recents.rs
+++ b/clients/desktop/src/components/domain/tree/recents.rs
@@ -10,6 +10,7 @@ use crate::components::{
 };
 use crate::shell::ShellApp;
 use crate::shell::action::Action;
+use crate::shell::ops::is_saved_share;
 use crate::shell::prefs::recents_bucket;
 
 use super::{FileCmd, RowGeom, TreeRowChrome, empty_state, paint_tree_file_row, row_type_icon};
@@ -86,14 +87,19 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                         visible_doc_ids.push(docs[*idx].0);
                     }
                 }
-                let parents: std::collections::HashMap<Uuid, Uuid> = app
+                let parents: std::collections::HashMap<Uuid, (Uuid, bool)> = app
                     .session
                     .ready()
                     .map(|r| {
+                        let me = r.workspace.account.username.as_str();
                         let files = r.workspace.files.read().unwrap();
                         visible_doc_ids
                             .iter()
-                            .filter_map(|id| files.get_by_id(*id).map(|f| (*id, f.parent)))
+                            .filter_map(|id| {
+                                files
+                                    .get_by_id(*id)
+                                    .map(|f| (*id, (f.parent, is_saved_share(f, me))))
+                            })
                             .collect()
                     })
                     .unwrap_or_default();
@@ -138,7 +144,10 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                             if resp.middle_clicked() {
                                 queue.push(Action::OpenFileNewTab(*id));
                             }
-                            let parent = parents.get(id).copied();
+                            let (parent, saved_share) = parents
+                                .get(id)
+                                .map(|(p, share)| (Some(*p), *share))
+                                .unwrap_or((None, false));
                             let pinned = *pinned;
                             if let Some(cmd) = context_menu::show(&resp, t, |e| {
                                 e.item(phosphor::ARROW_SQUARE_OUT, "Open", FileCmd::Open);
@@ -163,7 +172,15 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                                 e.item(phosphor::LINK, "Copy link", FileCmd::CopyLink);
                                 e.item(phosphor::DOWNLOAD_SIMPLE, "Export…", FileCmd::Export);
                                 e.separator();
-                                e.item_danger(phosphor::TRASH, "Delete…", FileCmd::Delete);
+                                if saved_share {
+                                    e.item(
+                                        phosphor::FOLDER_MINUS,
+                                        "Remove from files…",
+                                        FileCmd::Delete,
+                                    );
+                                } else {
+                                    e.item_danger(phosphor::TRASH, "Delete…", FileCmd::Delete);
+                                }
                             }) {
                                 match cmd {
                                     FileCmd::Open => queue.push(Action::OpenFile(*id)),

--- a/clients/desktop/src/components/domain/tree/recents.rs
+++ b/clients/desktop/src/components/domain/tree/recents.rs
@@ -75,7 +75,7 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                 let inner_w = (view_screen.width() - pad * 2.0).max(1.0);
                 let text_left = view_screen.left() + pad;
 
-                // Visible doc ids → parents (one lock, only rows we paint).
+                // Visible doc ids → saved-share (one lock, only rows we paint).
                 let mut visible_doc_ids: Vec<Uuid> = Vec::new();
                 for (i, item) in items.iter().enumerate() {
                     let y0 = pad + geom.top(i);
@@ -87,7 +87,7 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                         visible_doc_ids.push(docs[*idx].0);
                     }
                 }
-                let parents: std::collections::HashMap<Uuid, (Uuid, bool)> = app
+                let saved_shares: std::collections::HashMap<Uuid, bool> = app
                     .session
                     .ready()
                     .map(|r| {
@@ -96,9 +96,7 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                         visible_doc_ids
                             .iter()
                             .filter_map(|id| {
-                                files
-                                    .get_by_id(*id)
-                                    .map(|f| (*id, (f.parent, is_saved_share(f, me))))
+                                files.get_by_id(*id).map(|f| (*id, is_saved_share(f, me)))
                             })
                             .collect()
                     })
@@ -144,10 +142,7 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                             if resp.middle_clicked() {
                                 queue.push(Action::OpenFileNewTab(*id));
                             }
-                            let (parent, saved_share) = parents
-                                .get(id)
-                                .map(|(p, share)| (Some(*p), *share))
-                                .unwrap_or((None, false));
+                            let saved_share = saved_shares.get(id).copied().unwrap_or(false);
                             let pinned = *pinned;
                             if let Some(cmd) = context_menu::show(&resp, t, |e| {
                                 e.item(phosphor::ARROW_SQUARE_OUT, "Open", FileCmd::Open);
@@ -185,9 +180,11 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                                 match cmd {
                                     FileCmd::Open => queue.push(Action::OpenFile(*id)),
                                     FileCmd::OpenNewTab => queue.push(Action::OpenFileNewTab(*id)),
-                                    FileCmd::Create => {
-                                        queue.push(Action::OpenCreate { parent, is_folder: false })
-                                    }
+                                    FileCmd::Create => queue.push(Action::OpenCreate {
+                                        folder: None,
+                                        alongside: Some(*id),
+                                        is_folder: false,
+                                    }),
                                     FileCmd::Rename => queue.push(Action::OpenRename(*id)),
                                     FileCmd::Pin => queue.push(Action::TogglePin(*id)),
                                     FileCmd::Move => queue.push(Action::OpenMove(vec![*id])),

--- a/clients/desktop/src/components/foundation/chrome.rs
+++ b/clients/desktop/src/components/foundation/chrome.rs
@@ -199,6 +199,8 @@ pub mod phosphor {
     pub const COMMAND: &str = "\u{e1c4}";
     /// Return corner (`ph-arrow-elbow-down-left`).
     pub const KEY_RETURN: &str = "\u{e044}";
+    /// Create-sheet “Alongside …” (`ph-arrow-bend-down-right`).
+    pub const ARROW_BEND_DOWN_RIGHT: &str = "\u{e01a}";
     pub const FOLDER: &str = "\u{e24a}";
     /// Open folder.
     pub const FOLDER_OPEN: &str = "\u{e256}";
@@ -255,6 +257,8 @@ pub mod phosphor {
     /// New note.
     pub const NOTE_PENCIL: &str = "\u{e34c}";
     pub const FOLDER_PLUS: &str = "\u{e258}";
+    /// Phosphor 2.1 IcoMoon PUA (`folder-minus` / `folder-notch-minus`).
+    pub const FOLDER_MINUS: &str = "\u{e254}";
     pub const CARET_DOWN: &str = "\u{e136}";
     pub const CARET_LEFT: &str = "\u{e138}";
     pub const CARET_RIGHT: &str = "\u{e13a}";
@@ -265,6 +269,10 @@ pub mod phosphor {
     pub const PUSH_PIN: &str = "\u{e3e2}";
     pub const SCISSORS: &str = "\u{eae0}";
     pub const COPY: &str = "\u{e1ca}";
+    /// Paste (`ph-clipboard-text`).
+    pub const CLIPBOARD_TEXT: &str = "\u{e198}";
+    /// Select all (`ph-selection-all`).
+    pub const SELECTION_ALL: &str = "\u{e746}";
     /// Sync / refresh (sidebar footer).
     pub const ARROWS_CLOCKWISE: &str = "\u{e094}";
     /// Zen / hide sidebar.

--- a/clients/desktop/src/components/foundation/chrome.rs
+++ b/clients/desktop/src/components/foundation/chrome.rs
@@ -319,6 +319,12 @@ pub fn file_row_icon(name: &str, is_folder: bool) -> &'static str {
     }
 }
 
+/// Visible file name in chrome: strip the extension when the doc type hides it
+/// (Markdown, drawing, PDF, chat). Do not pass paths.
+pub fn display_file_name(name: &str) -> &str {
+    workspace_rs::show::DocType::from_name(name).display_name(name)
+}
+
 /// Tab-strip glyph for a workspace [`Destination`].
 ///
 /// Search / mind map / space inspector are not files — do not go through

--- a/clients/desktop/src/components/foundation/mod.rs
+++ b/clients/desktop/src/components/foundation/mod.rs
@@ -12,9 +12,10 @@ pub mod tree_metrics;
 pub mod typography;
 
 pub use chrome::{
-    Radius, STROKE_HAIRLINE, control_height, file_row_icon, fit_outside_stroke_fill, paint_plate,
-    paint_plate_stroke, phosphor, phosphor_font_id, phosphor_ui_font_id, plate_content,
-    shortcut_cmd_i, shortcut_cmd_n, shortcut_enter, shortcut_esc, shortcut_return, tab_icon,
+    Radius, STROKE_HAIRLINE, control_height, display_file_name, file_row_icon,
+    fit_outside_stroke_fill, paint_plate, paint_plate_stroke, phosphor, phosphor_font_id,
+    phosphor_ui_font_id, plate_content, shortcut_cmd_i, shortcut_cmd_n, shortcut_enter,
+    shortcut_esc, shortcut_return, tab_icon,
 };
 pub use color::{FG_HOVER, FG_PRESS, Theme, ThemeExt};
 pub use interact::sense_click;

--- a/clients/desktop/src/components/mod.rs
+++ b/clients/desktop/src/components/mod.rs
@@ -16,8 +16,8 @@ pub mod foundation;
 
 pub use foundation::{
     FG_HOVER, FG_PRESS, FixedPadContent, ModePreference, ROW_H, Radius, STROKE_HAIRLINE, Space,
-    Spacer, Theme, ThemeExt, ThemeFamily, TypeRole, claim, control_height, file_row_icon,
-    fit_outside_stroke_fill, handle_toggle_shortcut, install, origin, paint_plate,
+    Spacer, Theme, ThemeExt, ThemeFamily, TypeRole, claim, control_height, display_file_name,
+    file_row_icon, fit_outside_stroke_fill, handle_toggle_shortcut, install, origin, paint_plate,
     paint_plate_stroke, phosphor, phosphor_font_id, phosphor_ui_font_id, place_at, plate_content,
     remaining_height, sense_click, set_mode_preference, set_theme_family, shortcut_cmd_i,
     shortcut_cmd_n, shortcut_enter, shortcut_esc, shortcut_return, tab_icon, ui_width, with_h_pad,

--- a/clients/desktop/src/components/mod.rs
+++ b/clients/desktop/src/components/mod.rs
@@ -30,7 +30,7 @@ pub use atoms::{
     Button, Chip, ChipHue, EqualCells, Field, FileRow, NavItem, PersonRow, PersonTone,
     QuietChipAlign, QuietChipLabel, icon_button, icon_button_glyph, icon_button_hit,
     measure_file_name, paint_file_name, person_row_height, quiet_chip, quiet_chip_height,
-    quiet_chip_labeled_min_width, segmented, segmented_h,
+    quiet_chip_labeled_min_width, segmented, segmented_h, segmented_width,
 };
 
 pub use compounds::{

--- a/clients/desktop/src/shell/action.rs
+++ b/clients/desktop/src/shell/action.rs
@@ -125,12 +125,15 @@ pub enum Modal {
     Create {
         name: String,
         kind: CreateKind,
-        /// Destination parent (resolved from location chips).
+        /// Destination parent (resolved from the selected location plate).
         parent: Option<Uuid>,
         loc: CreateLoc,
-        /// Open document (tab) parent + name for the "Alongside …" plate.
-        /// Chrome Create (⌘N) offers this; folder-context create does not.
+        /// Document to create next to: (parent folder, document name).
+        /// Shown whenever a document tab is open or Create was invoked on a file.
         alongside: Option<(Uuid, String)>,
+        /// Folder from Choose… / folder-context Create. Independent of `loc`.
+        /// Never the account root — Home is its own plate.
+        chosen: Option<Uuid>,
         /// Nested folder list for "Choose…".
         picking: bool,
         error: Option<String>,
@@ -311,9 +314,12 @@ pub enum Action {
     ShareInvite,
     /// Drop someone from the multi-add stage (chip dismiss).
     ShareUnstage(String),
-    /// Open create sheet. `parent` seeds location; `is_folder` seeds type.
+    /// Open create sheet. Folder-context fills `folder` and selects Choose;
+    /// file-context fills `alongside` and selects that plate (Choose stays empty).
+    /// Chrome / ⌘N leaves both None and follows the open document tab.
     OpenCreate {
-        parent: Option<Uuid>,
+        folder: Option<Uuid>,
+        alongside: Option<Uuid>,
         is_folder: bool,
     },
     CreateSetKind(CreateKind),

--- a/clients/desktop/src/shell/action.rs
+++ b/clients/desktop/src/shell/action.rs
@@ -128,8 +128,8 @@ pub enum Modal {
         /// Destination parent (resolved from location chips).
         parent: Option<Uuid>,
         loc: CreateLoc,
-        /// Tree-selected document’s parent + name for the "Alongside …" plate.
-        /// (Tab focus usually tracks selection; plate follows the sidebar cursor.)
+        /// Open document (tab) parent + name for the "Alongside …" plate.
+        /// Chrome Create (⌘N) offers this; folder-context create does not.
         alongside: Option<(Uuid, String)>,
         /// Nested folder list for "Choose…".
         picking: bool,
@@ -352,10 +352,7 @@ pub enum Action {
     TogglePin(Uuid),
     /// Toggle pin on each id (own state).
     TogglePinMany(Vec<Uuid>),
-    Cut(Vec<Uuid>),
-    Copy(Vec<Uuid>),
-    Paste,
-    /// Drag-drop or cut-paste: move ids into parent.
+    /// Drag-drop: move ids into parent.
     MoveInto {
         ids: Vec<Uuid>,
         parent: Uuid,
@@ -481,9 +478,6 @@ impl Action {
             Self::RequestSync => "RequestSync",
             Self::TogglePin(_) => "TogglePin",
             Self::TogglePinMany(_) => "TogglePinMany",
-            Self::Cut(_) => "Cut",
-            Self::Copy(_) => "Copy",
-            Self::Paste => "Paste",
             Self::MoveInto { .. } => "MoveInto",
             Self::Duplicate(_) => "Duplicate",
             Self::Export(_) => "Export",

--- a/clients/desktop/src/shell/action.rs
+++ b/clients/desktop/src/shell/action.rs
@@ -178,6 +178,8 @@ pub enum Modal {
         uname_lookup_for: String,
         /// Compact key or 24-word phrase — `import_account` accepts either.
         account_key: String,
+        /// Custom API URL. Empty = [`lb::DEFAULT_API_LOCATION`].
+        api_url: String,
         busy: bool,
         err: Option<String>,
     },

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -480,17 +480,6 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
         A::RequestSync => request_sync(app, ctx),
         A::TogglePin(id) => toggle_pins(app, &[id]),
         A::TogglePinMany(ids) => toggle_pins(app, &ids),
-        A::Cut(ids) => {
-            if let Some(r) = app.session.ready_mut() {
-                r.clipboard = super::session::FileClipboard { ids, cut: true };
-            }
-        }
-        A::Copy(ids) => {
-            if let Some(r) = app.session.ready_mut() {
-                r.clipboard = super::session::FileClipboard { ids, cut: false };
-            }
-        }
-        A::Paste => paste_clip(app, None),
         A::MoveInto { ids, parent } => {
             if let Some(r) = app.session.ready_mut() {
                 for id in &ids {
@@ -729,9 +718,8 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
             }
         }
         A::Create => {
-            // Sidebar Create chip / ⌘N — create sheet, default Note at focus parent.
-            let parent = focused_create_parent(app);
-            open_create_sheet(app, ctx, parent, false);
+            // Sidebar Create chip / ⌘N — open tab (not tree selection).
+            open_create_sheet(app, ctx, None, false);
         }
         A::SaveAll => {
             if let Some(r) = app.session.ready_mut() {
@@ -767,21 +755,47 @@ fn sync_selection_after_tab_close(r: &mut Ready) {
     }
 }
 
-fn focused_create_parent(app: &ShellApp) -> Option<Uuid> {
-    let r = app.session.ready()?;
-    if let Some(id) = r.cursor {
-        let files = r.workspace.files.read().unwrap();
-        return files
-            .get_by_id(id)
-            .map(|f| if f.is_folder() { f.id } else { f.parent });
-    }
-    r.workspace
-        .current_tab_id()
-        .and_then(|id| {
-            let files = r.workspace.files.read().unwrap();
-            files.get_by_id(id).map(|f| f.parent)
-        })
-        .or_else(|| Some(r.workspace.files.read().unwrap().root().id))
+/// Open document tab → (parent, name). Tree `cursor` is not read.
+fn open_doc_alongside(r: &Ready) -> Option<(Uuid, String)> {
+    let id = r.workspace.current_tab_id()?;
+    let files = r.workspace.files.read().unwrap();
+    let f = files.get_by_id(id)?;
+    if f.is_folder() { None } else { Some((f.parent, f.name.clone())) }
+}
+
+fn dest_folder_from_open_tab(r: &Ready) -> Uuid {
+    open_doc_alongside(r)
+        .map(|(p, _)| p)
+        .unwrap_or_else(|| r.workspace.files.read().unwrap().root().id)
+}
+
+struct CreateSheetPlan {
+    loc: CreateLoc,
+    parent: Option<Uuid>,
+    alongside: Option<(Uuid, String)>,
+}
+
+/// Chrome Create (`parent_hint` None) follows the open tab.
+/// Context-menu Create (`parent_hint` Some) lands in that folder; the Alongside
+/// plate is offered only when that folder is the open note's parent.
+fn create_sheet_plan(
+    root: Uuid, parent_hint: Option<Uuid>, open_doc: Option<(Uuid, String)>,
+) -> CreateSheetPlan {
+    let alongside = match parent_hint {
+        None => open_doc,
+        Some(hint) => open_doc.filter(|(p, _)| *p == hint),
+    };
+    let hint = parent_hint
+        .or_else(|| alongside.as_ref().map(|(p, _)| *p))
+        .unwrap_or(root);
+    let loc = if hint == root {
+        CreateLoc::Root
+    } else if alongside.as_ref().is_some_and(|(p, _)| *p == hint) {
+        CreateLoc::Alongside
+    } else {
+        CreateLoc::Custom
+    };
+    CreateSheetPlan { loc, parent: Some(hint), alongside }
 }
 
 fn open_create_sheet(
@@ -792,40 +806,18 @@ fn open_create_sheet(
     };
     let files = r.workspace.files.read().unwrap();
     let root = files.root().id;
-    // Alongside plate = tree cursor when that row is a document (same parent).
-    // Tab focus usually mirrors selection (`SelectTab` → select_only + reveal), but
-    // a tree click without open can diverge — invocation context is the sidebar.
-    let (alongside_parent, alongside_label) = r
-        .cursor
-        .and_then(|id| {
-            let f = files.get_by_id(id)?;
-            if f.is_folder() { None } else { Some((f.parent, f.name.clone())) }
-        })
-        .map(|(p, n)| (Some(p), Some(n)))
-        .unwrap_or((None, None));
-
-    let hint = parent_hint.unwrap_or(root);
-    let (loc, parent) = if hint == root {
-        (CreateLoc::Root, Some(root))
-    } else if alongside_parent == Some(hint) {
-        (CreateLoc::Alongside, Some(hint))
-    } else {
-        (CreateLoc::Custom, Some(hint))
-    };
+    drop(files);
+    let open_doc = open_doc_alongside(r);
+    let plan = create_sheet_plan(root, parent_hint, open_doc);
 
     let kind = if prefer_folder { CreateKind::Folder } else { CreateKind::Note };
-    drop(files);
-    let name = suggested_create_name(app, parent, kind);
-    let alongside = match (alongside_parent, alongside_label) {
-        (Some(id), Some(label)) => Some((id, label)),
-        _ => None,
-    };
+    let name = suggested_create_name(app, plan.parent, kind);
     app.modal = Some(Modal::Create {
         name,
         kind,
-        parent,
-        loc,
-        alongside,
+        parent: plan.parent,
+        loc: plan.loc,
+        alongside: plan.alongside,
         picking: false,
         error: None,
         name_dirty: false,
@@ -1125,53 +1117,6 @@ fn expand_or_collapse(app: &mut ShellApp, id: Uuid, expand: bool) {
     }
 }
 
-fn paste_clip(app: &mut ShellApp, dest_override: Option<Uuid>) {
-    let Some(r) = app.session.ready_mut() else {
-        return;
-    };
-    let dest = dest_override
-        .map(|d| {
-            // If dest is a document, paste into its parent (recents menus).
-            let files = r.workspace.files.read().unwrap();
-            files
-                .get_by_id(d)
-                .map(|f| if f.is_folder() { f.id } else { f.parent })
-                .unwrap_or(d)
-        })
-        .unwrap_or_else(|| {
-            r.cursor
-                .and_then(|id| {
-                    let files = r.workspace.files.read().unwrap();
-                    files
-                        .get_by_id(id)
-                        .map(|f| if f.is_folder() { f.id } else { f.parent })
-                })
-                .unwrap_or_else(|| r.workspace.files.read().unwrap().root().id)
-        });
-    let clip = r.clipboard.clone();
-    if clip.ids.is_empty() {
-        return;
-    }
-    if clip.cut {
-        for id in &clip.ids {
-            if *id != dest {
-                r.workspace.move_file((*id, dest));
-            }
-        }
-        r.clipboard = Default::default();
-        r.expanded.insert(dest);
-    } else {
-        for id in &clip.ids {
-            if let Ok(f) = r.workspace.core.duplicate_file(id) {
-                if f.parent != dest {
-                    let _ = r.workspace.core.move_file(&f.id, &dest);
-                }
-            }
-        }
-        r.expanded.insert(dest);
-    }
-}
-
 fn export_files(app: &mut ShellApp, ids: &[Uuid]) {
     if ids.is_empty() {
         return;
@@ -1226,19 +1171,10 @@ fn import_pick(app: &mut ShellApp, ctx: &Context) {
     open_import_parent_sheet(app, ctx, paths);
 }
 
-/// Open the Import folder-picker sheet. Seeds `dest` from the cursor folder
-/// (or its parent / root) so chip and drop share one path.
+/// Open the Import folder-picker sheet. Seeds `dest` from the open tab's folder
+/// (not tree selection).
 fn open_import_parent_sheet(app: &mut ShellApp, ctx: &Context, paths: Vec<PathBuf>) {
-    let dest = app.session.ready().map(|r| {
-        r.cursor
-            .and_then(|id| {
-                let files = r.workspace.files.read().unwrap();
-                files
-                    .get_by_id(id)
-                    .map(|f| if f.is_folder() { f.id } else { f.parent })
-            })
-            .unwrap_or_else(|| r.workspace.files.read().unwrap().root().id)
-    });
+    let dest = app.session.ready().map(dest_folder_from_open_tab);
     ctx.data_mut(|d| {
         d.remove::<std::collections::HashSet<Uuid>>(egui::Id::new((
             "shell_folder_pick_exp",
@@ -1286,4 +1222,49 @@ fn request_sync(app: &mut ShellApp, ctx: &Context) {
 fn persist_zen(app: &mut ShellApp) {
     // Disk: zen = sidebar collapsed at next launch.
     let _ = app.settings.write_zen_mode(!app.sidebar_open);
+}
+
+#[cfg(test)]
+mod create_sheet_plan_tests {
+    use super::{CreateLoc, create_sheet_plan};
+    use lb::Uuid;
+
+    fn ids() -> (Uuid, Uuid, Uuid) {
+        (Uuid::from_u128(1), Uuid::from_u128(2), Uuid::from_u128(3))
+    }
+
+    #[test]
+    fn cmd_n_follows_open_tab() {
+        let (root, _folder, doc_parent) = ids();
+        let plan = create_sheet_plan(root, None, Some((doc_parent, "note.md".into())));
+        assert_eq!(plan.loc, CreateLoc::Alongside);
+        assert_eq!(plan.parent, Some(doc_parent));
+        assert!(plan.alongside.is_some());
+    }
+
+    #[test]
+    fn folder_context_create_is_custom_without_alongside() {
+        let (root, folder, doc_parent) = ids();
+        let plan = create_sheet_plan(root, Some(folder), Some((doc_parent, "note.md".into())));
+        assert_eq!(plan.loc, CreateLoc::Custom);
+        assert_eq!(plan.parent, Some(folder));
+        assert!(plan.alongside.is_none());
+    }
+
+    #[test]
+    fn cmd_n_without_open_doc_is_root() {
+        let (root, _, _) = ids();
+        let plan = create_sheet_plan(root, None, None);
+        assert_eq!(plan.loc, CreateLoc::Root);
+        assert_eq!(plan.parent, Some(root));
+        assert!(plan.alongside.is_none());
+    }
+
+    #[test]
+    fn context_create_in_open_docs_folder_offers_alongside() {
+        let (root, _, doc_parent) = ids();
+        let plan = create_sheet_plan(root, Some(doc_parent), Some((doc_parent, "note.md".into())));
+        assert_eq!(plan.loc, CreateLoc::Alongside);
+        assert!(plan.alongside.is_some());
+    }
 }

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -235,7 +235,9 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
             }
         }
         A::ShareInvite => share_invite(app, ctx),
-        A::OpenCreate { parent, is_folder } => open_create_sheet(app, ctx, parent, is_folder),
+        A::OpenCreate { folder, alongside, is_folder } => {
+            open_create_sheet(app, ctx, folder, alongside, is_folder)
+        }
         A::CreateSetKind(kind) => {
             let (parent, dirty) = match &app.modal {
                 Some(Modal::Create { parent, name_dirty, .. }) => (*parent, *name_dirty),
@@ -252,9 +254,9 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
             }
         }
         A::CreateSetLoc(loc) => {
-            let (alongside, kind, dirty, cur_parent) = match &app.modal {
-                Some(Modal::Create { alongside, kind, name_dirty, parent, .. }) => {
-                    (alongside.clone(), *kind, *name_dirty, *parent)
+            let (alongside, kind, dirty, chosen) = match &app.modal {
+                Some(Modal::Create { alongside, kind, name_dirty, chosen, .. }) => {
+                    (alongside.clone(), *kind, *name_dirty, *chosen)
                 }
                 _ => return,
             };
@@ -265,7 +267,7 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
             let parent = match loc {
                 CreateLoc::Root => root,
                 CreateLoc::Alongside => alongside.as_ref().map(|(id, _)| *id).or(root),
-                CreateLoc::Custom => cur_parent.or(root),
+                CreateLoc::Custom => chosen.or(root),
             };
             let suggested =
                 if dirty { None } else { Some(suggested_create_name(app, parent, kind)) };
@@ -302,11 +304,19 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
             };
             let suggested =
                 if dirty { None } else { Some(suggested_create_name(app, Some(id), kind)) };
-            if let Some(Modal::Create { picking, parent, loc, name, error, .. }) = &mut app.modal {
+            if let Some(Modal::Create { picking, parent, loc, chosen, name, error, .. }) =
+                &mut app.modal
+            {
                 // Collapse the browser after a pick.
                 *picking = false;
-                *loc = if root == Some(id) { CreateLoc::Root } else { CreateLoc::Custom };
                 *parent = Some(id);
+                if root == Some(id) {
+                    *loc = CreateLoc::Root;
+                    *chosen = None;
+                } else {
+                    *loc = CreateLoc::Custom;
+                    *chosen = Some(id);
+                }
                 *error = None;
                 if let Some(s) = suggested {
                     *name = s;
@@ -719,7 +729,7 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
         }
         A::Create => {
             // Sidebar Create chip / ⌘N — open tab (not tree selection).
-            open_create_sheet(app, ctx, None, false);
+            open_create_sheet(app, ctx, None, None, false);
         }
         A::SaveAll => {
             if let Some(r) = app.session.ready_mut() {
@@ -755,12 +765,16 @@ fn sync_selection_after_tab_close(r: &mut Ready) {
     }
 }
 
-/// Open document tab → (parent, name). Tree `cursor` is not read.
-fn open_doc_alongside(r: &Ready) -> Option<(Uuid, String)> {
-    let id = r.workspace.current_tab_id()?;
+/// Document → (parent, name) for the Alongside plate. Folders yield None.
+fn file_alongside(r: &Ready, id: Uuid) -> Option<(Uuid, String)> {
     let files = r.workspace.files.read().unwrap();
     let f = files.get_by_id(id)?;
     if f.is_folder() { None } else { Some((f.parent, f.name.clone())) }
+}
+
+/// Open document tab → (parent, name). Tree `cursor` is not read.
+fn open_doc_alongside(r: &Ready) -> Option<(Uuid, String)> {
+    file_alongside(r, r.workspace.current_tab_id()?)
 }
 
 fn dest_folder_from_open_tab(r: &Ready) -> Uuid {
@@ -773,42 +787,46 @@ struct CreateSheetPlan {
     loc: CreateLoc,
     parent: Option<Uuid>,
     alongside: Option<(Uuid, String)>,
+    chosen: Option<Uuid>,
 }
 
-/// Chrome Create (`parent_hint` None) follows the open tab.
-/// Context-menu Create (`parent_hint` Some) lands in that folder; the Alongside
-/// plate is offered only when that folder is the open note's parent.
+/// Home is always a plate. Alongside is offered whenever `alongside` is Some
+/// (open document tab, or file-context Create). `chosen_folder` is the
+/// independent Choose… slot (folder-context Create / a later pick).
+///
+/// Default loc: explicit folder (root → Home, else Choose) > alongside > Home.
 fn create_sheet_plan(
-    root: Uuid, parent_hint: Option<Uuid>, open_doc: Option<(Uuid, String)>,
+    root: Uuid, chosen_folder: Option<Uuid>, alongside: Option<(Uuid, String)>,
 ) -> CreateSheetPlan {
-    let alongside = match parent_hint {
-        None => open_doc,
-        Some(hint) => open_doc.filter(|(p, _)| *p == hint),
+    let chosen = chosen_folder.filter(|id| *id != root);
+    // Folder-context (including root → Home) wins over Alongside.
+    let loc = match chosen_folder {
+        Some(id) if id == root => CreateLoc::Root,
+        Some(_) => CreateLoc::Custom,
+        None if alongside.is_some() => CreateLoc::Alongside,
+        None => CreateLoc::Root,
     };
-    let hint = parent_hint
-        .or_else(|| alongside.as_ref().map(|(p, _)| *p))
-        .unwrap_or(root);
-    let loc = if hint == root {
-        CreateLoc::Root
-    } else if alongside.as_ref().is_some_and(|(p, _)| *p == hint) {
-        CreateLoc::Alongside
-    } else {
-        CreateLoc::Custom
+    let parent = match loc {
+        CreateLoc::Root => Some(root),
+        CreateLoc::Alongside => alongside.as_ref().map(|(p, _)| *p).or(Some(root)),
+        CreateLoc::Custom => chosen.or(Some(root)),
     };
-    CreateSheetPlan { loc, parent: Some(hint), alongside }
+    CreateSheetPlan { loc, parent, alongside, chosen }
 }
 
 fn open_create_sheet(
-    app: &mut ShellApp, ctx: &Context, parent_hint: Option<Uuid>, prefer_folder: bool,
+    app: &mut ShellApp, ctx: &Context, folder: Option<Uuid>, alongside_file: Option<Uuid>,
+    prefer_folder: bool,
 ) {
     let Some(r) = app.session.ready() else {
         return;
     };
-    let files = r.workspace.files.read().unwrap();
-    let root = files.root().id;
-    drop(files);
-    let open_doc = open_doc_alongside(r);
-    let plan = create_sheet_plan(root, parent_hint, open_doc);
+    let root = r.workspace.files.read().unwrap().root().id;
+    let alongside = match alongside_file {
+        Some(id) => file_alongside(r, id),
+        None => open_doc_alongside(r),
+    };
+    let plan = create_sheet_plan(root, folder, alongside);
 
     let kind = if prefer_folder { CreateKind::Folder } else { CreateKind::Note };
     let name = suggested_create_name(app, plan.parent, kind);
@@ -818,6 +836,7 @@ fn open_create_sheet(
         parent: plan.parent,
         loc: plan.loc,
         alongside: plan.alongside,
+        chosen: plan.chosen,
         picking: false,
         error: None,
         name_dirty: false,
@@ -1240,15 +1259,17 @@ mod create_sheet_plan_tests {
         assert_eq!(plan.loc, CreateLoc::Alongside);
         assert_eq!(plan.parent, Some(doc_parent));
         assert!(plan.alongside.is_some());
+        assert!(plan.chosen.is_none());
     }
 
     #[test]
-    fn folder_context_create_is_custom_without_alongside() {
+    fn folder_context_selects_chosen_and_keeps_alongside() {
         let (root, folder, doc_parent) = ids();
         let plan = create_sheet_plan(root, Some(folder), Some((doc_parent, "note.md".into())));
         assert_eq!(plan.loc, CreateLoc::Custom);
         assert_eq!(plan.parent, Some(folder));
-        assert!(plan.alongside.is_none());
+        assert_eq!(plan.chosen, Some(folder));
+        assert!(plan.alongside.is_some());
     }
 
     #[test]
@@ -1258,13 +1279,36 @@ mod create_sheet_plan_tests {
         assert_eq!(plan.loc, CreateLoc::Root);
         assert_eq!(plan.parent, Some(root));
         assert!(plan.alongside.is_none());
+        assert!(plan.chosen.is_none());
     }
 
     #[test]
-    fn context_create_in_open_docs_folder_offers_alongside() {
+    fn file_context_selects_alongside_choose_unchosen() {
         let (root, _, doc_parent) = ids();
-        let plan = create_sheet_plan(root, Some(doc_parent), Some((doc_parent, "note.md".into())));
+        let plan = create_sheet_plan(root, None, Some((doc_parent, "note.md".into())));
         assert_eq!(plan.loc, CreateLoc::Alongside);
+        assert_eq!(plan.parent, Some(doc_parent));
         assert!(plan.alongside.is_some());
+        assert!(plan.chosen.is_none());
+    }
+
+    #[test]
+    fn folder_context_on_root_is_home() {
+        let (root, _, doc_parent) = ids();
+        let plan = create_sheet_plan(root, Some(root), Some((doc_parent, "note.md".into())));
+        assert_eq!(plan.loc, CreateLoc::Root);
+        assert_eq!(plan.parent, Some(root));
+        assert!(plan.chosen.is_none());
+        assert!(plan.alongside.is_some());
+    }
+
+    #[test]
+    fn folder_context_without_open_doc_is_custom() {
+        let (root, folder, _) = ids();
+        let plan = create_sheet_plan(root, Some(folder), None);
+        assert_eq!(plan.loc, CreateLoc::Custom);
+        assert_eq!(plan.parent, Some(folder));
+        assert_eq!(plan.chosen, Some(folder));
+        assert!(plan.alongside.is_none());
     }
 }

--- a/clients/desktop/src/shell/apply_onboard.rs
+++ b/clients/desktop/src/shell/apply_onboard.rs
@@ -11,6 +11,63 @@ use super::action::{Modal, OnboardLookup, OnboardMode};
 use super::apply_share::spawn_username_exists;
 use super::session::Session;
 
+/// Seed the onboard URL field: `API_URL` when it isn’t the hosted default.
+pub(crate) fn initial_api_url() -> String {
+    match std::env::var("API_URL") {
+        Ok(s) => {
+            let t = s.trim();
+            if t.is_empty() || t == lb::DEFAULT_API_LOCATION { String::new() } else { t.to_owned() }
+        }
+        Err(_) => String::new(),
+    }
+}
+
+/// Empty / whitespace → hosted default.
+pub(crate) fn resolved_api_url(api_url: &str) -> String {
+    let t = api_url.trim();
+    if t.is_empty() { lb::DEFAULT_API_LOCATION.to_string() } else { t.to_owned() }
+}
+
+/// Hostname (or host:port) for the welcome caption.
+pub(crate) fn display_server_host(api_url: &str) -> String {
+    let url = resolved_api_url(api_url);
+    url.trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn env_or_default_api_url() -> String {
+    std::env::var("API_URL").unwrap_or_else(|_| lb::DEFAULT_API_LOCATION.to_string())
+}
+
+/// Live username check hits env/default inside core; skip it when the form URL differs.
+pub(crate) fn uname_check_matches_core(api_url: &str) -> bool {
+    resolved_api_url(api_url) == env_or_default_api_url()
+}
+
+pub(crate) fn onboard_modal(mode: OnboardMode, err: Option<String>) -> Modal {
+    Modal::Onboard {
+        mode,
+        uname: String::new(),
+        uname_lookup: OnboardLookup::Idle,
+        uname_lookup_for: String::new(),
+        account_key: String::new(),
+        api_url: initial_api_url(),
+        busy: false,
+        err,
+    }
+}
+
+pub(crate) fn onboard_server_editing_key() -> egui::Id {
+    egui::Id::new("onboard_server_editing")
+}
+
+pub(crate) fn onboard_server_snap_key() -> egui::Id {
+    egui::Id::new("onboard_server_snap")
+}
+
 pub(crate) fn onboard_import_focus(ctx: &Context) {
     ctx.data_mut(|d| d.insert_temp(egui::Id::new("onboard_account_key_need_focus"), true));
 }
@@ -57,12 +114,13 @@ pub(crate) fn onboard_poll_uname(app: &mut ShellApp, ctx: &Context) {
 /// Debounced availability check via `username_exists` (works signed-out).
 pub(crate) fn onboard_verify_uname(app: &mut ShellApp, ctx: &Context) {
     onboard_poll_uname(app, ctx);
-    let q = match &app.modal {
+    let (q, api_url) = match &app.modal {
         Some(Modal::Onboard {
             mode: OnboardMode::Create,
             uname,
             uname_lookup,
             uname_lookup_for,
+            api_url,
             ..
         }) => {
             let q = uname.trim().to_owned();
@@ -75,7 +133,7 @@ pub(crate) fn onboard_verify_uname(app: &mut ShellApp, ctx: &Context) {
             {
                 return;
             }
-            q
+            (q, api_url.clone())
         }
         _ => return,
     };
@@ -89,6 +147,13 @@ pub(crate) fn onboard_verify_uname(app: &mut ShellApp, ctx: &Context) {
     if !onboard_uname_format_ok(&q) {
         if let Some(Modal::Onboard { uname_lookup, uname_lookup_for, .. }) = &mut app.modal {
             *uname_lookup = OnboardLookup::Error("Invalid username".into());
+            *uname_lookup_for = q;
+        }
+        return;
+    }
+    if !uname_check_matches_core(&api_url) {
+        if let Some(Modal::Onboard { uname_lookup, uname_lookup_for, .. }) = &mut app.modal {
+            *uname_lookup = OnboardLookup::Available;
             *uname_lookup_for = q;
         }
         return;
@@ -138,14 +203,26 @@ fn onboard_import_secret(account_key: &str) -> String {
 }
 
 pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool) {
-    let (mode, uname, import_secret, lookup_ok) = match &app.modal {
+    let (mode, uname, import_secret, lookup_ok, api) = match &app.modal {
         Some(Modal::Onboard {
-            mode, uname, account_key, uname_lookup, uname_lookup_for, ..
+            mode,
+            uname,
+            account_key,
+            uname_lookup,
+            uname_lookup_for,
+            api_url,
+            ..
         }) => {
             let u = uname.trim();
             let lookup_ok = u.eq_ignore_ascii_case(uname_lookup_for)
                 && matches!(uname_lookup, OnboardLookup::Available);
-            (*mode, uname.clone(), onboard_import_secret(account_key), lookup_ok)
+            (
+                *mode,
+                uname.clone(),
+                onboard_import_secret(account_key),
+                lookup_ok,
+                resolved_api_url(api_url),
+            )
         }
         _ => return,
     };
@@ -213,8 +290,6 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
     thread::spawn(move || {
         use super::session::{CoreLoad, set_load_status};
 
-        let api = std::env::var("API_URL").unwrap_or_else(|_| lb::DEFAULT_API_LOCATION.to_string());
-
         let account_res = match mode {
             OnboardMode::Create => {
                 set_load_status(&status, "Creating account…");
@@ -270,4 +345,18 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
         }
         ctx.request_repaint();
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{display_server_host, resolved_api_url};
+
+    #[test]
+    fn empty_url_is_hosted_default() {
+        assert_eq!(resolved_api_url(""), lb::DEFAULT_API_LOCATION);
+        assert_eq!(resolved_api_url("  "), lb::DEFAULT_API_LOCATION);
+        assert_eq!(resolved_api_url("http://localhost:8000"), "http://localhost:8000");
+        assert_eq!(display_server_host(""), "app.lockbook.net");
+        assert_eq!(display_server_host("http://localhost:8000"), "localhost:8000");
+    }
 }

--- a/clients/desktop/src/shell/editor.rs
+++ b/clients/desktop/src/shell/editor.rs
@@ -1,7 +1,6 @@
 //! Shell tab strip + Workspace content (`show_tabs = false`).
 
 use egui::{Align, Layout, Ui};
-use workspace_rs::file_cache::FilesExt;
 
 use crate::components::{Theme, claim, place_at};
 
@@ -25,15 +24,9 @@ pub fn show(app: &mut ShellApp, ui: &mut Ui, _t: &Theme, queue: &mut Vec<Action>
 
         ready.workspace.show_tabs = false;
         ready.workspace.sidebar_open = sidebar_open;
-        if let Some(id) = ready.cursor {
-            let parent = {
-                let files = ready.workspace.files.read().unwrap();
-                files
-                    .get_by_id(id)
-                    .map(|f| if f.is_folder() { f.id } else { f.parent })
-            };
-            ready.workspace.focused_parent = parent;
-        }
+        // Workspace create-dest follows the open tab. Tree `cursor` is selection
+        // only — a folder right-click must not retarget ⌘N / landing create.
+        ready.workspace.focused_parent = ready.workspace.current_tab_id();
 
         let (out, _) =
             place_at(ui, rest, Layout::top_down(Align::Min), |ui| ready.workspace.show(ui));

--- a/clients/desktop/src/shell/mod.rs
+++ b/clients/desktop/src/shell/mod.rs
@@ -271,15 +271,7 @@ impl ShellApp {
         }
         if let Some(err) = self.session.poll(ctx) {
             // Sign-in worker failed; session is SignedOut again — show onboard error.
-            self.modal = Some(Modal::Onboard {
-                mode: action::OnboardMode::Import,
-                uname: String::new(),
-                uname_lookup: action::OnboardLookup::Idle,
-                uname_lookup_for: String::new(),
-                account_key: String::new(),
-                busy: false,
-                err: Some(err),
-            });
+            self.modal = Some(apply_onboard::onboard_modal(action::OnboardMode::Import, Some(err)));
         }
         if let Session::Ready(r) = &self.session {
             if self.lb_rx.is_none() {
@@ -332,15 +324,8 @@ impl ShellApp {
             Session::SignedOut { .. } => {
                 // Offer onboard immediately
                 if self.modal.is_none() {
-                    self.modal = Some(Modal::Onboard {
-                        mode: action::OnboardMode::Choice,
-                        uname: String::new(),
-                        uname_lookup: action::OnboardLookup::Idle,
-                        uname_lookup_for: String::new(),
-                        account_key: String::new(),
-                        busy: false,
-                        err: None,
-                    });
+                    self.modal =
+                        Some(apply_onboard::onboard_modal(action::OnboardMode::Choice, None));
                 }
             }
             Session::Ready(_) => {}
@@ -542,26 +527,48 @@ impl ShellApp {
     fn process_keys(&mut self, ctx: &egui::Context) {
         const CMD: egui::Modifiers = egui::Modifiers::COMMAND;
 
-        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
-            if let Some(modal) = &self.modal {
-                let action = match modal {
-                    // Account subpanels (incl. upgrade) stay in Settings — Esc backs the panel.
-                    Modal::Settings { .. } => match &self.account_panel {
-                        AccountPanel::Upgrade {
-                            stage: action::UpgradeStage::Paying,
-                            done: None,
-                            ..
-                        } => None, // mid-charge
-                        AccountPanel::Upgrade { .. } => Some(A::UpgradeBack),
-                        AccountPanel::Closed => Some(A::CloseModal),
-                        _ => Some(A::HideAccountKey),
-                    },
-                    _ => Some(A::CloseModal),
-                };
-                if let Some(a) = action {
-                    self.queue.push(a);
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) && self.modal.is_some() {
+            let revert_server = matches!(
+                &self.modal,
+                Some(Modal::Onboard { mode: action::OnboardMode::Choice, .. })
+            ) && ctx.data(|d| {
+                d.get_temp::<bool>(apply_onboard::onboard_server_editing_key())
+                    .unwrap_or(false)
+            });
+            let action = match &self.modal {
+                // Account subpanels (incl. upgrade) stay in Settings — Esc backs the panel.
+                Some(Modal::Settings { .. }) => match &self.account_panel {
+                    AccountPanel::Upgrade {
+                        stage: action::UpgradeStage::Paying,
+                        done: None,
+                        ..
+                    } => None, // mid-charge
+                    AccountPanel::Upgrade { .. } => Some(A::UpgradeBack),
+                    AccountPanel::Closed => Some(A::CloseModal),
+                    _ => Some(A::HideAccountKey),
+                },
+                Some(Modal::Onboard { mode, .. }) => match mode {
+                    action::OnboardMode::Choice => None,
+                    _ => Some(A::OnboardSetMode(action::OnboardMode::Choice)),
+                },
+                Some(_) => Some(A::CloseModal),
+                None => None,
+            };
+            if let Some(a) = action {
+                self.queue.push(a);
+            }
+            ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
+            if revert_server {
+                if let Some(snap) =
+                    ctx.data(|d| d.get_temp::<String>(apply_onboard::onboard_server_snap_key()))
+                {
+                    if let Some(Modal::Onboard { api_url, .. }) = &mut self.modal {
+                        *api_url = snap;
+                    }
                 }
-                ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
+                ctx.data_mut(|d| {
+                    d.insert_temp(apply_onboard::onboard_server_editing_key(), false);
+                });
             }
         }
 
@@ -644,8 +651,8 @@ impl ShellApp {
                 }
             }
             // No Files-tree keybinding surface: the editor holds focus whenever a
-            // doc is open, so ↑↓/⌘C/… almost never hit the tree. Rename / cut /
-            // copy / paste / delete stay on context menus (and global chrome above).
+            // doc is open, so ↑↓/⌘C/… almost never hit the tree. Rename / delete
+            // stay on context menus (and global chrome above).
         }
 
         if let Some(modal) = &self.modal {
@@ -716,9 +723,24 @@ impl ShellApp {
                             _ => {}
                         },
                         Modal::ImportParent { .. } => self.queue.push(A::ConfirmImportParent),
-                        Modal::Onboard { .. } => {
-                            self.queue.push(A::OnboardSubmit { show_error: true })
-                        }
+                        Modal::Onboard { mode, .. } => match mode {
+                            action::OnboardMode::Create | action::OnboardMode::Import => {
+                                self.queue.push(A::OnboardSubmit { show_error: true })
+                            }
+                            action::OnboardMode::Choice => {
+                                if ctx.data(|d| {
+                                    d.get_temp::<bool>(apply_onboard::onboard_server_editing_key())
+                                        .unwrap_or(false)
+                                }) {
+                                    ctx.data_mut(|d| {
+                                        d.insert_temp(
+                                            apply_onboard::onboard_server_editing_key(),
+                                            false,
+                                        );
+                                    });
+                                }
+                            }
+                        },
                         Modal::Share { .. } => unreachable!(),
                         _ => {}
                     }
@@ -736,18 +758,8 @@ impl ShellApp {
         if paths.is_empty() {
             return;
         }
-        // Pick parent when drop lands (folder picker), unless a folder is cursored.
-        let parent = self.session.ready().and_then(|r| {
-            let id = r.cursor?;
-            let files = r.workspace.files.read().unwrap();
-            let f = files.get_by_id(id)?;
-            if f.is_folder() { Some(f.id) } else { None }
-        });
-        if let Some(parent) = parent {
-            self.queue.push(A::ImportPaths { paths, parent });
-        } else {
-            self.queue.push(A::OpenImportParent { paths });
-        }
+        // Always pick a folder — tree `cursor` is not a drop target.
+        self.queue.push(A::OpenImportParent { paths });
     }
 }
 

--- a/clients/desktop/src/shell/ops.rs
+++ b/clients/desktop/src/shell/ops.rs
@@ -1,6 +1,8 @@
 //! Shared session mutations used from `apply` (cache epoch, pins).
 
 use lb::Uuid;
+use lb::model::file::File;
+use workspace_rs::file_cache::FilesExt;
 
 use super::session::Ready;
 
@@ -18,4 +20,19 @@ pub fn refresh_pinned(r: &mut Ready) {
 
 pub fn is_pinned(r: &Ready, id: Uuid) -> bool {
     r.pinned.contains(&id)
+}
+
+/// File in your tree that you don't own. `list_metadatas` hides the Link and
+/// shows the target (e.g. luca's `movies.md` sitting in your root), so
+/// `FileType::Link` never appears in the UI. Removing it deletes your link,
+/// not the owner's file.
+pub fn is_saved_share(f: &File, me: &str) -> bool {
+    !f.owner.eq_ignore_ascii_case(me)
+}
+
+pub fn ids_are_saved_shares(files: &impl FilesExt, ids: &[Uuid], me: &str) -> bool {
+    !ids.is_empty()
+        && ids
+            .iter()
+            .all(|&id| files.get_by_id(id).is_some_and(|f| is_saved_share(f, me)))
 }

--- a/clients/desktop/src/shell/session.rs
+++ b/clients/desktop/src/shell/session.rs
@@ -69,17 +69,12 @@ pub fn read_load_status(status: &LoadStatus) -> String {
         .unwrap_or_else(|| "Loading…".into())
 }
 
-/// Clipboard of file ids for cut/copy/paste.
-#[derive(Clone, Debug, Default)]
-pub struct FileClipboard {
-    pub ids: Vec<Uuid>,
-    pub cut: bool,
-}
-
 pub struct Ready {
     pub workspace: Workspace,
     pub expanded: HashSet<Uuid>,
-    /// Primary cursor (last click / open).
+    /// Tree / list selection (highlight, multi-select, context-menu targets).
+    /// Not keyboard focus and not create/import destination — those follow the
+    /// open tab. Right-clicking a folder updates this without opening a file.
     pub cursor: Option<Uuid>,
     /// Shift-range anchor (Finder-style).
     pub anchor: Option<Uuid>,
@@ -89,7 +84,6 @@ pub struct Ready {
     pub status_msg: String,
     pub syncing: bool,
     pub pinned: Vec<Uuid>,
-    pub clipboard: FileClipboard,
     pub sub_info: Option<SubscriptionInfo>,
     /// Flattened visible tree order (Shift-range select).
     pub nav_order: Vec<Uuid>,
@@ -127,7 +121,6 @@ impl Ready {
             status_msg: "Up to date".into(),
             syncing: false,
             pinned,
-            clipboard: FileClipboard::default(),
             sub_info,
             nav_order: Vec::new(),
             // Start at 1 so empty caches (epoch 0) rebuild on first paint.

--- a/clients/desktop/src/shell/sheet_create.rs
+++ b/clients/desktop/src/shell/sheet_create.rs
@@ -5,9 +5,9 @@ use workspace_rs::file_cache::FilesExt;
 use crate::components::interact::{ControlFills, interact_fill, sense_click};
 use crate::components::{
     Button, EqualCells, FG_HOVER, FG_PRESS, Field, Radius, SheetFooterOpts, Space, Spacer, Theme,
-    TypeRole, file_row_icon, measure_file_name, paint_file_name, phosphor, phosphor_ui_font_id,
-    segmented, sheet_band, sheet_band_centered, sheet_dim, sheet_equal_row, sheet_footer,
-    sheet_panel_fixed, sheet_title_muted, shortcut_enter,
+    TypeRole, claim, measure_file_name, origin, paint_file_name, phosphor, phosphor_ui_font_id,
+    place_at, segmented, segmented_width, sheet_band, sheet_band_centered, sheet_dim,
+    sheet_equal_row, sheet_footer, sheet_panel_fixed, sheet_title_muted, shortcut_enter,
 };
 
 use super::ShellApp;
@@ -15,7 +15,7 @@ use super::action::Action as A;
 use super::action::{Action, CreateKind, CreateLoc, Modal};
 
 /// Wide enough for location plates (username · Alongside {note} · Choose…).
-const CREATE_SHEET_W: f32 = 420.0;
+const CREATE_SHEET_W: f32 = 480.0;
 
 fn create_sheet_h_key() -> Id {
     Id::new("shell_create_inner_h")
@@ -140,9 +140,9 @@ pub(crate) fn show_create(
 
 /// Create form body (no footer). Top-aligned inside a fixed body slot when locked.
 fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mut Vec<Action>) {
-    let (kind, parent, loc, alongside, error) = match &app.modal {
-        Some(Modal::Create { kind, parent, loc, alongside, error, .. }) => {
-            (*kind, *parent, *loc, alongside.clone(), error.clone())
+    let (kind, parent, loc, alongside, chosen, error) = match &app.modal {
+        Some(Modal::Create { kind, parent, loc, alongside, chosen, error, .. }) => {
+            (*kind, *parent, *loc, alongside.clone(), *chosen, error.clone())
         }
         _ => return,
     };
@@ -159,33 +159,44 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
         .ready()
         .map(|r| r.workspace.files.read().unwrap().root().id);
 
-    let root_sel = matches!(loc, CreateLoc::Root)
-        || (matches!(loc, CreateLoc::Custom) && parent.is_some() && parent == root_id);
+    let root_sel = matches!(loc, CreateLoc::Root);
     let along_sel = matches!(loc, CreateLoc::Alongside);
+    let custom_sel = matches!(loc, CreateLoc::Custom) && chosen.is_some() && chosen != root_id;
 
     if sheet_title_muted(ui, t, "Create") {
         queue.push(A::CloseModal);
     }
     ui.add(Spacer::new(Space::Md));
 
-    // Center in a fixed control band (not unconstrained Area height).
+    // Type + name share one centered column (segmented natural width). Location
+    // plates keep the full sheet.
+    let col_w = segmented_width(ui, t, &labels);
     sheet_band_centered(ui, crate::components::segmented_h(), |ui| {
         if segmented(ui, t, &labels, &mut kind_i).changed() {
             queue.push(A::CreateSetKind(CreateKind::from_index(kind_i)));
         }
     });
     ui.add(Spacer::new(Space::Md));
-    ui.label(TypeRole::Body.rich("Name").color(t.neutral_fg_secondary()));
-    ui.add(Spacer::new(Space::Xs));
 
-    // Field edits Modal::Create.name in place (in-place modal fields).
-    {
+    let total = crate::components::ui_width(ui);
+    let top_left = origin(ui);
+    let col_left = top_left.x + ((total - col_w) / 2.0).max(0.0);
+    let budget = egui::Rect::from_min_size(
+        egui::pos2(col_left, top_left.y),
+        egui::vec2(col_w.max(1.0), crate::components::remaining_height(ui).max(1.0)),
+    );
+    let (_, used) = place_at(ui, budget, Layout::top_down(Align::Min), |ui| {
+        ui.set_width(col_w.max(1.0));
+        ui.label(TypeRole::Body.rich("Name").color(t.neutral_fg_secondary()));
+        ui.add(Spacer::new(Space::Xs));
+
         let Some(Modal::Create { name, name_dirty, error, .. }) = &mut app.modal else {
             return;
         };
         let before = name.clone();
         let mut field = Field::new(t, name)
             .id("shell_create_field")
+            .width(col_w)
             .select_all_on_focus(true);
         if let Some(ext) = kind.ext() {
             field = field.trailing_static(ext);
@@ -203,7 +214,8 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
             *name_dirty = true;
             *error = None;
         }
-    }
+    });
+    claim(ui, egui::Rect::from_min_size(top_left, egui::vec2(total, used.height().max(1.0))));
 
     ui.add(Spacer::new(Space::Md));
     ui.label(
@@ -213,8 +225,8 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
     );
     ui.add(Spacer::new(Space::Xs));
 
-    // Exclusive location plates: unselected = surface rest; selected elevates to
-    // canvas + hairline (segmented-pill language — not press-wash-as-selection).
+    // Exclusive location plates: unselected = surface rest; selected = canvas
+    // + accent hairline (destination, not the type segmented).
     // Compact labels keep natural width; name-bearing plates take the leftover so
     // “Alongside {note}” can show a real title instead of permanent ellipsis.
     let username = app
@@ -223,22 +235,16 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
         .map(|r| r.workspace.account.username.clone())
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "Home".into());
-    let custom_sel =
-        matches!(loc, CreateLoc::Custom) && parent.is_some() && parent != root_id && !along_sel;
-    let custom_folder = if custom_sel {
-        parent.and_then(|id| {
-            app.session.ready().and_then(|r| {
-                r.workspace
-                    .files
-                    .read()
-                    .unwrap()
-                    .get_by_id(id)
-                    .map(|f| f.name.clone())
-            })
+    let custom_folder = chosen.filter(|id| Some(*id) != root_id).and_then(|id| {
+        app.session.ready().and_then(|r| {
+            r.workspace
+                .files
+                .read()
+                .unwrap()
+                .get_by_id(id)
+                .map(|f| f.name.clone())
         })
-    } else {
-        None
-    };
+    });
 
     let mut plates: Vec<CreateLocPlate> = Vec::new();
     plates.push(CreateLocPlate {
@@ -250,27 +256,35 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
     });
     if let Some((_, doc_name)) = alongside.as_ref() {
         plates.push(CreateLocPlate {
-            icon: file_row_icon(doc_name, false),
+            icon: phosphor::ARROW_BEND_DOWN_RIGHT,
             label: LocPlateLabel::Alongside(doc_name.clone()),
             selected: along_sel,
             flex: true,
             action: CreateLocPlateAction::Set(CreateLoc::Alongside),
         });
     }
+    // Third slot is always flex (Choose… or a picked folder). Flipping flex
+    // on pick used to steal width from Alongside. A chosen folder stays on
+    // the plate even when Home / Alongside is selected; click selects it,
+    // click-again (already Custom) reopens the picker.
     if let Some(folder) = custom_folder {
         plates.push(CreateLocPlate {
             icon: phosphor::FOLDER,
             label: LocPlateLabel::FileName(folder),
-            selected: true,
+            selected: custom_sel,
             flex: true,
-            action: CreateLocPlateAction::Pick,
+            action: if custom_sel {
+                CreateLocPlateAction::Pick
+            } else {
+                CreateLocPlateAction::Set(CreateLoc::Custom)
+            },
         });
     } else {
         plates.push(CreateLocPlate {
             icon: phosphor::FOLDERS,
             label: LocPlateLabel::Text("Choose…".into()),
             selected: false,
-            flex: false,
+            flex: true,
             action: CreateLocPlateAction::Pick,
         });
     }
@@ -382,16 +396,13 @@ struct CreateLocPlate {
 
 const LOC_PLATE_H: f32 = 30.0;
 
-/// Location plate fills. Selected elevates to canvas (same as segmented pill);
-/// unselected stays surface with hover/press washes only.
+/// Location plate fills. Selected elevates to canvas; unselected stays surface.
 fn create_loc_plate_fills(t: &Theme, selected: bool) -> ControlFills {
     if selected {
         let canvas = t.neutral_bg();
         ControlFills {
             rest: canvas,
             hover: canvas,
-            // Still pressable if re-clicked; keep feedback without looking like
-            // “stuck press” at rest.
             press: t.wash_toward_neutral_fg(canvas, FG_HOVER),
         }
     } else {
@@ -429,7 +440,7 @@ fn create_loc_plate_natural_w(ui: &egui::Ui, t: &Theme, plate: &CreateLocPlate) 
     chrome + label_w
 }
 
-/// Location plate: left icon + label. Selected = raised canvas + hairline.
+/// Location plate: left icon + label. Selected = canvas + accent hairline.
 fn create_loc_plate(ui: &mut egui::Ui, t: &Theme, plate: &CreateLocPlate) -> egui::Response {
     let w = crate::components::ui_width(ui);
     let (rect, resp) = ui.allocate_exact_size(egui::vec2(w, LOC_PLATE_H), sense_click());
@@ -450,7 +461,7 @@ fn create_loc_plate(ui: &mut egui::Ui, t: &Theme, plate: &CreateLocPlate) -> egu
         ui.painter().rect_stroke(
             rect,
             r,
-            Stroke::new(crate::components::STROKE_HAIRLINE, t.neutral()),
+            Stroke::new(crate::components::STROKE_HAIRLINE, t.accent()),
             StrokeKind::Inside,
         );
     }
@@ -458,6 +469,7 @@ fn create_loc_plate(ui: &mut egui::Ui, t: &Theme, plate: &CreateLocPlate) -> egu
     let icon_ink = if plate.icon == phosphor::FOLDER
         || plate.icon == phosphor::FOLDERS
         || plate.icon == phosphor::FOLDER_OPEN
+        || plate.icon == phosphor::ARROW_BEND_DOWN_RIGHT
     {
         t.accent()
     } else {

--- a/clients/desktop/src/shell/sheet_create.rs
+++ b/clients/desktop/src/shell/sheet_create.rs
@@ -5,9 +5,9 @@ use workspace_rs::file_cache::FilesExt;
 use crate::components::interact::{ControlFills, interact_fill, sense_click};
 use crate::components::{
     Button, EqualCells, FG_HOVER, FG_PRESS, Field, Radius, SheetFooterOpts, Space, Spacer, Theme,
-    TypeRole, claim, measure_file_name, origin, paint_file_name, phosphor, phosphor_ui_font_id,
-    place_at, segmented, segmented_width, sheet_band, sheet_band_centered, sheet_dim,
-    sheet_equal_row, sheet_footer, sheet_panel_fixed, sheet_title_muted, shortcut_enter,
+    TypeRole, claim, display_file_name, measure_file_name, origin, paint_file_name, phosphor,
+    phosphor_ui_font_id, place_at, segmented, segmented_width, sheet_band, sheet_band_centered,
+    sheet_dim, sheet_equal_row, sheet_footer, sheet_panel_fixed, sheet_title_muted, shortcut_enter,
 };
 
 use super::ShellApp;
@@ -257,7 +257,7 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
     if let Some((_, doc_name)) = alongside.as_ref() {
         plates.push(CreateLocPlate {
             icon: phosphor::ARROW_BEND_DOWN_RIGHT,
-            label: LocPlateLabel::Alongside(doc_name.clone()),
+            label: LocPlateLabel::Alongside(display_file_name(doc_name).to_owned()),
             selected: along_sel,
             flex: true,
             action: CreateLocPlateAction::Set(CreateLoc::Alongside),

--- a/clients/desktop/src/shell/sheet_create.rs
+++ b/clients/desktop/src/shell/sheet_create.rs
@@ -621,13 +621,14 @@ fn create_summary_line(
 
     let kind_l = kind.label();
     let ext = kind.ext().unwrap_or("");
-    let display_name = if name.is_empty() {
+    let full = if name.is_empty() {
         format!("untitled{ext}")
     } else if ext.is_empty() || name.ends_with(ext) {
         name.to_owned()
     } else {
         format!("{name}{ext}")
     };
+    let display_name = display_file_name(&full);
 
     let dest = super::sheet_folder::folder_path_slash(app, parent);
 
@@ -648,12 +649,12 @@ fn create_summary_line(
     let mid = " will be created at: ";
     let path_w = measure(&dest, true);
     let one_line_w =
-        measure(&head, false) + measure(&display_name, true) + measure(mid, false) + path_w;
+        measure(&head, false) + measure(display_name, true) + measure(mid, false) + path_w;
 
     if one_line_w <= max_w {
         ui.add(
             GlyphonLabel::new_rich(
-                vec![(&head, false), (&display_name, true), (mid, false), (&dest, true)],
+                vec![(&head, false), (display_name, true), (mid, false), (&dest, true)],
                 ink,
             )
             .font_size(fs)
@@ -663,7 +664,7 @@ fn create_summary_line(
     } else {
         // Line 1: prose; line 2: path fitted to full sheet width (no Clip chop).
         ui.add(
-            GlyphonLabel::new_rich(vec![(&head, false), (&display_name, true), (mid, false)], ink)
+            GlyphonLabel::new_rich(vec![(&head, false), (display_name, true), (mid, false)], ink)
                 .font_size(fs)
                 .line_height(lh)
                 .max_width(max_w)

--- a/clients/desktop/src/shell/sheet_folder.rs
+++ b/clients/desktop/src/shell/sheet_folder.rs
@@ -3,8 +3,8 @@ use lb::Uuid;
 use workspace_rs::file_cache::FilesExt;
 
 use crate::components::{
-    SheetFooterOpts, Space, Spacer, Theme, TypeRole, sheet_dim, sheet_footer, sheet_panel_fit,
-    sheet_title_muted, shortcut_enter, shortcut_return,
+    SheetFooterOpts, Space, Spacer, Theme, TypeRole, display_file_name, sheet_dim, sheet_footer,
+    sheet_panel_fit, sheet_title_muted, shortcut_enter, shortcut_return,
 };
 
 use super::ShellApp;
@@ -183,8 +183,13 @@ fn move_cascade_stats(app: &ShellApp, ids: &[Uuid]) -> (Option<String>, usize, u
         bytes += files.size_bytes_recursive.get(id).copied().unwrap_or(0);
     }
 
-    let single =
-        if roots.len() == 1 { files.get_by_id(roots[0]).map(|f| f.name.clone()) } else { None };
+    let single = if roots.len() == 1 {
+        files
+            .get_by_id(roots[0])
+            .map(|f| display_file_name(&f.name).to_owned())
+    } else {
+        None
+    };
     (single, cascade, bytes)
 }
 
@@ -375,6 +380,7 @@ pub(crate) fn show_decline_share(
 /// You will lose access to **name**.
 fn paint_decline_summary(ui: &mut egui::Ui, t: &Theme, name: &str) {
     use workspace_rs::widgets::GlyphonLabel;
+    let name = display_file_name(name);
     let ink = t.neutral_fg();
     let fs = TypeRole::Body.size();
     let lh = TypeRole::Body.line_height();
@@ -549,6 +555,7 @@ fn dest_action_summary(
         return;
     };
     let path = folder_path_slash(app, Some(dest));
+    let subject = display_file_name(subject);
     let ink = t.neutral_fg();
     let fs = TypeRole::Body.size();
     let lh = TypeRole::Body.line_height();

--- a/clients/desktop/src/shell/sheet_folder.rs
+++ b/clients/desktop/src/shell/sheet_folder.rs
@@ -372,7 +372,7 @@ pub(crate) fn show_decline_share(
         });
 }
 
-/// You will lose access to **name**. The owner will not be affected.
+/// You will lose access to **name**.
 fn paint_decline_summary(ui: &mut egui::Ui, t: &Theme, name: &str) {
     use workspace_rs::widgets::GlyphonLabel;
     let ink = t.neutral_fg();
@@ -381,11 +381,7 @@ fn paint_decline_summary(ui: &mut egui::Ui, t: &Theme, name: &str) {
     let max_w = crate::components::ui_width(ui).max(1.0);
     ui.add(
         GlyphonLabel::new_rich(
-            vec![
-                ("You will lose access to ", false),
-                (name, true),
-                (". The owner will not be affected.", false),
-            ],
+            vec![("You will lose access to ", false), (name, true), (".", false)],
             ink,
         )
         .font_size(fs)

--- a/clients/desktop/src/shell/sheet_onboard.rs
+++ b/clients/desktop/src/shell/sheet_onboard.rs
@@ -1,21 +1,32 @@
 use egui::{Align, Area, Id, Layout, Order};
 
 use crate::components::{
-    Button, Field, SheetFooterOpts, Space, Spacer, Theme, TypeRole, phosphor, sheet_dim,
-    sheet_footer, sheet_panel_fit, shortcut_cmd_i, shortcut_cmd_n, shortcut_return,
+    Button, Field, SheetFooterOpts, Space, Spacer, Theme, TypeRole, phosphor, sense_click,
+    sheet_dim, sheet_footer, sheet_panel_fit, shortcut_cmd_i, shortcut_cmd_n, shortcut_return,
 };
 
 use super::ShellApp;
 use super::action::Action as A;
 use super::action::{Action, Modal, OnboardLookup, OnboardMode};
+use super::apply_onboard::{
+    display_server_host, onboard_server_editing_key, onboard_server_snap_key,
+    uname_check_matches_core,
+};
 
 pub(crate) fn show_onboard(
     app: &mut ShellApp, ctx: &egui::Context, t: &Theme, queue: &mut Vec<Action>,
 ) {
-    let (mode, uname_lookup, uname_lookup_for, busy, err) = match &app.modal {
-        Some(Modal::Onboard { mode, uname_lookup, uname_lookup_for, busy, err, .. }) => {
-            (*mode, uname_lookup.clone(), uname_lookup_for.clone(), *busy, err.clone())
-        }
+    let (mode, uname_lookup, uname_lookup_for, busy, err, api_url) = match &app.modal {
+        Some(Modal::Onboard {
+            mode, uname_lookup, uname_lookup_for, busy, err, api_url, ..
+        }) => (
+            *mode,
+            uname_lookup.clone(),
+            uname_lookup_for.clone(),
+            *busy,
+            err.clone(),
+            api_url.clone(),
+        ),
         _ => return,
     };
 
@@ -126,6 +137,8 @@ pub(crate) fn show_onboard(
                                 },
                             );
                         });
+                        ui.add(Spacer::new(Space::Md));
+                        onboard_server_row(app, ui, t, &api_url);
                     }
                     OnboardMode::Create => {
                         ui.label(
@@ -196,7 +209,13 @@ pub(crate) fn show_onboard(
                             ("Checking…", t.neutral_fg_secondary())
                         } else {
                             match &uname_lookup {
-                                OnboardLookup::Available => ("Available", t.accent()),
+                                OnboardLookup::Available => {
+                                    if uname_check_matches_core(&api_url) {
+                                        ("Available", t.accent())
+                                    } else {
+                                        ("", t.neutral_fg_secondary())
+                                    }
+                                }
                                 OnboardLookup::Taken => ("Username taken", t.danger()),
                                 OnboardLookup::Error(e) => (e.as_str(), t.danger()),
                                 OnboardLookup::Idle | OnboardLookup::Checking => {
@@ -324,4 +343,75 @@ pub(crate) fn show_onboard(
                 }
             });
         });
+}
+
+fn onboard_server_edit_id() -> Id {
+    Id::new("onboard_server").with("edit")
+}
+
+fn onboard_server_need_focus_key() -> Id {
+    Id::new("onboard_server_need_focus")
+}
+
+/// Rest: hostname caption. Click: field. Blur / Enter commit; Esc reverts; × defaults.
+fn onboard_server_row(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, api_url: &str) {
+    let editing_key = onboard_server_editing_key();
+    let snap_key = onboard_server_snap_key();
+    let mut editing = ui
+        .ctx()
+        .data(|d| d.get_temp::<bool>(editing_key))
+        .unwrap_or(false);
+    let mut need_focus = ui
+        .ctx()
+        .data(|d| d.get_temp::<bool>(onboard_server_need_focus_key()))
+        .unwrap_or(false);
+
+    if editing {
+        {
+            let Some(Modal::Onboard { api_url, .. }) = &mut app.modal else {
+                return;
+            };
+            let _ = Field::new(t, api_url)
+                .hint(lb::DEFAULT_API_LOCATION)
+                .id("onboard_server")
+                .clearable(true)
+                .sticky(false)
+                .show(ui);
+            if need_focus {
+                ui.memory_mut(|m| m.request_focus(onboard_server_edit_id()));
+                if ui.memory(|m| m.has_focus(onboard_server_edit_id())) {
+                    need_focus = false;
+                }
+            }
+        }
+        let focused = ui.memory(|m| m.has_focus(onboard_server_edit_id()));
+        if !need_focus && !focused {
+            editing = false;
+        }
+    } else if onboard_server_caption(ui, t, &display_server_host(api_url)) {
+        editing = true;
+        need_focus = true;
+        ui.ctx()
+            .data_mut(|d| d.insert_temp(snap_key, api_url.to_owned()));
+    }
+
+    ui.ctx().data_mut(|d| {
+        d.insert_temp(editing_key, editing);
+        d.insert_temp(onboard_server_need_focus_key(), need_focus);
+    });
+}
+
+fn onboard_server_caption(ui: &mut egui::Ui, t: &Theme, host: &str) -> bool {
+    let rest = t.neutral_fg_secondary();
+    let g = ui
+        .painter()
+        .layout_no_wrap(host.to_owned(), TypeRole::Body.font_id(), rest);
+    let h = crate::components::control_height();
+    let w = crate::components::ui_width(ui).max(1.0);
+    let (rect, resp) = ui.allocate_exact_size(egui::vec2(w, h), sense_click());
+    let over = ui.ctx().rect_contains_pointer(ui.layer_id(), rect);
+    let ink = if over { t.neutral_fg() } else { rest };
+    ui.painter()
+        .galley(egui::pos2(rect.left(), rect.center().y - g.size().y / 2.0), g, ink);
+    resp.clicked()
 }

--- a/clients/desktop/src/shell/sheets.rs
+++ b/clients/desktop/src/shell/sheets.rs
@@ -12,6 +12,7 @@ use crate::components::{
 use super::ShellApp;
 use super::action::Action as A;
 use super::action::{Action, Modal};
+use super::ops::is_saved_share;
 use super::settings;
 
 /// True when `q` has been stable for 100ms and verify should run.
@@ -156,6 +157,9 @@ fn show_delete(
     let mut expanded: std::collections::HashSet<Uuid> =
         ctx.data(|d| d.get_temp(exp_id)).unwrap_or_default();
 
+    let parts = delete_parts(app, ids);
+    let remove_only = parts.owned.is_empty() && !parts.shares.is_empty();
+
     let layer = egui::LayerId::new(Order::Foreground, Id::new("shell_delete"));
     if sheet_dim(ctx, Id::new("shell_delete_dim"), layer) {
         queue.push(A::CloseModal);
@@ -168,22 +172,25 @@ fn show_delete(
             sheet_panel_fit(ui, t, 320.0, |ui| {
                 // Pure confirm: optional folder tree + copy + danger footer.
                 // Files-only: summary alone (tree would be static rows in a plate).
-                // Md throughout — no Xl “read vs act” gap.
-                if sheet_title_muted(ui, t, "Delete") {
+                // Share links: Remove (not Delete) — opposite of Save to your files.
+                let title = if remove_only { "Remove" } else { "Delete" };
+                if sheet_title_muted(ui, t, title) {
                     queue.push(A::CloseModal);
                 }
                 ui.add(Spacer::new(Space::Md));
-                if super::tree::show_delete_tree(app, ui, t, ids, &mut expanded) {
+                if !parts.owned_ids.is_empty()
+                    && super::tree::show_delete_tree(app, ui, t, &parts.owned_ids, &mut expanded)
+                {
                     ui.add(Spacer::new(Space::Md));
                 }
-                paint_delete_summary(ui, t, app, ids);
+                paint_delete_parts(ui, t, &parts);
                 ui.add(Spacer::new(Space::Md));
                 let foot = sheet_footer(
                     ui,
                     t,
-                    "Delete",
+                    if remove_only { "Remove" } else { "Delete" },
                     SheetFooterOpts::default()
-                        .danger(true)
+                        .danger(!remove_only)
                         .divider(false)
                         .primary_shortcut(shortcut_return()),
                 );
@@ -199,21 +206,34 @@ fn show_delete(
     ctx.data_mut(|d| d.insert_temp(exp_id, expanded));
 }
 
-/// Confirm copy: specific when we can, bold on names / counts / size (share style).
-///
-/// Body fg; Glyphon so emoji names shape. Always ends with the undo clause.
-fn paint_delete_summary(ui: &mut egui::Ui, t: &Theme, app: &ShellApp, ids: &[Uuid]) {
-    use workspace_rs::widgets::GlyphonLabel;
+struct DeleteParts {
+    owned_ids: Vec<Uuid>,
+    owned: Vec<(String, bool)>,
+    shares: Vec<(String, bool)>,
+}
 
+fn paint_delete_parts(ui: &mut egui::Ui, t: &Theme, parts: &DeleteParts) {
+    let mixed = !parts.owned.is_empty() && !parts.shares.is_empty();
+    if mixed {
+        paint_delete_para(ui, t, &parts.owned);
+        ui.add(Spacer::new(Space::Md));
+        paint_delete_para(ui, t, &parts.shares);
+    } else if !parts.owned.is_empty() {
+        paint_delete_para(ui, t, &parts.owned);
+    } else if !parts.shares.is_empty() {
+        paint_delete_para(ui, t, &parts.shares);
+    }
+}
+
+fn paint_delete_para(ui: &mut egui::Ui, t: &Theme, spans: &[(String, bool)]) {
+    use workspace_rs::widgets::GlyphonLabel;
+    if spans.is_empty() {
+        return;
+    }
     let ink = t.neutral_fg();
     let fs = TypeRole::Body.size();
     let lh = TypeRole::Body.line_height();
     let max_w = crate::components::ui_width(ui).max(1.0);
-
-    let spans = delete_summary_spans(app, ids);
-    if spans.is_empty() {
-        return;
-    }
     let rich: Vec<(&str, bool)> = spans.iter().map(|(s, b)| (s.as_str(), *b)).collect();
     ui.add(
         GlyphonLabel::new_rich(rich, ink)
@@ -223,12 +243,17 @@ fn paint_delete_summary(ui: &mut egui::Ui, t: &Theme, app: &ShellApp, ids: &[Uui
     );
 }
 
-/// Build (text, bold) spans for the delete confirm sentence.
-fn delete_summary_spans(app: &ShellApp, ids: &[Uuid]) -> Vec<(String, bool)> {
+fn delete_parts(app: &ShellApp, ids: &[Uuid]) -> DeleteParts {
     let undo = "This cannot be undone.";
-    let Some(ready) = app.session.ready() else {
-        return vec![(undo.into(), false)];
+    let empty = DeleteParts {
+        owned_ids: Vec::new(),
+        owned: vec![(undo.into(), false)],
+        shares: Vec::new(),
     };
+    let Some(ready) = app.session.ready() else {
+        return empty;
+    };
+    let me = ready.workspace.account.username.as_str();
     let files = ready.workspace.files.read().unwrap();
 
     // Folder covers its selected kids — same roots as the delete tree.
@@ -241,21 +266,34 @@ fn delete_summary_spans(app: &ShellApp, ids: &[Uuid]) -> Vec<(String, bool)> {
         })
         .collect();
     if roots.is_empty() {
-        return vec![(undo.into(), false)];
+        return empty;
     }
 
     let mut cascade = 0usize;
     let mut bytes = 0u64;
     let mut any_folder = false;
+    let mut owned_ids = Vec::new();
     let mut names: Vec<String> = Vec::with_capacity(roots.len());
+    let mut link_names: Vec<String> = Vec::new();
     for id in &roots {
-        let is_folder = files.get_by_id(*id).is_some_and(|f| f.is_folder());
+        let Some(f) = files.get_by_id(*id) else {
+            continue;
+        };
+        if is_saved_share(f, me) {
+            link_names.push(f.name.clone());
+            continue;
+        }
+        let is_folder = f.is_folder();
         any_folder |= is_folder;
         cascade += 1 + files.descendents(*id).len();
         bytes += files.size_bytes_recursive.get(id).copied().unwrap_or(0);
-        if let Some(f) = files.get_by_id(*id) {
-            names.push(f.name.clone());
-        }
+        names.push(f.name.clone());
+        owned_ids.push(*id);
+    }
+
+    let shares = if link_names.is_empty() { Vec::new() } else { delete_link_spans(&link_names) };
+    if names.is_empty() {
+        return DeleteParts { owned_ids, owned: Vec::new(), shares };
     }
 
     // Descendants only (excludes the folder row itself).
@@ -263,7 +301,7 @@ fn delete_summary_spans(app: &ShellApp, ids: &[Uuid]) -> Vec<(String, bool)> {
     let size = delete_size_paren(bytes);
     let mut spans: Vec<(String, bool)> = Vec::new();
 
-    match (roots.len(), any_folder, cascade) {
+    match (names.len(), any_folder, cascade) {
         (1, false, _) => {
             // **Linux.md** will be permanently deleted (12.4 MB).
             if let Some(n) = names.first() {
@@ -306,7 +344,7 @@ fn delete_summary_spans(app: &ShellApp, ids: &[Uuid]) -> Vec<(String, bool)> {
             spans.push((".".into(), false));
         }
         // Few named roots, no cascade (docs and/or empty folders): list names.
-        (n, _, c) if n <= 4 && c == roots.len() && names.len() == n => {
+        (n, _, c) if n <= 4 && c == names.len() && names.len() == n => {
             delete_push_name_list(&mut spans, &names);
             spans.push((" will be permanently deleted".into(), false));
             if !size.is_empty() {
@@ -324,7 +362,7 @@ fn delete_summary_spans(app: &ShellApp, ids: &[Uuid]) -> Vec<(String, bool)> {
             spans.push((".".into(), false));
         }
         // Multi with folder(s), no extra descendants.
-        (_, true, n) if n == roots.len() => {
+        (_, true, n) if n == names.len() => {
             spans.push((delete_count_noun(n, "item", "items"), true));
             spans.push((" will be permanently deleted".into(), false));
             if !size.is_empty() {
@@ -345,6 +383,17 @@ fn delete_summary_spans(app: &ShellApp, ids: &[Uuid]) -> Vec<(String, bool)> {
 
     spans.push((" ".into(), false));
     spans.push((undo.into(), false));
+    DeleteParts { owned_ids, owned: spans, shares }
+}
+
+/// Removing an accepted share from Files — not a real delete.
+fn delete_link_spans(names: &[String]) -> Vec<(String, bool)> {
+    let mut spans = Vec::new();
+    delete_push_name_list(&mut spans, names);
+    spans.push((
+        " will be removed from files. You'll still have access through Shared with me.".into(),
+        false,
+    ));
     spans
 }
 
@@ -600,4 +649,42 @@ fn help_shortcut_row(ui: &mut egui::Ui, t: &Theme, key: &str, label: &str) {
         label_galley,
         ink,
     );
+}
+
+#[cfg(test)]
+mod delete_link_copy_tests {
+    use super::{delete_link_spans, delete_push_name_list};
+
+    fn text(spans: &[(String, bool)]) -> String {
+        spans.iter().map(|(s, _)| s.as_str()).collect()
+    }
+
+    #[test]
+    fn single_link_is_not_permanent_delete() {
+        let t = text(&delete_link_spans(&["Notes".into()]));
+        assert_eq!(
+            t,
+            "Notes will be removed from files. You'll still have access through Shared with me."
+        );
+        assert!(!t.to_ascii_lowercase().contains("delete"));
+        assert!(!t.contains("lose access"));
+        assert!(!t.contains("cannot be undone"));
+    }
+
+    #[test]
+    fn multiple_links_pluralize() {
+        let t = text(&delete_link_spans(&["A".into(), "B".into()]));
+        assert_eq!(
+            t,
+            "A and B will be removed from files. You'll still have access through Shared with me."
+        );
+        assert!(!t.to_ascii_lowercase().contains("delete"));
+    }
+
+    #[test]
+    fn name_list_three() {
+        let mut spans = Vec::new();
+        delete_push_name_list(&mut spans, &["a".into(), "b".into(), "c".into()]);
+        assert_eq!(text(&spans), "a, b, and c");
+    }
 }

--- a/clients/desktop/src/shell/sheets.rs
+++ b/clients/desktop/src/shell/sheets.rs
@@ -5,8 +5,8 @@ use lb::Uuid;
 use workspace_rs::file_cache::FilesExt;
 
 use crate::components::{
-    Button, Field, SheetFooterOpts, Space, Spacer, Theme, TypeRole, phosphor, sheet_dim,
-    sheet_footer, sheet_panel_fit, sheet_title_muted, shortcut_enter, shortcut_return,
+    Button, Field, SheetFooterOpts, Space, Spacer, Theme, TypeRole, display_file_name, phosphor,
+    sheet_dim, sheet_footer, sheet_panel_fit, sheet_title_muted, shortcut_enter, shortcut_return,
 };
 
 use super::ShellApp;
@@ -143,7 +143,7 @@ pub(crate) fn file_name(app: &ShellApp, id: Uuid) -> String {
                 .read()
                 .unwrap()
                 .get_by_id(id)
-                .map(|f| f.name.clone())
+                .map(|f| display_file_name(&f.name).to_owned())
         })
         .unwrap_or_else(|| "item".into())
 }
@@ -279,15 +279,16 @@ fn delete_parts(app: &ShellApp, ids: &[Uuid]) -> DeleteParts {
         let Some(f) = files.get_by_id(*id) else {
             continue;
         };
+        let shown = display_file_name(&f.name).to_owned();
         if is_saved_share(f, me) {
-            link_names.push(f.name.clone());
+            link_names.push(shown);
             continue;
         }
         let is_folder = f.is_folder();
         any_folder |= is_folder;
         cascade += 1 + files.descendents(*id).len();
         bytes += files.size_bytes_recursive.get(id).copied().unwrap_or(0);
-        names.push(f.name.clone());
+        names.push(shown);
         owned_ids.push(*id);
     }
 
@@ -303,7 +304,7 @@ fn delete_parts(app: &ShellApp, ids: &[Uuid]) -> DeleteParts {
 
     match (names.len(), any_folder, cascade) {
         (1, false, _) => {
-            // **Linux.md** will be permanently deleted (12.4 MB).
+            // **Linux** will be permanently deleted (12.4 MB).
             if let Some(n) = names.first() {
                 spans.push((n.clone(), true));
                 spans.push((" will be permanently deleted".into(), false));


### PR DESCRIPTION
Quick, low-risk wins for the new desktop client.

**Create Sheet**
* Create destination follows the open tab
* Home, Alongside, and Choose are shown and selected/populated more thoughtfully based on how you invoked the create sheet
* Home, Alongside, and Choose have improved layout that doesn't rearrange after choosing a destination

**Everything Else**
* Choose an alternate server during onboard with an Android-inspired control
* Right-click Cut / Copy / Paste / Select all for text fields
* File extensions hidden according to usual rules
* "Deleting" a link is now referred to as removing from files with clear language
* Cleanup unused code

Closes #4407
Closes #1925
Closes #5026
