### PR TITLE
desktop: create eror, shared folder delete, import dest seed

### DIFF
--- a/clients/desktop/src/components/domain/pins.rs
+++ b/clients/desktop/src/components/domain/pins.rs
@@ -65,7 +65,7 @@ pub fn show(
                 id: *id,
                 name: f.name.clone(),
                 is_folder: false,
-                saved_share: is_saved_share(f, me),
+                saved_share: is_saved_share(f, files.get_by_id(f.parent), me),
             })
         })
         .collect();

--- a/clients/desktop/src/components/domain/tree/recents.rs
+++ b/clients/desktop/src/components/domain/tree/recents.rs
@@ -104,7 +104,9 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                         visible_doc_ids
                             .iter()
                             .filter_map(|id| {
-                                files.get_by_id(*id).map(|f| (*id, is_saved_share(f, me)))
+                                files.get_by_id(*id).map(|f| {
+                                    (*id, is_saved_share(f, files.get_by_id(f.parent), me))
+                                })
                             })
                             .collect()
                     })

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -807,10 +807,29 @@ fn open_doc_alongside(r: &Ready) -> Option<(Uuid, String)> {
     file_alongside(r, r.workspace.current_tab_id()?)
 }
 
-fn dest_folder_from_open_tab(r: &Ready) -> Uuid {
-    open_doc_alongside(r)
-        .map(|(p, _)| p)
-        .unwrap_or_else(|| r.workspace.files.read().unwrap().root().id)
+/// Import dest follows the highlighted folder so drop/import land where you are.
+fn dest_folder_for_import(r: &Ready) -> Uuid {
+    let files = r.workspace.files.read().unwrap();
+    let root = files.root().id;
+    let cursor = r.cursor.and_then(|id| {
+        let f = files.get_by_id(id)?;
+        Some((id, f.is_folder(), f.parent))
+    });
+    let tab_parent = r.workspace.current_tab_id().and_then(|id| {
+        files
+            .get_by_id(id)
+            .and_then(|f| if f.is_folder() { None } else { Some(f.parent) })
+    });
+    import_dest_id(root, cursor, tab_parent)
+}
+
+fn import_dest_id(
+    root: Uuid, cursor: Option<(Uuid, bool, Uuid)>, tab_parent: Option<Uuid>,
+) -> Uuid {
+    if let Some((id, is_folder, parent)) = cursor {
+        return if is_folder { id } else { parent };
+    }
+    tab_parent.unwrap_or(root)
 }
 
 struct CreateSheetPlan {
@@ -1032,7 +1051,7 @@ fn confirm_create(app: &mut ShellApp) {
                     }
                     Ok(file.name)
                 }
-                // Display — Debug includes a backtrace.
+                // Display, not Debug: Debug dumps the lb-rs backtrace into the sheet.
                 Err(e) => Err(e.to_string()),
             }
         }
@@ -1292,10 +1311,10 @@ fn import_pick(app: &mut ShellApp, ctx: &Context) {
     spawn_native_dialog(app, ctx, || NativeDialogResult::Import(FileDialog::new().pick_files()));
 }
 
-/// Open the Import folder-picker sheet. Seeds `dest` from the open tab's folder
-/// (not tree selection).
+/// Open the Import folder-picker sheet. Seeds `dest` from tree selection
+/// (folder, or parent of a selected file), then the open tab, then home.
 fn open_import_parent_sheet(app: &mut ShellApp, ctx: &Context, paths: Vec<PathBuf>) {
-    let dest = app.session.ready().map(dest_folder_from_open_tab);
+    let dest = app.session.ready().map(dest_folder_for_import);
     ctx.data_mut(|d| {
         d.remove::<std::collections::HashSet<Uuid>>(egui::Id::new((
             "shell_folder_pick_exp",
@@ -1412,5 +1431,39 @@ mod create_sheet_plan_tests {
         assert_eq!(plan.parent, Some(folder));
         assert_eq!(plan.chosen, Some(folder));
         assert!(plan.alongside.is_none());
+    }
+}
+
+#[cfg(test)]
+mod import_dest_tests {
+    use super::import_dest_id;
+    use lb::Uuid;
+
+    fn ids() -> (Uuid, Uuid, Uuid) {
+        (Uuid::from_u128(1), Uuid::from_u128(2), Uuid::from_u128(3))
+    }
+
+    #[test]
+    fn selected_folder_wins() {
+        let (root, folder, tab_parent) = ids();
+        assert_eq!(import_dest_id(root, Some((folder, true, root)), Some(tab_parent)), folder);
+    }
+
+    #[test]
+    fn selected_file_uses_parent() {
+        let (root, folder, file) = ids();
+        assert_eq!(import_dest_id(root, Some((file, false, folder)), None), folder);
+    }
+
+    #[test]
+    fn open_tab_when_nothing_selected() {
+        let (root, _, tab_parent) = ids();
+        assert_eq!(import_dest_id(root, None, Some(tab_parent)), tab_parent);
+    }
+
+    #[test]
+    fn home_when_no_context() {
+        let (root, _, _) = ids();
+        assert_eq!(import_dest_id(root, None, None), root);
     }
 }

--- a/clients/desktop/src/shell/apply.rs
+++ b/clients/desktop/src/shell/apply.rs
@@ -921,6 +921,16 @@ pub(crate) fn rename_validate_name(full: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn create_name_taken(r: &Ready, parent: Uuid, full: &str) -> bool {
+    r.workspace
+        .files
+        .read()
+        .unwrap()
+        .children(parent)
+        .into_iter()
+        .any(|c| c.name == full)
+}
+
 /// Another sibling under the same parent already has `full` (case-sensitive, core path rules).
 pub(crate) fn rename_name_taken(r: &Ready, id: Uuid, full: &str) -> bool {
     let files = r.workspace.files.read().unwrap();
@@ -1001,25 +1011,30 @@ fn confirm_create(app: &mut ShellApp) {
             return;
         };
         let parent_id = parent.unwrap_or_else(|| r.workspace.effective_focused_parent());
-        let result = if is_folder {
-            r.workspace
-                .core
-                .create_file(&full_name, &parent_id, FileType::Folder)
+        if create_name_taken(r, parent_id, &full_name) {
+            Err("A file with that name already exists".into())
         } else {
-            r.workspace
-                .core
-                .create_file(&full_name, &parent_id, FileType::Document)
-        };
-        match result {
-            Ok(file) => {
-                r.expanded.insert(parent_id);
-                r.select_only(file.id);
-                if !is_folder {
-                    r.workspace.open_file(file.id, true, true);
+            let result = if is_folder {
+                r.workspace
+                    .core
+                    .create_file(&full_name, &parent_id, FileType::Folder)
+            } else {
+                r.workspace
+                    .core
+                    .create_file(&full_name, &parent_id, FileType::Document)
+            };
+            match result {
+                Ok(file) => {
+                    r.expanded.insert(parent_id);
+                    r.select_only(file.id);
+                    if !is_folder {
+                        r.workspace.open_file(file.id, true, true);
+                    }
+                    Ok(file.name)
                 }
-                Ok(file.name)
+                // Display — Debug includes a backtrace.
+                Err(e) => Err(e.to_string()),
             }
-            Err(e) => Err(format!("{e:?}")),
         }
     };
     match outcome {

--- a/clients/desktop/src/shell/mod.rs
+++ b/clients/desktop/src/shell/mod.rs
@@ -821,7 +821,7 @@ impl ShellApp {
         if paths.is_empty() {
             return;
         }
-        // Always pick a folder — tree `cursor` is not a drop target.
+        // Folder picker, pre-selected from tree context (then open tab / home).
         self.queue.push(A::OpenImportParent { paths });
     }
 }

--- a/clients/desktop/src/shell/ops.rs
+++ b/clients/desktop/src/shell/ops.rs
@@ -22,17 +22,64 @@ pub fn is_pinned(r: &Ready, id: Uuid) -> bool {
     r.pinned.contains(&id)
 }
 
-/// File in your tree that you don't own. `list_metadatas` hides the Link and
-/// shows the target (e.g. luca's `movies.md` sitting in your root), so
-/// `FileType::Link` never appears in the UI. Removing it deletes your link,
-/// not the owner's file.
-pub fn is_saved_share(f: &File, me: &str) -> bool {
-    !f.owner.eq_ignore_ascii_case(me)
+/// Unowned file whose tree parent is owned by `me` (accepted link after parent rewrite).
+pub fn is_saved_share(f: &File, parent: Option<&File>, me: &str) -> bool {
+    !f.owner.eq_ignore_ascii_case(me) && parent.is_some_and(|p| p.owner.eq_ignore_ascii_case(me))
 }
 
 pub fn ids_are_saved_shares(files: &impl FilesExt, ids: &[Uuid], me: &str) -> bool {
     !ids.is_empty()
-        && ids
-            .iter()
-            .all(|&id| files.get_by_id(id).is_some_and(|f| is_saved_share(f, me)))
+        && ids.iter().all(|&id| {
+            files
+                .get_by_id(id)
+                .is_some_and(|f| is_saved_share(f, files.get_by_id(f.parent), me))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_saved_share;
+    use lb::Uuid;
+    use lb::model::file::File;
+    use lb::model::file_metadata::FileType;
+
+    fn file(id: Uuid, parent: Uuid, owner: &str) -> File {
+        File {
+            id,
+            parent,
+            name: "x".into(),
+            file_type: FileType::Folder,
+            last_modified: 0,
+            last_modified_by: owner.into(),
+            owner: owner.into(),
+            shares: Vec::new(),
+            size_bytes: 0,
+        }
+    }
+
+    #[test]
+    fn saved_share_is_unowned_file_parented_to_me() {
+        let me_root = Uuid::new_v4();
+        let shared = Uuid::new_v4();
+        let mine = file(me_root, me_root, "jane");
+        let root_share = file(shared, me_root, "luca");
+        let child = file(Uuid::new_v4(), shared, "luca");
+        // Nested folder also shared with jane, but she did not accept a second link —
+        // parent is still luca's shared folder, not jane's.
+        let nested_also_shared = file(Uuid::new_v4(), shared, "luca");
+
+        assert!(is_saved_share(&root_share, Some(&mine), "jane"));
+        assert!(!is_saved_share(&child, Some(&root_share), "jane"));
+        assert!(!is_saved_share(&nested_also_shared, Some(&root_share), "jane"));
+        assert!(!is_saved_share(&mine, Some(&mine), "jane"));
+    }
+
+    #[test]
+    fn second_link_to_nested_folder_is_its_own_saved_share() {
+        let me_root = Uuid::new_v4();
+        let mine = file(me_root, me_root, "jane");
+        // Closest-link rewrite: nested folder's parent is jane's root, not luca's outer folder.
+        let nested = file(Uuid::new_v4(), me_root, "luca");
+        assert!(is_saved_share(&nested, Some(&mine), "jane"));
+    }
 }

--- a/clients/desktop/src/shell/session.rs
+++ b/clients/desktop/src/shell/session.rs
@@ -84,8 +84,9 @@ pub struct Ready {
     pub workspace: Workspace,
     pub expanded: HashSet<Uuid>,
     /// Tree / list selection (highlight, multi-select, context-menu targets).
-    /// Not keyboard focus and not create/import destination — those follow the
-    /// open tab. Right-clicking a folder updates this without opening a file.
+    /// Import dest uses it (folder, or parent of a selected file), then the
+    /// open tab, then home. Create still ignores it. Right-clicking a folder
+    /// updates this without opening a file.
     pub cursor: Option<Uuid>,
     /// Shift-range anchor (Finder-style).
     pub anchor: Option<Uuid>,

--- a/clients/desktop/src/shell/sheet_create.rs
+++ b/clients/desktop/src/shell/sheet_create.rs
@@ -69,6 +69,18 @@ pub(crate) fn show_create(
         });
     }
 
+    // Relock height when the error line appears so it isn't clipped into the footer.
+    let has_err = matches!(
+        &app.modal,
+        Some(Modal::Create { error: Some(e), .. }) if !e.is_empty()
+    );
+    let err_key = Id::new("shell_create_inner_h_err");
+    let prev_err = ctx.data(|d| d.get_temp::<bool>(err_key)).unwrap_or(false);
+    if has_err != prev_err {
+        ctx.data_mut(|d| d.remove::<f32>(create_sheet_h_key()));
+    }
+    ctx.data_mut(|d| d.insert_temp(err_key, has_err));
+
     let locked_h = ctx.data(|d| d.get_temp::<f32>(create_sheet_h_key()));
 
     Area::new(Id::new("shell_create"))

--- a/clients/desktop/src/shell/sheets.rs
+++ b/clients/desktop/src/shell/sheets.rs
@@ -280,7 +280,7 @@ fn delete_parts(app: &ShellApp, ids: &[Uuid]) -> DeleteParts {
             continue;
         };
         let shown = display_file_name(&f.name).to_owned();
-        if is_saved_share(f, me) {
+        if is_saved_share(f, files.get_by_id(f.parent), me) {
             link_names.push(shown);
             continue;
         }


### PR DESCRIPTION
Fixes for issues raised during QA.

- **Create with duplicate name** shows a one-line error instead of a backtrace.
- **Remove from files** only on direct shares.
- **Import destination** is seeded with the highlighted folder (or the parent of a selected file), then the open tab, then home.
