### PR TITLE
desktop: cleanup file double click code

### DIFF
--- a/clients/desktop/src/components/domain/pins.rs
+++ b/clients/desktop/src/components/domain/pins.rs
@@ -187,7 +187,7 @@ fn pin_chip(ui: &mut Ui, t: &Theme, row: &PinRow, queue: &mut Vec<Action>) {
         QuietChipAlign::Start,
     );
 
-    if resp.clicked() {
+    if resp.clicked() && !resp.double_clicked() {
         if row.is_folder {
             // Reveal/select in the tree; expand so contents are visible.
             queue.push(A::SelectFile(row.id));

--- a/clients/desktop/src/components/domain/tree/mod.rs
+++ b/clients/desktop/src/components/domain/tree/mod.rs
@@ -1294,7 +1294,7 @@ fn paint_row(
     let _ = over;
 
     let modifiers = ui.input(|i| i.modifiers);
-    if resp.clicked() {
+    if resp.clicked() && !resp.double_clicked() {
         if modifiers.shift {
             queue.push(Action::SelectRange(row.id));
         } else if modifiers.command {
@@ -1307,9 +1307,6 @@ fn paint_row(
         }
     }
     if resp.middle_clicked() && !row.is_folder {
-        queue.push(Action::OpenFileNewTab(row.id));
-    }
-    if resp.double_clicked() && !row.is_folder {
         queue.push(Action::OpenFileNewTab(row.id));
     }
     if resp.secondary_clicked() && !selected {

--- a/clients/desktop/src/components/domain/tree/recents.rs
+++ b/clients/desktop/src/components/domain/tree/recents.rs
@@ -146,7 +146,7 @@ pub fn show_recents(app: &mut ShellApp, ui: &mut Ui, t: &Theme, queue: &mut Vec<
                                 rect,
                                 |r| r.subtitle(path),
                             );
-                            if resp.clicked() {
+                            if resp.clicked() && !resp.double_clicked() {
                                 queue.push(Action::OpenFile(*id));
                             }
                             if resp.middle_clicked() {

--- a/clients/desktop/src/components/domain/tree/shared.rs
+++ b/clients/desktop/src/components/domain/tree/shared.rs
@@ -188,7 +188,7 @@ fn paint_shared_row(
         );
         if accept {
             queue.push(Action::OpenAcceptShare { id: row.id, name: row.name.clone() });
-        } else if resp.clicked() {
+        } else if resp.clicked() && !resp.double_clicked() {
             if row.is_folder {
                 queue.push(Action::ToggleExpand(row.id));
             } else {
@@ -196,9 +196,6 @@ fn paint_shared_row(
             }
         }
         if resp.middle_clicked() && !row.is_folder {
-            queue.push(Action::OpenFileNewTab(row.id));
-        }
-        if resp.double_clicked() && !row.is_folder {
             queue.push(Action::OpenFileNewTab(row.id));
         }
         if let Some(cmd) = context_menu::show(&resp, t, |e| {
@@ -236,7 +233,7 @@ fn paint_shared_row(
             paint_tree_file_row(ui, t, row.name.clone(), icon, chrome, id, rect, rect, |r| {
                 r.sense(sense_click())
             });
-        if resp.clicked() {
+        if resp.clicked() && !resp.double_clicked() {
             if row.is_folder {
                 queue.push(Action::ToggleExpand(row.id));
             } else {
@@ -244,9 +241,6 @@ fn paint_shared_row(
             }
         }
         if resp.middle_clicked() && !row.is_folder {
-            queue.push(Action::OpenFileNewTab(row.id));
-        }
-        if resp.double_clicked() && !row.is_folder {
             queue.push(Action::OpenFileNewTab(row.id));
         }
         if let Some(cmd) = context_menu::show(&resp, t, |e| {


### PR DESCRIPTION
In the pre-August desktop client, you could double click to rename the file inline. In the new client, double click was half-implemented as open-in-new-tab, but the first click opened the file in the current tab so the second click simply focused it (did nothing). This PR cleans up the broken logic without restoring the dropped rename behavior or implementing in-new-tab opening (what would the first click of the double click be expected to do? wait for a possible second one before opening the file?)