### PR TITLE
md: do not fetch link-preview images from height layout

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/image/image.rs
@@ -5,7 +5,9 @@ use egui::{self, Vec2};
 use lb_rs::model::text::offset_types::{Grapheme, RangeExt as _};
 use lb_rs::model::text::operation_types::Operation;
 
+use crate::file_cache::ResolvedLink;
 use crate::tab::markdown_editor::input::{Advance, Bound, Event, Increment, Location, Region};
+use crate::tab::markdown_editor::widget::inline::link::meta::LinkMetaState;
 use crate::tab::markdown_editor::widget::inline::link::{LinkMenuAction, link_menu_buttons};
 use crate::tab::markdown_editor::widget::utils::NodeValueExt as _;
 use crate::tab::markdown_editor::widget::utils::wrap_layout::{EmbedKind, EmbedSpec, Layout};
@@ -13,13 +15,36 @@ use crate::tab::markdown_editor::{MdEdit, MdRender};
 use crate::tab::{ContextMenuTarget, ExtendedOutput as _};
 
 impl MdRender {
+    /// Prefetch textures under `node` so the image cache does not drop them.
+    /// Used for off-screen neighbors about to scroll into view. Covers
+    /// markdown `![]()` images and link-preview thumbnails/favicons.
     pub fn warm_images<'a>(&self, node: &'a comrak::nodes::AstNode<'a>) {
         for descendant in node.descendants() {
-            let url = match &descendant.data.borrow().value {
-                comrak::nodes::NodeValue::Image(link) => link.url.clone(),
-                _ => continue,
-            };
-            self.embeds.prefetch(&url);
+            match &descendant.data.borrow().value {
+                NodeValue::Image(link) => {
+                    self.embeds.prefetch(&link.url);
+                }
+                NodeValue::Link(link) => {
+                    let resolved = match self.resolve_link(&link.url) {
+                        Some(ResolvedLink::External(url)) => url,
+                        _ => continue,
+                    };
+                    let Some(arc) = self.layout_cache.link_meta.borrow().get(&resolved).cloned()
+                    else {
+                        continue;
+                    };
+                    let LinkMetaState::Loaded(meta) = &*arc.lock().unwrap() else {
+                        continue;
+                    };
+                    if let Some(url) = meta.thumbnail_url.as_deref() {
+                        self.embeds.prefetch(url);
+                    }
+                    if let Some(url) = meta.favicon_url.as_deref() {
+                        self.embeds.prefetch(url);
+                    }
+                }
+                _ => {}
+            }
         }
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/widget/inline/link/card.rs
@@ -89,11 +89,9 @@ impl<'ast> MdRender {
                 self.ctx.fonts(|f| f.layout_job(job))
             };
 
-        // Warm so the texture (hence real aspect) loads before the first paint.
+        // Layout size only (declared og:image dims, else persisted
+        // texture size). Fetch is `embeds.show` / `warm_images`.
         let thumb = meta.thumbnail_url.as_deref();
-        if let Some(t) = thumb {
-            self.embeds.prefetch(t);
-        }
 
         // Hero (full-width landscape band) vs. horizontal (square/portrait
         // thumbnail beside text) vs. text-only.

--- a/libs/content/workspace/src/widgets/image_cache.rs
+++ b/libs/content/workspace/src/widgets/image_cache.rs
@@ -104,13 +104,24 @@ impl ImageCache {
 
     pub fn end_frame(&self) {
         let mut inner = self.inner.lock().unwrap();
-        // free textures for any URLs that weren't looked up this frame
+        // Unused Loaded textures are freed. Failed is dropped so a later
+        // lookup can retry. Loading stays so we don't spawn a second
+        // in-flight request.
         let texture_manager = self.ctx.tex_manager();
-        for (_, state) in inner.previous.drain() {
-            if let ImageState::Loaded(texture_id) = state.lock().unwrap().deref() {
-                texture_manager.write().free(*texture_id);
+        let mut keep = Vec::new();
+        for (url, state) in inner.previous.drain() {
+            let (keep_loading, free_id) = match state.lock().unwrap().deref() {
+                ImageState::Loading => (true, None),
+                ImageState::Loaded(id) => (false, Some(*id)),
+                ImageState::Failed(_) => (false, None),
+            };
+            if keep_loading {
+                keep.push((url, state));
+            } else if let Some(id) = free_id {
+                texture_manager.write().free(id);
             }
         }
+        inner.current.extend(keep);
         inner.began_this_frame = false;
     }
 


### PR DESCRIPTION
Card height layout started thumbnail downloads for blocks that were not painted. The image cache then dropped those textures, and the next `embeds_seq` bump fetched them again.

- Measure cards from declared og:image dims or persisted texture size. Do not start a download from height().
- Fetch from paint and `warm_images` (buffer-zone neighbors), including preview thumbnails and favicons — the same keep-alive as markdown `![]()` images.
- Keep in-flight image-cache loads so a missed frame does not duplicate a request. Failed loads still evict so they can retry (429 after cooldown, Refresh Preview, scroll back).

Verified on desktop with a GitHub-link-heavy note: HTML once per URL, favicon once, no idle asset loop. Scrolling off and back re-downloads thumbs that left the buffer, which is expected Loaded eviction.

Bug likely existed since early July