### PR TITLE
chat: fix iOS crash on send

### DIFF
--- a/libs/content/workspace-ffi/src/apple/ios/api.rs
+++ b/libs/content/workspace-ffi/src/apple/ios/api.rs
@@ -151,6 +151,10 @@ pub unsafe extern "C" fn cut_selection(obj: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *const c_char {
     let obj = &mut *(obj as *mut WgpuWorkspace);
+    let is_chat = obj
+        .workspace
+        .current_tab()
+        .is_some_and(|tab| tab.chat().is_some());
     let markdown = match obj.workspace.focused_mdedit_mut() {
         Some(markdown) => markdown,
         None => return null(),
@@ -158,6 +162,11 @@ pub unsafe extern "C" fn text_in_range(obj: *mut c_void, range: CTextRange) -> *
 
     let range: Option<(Grapheme, Grapheme)> = range.into();
     if let Some(range) = range {
+        let last = markdown.renderer.buffer.current.segs.last_cursor_position();
+        // Chat send-clear: UIKit still holds pre-clear positions and asks
+        // text(in:) during textDidChange. Clamp like a normal UITextInput.
+        // Notes keep the index so a bad range stays loud.
+        let range = if is_chat { (range.start().min(last), range.end().min(last)) } else { range };
         CString::new(&markdown.renderer.buffer[range])
             .expect("Could not Rust String -> C String")
             .into_raw()

--- a/libs/content/workspace/src/tab/chat/mod.rs
+++ b/libs/content/workspace/src/tab/chat/mod.rs
@@ -364,6 +364,10 @@ pub struct Chat {
     /// (iOS) text bridge didn't originate — a send-clear, edit-prefill, or
     /// stash-restore — so we tell it to re-sync its caret.
     composer_seq: usize,
+    /// `MdRender::text_seq` last frame. Unlike `composer_seq`, this ignores
+    /// caret-only changes — send-clear must report `text_updated` so iOS
+    /// drops UITextPositions from the message that was just sent.
+    composer_text_seq: u64,
     /// Sending while scrolled up jumps back to the bottom (which also
     /// re-sticks the scroll). Set on submit, consumed next frame.
     scroll_to_bottom: bool,
@@ -675,6 +679,7 @@ impl Chat {
             key_field_hit_rect: Rect::NOTHING,
             composer_rect: Rect::NOTHING,
             composer_seq: 0,
+            composer_text_seq: 0,
             scroll_to_bottom: false,
             branch_choice: HashMap::new(),
             branch_anchor: None,

--- a/libs/content/workspace/src/tab/chat/view.rs
+++ b/libs/content/workspace/src/tab/chat/view.rs
@@ -172,9 +172,10 @@ impl Chat {
     }
     /// Renders the transcript + composer. Returns whether the transcript
     /// changed this frame (user sent or the agent replied — triggers a save),
-    /// and the composer's text rect (egui points) used to position the native
-    /// iOS text-interaction overlay.
-    pub fn show(&mut self, ui: &mut Ui) -> (bool, Rect, bool) {
+    /// the composer's text rect (egui points) used to position the native
+    /// iOS text-interaction overlay, whether the composer selection moved,
+    /// and whether the composer text itself changed (send-clear, prefill).
+    pub fn show(&mut self, ui: &mut Ui) -> (bool, Rect, bool, bool) {
         self.kick_initial_config_load();
         self.pump_models();
         self.pump_config();
@@ -2813,7 +2814,15 @@ impl Chat {
         let composer_seq = self.composer.renderer.buffer.current.seq;
         let composer_updated = composer_seq != self.composer_seq;
         self.composer_seq = composer_seq;
+        let text_seq = self.composer.renderer.text_seq;
+        let composer_text_updated = text_seq != self.composer_text_seq;
+        self.composer_text_seq = text_seq;
 
-        (sent || agent_changed || changed, interaction_rect, composer_updated)
+        (
+            sent || agent_changed || changed,
+            interaction_rect,
+            composer_updated,
+            composer_text_updated,
+        )
     }
 }

--- a/libs/content/workspace/src/tab/mod.rs
+++ b/libs/content/workspace/src/tab/mod.rs
@@ -374,14 +374,16 @@ impl Tab {
                 match content {
                     #[cfg(not(target_family = "wasm"))]
                     TabContent::Chat(chat) => {
-                        let (sent, interaction_rect, composer_updated) = chat.show(ui);
+                        let (sent, interaction_rect, composer_updated, composer_text_updated) =
+                            chat.show(ui);
                         if sent {
                             self.last_changed = Instant::now();
                         }
                         // App-driven composer edits (send-clear, prefill) must
-                        // re-sync the native text view's caret, same as the
-                        // markdown editor reports.
+                        // re-sync the native text view. `text_updated` is the
+                        // document replacement; selection-only is the caret.
                         resp.selection_updated = composer_updated;
+                        resp.text_updated = composer_text_updated;
                         // `Rect::NOTHING` means "no text field this frame" —
                         // report None like the markdown editor does. Forwarded
                         // as Some it sets the native iOS text view's frame to


### PR DESCRIPTION
Sending a chat message clears the composer while UIKit still holds `UITextPosition`s from that message. `text(in:)` then indexes past the empty buffer and aborts.

- Report `text_updated` on composer text changes, not only `selection_updated`.
- Clamp out-of-range `text(in:)` on chat tabs only; notes still panic on a bad range.