### PR TITLE
md: keep off-screen iOS selection handles stable

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/cursor.rs
@@ -174,8 +174,8 @@ impl MdEdit {
         use crate::tab::markdown_editor::scroll_content::DocScrollContent;
         use crate::widgets::affine_scroll::Align;
 
-        // Make the moving end of the selection visible. During a handle drag
-        // that's the dragged handle (either end); otherwise the selection end.
+        // Make the moving end of the selection visible. Handle drag sets
+        // `in_progress_handle`; otherwise the active end.
         // Passed as a zero-length range — `build_target_reveal` handles
         // single-point and multi-line ranges identically.
         let cursor = self.in_progress_handle.unwrap_or_else(|| {

--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -17,6 +17,17 @@ use lb_rs::model::text::operation_types::{Operation, Replace};
 
 use super::{Advance, Bound, Location, Region};
 
+/// The endpoint that moved. If both (or neither) of the new ends were
+/// already endpoints, the active end (`.1`).
+fn moving_selection_end(old: (Grapheme, Grapheme), new: (Grapheme, Grapheme)) -> Grapheme {
+    let old_has = |g| g == old.0 || g == old.1;
+    match (old_has(new.0), old_has(new.1)) {
+        (true, false) => new.1,
+        (false, true) => new.0,
+        _ => new.1,
+    }
+}
+
 /// tracks editor state necessary to support translating input events to buffer operations
 #[derive(Default)]
 pub struct EventState {
@@ -67,6 +78,7 @@ impl<'ast> MdEdit {
             Event::Select { region } => {
                 let range = self.region_to_range(region);
                 let range = self.renderer.snap_selection_out_of_fold_tags(range);
+                self.in_progress_handle = Some(moving_selection_end(current_selection, range));
                 operations.push(Operation::Select(range));
             }
             Event::Replace { region, text, advance_cursor } => {

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -226,9 +226,8 @@ pub struct MdEdit {
     /// when `None`.
     pub in_progress_selection: Option<(Grapheme, Grapheme)>,
 
-    /// Offset of the selection handle being dragged (Android), so auto-scroll
-    /// follows the moving handle rather than always the selection end. `None`
-    /// outside a handle drag — scroll then falls back to the selection end.
+    /// Endpoint the last Select / handle-drag moved. `scroll_to_cursor`
+    /// follows this when set, then it is cleared.
     pub in_progress_handle: Option<Grapheme>,
 
     /// Active list-item drag-to-reorder — `Some` from grab until release.
@@ -1512,6 +1511,30 @@ impl Editor {
                                     top += height;
                                     walked += height;
                                     id = next_id;
+                                }
+                            }
+                            // Also paint the two selection-endpoint rows so
+                            // off-screen iOS caret/selection geometry still
+                            // resolves.
+                            let sel = self.edit.renderer.buffer.current.selection;
+                            for offset in [sel.0, sel.1] {
+                                let Some(target) = content.find_text_row(offset) else {
+                                    continue;
+                                };
+                                if resp
+                                    .visible
+                                    .iter()
+                                    .chain(neighbors.iter())
+                                    .any(|r| r.id == target)
+                                {
+                                    continue;
+                                }
+                                if let Some(row) = scroll_content::row_from_visible(
+                                    &content,
+                                    &resp.visible,
+                                    target,
+                                ) {
+                                    neighbors.push(row);
                                 }
                             }
                             (resp.visible, neighbors, resp.scrollbar_grab)

--- a/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/scroll_content.rs
@@ -22,7 +22,7 @@ use egui::{Pos2, Ui};
 use lb_rs::model::text::offset_types::Grapheme;
 
 use crate::tab::markdown_editor::MdRender;
-use crate::widgets::affine_scroll::Rows;
+use crate::widgets::affine_scroll::{Rows, VisibleRow};
 
 /// Stable identity of a row in the document. `Leading` and `Trailing`
 /// are the always-present virtual padding rows; `Block(i)` is a top-
@@ -258,6 +258,57 @@ impl<'a, 'ast> Rows for DocScrollContent<'a, 'ast> {
             // upstream. Default to first().
             DocRowId::Leading | DocRowId::Trailing => self.first(),
         }
+    }
+}
+
+/// Viewport-local row for `target`, positioned from a visible row by
+/// walking `precise()` heights. Does not paint the rows in between.
+pub fn row_from_visible(
+    content: &DocScrollContent, visible: &[VisibleRow<DocRowId>], target: DocRowId,
+) -> Option<VisibleRow<DocRowId>> {
+    let first = visible.first()?;
+    let last = visible.last()?;
+    match row_cmp(target, first.id) {
+        Some(std::cmp::Ordering::Less) => {
+            let mut id = first.id;
+            let mut top = first.top;
+            while let Some(prev_id) = content.prev(&id) {
+                let height = content.precise(&prev_id);
+                top -= height;
+                if prev_id == target {
+                    return Some(VisibleRow { id: prev_id, top, height });
+                }
+                id = prev_id;
+            }
+            None
+        }
+        _ => match row_cmp(target, last.id) {
+            Some(std::cmp::Ordering::Greater) => {
+                let mut id = last.id;
+                let mut top = last.top + last.height;
+                while let Some(next_id) = content.next(&id) {
+                    let height = content.precise(&next_id);
+                    if next_id == target {
+                        return Some(VisibleRow { id: next_id, top, height });
+                    }
+                    top += height;
+                    id = next_id;
+                }
+                None
+            }
+            _ => None,
+        },
+    }
+}
+
+fn row_cmp(a: DocRowId, b: DocRowId) -> Option<std::cmp::Ordering> {
+    use DocRowId::*;
+    match (a, b) {
+        (x, y) if x == y => Some(std::cmp::Ordering::Equal),
+        (Leading, _) | (_, Trailing) => Some(std::cmp::Ordering::Less),
+        (Trailing, _) | (_, Leading) => Some(std::cmp::Ordering::Greater),
+        (Block(i), Block(j)) | (Line(i), Line(j)) => Some(i.cmp(&j)),
+        _ => None,
     }
 }
 

--- a/libs/content/workspace/src/tab/markdown_editor/show.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/show.rs
@@ -883,6 +883,7 @@ impl MdEdit {
             self.pending_scroll = None;
             self.scroll_to_cursor(rect);
         }
+        self.in_progress_handle = None;
 
         // lock focus filter so arrow keys / tab / shift+enter keep reaching us
         if focused {


### PR DESCRIPTION
* fixes an issue where dragging one iOS selection handle would move the other when the selection was 3x the screen height or more
* fixes an issue where dragging one iOS selection handle would scroll you to the other