### PR TITLE
desktop: ui fixes/polish

### DIFF
--- a/clients/desktop/src/components/atoms/mod.rs
+++ b/clients/desktop/src/components/atoms/mod.rs
@@ -24,4 +24,4 @@ pub use quiet_chip::height as quiet_chip_height;
 pub use quiet_chip::{
     QuietChipAlign, QuietChipLabel, labeled_min_width as quiet_chip_labeled_min_width, quiet_chip,
 };
-pub use segmented::{segmented, segmented_h, segmented_width};
+pub use segmented::{segmented, segmented_h};

--- a/clients/desktop/src/components/atoms/segmented.rs
+++ b/clients/desktop/src/components/atoms/segmented.rs
@@ -25,11 +25,6 @@ pub fn segmented_h() -> f32 {
 /// Equalize segment widths so the strip doesn’t look lopsided.
 const EQUALIZE: bool = true;
 
-/// Natural width of a [`segmented`] for `options` (equalized cells).
-pub fn segmented_width(ui: &Ui, t: &Theme, options: &[&str]) -> f32 {
-    segmented_cell_widths(ui, t, options).iter().sum()
-}
-
 fn segmented_cell_widths(ui: &Ui, t: &Theme, options: &[&str]) -> Vec<f32> {
     let n = options.len().max(1);
     let h = segmented_h();

--- a/clients/desktop/src/components/compounds/form.rs
+++ b/clients/desktop/src/components/compounds/form.rs
@@ -20,11 +20,11 @@ use egui::text::{LayoutJob, TextWrapping};
 use egui::{Align, FontId, Id, Layout, Rect, Response, Stroke, TextFormat, Ui, pos2, vec2};
 
 use crate::components::foundation::chrome::{
-    Radius, STROKE_HAIRLINE, TOGGLE_ANIM_SECS, control_height,
+    Radius, STROKE_HAIRLINE, TOGGLE_ANIM_SECS, control_height, phosphor, phosphor_ui_font_id,
 };
-use crate::components::foundation::color::Theme;
+use crate::components::foundation::color::{FG_HOVER, Theme};
 use crate::components::foundation::interact::sense_click;
-use crate::components::foundation::layout::{claim, origin, place_at};
+use crate::components::foundation::layout::{claim, origin, place_at, ui_width};
 use crate::components::foundation::space::Space;
 use crate::components::foundation::spacer::Spacer;
 use crate::components::foundation::typography::TypeRole;
@@ -316,4 +316,57 @@ pub fn form_picker(
         out = Some(crate::components::atoms::picker::picker(ui, t, options, selected));
     });
     out.expect("form_row always runs trailing")
+}
+
+/// Checkbox + wrapping copy; the whole row toggles (logout / key-backup ack).
+pub fn ack_row(ui: &mut Ui, t: &Theme, label: &str, on: &mut bool) {
+    let box_s = TypeRole::Body.line_height().min(control_height() * 0.85);
+    let gap = Space::Sm.pts();
+    let max_w = ui_width(ui).max(1.0);
+    let text_w = (max_w - box_s - gap).max(1.0);
+    let galley =
+        ui.painter()
+            .layout(label.to_owned(), TypeRole::Body.font_id(), t.neutral_fg(), text_w);
+    let row_h = galley.size().y.max(box_s);
+    let (row, resp) = ui.allocate_exact_size(egui::vec2(max_w, row_h), sense_click());
+    if resp.clicked() {
+        *on = !*on;
+    }
+    let over = ui.ctx().rect_contains_pointer(ui.layer_id(), row);
+    let box_rect = egui::Rect::from_min_size(
+        egui::pos2(row.left(), row.center().y - box_s / 2.0),
+        egui::vec2(box_s, box_s),
+    );
+    let ground = t.neutral_bg();
+    let fill = if *on {
+        t.accent()
+    } else if over {
+        t.wash_toward_neutral_fg(ground, FG_HOVER)
+    } else {
+        ground
+    };
+    ui.painter().rect(
+        box_rect,
+        Radius::Sm.corner(),
+        fill,
+        Stroke::new(STROKE_HAIRLINE, if *on { t.accent() } else { t.neutral() }),
+        egui::StrokeKind::Inside,
+    );
+    if *on {
+        let ig = ui.painter().layout_no_wrap(
+            phosphor::CHECK.into(),
+            phosphor_ui_font_id(),
+            t.neutral_bg(),
+        );
+        ui.painter().galley(
+            egui::pos2(
+                box_rect.center().x - ig.size().x / 2.0,
+                box_rect.center().y - ig.size().y / 2.0,
+            ),
+            ig,
+            t.neutral_bg(),
+        );
+    }
+    ui.painter()
+        .galley(egui::pos2(row.left() + box_s + gap, row.top()), galley, t.neutral_fg());
 }

--- a/clients/desktop/src/components/compounds/mod.rs
+++ b/clients/desktop/src/components/compounds/mod.rs
@@ -7,8 +7,8 @@ pub mod scroll;
 pub mod sheet;
 pub mod tip;
 pub use form::{
-    footnote, form_group, form_picker, form_row, form_row_detail, form_segmented, form_toggle,
-    form_toggle_detail, form_value, section_label,
+    ack_row, footnote, form_group, form_picker, form_row, form_row_detail, form_segmented,
+    form_toggle, form_toggle_detail, form_value, section_label,
 };
 pub use list_chrome::{LIST_PAD, SECTION_GAP, SECTION_HEAD_GAP, paint_list_section};
 pub use scroll::{fixed_height_list, with_overlay_scroll};

--- a/clients/desktop/src/components/domain/chips.rs
+++ b/clients/desktop/src/components/domain/chips.rs
@@ -1,4 +1,4 @@
-//! Files-pane action chips: Create / Import / Search.
+//! Files / Recents action chips: Create / Import / Search.
 //!
 //! Equal-width quiet chips ([`quiet_chip`]) on canvas.
 //! Widths from [`EqualCells::measure`]; cells placed at absolute x.

--- a/clients/desktop/src/components/domain/pins.rs
+++ b/clients/desktop/src/components/domain/pins.rs
@@ -4,7 +4,7 @@
 //! Layout air uses [`Spacer`] so F2 space overlay paints token bands.
 //! Right-click: file menu (same intents as tree/recents; always **Unpin**).
 
-use egui::{Id, Ui, pos2, vec2};
+use egui::{FontFamily, FontId, Id, Ui, pos2, vec2};
 use lb::Uuid;
 use workspace_rs::file_cache::FilesExt;
 
@@ -91,15 +91,20 @@ pub fn show(
                 let n = row_count.max(1) as f32;
                 n * ch + (row_count.saturating_sub(1) as f32) * EqualCells::gap_pts()
             };
-            let pins_h = 14.0 + Space::Sm.pts() + grid_h;
+            let head_h = TypeRole::Body.line_height();
+            let pins_h = head_h + Space::Sm.pts() + grid_h;
             let mut pins_body = FixedPadContent::new(pins_h, |ui| {
                 ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
 
+                // Same type as Recents “Today” / Shared sharer section labels.
                 ui.label(
                     TypeRole::Body
                         .rich("Pinned")
-                        .color(t.neutral_fg_secondary())
-                        .size(11.0),
+                        .font(FontId::new(
+                            TypeRole::Body.size(),
+                            FontFamily::Name(std::sync::Arc::from("Bold")),
+                        ))
+                        .color(t.neutral_fg_secondary()),
                 );
                 ui.add(Spacer::new(Space::Sm));
 

--- a/clients/desktop/src/components/domain/tree/mod.rs
+++ b/clients/desktop/src/components/domain/tree/mod.rs
@@ -633,6 +633,11 @@ pub fn show_tree(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<Act
     };
     let flat = app.tree_walk.flat.clone();
 
+    if flat.is_empty() {
+        empty_state(ui, t, "No files");
+        return;
+    }
+
     if let Some(ready) = app.session.ready() {
         let files = ready.workspace.files.read().unwrap();
         app.sync_dots

--- a/clients/desktop/src/components/domain/tree/recents.rs
+++ b/clients/desktop/src/components/domain/tree/recents.rs
@@ -4,6 +4,7 @@ use egui::{Id, Rect, ScrollArea, Sense, Ui, pos2, vec2};
 use lb::Uuid;
 use workspace_rs::file_cache::FilesExt;
 
+use crate::components::domain::pins;
 use crate::components::{
     FileRow, LIST_PAD, SECTION_GAP, SECTION_HEAD_GAP, Theme, TypeRole, context_menu,
     paint_list_section, phosphor, with_overlay_scroll,
@@ -20,6 +21,13 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
     if app.session.ready().is_none() {
         return;
     }
+
+    if let Some(ready) = app.session.ready() {
+        let pins = ready.pinned.clone();
+        let files = ready.workspace.files.read().unwrap();
+        pins::show(ui, t, &*files, &pins, &ready.workspace.account.username, queue);
+    }
+
     // Clone row ids/meta once; paint path is virtualized (was full-list every frame).
     let docs = app.recents_cache.rows.clone();
 

--- a/clients/desktop/src/components/domain/tree/shared.rs
+++ b/clients/desktop/src/components/domain/tree/shared.rs
@@ -33,7 +33,7 @@ pub fn show_shared(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<A
     let pending = app.shared_cache.pending.clone();
 
     if pending.is_empty() {
-        empty_state(ui, t, "Nothing shared with you yet");
+        empty_state(ui, t, "Nothing shared with you");
         return;
     }
 

--- a/clients/desktop/src/components/mod.rs
+++ b/clients/desktop/src/components/mod.rs
@@ -34,7 +34,7 @@ pub use atoms::{
 };
 
 pub use compounds::{
-    LIST_PAD, SECTION_GAP, SECTION_HEAD_GAP, SheetFooterOpts, fixed_height_list, footnote,
+    LIST_PAD, SECTION_GAP, SECTION_HEAD_GAP, SheetFooterOpts, ack_row, fixed_height_list, footnote,
     form_group, form_picker, form_row, form_row_detail, form_segmented, form_toggle,
     form_toggle_detail, form_value, paint_list_section, section_label, sheet_band,
     sheet_band_centered, sheet_dim, sheet_equal_row, sheet_footer, sheet_panel_fit,

--- a/clients/desktop/src/components/mod.rs
+++ b/clients/desktop/src/components/mod.rs
@@ -30,7 +30,7 @@ pub use atoms::{
     Button, Chip, ChipHue, EqualCells, Field, FileRow, NavItem, PersonRow, PersonTone,
     QuietChipAlign, QuietChipLabel, icon_button, icon_button_glyph, icon_button_hit,
     measure_file_name, paint_file_name, person_row_height, quiet_chip, quiet_chip_height,
-    quiet_chip_labeled_min_width, segmented, segmented_h, segmented_width,
+    quiet_chip_labeled_min_width, segmented, segmented_h,
 };
 
 pub use compounds::{

--- a/clients/desktop/src/host.rs
+++ b/clients/desktop/src/host.rs
@@ -157,6 +157,11 @@ impl ApplicationHandler<UserEvent> for App {
 
         match event {
             WindowEvent::CloseRequested => {
+                // Native file dialogs (NSOpenPanel) synthesize a window-close on
+                // cancel. Ignore it while a picker is in flight.
+                if crate::shell::native_file_dialog_open() {
+                    return;
+                }
                 state.close_requested = true;
                 state.window.request_redraw();
             }

--- a/clients/desktop/src/shell/action.rs
+++ b/clients/desktop/src/shell/action.rs
@@ -352,7 +352,7 @@ pub enum Action {
     OnboardSetMode(OnboardMode),
     /// Debounced create-username availability (share-style network verify).
     OnboardVerifyUname,
-    /// `show_error`: false for auto-submit (silent fail until the secret changes).
+    /// `show_error`: false for auto-submit (silent fail; Import button surfaces).
     OnboardSubmit {
         show_error: bool,
     },

--- a/clients/desktop/src/shell/action.rs
+++ b/clients/desktop/src/shell/action.rs
@@ -182,6 +182,8 @@ pub enum Modal {
         api_url: String,
         busy: bool,
         err: Option<String>,
+        /// Backup step: user confirmed they stored the key.
+        key_stored: bool,
     },
 }
 
@@ -191,6 +193,8 @@ pub enum OnboardMode {
     Choice,
     Create,
     Import,
+    /// After create: show the 24-word key and require a backup ack.
+    Backup,
 }
 
 /// Stripe upgrade sheet stages.
@@ -356,6 +360,8 @@ pub enum Action {
     OnboardSubmit {
         show_error: bool,
     },
+    /// Backup step finished (key ack). Dismisses onboard.
+    OnboardFinishBackup,
     RequestSync,
     TogglePin(Uuid),
     /// Toggle pin on each id (own state).
@@ -483,6 +489,7 @@ impl Action {
             Self::OnboardSetMode(_) => "OnboardSetMode",
             Self::OnboardVerifyUname => "OnboardVerifyUname",
             Self::OnboardSubmit { .. } => "OnboardSubmit",
+            Self::OnboardFinishBackup => "OnboardFinishBackup",
             Self::RequestSync => "RequestSync",
             Self::TogglePin(_) => "TogglePin",
             Self::TogglePinMany(_) => "TogglePinMany",

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -475,6 +475,9 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
         }
         A::OpenHelp => app.modal = Some(Modal::Help),
         A::OnboardSetMode(m) => {
+            if matches!(&app.modal, Some(Modal::Onboard { mode: OnboardMode::Backup, .. })) {
+                return;
+            }
             if let Some(Modal::Onboard { mode, err, uname_lookup, uname_lookup_for, .. }) =
                 &mut app.modal
             {
@@ -495,11 +498,25 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                 OnboardMode::Import => {
                     onboard_import_focus(ctx);
                 }
-                OnboardMode::Choice => {}
+                OnboardMode::Choice | OnboardMode::Backup => {}
             }
         }
         A::OnboardVerifyUname => onboard_verify_uname(app, ctx),
         A::OnboardSubmit { show_error } => onboard_submit(app, ctx, show_error),
+        A::OnboardFinishBackup => {
+            let stored = matches!(
+                &app.modal,
+                Some(Modal::Onboard { mode: OnboardMode::Backup, key_stored: true, .. })
+            );
+            let phrase_ok = app
+                .phrase_cache
+                .as_deref()
+                .is_some_and(|p| p.split_whitespace().count() == 24);
+            if stored && phrase_ok {
+                app.modal = None;
+                app.phrase_cache = None;
+            }
+        }
         A::RequestSync => request_sync(app, ctx),
         A::TogglePin(id) => toggle_pins(app, &[id]),
         A::TogglePinMany(ids) => toggle_pins(app, &ids),

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -8,10 +8,13 @@ use super::apply_share::*;
 pub(crate) use super::apply_share::{share_poll_network, share_shortest_prefix_match};
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::thread;
 
 use egui::Context;
 use lb::Uuid;
+use lb::model::file::File;
 use lb::model::file_metadata::FileType;
 use rfd::FileDialog;
 use workspace_rs::file_cache::FilesExt;
@@ -511,7 +514,7 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
             }
         }
         A::Duplicate(ids) => duplicate_files(app, &ids),
-        A::Export(ids) => export_files(app, &ids),
+        A::Export(ids) => export_files(app, ctx, &ids),
         A::CopyLink(id) => {
             if let Some(r) = app.session.ready() {
                 if let Ok(url) = r.workspace.core.get_file_link_url(id) {
@@ -1135,7 +1138,66 @@ fn expand_or_collapse(app: &mut ShellApp, id: Uuid, expand: bool) {
     }
 }
 
-fn export_files(app: &mut ShellApp, ids: &[Uuid]) {
+/// Result of a system file/folder picker that ran off the UI thread.
+pub(crate) enum NativeDialogResult {
+    Import(Option<Vec<PathBuf>>),
+    Export { files: Vec<File>, dest: Option<PathBuf> },
+}
+
+/// NSOpenPanel's nested modal often synthesizes `CloseRequested` on cancel.
+/// Host ignores window-close while this is set; cleared when the result is polled.
+static NATIVE_FILE_DIALOG: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn native_file_dialog_open() -> bool {
+    NATIVE_FILE_DIALOG.load(Ordering::SeqCst)
+}
+
+/// Poll a finished system picker. Cancel (`None`) is a no-op.
+pub(crate) fn poll_native_dialog(app: &mut ShellApp, ctx: &Context) {
+    let Some(rx) = &app.native_dialog_rx else {
+        return;
+    };
+    let result = match rx.try_recv() {
+        Ok(r) => r,
+        Err(mpsc::TryRecvError::Empty) => return,
+        Err(mpsc::TryRecvError::Disconnected) => {
+            app.native_dialog_rx = None;
+            NATIVE_FILE_DIALOG.store(false, Ordering::SeqCst);
+            return;
+        }
+    };
+    app.native_dialog_rx = None;
+    NATIVE_FILE_DIALOG.store(false, Ordering::SeqCst);
+    match result {
+        NativeDialogResult::Import(Some(paths)) if !paths.is_empty() => {
+            open_import_parent_sheet(app, ctx, paths);
+        }
+        NativeDialogResult::Export { files, dest: Some(dest) } => {
+            finish_export(app, files, dest);
+        }
+        _ => {}
+    }
+}
+
+fn spawn_native_dialog(
+    app: &mut ShellApp, ctx: &Context, work: impl FnOnce() -> NativeDialogResult + Send + 'static,
+) {
+    if app.native_dialog_rx.is_some() {
+        return;
+    }
+    let (tx, rx) = mpsc::channel();
+    app.native_dialog_rx = Some(rx);
+    let ctx = ctx.clone();
+    // Set on the UI thread so a cancel-close during thread start is ignored.
+    NATIVE_FILE_DIALOG.store(true, Ordering::SeqCst);
+    thread::spawn(move || {
+        let result = work();
+        let _ = tx.send(result);
+        ctx.request_repaint();
+    });
+}
+
+fn export_files(app: &mut ShellApp, ctx: &Context, ids: &[Uuid]) {
     if ids.is_empty() {
         return;
     }
@@ -1151,7 +1213,14 @@ fn export_files(app: &mut ShellApp, ids: &[Uuid]) {
     if files.is_empty() {
         return;
     }
-    let Some(dest) = FileDialog::new().pick_folder() else {
+    spawn_native_dialog(app, ctx, move || NativeDialogResult::Export {
+        files,
+        dest: FileDialog::new().pick_folder(),
+    });
+}
+
+fn finish_export(app: &mut ShellApp, files: Vec<File>, dest: PathBuf) {
+    let Some(r) = app.session.ready() else {
         return;
     };
     let core = r.workspace.core.clone();
@@ -1179,14 +1248,9 @@ fn export_files(app: &mut ShellApp, ids: &[Uuid]) {
 }
 
 fn import_pick(app: &mut ShellApp, ctx: &Context) {
-    // Sidebar Import chip: system file picker → same destination sheet as drop.
-    let Some(paths) = FileDialog::new().pick_files() else {
-        return;
-    };
-    if paths.is_empty() {
-        return;
-    }
-    open_import_parent_sheet(app, ctx, paths);
+    // Off-thread: blocking NSOpenPanel inside the egui/wgpu frame crashes/quits
+    // on cancel (spurious window-close). Same pattern as the old linux client.
+    spawn_native_dialog(app, ctx, || NativeDialogResult::Import(FileDialog::new().pick_files()));
 }
 
 /// Open the Import folder-picker sheet. Seeds `dest` from the open tab's folder

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -399,6 +399,16 @@ pub fn apply(app: &mut ShellApp, ctx: &Context, action: A) {
                     return;
                 }
                 if let Some(r) = app.session.ready_mut() {
+                    let unchanged = r
+                        .workspace
+                        .files
+                        .read()
+                        .unwrap()
+                        .get_by_id(id)
+                        .is_some_and(|f| f.name == full);
+                    if unchanged {
+                        return;
+                    }
                     if rename_name_taken(r, id, &full) {
                         app.toasts.error("A file with that name already exists");
                         return;
@@ -908,19 +918,8 @@ pub(crate) fn rename_live_status(
     app: &ShellApp, id: Uuid, stem: &str, ext: Option<&str>,
 ) -> RenameLive {
     let full = rename_join_name(stem, ext);
-    let original = app.session.ready().and_then(|r| {
-        r.workspace
-            .files
-            .read()
-            .unwrap()
-            .get_by_id(id)
-            .map(|f| f.name.clone())
-    });
     if let Err(msg) = rename_validate_name(&full) {
         return RenameLive { error: Some(msg), can_commit: false };
-    }
-    if original.as_deref() == Some(full.as_str()) {
-        return RenameLive { error: None, can_commit: false };
     }
     if let Some(r) = app.session.ready() {
         if rename_name_taken(r, id, &full) {

--- a/clients/desktop/src/shell/apply_onboard.rs
+++ b/clients/desktop/src/shell/apply_onboard.rs
@@ -9,7 +9,7 @@ use workspace_rs::file_cache::FileCache;
 use super::ShellApp;
 use super::action::{Modal, OnboardLookup, OnboardMode};
 use super::apply_share::spawn_username_exists;
-use super::session::Session;
+use super::session::{self, CoreLoad, OnboardFail, Session};
 
 /// Seed the onboard URL field: `API_URL` when it isn’t the hosted default.
 pub(crate) fn initial_api_url() -> String {
@@ -48,13 +48,19 @@ pub(crate) fn uname_check_matches_core(api_url: &str) -> bool {
 }
 
 pub(crate) fn onboard_modal(mode: OnboardMode, err: Option<String>) -> Modal {
+    onboard_form(mode, String::new(), String::new(), initial_api_url(), err)
+}
+
+pub(crate) fn onboard_form(
+    mode: OnboardMode, uname: String, account_key: String, api_url: String, err: Option<String>,
+) -> Modal {
     Modal::Onboard {
         mode,
-        uname: String::new(),
+        uname,
         uname_lookup: OnboardLookup::Idle,
         uname_lookup_for: String::new(),
-        account_key: String::new(),
-        api_url: initial_api_url(),
+        account_key,
+        api_url,
         busy: false,
         err,
     }
@@ -197,13 +203,62 @@ pub(crate) fn onboard_verify_uname(app: &mut ShellApp, ctx: &Context) {
     });
 }
 
-/// Flatten paste (newlines / extra spaces) so both compact keys and phrases work.
+/// Flatten paste so both compact keys and phrases work.
+///
+/// 24 tokens → phrase (spaces kept). Otherwise drop whitespace so a wrapped
+/// compact key still base64-decodes.
 fn onboard_import_secret(account_key: &str) -> String {
-    account_key.split_whitespace().collect::<Vec<_>>().join(" ")
+    let words: Vec<&str> = account_key.split_whitespace().collect();
+    if words.len() == 24 { words.join(" ") } else { words.concat() }
+}
+
+pub(crate) enum AutoOnboard {
+    Ready {
+        core: lb::blocking::Lb,
+        files: FileCache,
+        sub_info: Option<lb::model::api::SubscriptionInfo>,
+    },
+    Failed,
+}
+
+/// Apply a finished auto-import. Failures are silent — the form stays put.
+pub(crate) fn poll_auto_import(app: &mut ShellApp, ctx: &Context) {
+    let Some(rx) = &app.onboard_auto_rx else {
+        return;
+    };
+    let result = match rx.try_recv() {
+        Ok(r) => r,
+        Err(mpsc::TryRecvError::Empty) => return,
+        Err(mpsc::TryRecvError::Disconnected) => {
+            app.onboard_auto_rx = None;
+            if let Some(Modal::Onboard { busy, .. }) = &mut app.modal {
+                *busy = false;
+            }
+            return;
+        }
+    };
+    app.onboard_auto_rx = None;
+    match result {
+        AutoOnboard::Ready { core, files, sub_info } => {
+            app.modal = None;
+            app.lb_rx = None;
+            app.recents_cache = Default::default();
+            app.shared_cache = Default::default();
+            app.session = Session::Ready(Box::new(session::Ready::new(core, files, ctx, sub_info)));
+        }
+        AutoOnboard::Failed => {
+            if let Some(Modal::Onboard { busy, .. }) = &mut app.modal {
+                *busy = false;
+            }
+        }
+    }
 }
 
 pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool) {
-    let (mode, uname, import_secret, lookup_ok, api) = match &app.modal {
+    if app.onboard_auto_rx.is_some() {
+        return;
+    }
+    let (mode, uname, account_key, import_secret, lookup_ok, api, api_url) = match &app.modal {
         Some(Modal::Onboard {
             mode,
             uname,
@@ -219,14 +274,15 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
             (
                 *mode,
                 uname.clone(),
+                account_key.clone(),
                 onboard_import_secret(account_key),
                 lookup_ok,
                 resolved_api_url(api_url),
+                api_url.clone(),
             )
         }
         _ => return,
     };
-
     // Cheap validation stays on the UI thread so errors stay on the form.
     let local_err: Option<String> = match mode {
         OnboardMode::Create => {
@@ -260,6 +316,52 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
         return;
     }
 
+    // Auto-import: try on every change. Failures are silent until Import.
+    if !show_error {
+        if mode != OnboardMode::Import {
+            return;
+        }
+        let Some(core) = app.session.signed_out_core().cloned() else {
+            return;
+        };
+        if let Some(Modal::Onboard { busy, err, .. }) = &mut app.modal {
+            *busy = true;
+            *err = None;
+        }
+        let (tx, rx) = mpsc::channel();
+        app.onboard_auto_rx = Some(rx);
+        let ctx = ctx.clone();
+        thread::spawn(move || {
+            match onboard_account(&core, mode, &uname, &import_secret, &api) {
+                Ok(()) => {
+                    // Import already wrote the account. Open even if sync fails
+                    // so we don't leave a signed-in core on the import form.
+                    let load = match onboard_sync_and_cache(core, None, &ctx) {
+                        Ok(CoreLoad::Ready { core, files, sub_info }) => {
+                            AutoOnboard::Ready { core, files, sub_info }
+                        }
+                        Ok(_) => AutoOnboard::Failed,
+                        Err((core, _)) => match FileCache::new(&core) {
+                            Ok(files) => {
+                                let sub_info = core.get_subscription_info().ok().flatten();
+                                AutoOnboard::Ready { core, files, sub_info }
+                            }
+                            Err(_) => AutoOnboard::Failed,
+                        },
+                    };
+                    let _ = tx.send(load);
+                }
+                Err(_) => {
+                    let _ = tx.send(AutoOnboard::Failed);
+                }
+            }
+            ctx.request_repaint();
+        });
+        return;
+    }
+
+    let fail = OnboardFail { err: String::new(), mode, uname: uname.clone(), account_key, api_url };
+
     // Take the live `Lb` off the session and finish create/import + initial
     let core = match std::mem::replace(
         &mut app.session,
@@ -288,68 +390,72 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
 
     let ctx = ctx.clone();
     thread::spawn(move || {
-        use super::session::{CoreLoad, set_load_status};
-
-        let account_res = match mode {
-            OnboardMode::Create => {
-                set_load_status(&status, "Creating account…");
-                ctx.request_repaint();
-                core.create_account(uname.trim(), &api, true)
-                    .map(|_| ())
-                    .map_err(|e| format!("{e:?}"))
-            }
-            OnboardMode::Import => {
-                set_load_status(&status, "Importing account…");
-                ctx.request_repaint();
-                core.import_account(&import_secret, Some(&api))
-                    .map(|_| ())
-                    .map_err(|e| format!("{e:?}"))
-            }
-            OnboardMode::Choice => Err("Pick Create or Import".into()),
-        };
-
-        if let Err(e) = account_res {
-            let _ = tx.send(CoreLoad::OnboardFailed { core, err: e });
+        if let Err(e) = onboard_account(&core, mode, &uname, &import_secret, &api) {
+            let _ = tx.send(CoreLoad::OnboardFailed { core, fail: OnboardFail { err: e, ..fail } });
             ctx.request_repaint();
             return;
         }
-
-        set_load_status(&status, "Syncing your files…");
-        ctx.request_repaint();
-        // Preview spinner: `LOCKBOOK_SLOW_SYNC_MS=4000 cargo run -p lockbook-desktop`
-        if let Ok(ms) = std::env::var("LOCKBOOK_SLOW_SYNC_MS") {
-            if let Ok(ms) = ms.parse::<u64>() {
-                if ms > 0 {
-                    std::thread::sleep(std::time::Duration::from_millis(ms));
-                }
+        match onboard_sync_and_cache(core, Some(&status), &ctx) {
+            Ok(load) => {
+                let _ = tx.send(load);
             }
-        }
-        if let Err(e) = core.sync() {
-            let _ = tx.send(CoreLoad::OnboardFailed { core, err: format!("Sync failed: {e:?}") });
-            ctx.request_repaint();
-            return;
-        }
-
-        set_load_status(&status, "Opening workspace…");
-        ctx.request_repaint();
-        match FileCache::new(&core) {
-            Ok(files) => {
-                let _ = tx.send(super::session::prepare_ready(core, files));
-            }
-            Err(e) => {
-                let _ = tx.send(CoreLoad::OnboardFailed {
-                    core,
-                    err: format!("Couldn’t load files: {e:?}"),
-                });
+            Err((core, err)) => {
+                let _ =
+                    tx.send(CoreLoad::OnboardFailed { core, fail: OnboardFail { err, ..fail } });
             }
         }
         ctx.request_repaint();
     });
 }
 
+fn onboard_account(
+    core: &lb::blocking::Lb, mode: OnboardMode, uname: &str, import_secret: &str, api: &str,
+) -> Result<(), String> {
+    match mode {
+        OnboardMode::Create => core
+            .create_account(uname.trim(), api, true)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        OnboardMode::Import => core
+            .import_account(import_secret, Some(api))
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        OnboardMode::Choice => Err("Pick Create or Import".into()),
+    }
+}
+
+fn onboard_sync_and_cache(
+    core: lb::blocking::Lb, status: Option<&session::LoadStatus>, ctx: &Context,
+) -> Result<CoreLoad, (lb::blocking::Lb, String)> {
+    use super::session::set_load_status;
+    if let Some(status) = status {
+        set_load_status(status, "Syncing your files…");
+        ctx.request_repaint();
+    }
+    // Preview spinner: `LOCKBOOK_SLOW_SYNC_MS=4000 cargo run -p lockbook-desktop`
+    if let Ok(ms) = std::env::var("LOCKBOOK_SLOW_SYNC_MS") {
+        if let Ok(ms) = ms.parse::<u64>() {
+            if ms > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(ms));
+            }
+        }
+    }
+    if let Err(e) = core.sync() {
+        return Err((core, format!("Sync failed: {e}")));
+    }
+    if let Some(status) = status {
+        set_load_status(status, "Opening workspace…");
+        ctx.request_repaint();
+    }
+    match FileCache::new(&core) {
+        Ok(files) => Ok(session::prepare_ready(core, files)),
+        Err(e) => Err((core, format!("Couldn’t load files: {e}"))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{display_server_host, resolved_api_url};
+    use super::{display_server_host, onboard_import_secret, resolved_api_url};
 
     #[test]
     fn empty_url_is_hosted_default() {
@@ -358,5 +464,16 @@ mod tests {
         assert_eq!(resolved_api_url("http://localhost:8000"), "http://localhost:8000");
         assert_eq!(display_server_host(""), "app.lockbook.net");
         assert_eq!(display_server_host("http://localhost:8000"), "localhost:8000");
+    }
+
+    #[test]
+    fn import_secret_phrase_keeps_spaces_compact_strips() {
+        let phrase = (0..24)
+            .map(|i| format!("w{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert_eq!(onboard_import_secret(&phrase), phrase);
+        assert_eq!(onboard_import_secret("abcd\n efgh"), "abcdefgh");
+        assert_eq!(onboard_import_secret("  abcd  "), "abcd");
     }
 }

--- a/clients/desktop/src/shell/apply_onboard.rs
+++ b/clients/desktop/src/shell/apply_onboard.rs
@@ -63,6 +63,7 @@ pub(crate) fn onboard_form(
         api_url,
         busy: false,
         err,
+        key_stored: false,
     }
 }
 
@@ -283,6 +284,10 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
         }
         _ => return,
     };
+    if mode == OnboardMode::Backup {
+        return;
+    }
+
     // Cheap validation stays on the UI thread so errors stay on the form.
     let local_err: Option<String> = match mode {
         OnboardMode::Create => {
@@ -303,6 +308,7 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
             }
         }
         OnboardMode::Choice => Some("Pick Create or Import".into()),
+        OnboardMode::Backup => None,
     };
     if let Some(e) = local_err {
         if let Some(Modal::Onboard { busy, err, .. }) = &mut app.modal {
@@ -375,11 +381,15 @@ pub(crate) fn onboard_submit(app: &mut ShellApp, ctx: &Context, show_error: bool
         }
     };
 
+    if mode == OnboardMode::Create {
+        app.onboard_backup_pending = true;
+    }
+
     let (tx, rx) = mpsc::channel();
     let status = super::session::load_status(match mode {
         OnboardMode::Create => "Creating account…",
         OnboardMode::Import => "Importing account…",
-        OnboardMode::Choice => "Signing in…",
+        OnboardMode::Choice | OnboardMode::Backup => "Signing in…",
     });
     app.lb_rx = None;
     app.modal = None;
@@ -420,7 +430,7 @@ fn onboard_account(
             .import_account(import_secret, Some(api))
             .map(|_| ())
             .map_err(|e| e.to_string()),
-        OnboardMode::Choice => Err("Pick Create or Import".into()),
+        OnboardMode::Choice | OnboardMode::Backup => Err("Pick Create or Import".into()),
     }
 }
 

--- a/clients/desktop/src/shell/mod.rs
+++ b/clients/desktop/src/shell/mod.rs
@@ -111,6 +111,8 @@ pub struct ShellApp {
     pub(crate) native_dialog_rx: Option<mpsc::Receiver<apply::NativeDialogResult>>,
     /// Auto-import worker (paste / complete key). Failures do not surface.
     pub(crate) onboard_auto_rx: Option<mpsc::Receiver<apply_onboard::AutoOnboard>>,
+    /// After a successful create, show the account-key backup sheet.
+    pub(crate) onboard_backup_pending: bool,
 }
 
 /// Dev harness: bounce Ready ↔ SignedOut without clicking UI.
@@ -177,6 +179,7 @@ impl Default for ShellApp {
             toasts: ToastHost::default(),
             native_dialog_rx: None,
             onboard_auto_rx: None,
+            onboard_backup_pending: false,
         }
     }
 }
@@ -194,8 +197,21 @@ impl ShellApp {
             .unwrap_or(false)
     }
 
+    fn showing_backup(&self) -> bool {
+        matches!(&self.modal, Some(Modal::Onboard { mode: action::OnboardMode::Backup, .. }))
+    }
+
+    /// Sidebar, editor, pane toggles. Hidden while the post-create key backup
+    /// sheet is up — that step is still onboard, not the signed-in app.
+    pub(crate) fn product_open(&self) -> bool {
+        matches!(self.session, Session::Ready(_)) && !self.showing_backup()
+    }
+
     /// Auto logout / re-import loop for crash hunting (`LOCKBOOK_SESSION_STRESS=1`).
     fn session_stress_tick(&mut self, ctx: &egui::Context) {
+        if self.showing_backup() {
+            return;
+        }
         let Some(stress) = self.session_stress.as_mut() else {
             return;
         };
@@ -279,6 +295,7 @@ impl ShellApp {
         }
         if let Some(fail) = self.session.poll(ctx) {
             // Manual sign-in failed; restore the form with the error.
+            self.onboard_backup_pending = false;
             let mode = fail.mode;
             self.modal = Some(apply_onboard::onboard_form(
                 fail.mode,
@@ -291,6 +308,21 @@ impl ShellApp {
                 apply_onboard::onboard_import_focus(ctx);
             }
         }
+        if self.onboard_backup_pending && matches!(self.session, Session::Ready(_)) {
+            self.onboard_backup_pending = false;
+            if let Some(r) = self.session.ready() {
+                if let Ok(p) = r.workspace.core.export_account_phrase() {
+                    self.phrase_cache = Some(p);
+                }
+            }
+            self.modal = Some(apply_onboard::onboard_form(
+                action::OnboardMode::Backup,
+                String::new(),
+                String::new(),
+                apply_onboard::initial_api_url(),
+                None,
+            ));
+        }
         apply_onboard::poll_auto_import(self, ctx);
         apply::poll_native_dialog(self, ctx);
         if let Session::Ready(r) = &self.session {
@@ -300,7 +332,9 @@ impl ShellApp {
         }
         self.drain_events();
         self.process_keys(ctx);
-        self.process_drops(ctx);
+        if self.product_open() {
+            self.process_drops(ctx);
+        }
 
         // Close window: save workspace tabs
         if ctx.input(|i| i.viewport().close_requested()) {
@@ -355,8 +389,7 @@ impl ShellApp {
             sheets::show_modals(self, ctx, &t, &mut queue);
         }
 
-        let show_side =
-            matches!(self.session, Session::Ready(_)) && self.sidebar_open && !self.defaults_zen();
+        let show_side = self.product_open() && self.sidebar_open && !self.defaults_zen();
 
         // One SidePanel: slide its contents (right edge glued to visible width).
         // Resting width is stored separately so the wipe does not persist 1px.
@@ -401,9 +434,9 @@ impl ShellApp {
         CentralPanel::default()
             .frame(Frame::new().fill(t.neutral_bg()).inner_margin(0.0))
             .show(ctx, |ui| {
-                if matches!(self.session, Session::Ready(_)) {
+                if self.product_open() {
                     editor::show(self, ui, &t, &mut queue);
-                } else {
+                } else if !self.showing_backup() {
                     ui.centered_and_justified(|ui| {
                         ui.label(
                             TypeRole::Body
@@ -568,7 +601,7 @@ impl ShellApp {
                     _ => Some(A::HideAccountKey),
                 },
                 Some(Modal::Onboard { mode, .. }) => match mode {
-                    action::OnboardMode::Choice => None,
+                    action::OnboardMode::Choice | action::OnboardMode::Backup => None,
                     _ => Some(A::OnboardSetMode(action::OnboardMode::Choice)),
                 },
                 Some(_) => Some(A::CloseModal),
@@ -607,7 +640,7 @@ impl ShellApp {
             }
         }
 
-        if matches!(self.session, Session::Ready(_)) {
+        if self.product_open() {
             // Help / Settings toggle even while open (same shortcut again closes).
             // Nested sheets over Settings (QR, upgrade, …) leave these alone.
             if ctx.input_mut(|i| i.consume_key(CMD, egui::Key::Slash)) {
@@ -626,7 +659,7 @@ impl ShellApp {
             }
         }
 
-        if self.modal.is_none() && matches!(self.session, Session::Ready(_)) {
+        if self.modal.is_none() && self.product_open() {
             // Global chrome shortcuts — safe while editing.
             if ctx.input_mut(|i| i.consume_key(CMD, egui::Key::N)) {
                 self.queue.push(A::Create);
@@ -743,10 +776,20 @@ impl ShellApp {
                             _ => {}
                         },
                         Modal::ImportParent { .. } => self.queue.push(A::ConfirmImportParent),
-                        Modal::Onboard { mode, .. } => match mode {
+                        Modal::Onboard { mode, key_stored, .. } => match mode {
                             action::OnboardMode::Create | action::OnboardMode::Import => {
                                 self.queue.push(A::OnboardSubmit { show_error: true })
                             }
+                            action::OnboardMode::Backup
+                                if *key_stored
+                                    && self
+                                        .phrase_cache
+                                        .as_deref()
+                                        .is_some_and(|p| p.split_whitespace().count() == 24) =>
+                            {
+                                self.queue.push(A::OnboardFinishBackup)
+                            }
+                            action::OnboardMode::Backup => {}
                             action::OnboardMode::Choice => {
                                 if ctx.data(|d| {
                                     d.get_temp::<bool>(apply_onboard::onboard_server_editing_key())

--- a/clients/desktop/src/shell/mod.rs
+++ b/clients/desktop/src/shell/mod.rs
@@ -109,6 +109,8 @@ pub struct ShellApp {
     pub toasts: ToastHost,
     /// In-flight system file/folder picker (import / export).
     pub(crate) native_dialog_rx: Option<mpsc::Receiver<apply::NativeDialogResult>>,
+    /// Auto-import worker (paste / complete key). Failures do not surface.
+    pub(crate) onboard_auto_rx: Option<mpsc::Receiver<apply_onboard::AutoOnboard>>,
 }
 
 /// Dev harness: bounce Ready ↔ SignedOut without clicking UI.
@@ -174,6 +176,7 @@ impl Default for ShellApp {
             }),
             toasts: ToastHost::default(),
             native_dialog_rx: None,
+            onboard_auto_rx: None,
         }
     }
 }
@@ -274,10 +277,21 @@ impl ShellApp {
         if matches!(&self.session, Session::Error(s) if s == "not started") {
             self.session = Session::start(ctx);
         }
-        if let Some(err) = self.session.poll(ctx) {
-            // Sign-in worker failed; session is SignedOut again — show onboard error.
-            self.modal = Some(apply_onboard::onboard_modal(action::OnboardMode::Import, Some(err)));
+        if let Some(fail) = self.session.poll(ctx) {
+            // Manual sign-in failed; restore the form with the error.
+            let mode = fail.mode;
+            self.modal = Some(apply_onboard::onboard_form(
+                fail.mode,
+                fail.uname,
+                fail.account_key,
+                fail.api_url,
+                Some(fail.err),
+            ));
+            if mode == action::OnboardMode::Import {
+                apply_onboard::onboard_import_focus(ctx);
+            }
         }
+        apply_onboard::poll_auto_import(self, ctx);
         apply::poll_native_dialog(self, ctx);
         if let Session::Ready(r) = &self.session {
             if self.lb_rx.is_none() {

--- a/clients/desktop/src/shell/mod.rs
+++ b/clients/desktop/src/shell/mod.rs
@@ -26,6 +26,7 @@ pub mod titlebar;
 pub mod toasts;
 
 pub use action::{Modal, SidebarPane};
+pub(crate) use apply::native_file_dialog_open;
 
 // Domain surfaces live in the component library; re-export for shell-local paths.
 pub use crate::components::domain::{footer, sync_dots, tabs, tree};
@@ -33,6 +34,7 @@ pub use crate::components::domain::{footer, sync_dots, tabs, tree};
 // OnboardMode / SettingsCat / Ready are used via module paths; re-export only what
 // other crates/bin need from `shell::`.
 
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
 use egui::{Area, CentralPanel, Frame, Id, Order, SidePanel};
@@ -105,6 +107,8 @@ pub struct ShellApp {
     session_stress: Option<SessionStress>,
     /// Transient errors / short notices (import, rename, workspace failures).
     pub toasts: ToastHost,
+    /// In-flight system file/folder picker (import / export).
+    pub(crate) native_dialog_rx: Option<mpsc::Receiver<apply::NativeDialogResult>>,
 }
 
 /// Dev harness: bounce Ready ↔ SignedOut without clicking UI.
@@ -169,6 +173,7 @@ impl Default for ShellApp {
                 last_kind: StressKind::Loading,
             }),
             toasts: ToastHost::default(),
+            native_dialog_rx: None,
         }
     }
 }
@@ -273,6 +278,7 @@ impl ShellApp {
             // Sign-in worker failed; session is SignedOut again — show onboard error.
             self.modal = Some(apply_onboard::onboard_modal(action::OnboardMode::Import, Some(err)));
         }
+        apply::poll_native_dialog(self, ctx);
         if let Session::Ready(r) = &self.session {
             if self.lb_rx.is_none() {
                 self.lb_rx = Some(r.workspace.core.subscribe());

--- a/clients/desktop/src/shell/session.rs
+++ b/clients/desktop/src/shell/session.rs
@@ -31,6 +31,8 @@ use lb::subscribers::status::Status;
 use workspace_rs::file_cache::FileCache;
 use workspace_rs::workspace::Workspace;
 
+use super::action::OnboardMode;
+
 pub enum CoreLoad {
     Ready {
         core: Lb,
@@ -43,9 +45,18 @@ pub enum CoreLoad {
     /// Create/import/sync failed — keep `core` for retry (may already hold keys).
     OnboardFailed {
         core: Lb,
-        err: String,
+        fail: OnboardFail,
     },
     Failed(String),
+}
+
+/// Form to restore after a **manual** onboard failure (errors stay on the sheet).
+pub struct OnboardFail {
+    pub err: String,
+    pub mode: OnboardMode,
+    pub uname: String,
+    pub account_key: String,
+    pub api_url: String,
 }
 
 /// Shared boot status for [`Session::Loading`] (worker may update mid-flight).
@@ -287,9 +298,9 @@ impl Session {
         Self::Loading { kind: LoadKind::Cold, status: load_status(""), rx }
     }
 
-    /// Poll a background load. Returns an onboard error string when sign-in
+    /// Poll a background load. Returns form state when a **manual** sign-in
     /// failed but we still have a usable `SignedOut` core to retry with.
-    pub fn poll(&mut self, ctx: &Context) -> Option<String> {
+    pub fn poll(&mut self, ctx: &Context) -> Option<OnboardFail> {
         let Session::Loading { rx, .. } = self else {
             return None;
         };
@@ -303,9 +314,9 @@ impl Session {
                 *self = Session::SignedOut { core };
                 None
             }
-            CoreLoad::OnboardFailed { core, err } => {
+            CoreLoad::OnboardFailed { core, fail } => {
                 *self = Session::SignedOut { core };
-                Some(err)
+                Some(fail)
             }
             CoreLoad::Failed(e) => {
                 *self = Session::Error(e);

--- a/clients/desktop/src/shell/settings_account.rs
+++ b/clients/desktop/src/shell/settings_account.rs
@@ -1,12 +1,11 @@
 //! Settings → Account (key, plan, Stripe, QR, logout / delete).
 
-use egui::{Id, Stroke, Ui};
+use egui::{Id, Ui};
 
 use crate::components::{
-    Button, FG_HOVER, Field, Radius, STROKE_HAIRLINE, SheetFooterOpts, Space, Spacer, Theme,
-    TypeRole, control_height, footnote, form_group, form_row, form_row_detail, form_value,
-    phosphor, phosphor_ui_font_id, plate_content, section_label, sense_click, sheet_band_centered,
-    sheet_footer, shortcut_enter, shortcut_return, ui_width,
+    Button, Field, Radius, SheetFooterOpts, Space, Spacer, Theme, TypeRole, control_height,
+    footnote, form_group, form_row, form_row_detail, form_value, plate_content, section_label,
+    sheet_band_centered, sheet_footer, shortcut_enter, shortcut_return, ui_width,
 };
 use crate::shell::ShellApp;
 use crate::shell::action::{Action, Action as A, UpgradeStage};
@@ -157,7 +156,12 @@ fn page_account_logout(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut V
         let AccountPanel::Logout { acked } = &mut app.account_panel else {
             return;
         };
-        logout_ack_row(ui, t, acked);
+        crate::components::ack_row(
+            ui,
+            t,
+            "I am signed in on another device or have access to a backup of my phrase or compact key.",
+            acked,
+        );
         *acked
     };
     ui.add(Spacer::new(Space::Md));
@@ -507,60 +511,6 @@ fn page_account_cancel_sub(app: &ShellApp, ui: &mut Ui, t: &Theme, queue: &mut V
     if foot.primary {
         queue.push(A::ConfirmCancelSub);
     }
-}
-
-/// Checkbox + wrapping copy; whole row toggles (logout confirm).
-fn logout_ack_row(ui: &mut Ui, t: &Theme, on: &mut bool) {
-    let label =
-        "I am signed in on another device or have access to a backup of my phrase or compact key.";
-    let box_s = TypeRole::Body.line_height().min(control_height() * 0.85);
-    let gap = Space::Sm.pts();
-    let max_w = ui_width(ui).max(1.0);
-    let text_w = (max_w - box_s - gap).max(1.0);
-    let galley =
-        ui.painter()
-            .layout(label.to_owned(), TypeRole::Body.font_id(), t.neutral_fg(), text_w);
-    let row_h = galley.size().y.max(box_s);
-    let (row, resp) = ui.allocate_exact_size(egui::vec2(max_w, row_h), sense_click());
-    if resp.clicked() {
-        *on = !*on;
-    }
-    let over = ui.ctx().rect_contains_pointer(ui.layer_id(), row);
-    let box_rect = egui::Rect::from_min_size(
-        egui::pos2(row.left(), row.center().y - box_s / 2.0),
-        egui::vec2(box_s, box_s),
-    );
-    let ground = t.neutral_bg();
-    let fill = if *on {
-        t.accent()
-    } else if over {
-        t.wash_toward_neutral_fg(ground, FG_HOVER)
-    } else {
-        ground
-    };
-    ui.painter().rect(
-        box_rect,
-        Radius::Sm.corner(),
-        fill,
-        Stroke::new(STROKE_HAIRLINE, if *on { t.accent() } else { t.neutral() }),
-        egui::StrokeKind::Inside,
-    );
-    if *on {
-        let check = phosphor::CHECK;
-        let ig = ui
-            .painter()
-            .layout_no_wrap(check.into(), phosphor_ui_font_id(), t.neutral_bg());
-        ui.painter().galley(
-            egui::pos2(
-                box_rect.center().x - ig.size().x / 2.0,
-                box_rect.center().y - ig.size().y / 2.0,
-            ),
-            ig,
-            t.neutral_bg(),
-        );
-    }
-    let text_pos = egui::pos2(row.left() + box_s + gap, row.top());
-    ui.painter().galley(text_pos, galley, t.neutral_fg());
 }
 
 /// In-settings QR view — same column as phrase (body · code · Back). Esc → HideAccountKey.

--- a/clients/desktop/src/shell/sheet_create.rs
+++ b/clients/desktop/src/shell/sheet_create.rs
@@ -5,9 +5,9 @@ use workspace_rs::file_cache::FilesExt;
 use crate::components::interact::{ControlFills, interact_fill, sense_click};
 use crate::components::{
     Button, EqualCells, FG_HOVER, FG_PRESS, Field, Radius, SheetFooterOpts, Space, Spacer, Theme,
-    TypeRole, claim, display_file_name, measure_file_name, origin, paint_file_name, phosphor,
-    phosphor_ui_font_id, place_at, segmented, segmented_width, sheet_band, sheet_band_centered,
-    sheet_dim, sheet_equal_row, sheet_footer, sheet_panel_fixed, sheet_title_muted, shortcut_enter,
+    TypeRole, display_file_name, measure_file_name, paint_file_name, phosphor, phosphor_ui_font_id,
+    segmented, sheet_band, sheet_band_centered, sheet_dim, sheet_equal_row, sheet_footer,
+    sheet_panel_fixed, sheet_title_muted, shortcut_enter,
 };
 
 use super::ShellApp;
@@ -168,35 +168,23 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
     }
     ui.add(Spacer::new(Space::Md));
 
-    // Type + name share one centered column (segmented natural width). Location
-    // plates keep the full sheet.
-    let col_w = segmented_width(ui, t, &labels);
     sheet_band_centered(ui, crate::components::segmented_h(), |ui| {
         if segmented(ui, t, &labels, &mut kind_i).changed() {
             queue.push(A::CreateSetKind(CreateKind::from_index(kind_i)));
         }
     });
     ui.add(Spacer::new(Space::Md));
+    ui.label(TypeRole::Body.rich("Name").color(t.neutral_fg_secondary()));
+    ui.add(Spacer::new(Space::Xs));
 
-    let total = crate::components::ui_width(ui);
-    let top_left = origin(ui);
-    let col_left = top_left.x + ((total - col_w) / 2.0).max(0.0);
-    let budget = egui::Rect::from_min_size(
-        egui::pos2(col_left, top_left.y),
-        egui::vec2(col_w.max(1.0), crate::components::remaining_height(ui).max(1.0)),
-    );
-    let (_, used) = place_at(ui, budget, Layout::top_down(Align::Min), |ui| {
-        ui.set_width(col_w.max(1.0));
-        ui.label(TypeRole::Body.rich("Name").color(t.neutral_fg_secondary()));
-        ui.add(Spacer::new(Space::Xs));
-
+    // Field edits Modal::Create.name in place (in-place modal fields).
+    {
         let Some(Modal::Create { name, name_dirty, error, .. }) = &mut app.modal else {
             return;
         };
         let before = name.clone();
         let mut field = Field::new(t, name)
             .id("shell_create_field")
-            .width(col_w)
             .select_all_on_focus(true);
         if let Some(ext) = kind.ext() {
             field = field.trailing_static(ext);
@@ -214,8 +202,7 @@ fn create_form_body(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mu
             *name_dirty = true;
             *error = None;
         }
-    });
-    claim(ui, egui::Rect::from_min_size(top_left, egui::vec2(total, used.height().max(1.0))));
+    }
 
     ui.add(Spacer::new(Space::Md));
     ui.label(

--- a/clients/desktop/src/shell/sheet_onboard.rs
+++ b/clients/desktop/src/shell/sheet_onboard.rs
@@ -311,8 +311,8 @@ pub(crate) fn show_onboard(
                             _ => String::new(),
                         };
                         let can_import = !secret.is_empty();
-                        // Auto-submit once per secret when valid. Failures stay silent
-                        // until the secret changes or the user hits Import manually.
+                        // Auto-submit on every change. Failures stay silent
+                        // until the user hits Import.
                         if can_import && !busy {
                             let last = ui.ctx().data(|d| {
                                 d.get_temp::<String>(Id::new("onboard_auto_submit_secret"))

--- a/clients/desktop/src/shell/sheet_onboard.rs
+++ b/clients/desktop/src/shell/sheet_onboard.rs
@@ -1,8 +1,9 @@
 use egui::{Align, Area, Id, Layout, Order};
 
 use crate::components::{
-    Button, Field, SheetFooterOpts, Space, Spacer, Theme, TypeRole, phosphor, sense_click,
-    sheet_dim, sheet_footer, sheet_panel_fit, shortcut_cmd_i, shortcut_cmd_n, shortcut_return,
+    Button, Field, Radius, SheetFooterOpts, Space, Spacer, Theme, TypeRole, control_height,
+    phosphor, plate_content, sense_click, sheet_dim, sheet_footer, sheet_panel_fit, shortcut_cmd_i,
+    shortcut_cmd_n, shortcut_return, ui_width, with_pad_fit,
 };
 
 use super::ShellApp;
@@ -31,10 +32,10 @@ pub(crate) fn show_onboard(
     };
 
     let layer = egui::LayerId::new(Order::Foreground, Id::new("shell_onboard"));
-    // Don't dismiss create/import by dim-click while busy.
+    // Don't dismiss create/import by dim-click while busy, or the backup step at all.
     if !busy && sheet_dim(ctx, Id::new("shell_onboard_dim"), layer) {
         // Stay on onboard when signed out — only cancel sub-modes.
-        if mode != OnboardMode::Choice {
+        if mode != OnboardMode::Choice && mode != OnboardMode::Backup {
             queue.push(A::OnboardSetMode(OnboardMode::Choice));
         }
     }
@@ -340,9 +341,142 @@ pub(crate) fn show_onboard(
                             queue.push(A::OnboardSubmit { show_error: true });
                         }
                     }
+                    OnboardMode::Backup => {
+                        onboard_backup(app, ui, t, queue);
+                    }
                 }
             });
         });
+}
+
+fn onboard_backup(app: &mut ShellApp, ui: &mut egui::Ui, t: &Theme, queue: &mut Vec<Action>) {
+    ui.label(
+        TypeRole::Heading
+            .rich("Your secret key")
+            .color(t.neutral_fg()),
+    );
+    ui.add(Spacer::new(Space::Sm));
+    ui.label(
+        TypeRole::Body
+            .rich(
+                "This 24-word phrase is your password — sign in on another device, write it down, or save it in a password manager.",
+            )
+            .color(t.neutral_fg()),
+    );
+    ui.add(Spacer::new(Space::Sm));
+    ui.label(
+        TypeRole::Body
+            .rich(
+                "Anyone with it can read your notes. If you lose your last copy, we can’t help you recover your files. You can always find it in Settings.",
+            )
+            .color(t.neutral_fg_secondary()),
+    );
+    ui.add(Spacer::new(Space::Md));
+
+    if app
+        .phrase_cache
+        .as_deref()
+        .is_none_or(|p| p.split_whitespace().count() != 24)
+    {
+        if let Some(r) = app.session.ready() {
+            if let Ok(p) = r.workspace.core.export_account_phrase() {
+                app.phrase_cache = Some(p);
+            }
+        }
+    }
+    let phrase = app.phrase_cache.as_deref().unwrap_or("");
+    let phrase_ok = phrase.split_whitespace().count() == 24;
+    plate_content(ui, t.neutral_bg_secondary(), t.neutral(), Radius::Control.corner(), |ui| {
+        ui.set_width(ui_width(ui));
+        ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
+        with_pad_fit(ui, Space::Md, |ui| {
+            onboard_phrase_columns(ui, t, phrase);
+        });
+    });
+
+    ui.add(Spacer::new(Space::Md));
+    {
+        let Some(Modal::Onboard { key_stored, .. }) = &mut app.modal else {
+            return;
+        };
+        crate::components::ack_row(ui, t, "I’ve stored my secret key in a safe place.", key_stored);
+    }
+    let stored = match &app.modal {
+        Some(Modal::Onboard { key_stored, .. }) => *key_stored,
+        _ => false,
+    };
+
+    ui.add(Spacer::new(Space::Md));
+    let row_w = ui_width(ui);
+    let row_h = control_height();
+    let gap = Space::Sm;
+    ui.horizontal(|ui| {
+        ui.set_min_height(row_h);
+        ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
+        let copy = Button::quiet(t, "Copy")
+            .copy_feedback("shell_onboard_copy_phrase")
+            .height(row_h)
+            .show(ui);
+        if copy.clicked() {
+            queue.push(A::CopyPhrase);
+        }
+        let copy_w = copy.rect.width();
+        ui.add(Spacer::new(gap).fill_cross(row_h));
+        let primary_max = (row_w - copy_w - gap.pts()).max(Space::Xl.pts() * 2.4);
+        ui.allocate_ui_with_layout(
+            egui::vec2(primary_max, row_h),
+            Layout::right_to_left(Align::Center),
+            |ui| {
+                ui.set_max_width(primary_max);
+                if Button::primary(t, "Done")
+                    .shortcut(shortcut_return())
+                    .height(row_h)
+                    .max_width(primary_max)
+                    .enabled(stored && phrase_ok)
+                    .show(ui)
+                    .clicked()
+                {
+                    queue.push(A::OnboardFinishBackup);
+                }
+            },
+        );
+    });
+}
+
+fn onboard_phrase_columns(ui: &mut egui::Ui, t: &Theme, phrase: &str) {
+    let words: Vec<&str> = phrase.split_whitespace().collect();
+    if words.len() != 24 {
+        ui.label(
+            TypeRole::Mono
+                .rich(if phrase.is_empty() { "Preparing phrase…" } else { phrase })
+                .color(t.neutral_fg()),
+        );
+        return;
+    }
+    let col_w = (ui_width(ui) / 2.0).max(1.0);
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
+        ui.vertical(|ui| {
+            ui.set_width(col_w);
+            for (i, word) in words.iter().take(12).enumerate() {
+                onboard_phrase_word(ui, t, i + 1, word);
+            }
+        });
+        ui.vertical(|ui| {
+            ui.set_width(col_w);
+            for (i, word) in words.iter().skip(12).enumerate() {
+                onboard_phrase_word(ui, t, i + 13, word);
+            }
+        });
+    });
+}
+
+fn onboard_phrase_word(ui: &mut egui::Ui, t: &Theme, n: usize, word: &str) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing = egui::vec2(Space::Xs.pts(), 0.0);
+        ui.label(TypeRole::Mono.rich(format!("{n}.")).color(t.accent()));
+        ui.label(TypeRole::Mono.rich(word).color(t.neutral_fg()));
+    });
 }
 
 fn onboard_server_edit_id() -> Id {

--- a/clients/desktop/src/shell/sidebar.rs
+++ b/clients/desktop/src/shell/sidebar.rs
@@ -84,7 +84,7 @@ pub fn show(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<Action>)
     ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
     ui.set_clip_rect(ui.max_rect().intersect(ui.clip_rect()));
 
-    let show_chips = app.pane == SidebarPane::Files;
+    let show_chips = matches!(app.pane, SidebarPane::Files | SidebarPane::Recents);
     egui::TopBottomPanel::top("shell_sidebar_head")
         .resizable(false)
         .show_separator_line(false)

--- a/clients/desktop/src/shell/titlebar/mod.rs
+++ b/clients/desktop/src/shell/titlebar/mod.rs
@@ -125,7 +125,7 @@ fn titleband_double_click_interval() -> f64 {
 pub fn show(app: &mut ShellApp, ctx: &egui::Context, t: &Theme, queue: &mut Vec<Action>) {
     // Chrome first so its rects are in the blocker list before drag_strip.
     // Pane / history icons are workspace chrome — hide them on onboard.
-    if app.session.ready().is_some() {
+    if app.product_open() {
         floating_toolbar(app, ctx, t, queue);
     }
 


### PR DESCRIPTION
* file tree empty state copy ("no files")
* create sheet layout fixes
* allow rename to same name (why not?)
* fix crash when importing a file then cancelling
* show pins & actions in recents so you never have to leave
* hide sign in errors due to automatic submissions
* show secret key during sign up like we used to (unsure when this got dropped)