### PR TITLE
md: skip scroll-to-cursor when dragging iOS handle to same pos

### DIFF
--- a/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/input/mutation.rs
@@ -17,14 +17,15 @@ use lb_rs::model::text::operation_types::{Operation, Replace};
 
 use super::{Advance, Bound, Location, Region};
 
-/// The endpoint that moved. If both (or neither) of the new ends were
-/// already endpoints, the active end (`.1`).
-fn moving_selection_end(old: (Grapheme, Grapheme), new: (Grapheme, Grapheme)) -> Grapheme {
+/// The endpoint that moved. `None` when the new range still uses both
+/// old endpoints (no unique moving end — e.g. handle touch-down).
+fn moving_selection_end(old: (Grapheme, Grapheme), new: (Grapheme, Grapheme)) -> Option<Grapheme> {
     let old_has = |g| g == old.0 || g == old.1;
     match (old_has(new.0), old_has(new.1)) {
-        (true, false) => new.1,
-        (false, true) => new.0,
-        _ => new.1,
+        (true, false) => Some(new.1),
+        (false, true) => Some(new.0),
+        (false, false) => Some(new.1),
+        (true, true) => None,
     }
 }
 
@@ -78,7 +79,9 @@ impl<'ast> MdEdit {
             Event::Select { region } => {
                 let range = self.region_to_range(region);
                 let range = self.renderer.snap_selection_out_of_fold_tags(range);
-                self.in_progress_handle = Some(moving_selection_end(current_selection, range));
+                if let Some(moving) = moving_selection_end(current_selection, range) {
+                    self.in_progress_handle = Some(moving);
+                }
                 operations.push(Operation::Select(range));
             }
             Event::Replace { region, text, advance_cursor } => {
@@ -1541,5 +1544,35 @@ impl HeadTail for NodeValue {
             NodeValue::Superscript => "^",
             _ => unimplemented!(), // many such cases!
         }
+    }
+}
+
+#[cfg(test)]
+mod moving_selection_end_tests {
+    use super::moving_selection_end;
+    use lb_rs::model::text::offset_types::Grapheme;
+
+    fn g(n: usize) -> Grapheme {
+        n.into()
+    }
+
+    #[test]
+    fn dragging_start_is_the_moving_end() {
+        assert_eq!(moving_selection_end((g(10), g(100)), (g(11), g(100))), Some(g(11)));
+    }
+
+    #[test]
+    fn dragging_end_is_the_moving_end() {
+        assert_eq!(moving_selection_end((g(10), g(100)), (g(10), g(99))), Some(g(99)));
+    }
+
+    #[test]
+    fn unchanged_range_has_no_moving_end() {
+        assert_eq!(moving_selection_end((g(10), g(100)), (g(10), g(100))), None);
+    }
+
+    #[test]
+    fn new_caret_follows_the_caret() {
+        assert_eq!(moving_selection_end((g(10), g(100)), (g(50), g(50))), Some(g(50)));
     }
 }

--- a/libs/content/workspace/src/tab/markdown_editor/mod.rs
+++ b/libs/content/workspace/src/tab/markdown_editor/mod.rs
@@ -989,10 +989,14 @@ impl Editor {
 
         let all_selected = self.edit.renderer.buffer.current.selection
             == (0.into(), self.edit.renderer.last_cursor_position());
+        // iOS handle touch-down re-sets the same range (no unique moving
+        // end). Don't scroll-to-cursor — that would follow `.1` and jump
+        // to the far end of a long selection.
         if self.initialized
             && buf_resp.selection_user_moved
             && !all_selected
             && self.edit.in_progress_block_drag.is_none()
+            && self.edit.in_progress_handle.is_some()
         {
             self.edit.pending_scroll = Some(ScrollTarget::Cursor);
         }


### PR DESCRIPTION
follow up to #5042